### PR TITLE
Fix Railway Yarn workspace deployment: install from repo root

### DIFF
--- a/backend/railpack.json
+++ b/backend/railpack.json
@@ -8,10 +8,10 @@
   "steps": {
     "install": {
       "commands": [
-        "npm i -g corepack@latest",
-        "corepack enable",
-        "corepack prepare yarn@4.9.2 --activate",
-        "yarn install --check-cache"
+        "cd /app && npm i -g corepack@latest",
+        "cd /app && corepack enable",
+        "cd /app && corepack prepare yarn@4.9.2 --activate",
+        "cd /app && yarn install --frozen-lockfile"
       ]
     },
     "build": {
@@ -25,7 +25,7 @@
     }
   },
   "deploy": {
-    "startCommand": "node backend/dist/src/index.js",
+    "startCommand": "node dist/src/index.js",
     "healthCheckPath": "/api/health",
     "healthCheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/frontend/railpack.json
+++ b/frontend/railpack.json
@@ -8,10 +8,10 @@
   "steps": {
     "install": {
       "commands": [
-        "npm i -g corepack@latest",
-        "corepack enable",
-        "corepack prepare yarn@4.9.2 --activate",
-        "yarn install --check-cache"
+        "cd /app && npm i -g corepack@latest",
+        "cd /app && corepack enable",
+        "cd /app && corepack prepare yarn@4.9.2 --activate",
+        "cd /app && yarn install --frozen-lockfile"
       ]
     },
     "build": {
@@ -24,7 +24,7 @@
     }
   },
   "deploy": {
-    "startCommand": "node frontend/serve.js",
+    "startCommand": "node serve.js",
     "healthCheckPath": "/healthz",
     "healthCheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
**Problem:**
- Backend/frontend services failing with "No project found in /app"
- Railway sets working dir to service subdir (e.g., /app/backend)
- Yarn install was running from service dir, but workspace files (.yarnrc.yml, yarn.lock) are in parent /app

**Solution:**
1. Install commands now run from workspace root: `cd /app && yarn install`
2. Replaced `--check-cache` with `--frozen-lockfile` (production best practice)
3. Fixed start command paths to be relative to service directory

**Files changed:**
- backend/railpack.json: Install from /app, start from dist/src/index.js
- frontend/railpack.json: Install from /app, start from serve.js

**Expected result:**
- Yarn will find workspace files and install dependencies correctly
- Both services should build and deploy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix deployment failures by running Yarn install from the workspace root and updating install flags and start paths in Railway configs for both backend and frontend

Bug Fixes:
- Install dependencies from the monorepo root to resolve "No project found" errors in subdirectories

Enhancements:
- Switch from --check-cache to --frozen-lockfile for production installs
- Update start command paths in backend and frontend railpack.json to point to correct service entry files