### PR TITLE
Revert "fix(backend): add express-rate-limit dependency to resolve Railway deployment failure"

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,6 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
-    "express-rate-limit": "^8.1.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2626,7 +2626,6 @@ __metadata:
     dotenv: "npm:^17.2.1"
     eslint: "npm:^9.33.0"
     express: "npm:^5.1.0"
-    express-rate-limit: "npm:^8.1.0"
     globals: "npm:^16.3.0"
     helmet: "npm:^8.1.0"
     jiti: "npm:^2.5.1"


### PR DESCRIPTION
Reverts GaryOcean428/poloniex-trading-platform#286

## Summary by Sourcery

Chores:
- Remove express-rate-limit from backend package.json and update the lockfile accordingly