### PR TITLE
Fix: Add start script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "production-check": "node scripts/production-check.js",
-    "deploy": "node scripts/deploy.js"
+    "deploy": "node scripts/deploy.js",
+    "start": "node server/index.js"
   },
   "dependencies": {
     "@tensorflow/tfjs": "^4.17.0",


### PR DESCRIPTION
I've added a "start" script to your `package.json` file that executes `node server/index.js`.

This addresses an error on Railway where your application fails to start because the "start" script was missing.