### PR TITLE
fix: align backend url detection with local development

### DIFF
--- a/frontend/src/utils/environment.ts
+++ b/frontend/src/utils/environment.ts
@@ -128,12 +128,13 @@ export const getBackendUrl = (): string => {
   // Priority 3: Environment detection
   if (typeof window !== 'undefined' && window.location) {
     const hostname = window.location.hostname;
-    const protocol = window.location.protocol;
-    
+    const protocol = window.location.protocol || 'http:';
+
     // Local development
     if (hostname === 'localhost' || hostname === '127.0.0.1') {
-      // Use .clinerules compliant backend port range (8765-8799)
-      return `${protocol}//localhost:8765`;
+      // Use the current origin when running locally so the backend and
+      // frontend can communicate without CORS issues during development.
+      return window.location.origin;
     }
     
     // Railway deployment detection


### PR DESCRIPTION
## Summary
- use current origin for backend URL in local dev to prevent undefined protocol

## Testing
- `npx vitest frontend/src/tests/connectivity-fix.test.ts`
- `npx vitest` *(fails: Cannot find package '@/services/advancedBacktestService')*

------
https://chatgpt.com/codex/tasks/task_e_689f107764bc83229a01f6f88a846f1b

## Summary by Sourcery

Use the browser's current origin for local development backend URL and default the protocol to http: to prevent undefined protocol errors.

Bug Fixes:
- Default to 'http:' when window.location.protocol is undefined
- Use window.location.origin for localhost and 127.0.0.1 backend URL to avoid CORS issues