### PR TITLE
Align backend start commands with flattened build output

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,9 +10,9 @@
   "scripts": {
     "prebuild": "node prebuild.mjs",
     "dev": "nodemon --watch src --ext ts,js,json --exec node --loader ts-node/esm src/index.ts",
-    "start": "node dist/src/index.js",
-    "build": "node prebuild.mjs && rm -rf dist && tsc -p tsconfig.build.json && rm -rf .shared-build",
-    "build:railway": "node prebuild.mjs && rm -rf dist && tsc -p tsconfig.build.json --incremental false --sourceMap false --removeComments true && rm -rf .shared-build",
+    "start": "node dist/index.js",
+    "build": "node prebuild.mjs && rm -rf dist && tsc -p tsconfig.build.json && node scripts/flatten-dist.mjs && rm -rf .shared-build",
+    "build:railway": "node prebuild.mjs && rm -rf dist && tsc -p tsconfig.build.json --incremental false --sourceMap false --removeComments true && node scripts/flatten-dist.mjs && rm -rf .shared-build",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/backend/railpack.json
+++ b/backend/railpack.json
@@ -22,7 +22,7 @@
     }
   },
   "deploy": {
-    "startCommand": "node backend/dist/src/index.js",
+    "startCommand": "node backend/dist/index.js",
     "healthCheckPath": "/api/health",
     "healthCheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/backend/railpack.json.template
+++ b/backend/railpack.json.template
@@ -25,7 +25,7 @@
     }
   },
   "deploy": {
-    "startCommand": "node dist/src/index.js",
+    "startCommand": "node dist/index.js",
     "healthCheckPath": "/api/health",
     "healthCheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/backend/scripts/flatten-dist.mjs
+++ b/backend/scripts/flatten-dist.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { readdirSync, renameSync, rmSync, existsSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const distDir = join(__dirname, '..', 'dist');
+const distSrcDir = join(distDir, 'src');
+
+if (!existsSync(distSrcDir)) {
+  console.log('No dist/src directory found; skipping flatten step.');
+  process.exit(0);
+}
+
+for (const entry of readdirSync(distSrcDir)) {
+  const fromPath = join(distSrcDir, entry);
+  const toPath = join(distDir, entry);
+
+  if (existsSync(toPath)) {
+    const stats = statSync(toPath);
+    if (stats.isDirectory()) {
+      rmSync(toPath, { recursive: true, force: true });
+    } else {
+      rmSync(toPath, { force: true });
+    }
+  }
+
+  renameSync(fromPath, toPath);
+}
+
+rmSync(distSrcDir, { recursive: true, force: true });
+console.log('Flattened dist/src into dist/.');


### PR DESCRIPTION
## Summary
- update the backend start script and Railpack deploy command to boot from `dist/index.js`
- add a `flatten-dist` helper and run it during builds so the compiled output matches the new entry path
- sync the backend Railpack template with the new start command

## Testing
- PORT=4100 DATABASE_URL=postgres://user:pass@localhost:5432/db JWT_SECRET=12345678901234567890123456789012 node backend/dist/index.js
- node backend/prebuild.mjs && node node_modules/typescript/bin/tsc -p backend/tsconfig.build.json --incremental false --sourceMap false --removeComments true && node backend/scripts/flatten-dist.mjs

------
https://chatgpt.com/codex/tasks/task_b_68fa05e7aee4832a9421594a325f3b88

## Summary by Sourcery

Align backend build output with flattened directory structure and update start and deploy commands to use the new entry path.

Enhancements:
- Introduce a flatten-dist helper script to move compiled files from dist/src into dist root
- Run flatten-dist as part of both build and build:railway scripts
- Change backend start script to boot from dist/index.js instead of dist/src/index.js
- Sync the backend Railpack template with the updated start command