### PR TITLE
auto-commit for fa30f295-6440-4b8a-830e-0c77eddbe68c

### DIFF
--- a/apps/api/database/migrations/003_autonomous_trading_schema.sql
+++ b/apps/api/database/migrations/003_autonomous_trading_schema.sql
@@ -262,7 +262,9 @@ WHERE status = 'completed'
 GROUP BY DATE(timestamp)
 ORDER BY date DESC;
 
-CREATE OR REPLACE VIEW strategy_performance_summary AS
+-- Use a distinct name from the backtesting view created in migration 002.
+-- PostgreSQL cannot CREATE OR REPLACE a view when column names/order change.
+CREATE OR REPLACE VIEW autonomous_strategy_performance_summary AS
 SELECT 
     s.id,
     s.name,

--- a/backend/tests/test_migration_rerun_safety.py
+++ b/backend/tests/test_migration_rerun_safety.py
@@ -129,3 +129,27 @@ def test_typescript_runner_uses_per_migration_transaction() -> None:
     assert "await client.query('BEGIN')" in runner_content
     assert "await client.query('COMMIT')" in runner_content
     assert "await client.query('ROLLBACK')" in runner_content
+
+
+# Feature: distinct views should not collide across migration files with incompatible schemas
+def test_no_duplicate_view_names_across_migrations() -> None:
+    create_view_pattern = re.compile(
+        r"\bCREATE\s+(?:OR\s+REPLACE\s+)?VIEW\s+([a-zA-Z_][a-zA-Z0-9_]*)\b",
+        re.IGNORECASE,
+    )
+    seen: dict[str, Path] = {}
+    duplicates: list[str] = []
+
+    for sql_file in _sql_files():
+        raw = sql_file.read_text(encoding="utf-8")
+        sanitized = _strip_line_comments(_strip_dollar_quoted_blocks(raw))
+
+        for match in create_view_pattern.finditer(sanitized):
+            view_name = match.group(1).lower()
+            prior = seen.get(view_name)
+            if prior and prior != sql_file:
+                duplicates.append(f"{view_name}: {prior.name} and {sql_file.name}")
+            else:
+                seen[view_name] = sql_file
+
+    assert not duplicates, "\n".join(duplicates)

--- a/memory/PRD.md
+++ b/memory/PRD.md
@@ -83,3 +83,11 @@ User follow-up: check past 10 PRs and ensure everything has been covered from al
   - direct database execution via `DATABASE_URL`
 - It fails clearly if neither migration credential path is configured.
 - It optionally checks deployed backend health after migration using `RAILWAY_BACKEND_HEALTH_URL`.
+
+
+## Runtime Migration Fix Update
+- Railway deploy logs exposed a Postgres 42P16 failure in `003_autonomous_trading_schema.sql`.
+- Root cause: `002_backtesting_schema.sql` and `003_autonomous_trading_schema.sql` both defined `strategy_performance_summary`, but with incompatible column layouts (`name` first vs `id` first).
+- Fixed by renaming the autonomous-trading view in migration 003 to `autonomous_strategy_performance_summary`.
+- Added a regression test to detect duplicate view names across SQL migrations so incompatible view replacements are caught before deploy.
+- Verification: `yarn build:api` ✅ and backend migration safety tests now `6 passed` ✅.


### PR DESCRIPTION
## Summary by Sourcery

Rename an autonomous trading database view to avoid schema conflicts with an existing backtesting view and guard against future duplicates across migrations.

Bug Fixes:
- Resolve a Postgres migration failure by giving the autonomous trading strategy performance view a distinct name from the backtesting view.

Documentation:
- Document the migration failure, root cause, fix, and verification steps in the runtime migration section of the PRD.

Tests:
- Add a regression test that scans SQL migration files to fail if duplicate view names are defined across migrations.