### PR TITLE
Fix backend URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Poloniex API Configuration
 VITE_POLONIEX_API_KEY=your_poloniex_api_key_here
 
+# Backend API URL
+VITE_BACKEND_URL=http://localhost:3000
+
 # Supabase Configuration (if needed)
 VITE_SUPABASE_URL=your_supabase_url_here
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm install
 ```
 VITE_POLONIEX_API_KEY=your_api_key
 VITE_POLONIEX_API_SECRET=your_api_secret
+VITE_BACKEND_URL=http://localhost:3000
 ```
 
 ### Development

--- a/src/services/websocketService.ts
+++ b/src/services/websocketService.ts
@@ -1,6 +1,7 @@
 import { io, Socket } from 'socket.io-client';
 import { MarketData, Trade } from '@/types';
 import { useErrorHandler } from '@/hooks/useErrorHandler';
+import { getBackendUrl } from '@/utils/environment';
 
 // Socket.io events
 const EVENTS = {
@@ -121,7 +122,7 @@ class WebSocketService {
   
   // Default connection config
   private config: ConnectionConfig = {
-    url: 'http://localhost:3000',
+    url: getBackendUrl(),
     options: {
       reconnectionStrategy: ReconnectionStrategy.EXPONENTIAL_BACKOFF,
       initialReconnectDelay: 1000,

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -28,3 +28,11 @@ export const getBaseUrl = () => {
   }
   return 'https://poloniex-trading-platform.vercel.app'; // Production URL
 };
+
+// Get backend API URL
+export const getBackendUrl = (): string => {
+  const envUrl = getEnvVariable('VITE_BACKEND_URL');
+  if (envUrl) return envUrl;
+  if (IS_LOCAL_DEV) return 'http://localhost:3000';
+  return window.location.origin;
+};


### PR DESCRIPTION
## Summary
- add `getBackendUrl` helper
- use backend URL in websocket service
- document backend URL in README and `.env.example`

## Testing
- `npm run lint` *(fails: 12 errors)*
- `npm test` *(fails: ReferenceError: expect is not defined)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f88d444788322b6b19a19d71e4abf

## Summary by Sourcery

Introduce a configurable backend URL by adding a getBackendUrl utility, update WebSocketService to use it, and document the new VITE_BACKEND_URL variable.

New Features:
- Add getBackendUrl helper to centralize backend API URL resolution

Enhancements:
- Switch WebSocketService to use the getBackendUrl helper instead of a hard-coded URL

Documentation:
- Document the VITE_BACKEND_URL environment variable in README and .env.example