### PR TITLE
fix(api): auto-run migrations on startup + trust proxy

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prebuild": "node prebuild.mjs",
     "dev": "nodemon --watch src --ext ts,js,json --exec node --loader ts-node/esm src/index.ts",
-    "start": "node dist/index.js",
+    "start": "node scripts/start.js",
     "build": "node prebuild.mjs && rm -rf dist && tsc -p tsconfig.build.json && node scripts/flatten-dist.mjs && rm -rf .shared-build",
     "build:railway": "node prebuild.mjs && rm -rf dist && tsc -p tsconfig.build.json --incremental false --sourceMap false --removeComments true && node scripts/flatten-dist.mjs && rm -rf .shared-build",
     "test": "jest",

--- a/apps/api/run-migration.js
+++ b/apps/api/run-migration.js
@@ -25,6 +25,13 @@ async function runMigration() {
   const client = await pool.connect();
   
   try {
+    // Prevent multiple instances (or restarts) from running migrations concurrently.
+    // This is important on Railway where there may be overlapping deploys.
+    // Uses an advisory lock scoped to the DB connection.
+    await client.query('SELECT pg_advisory_lock(hashtext($1)::bigint)', [
+      'polytrade:db-migrations',
+    ]);
+
     const migrationArg = process.argv[2] ?? 'all';
     
     console.log('🔄 Starting database migrations...\n');
@@ -96,11 +103,19 @@ async function runMigration() {
       });
     }
     
-  } catch (error) {
+      } catch (error) {
     console.error('❌ Migration error:', error.message);
     console.error('Stack trace:', error.stack);
     throw error;
   } finally {
+        // Best-effort unlock (connection might already be in a bad state).
+        try {
+          await client.query('SELECT pg_advisory_unlock(hashtext($1)::bigint)', [
+            'polytrade:db-migrations',
+          ]);
+        } catch {
+          // ignore
+        }
     client.release();
     await pool.end();
   }

--- a/apps/api/scripts/start.js
+++ b/apps/api/scripts/start.js
@@ -1,0 +1,84 @@
+/**
+ * API startup wrapper.
+ *
+ * Purpose:
+ * - Run database migrations on startup (configurable) so production never boots
+ *   with an outdated schema.
+ * - Then start the compiled server.
+ *
+ * This runs as part of `yarn workspace @poloniex-platform/api start`.
+ */
+
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// scripts/ -> apps/api
+const apiRoot = path.resolve(__dirname, '..');
+const migrationScript = path.join(apiRoot, 'run-migration.js');
+const serverEntry = path.join(apiRoot, 'dist', 'index.js');
+
+function runProcess(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      env: process.env,
+      ...options,
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (signal) return resolve({ code: 1, signal });
+      resolve({ code: code ?? 0, signal: null });
+    });
+  });
+}
+
+async function main() {
+  const shouldMigrate =
+    process.env.RUN_MIGRATIONS_ON_STARTUP !== 'false' &&
+    typeof process.env.DATABASE_URL === 'string' &&
+    process.env.DATABASE_URL.length > 0;
+
+  if (shouldMigrate) {
+    console.log('🗄️  Running database migrations before starting API...');
+    const { code } = await runProcess(process.execPath, [migrationScript, 'all'], {
+      cwd: apiRoot,
+    });
+    if (code !== 0) {
+      console.error('💥 Migrations failed; refusing to start API');
+      process.exit(code);
+    }
+  } else {
+    console.log('⏭️  Skipping migrations (RUN_MIGRATIONS_ON_STARTUP=false or DATABASE_URL missing)');
+  }
+
+  console.log('🚀 Starting API server...');
+  const server = spawn(process.execPath, [serverEntry], {
+    cwd: apiRoot,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  const forwardSignal = (signal) => {
+    if (!server.killed) server.kill(signal);
+  };
+
+  process.on('SIGTERM', () => forwardSignal('SIGTERM'));
+  process.on('SIGINT', () => forwardSignal('SIGINT'));
+
+  server.on('exit', (code, signal) => {
+    if (signal) {
+      process.exit(1);
+    }
+    process.exit(code ?? 0);
+  });
+}
+
+main().catch((err) => {
+  console.error('💥 Startup wrapper crashed:', err);
+  process.exit(1);
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -57,6 +57,13 @@ const __dirname = path.dirname(__filename);
 const app = express();
 const server = createServer(app);
 
+// Railway/Cloud proxies set X-Forwarded-* headers. Express defaults to not trusting
+// proxies, which breaks accurate client IP detection (and triggers express-rate-limit
+// ERR_ERL_UNEXPECTED_X_FORWARDED_FOR). Trust the first proxy hop in production.
+if (env.NODE_ENV === 'production') {
+  app.set('trust proxy', 1);
+}
+
 // Use Railway PORT environment variable or fallback to .clinerules compliant port range (8765-8799)
 const PORT = env.PORT;
 


### PR DESCRIPTION
## Problem

Production deploys failed with:
- `column "name" of relation "agent_strategies" does not exist`
- `relation "trades" does not exist`
- `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` (trust proxy)

Migrations 012 and 013 were never run on the production database.

## Changes

- **`apps/api/scripts/start.js`** — Startup wrapper that runs DB migrations before server start
- **`apps/api/run-migration.js`** — Added `pg_advisory_lock` for concurrent migration safety
- **`apps/api/src/index.ts`** — Added `app.set('trust proxy', 1)` in production
- **`apps/api/package.json`** — Start script uses wrapper

## Note

Migrations 012 and 013 were already applied directly to Railway Postgres. This PR ensures future migrations auto-apply on deploy.

## Summary by Sourcery

Ensure the API server runs database migrations safely on startup and correctly trusts proxy headers in production.

New Features:
- Add a startup wrapper script that runs database migrations before launching the compiled API server, controllable via environment variables.

Bug Fixes:
- Configure Express to trust the first proxy hop in production to fix client IP detection and related rate limiting errors.

Enhancements:
- Protect database migrations with a PostgreSQL advisory lock to prevent concurrent migration runs during overlapping deploys.

Build:
- Update the API package start script to invoke the new startup wrapper instead of running the server entrypoint directly.