### PR TITLE
SLE pipeline rebuild: observability, risk kernel, promotion engine, purge scaffold

### DIFF
--- a/apps/api/database/migrations/025_strategy_state_events.sql
+++ b/apps/api/database/migrations/025_strategy_state_events.sql
@@ -1,0 +1,52 @@
+-- Migration 025: Append-only strategy lifecycle event log
+--
+-- Captures every state transition (status change, promotion, demotion, kill,
+-- recalibration) as an immutable event row. Two jobs:
+--
+--   1. Audit trail — explains WHY a strategy changed state, which has been
+--      invisible historically (issue #447-449: "strategies vanish with just
+--      'retired' as the explanation").
+--
+--   2. Source-of-truth for promotion/demotion engine — concurrent writers
+--      (10 parallel strategies) no longer contend on row-level locks in
+--      strategy_performance; they append events and a projection layer
+--      materialises current state.
+--
+-- Also pre-provisions engine_version (git SHA) so every row written going
+-- forward is attributable to specific code. Commit 3 will add engine_version
+-- to legacy tables; this table is born with it.
+
+CREATE TABLE IF NOT EXISTS strategy_state_events (
+    id              BIGSERIAL PRIMARY KEY,
+    strategy_id     TEXT        NOT NULL,
+    from_status     TEXT,                      -- NULL for initial creation event
+    to_status       TEXT        NOT NULL,
+    reason          TEXT        NOT NULL,      -- short machine-parseable reason code
+    detail          TEXT,                      -- free-form human explanation
+    metadata        JSONB,                     -- metrics snapshot, trade count, etc.
+    engine_version  VARCHAR(40) NOT NULL,      -- git SHA at time of event
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_state_events_strategy_created
+    ON strategy_state_events(strategy_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_state_events_to_status
+    ON strategy_state_events(to_status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_state_events_engine_version
+    ON strategy_state_events(engine_version);
+
+-- Convenience view: latest event per strategy.
+-- Used by promotion engine to decide current state without contending on
+-- strategy_performance.
+CREATE OR REPLACE VIEW strategy_current_state AS
+SELECT DISTINCT ON (strategy_id)
+    strategy_id,
+    to_status           AS current_status,
+    reason              AS last_reason,
+    metadata            AS last_metadata,
+    engine_version      AS last_engine_version,
+    created_at          AS last_transition_at
+FROM strategy_state_events
+ORDER BY strategy_id, created_at DESC;

--- a/apps/api/database/migrations/026_engine_version_and_purge_scaffolding.sql
+++ b/apps/api/database/migrations/026_engine_version_and_purge_scaffolding.sql
@@ -1,0 +1,81 @@
+-- Migration 026: engine_version provenance + soft-delete + purge audit
+--
+-- Every row produced by the backtesting/paper/live pipeline is now tagged
+-- with the git SHA of the engine that produced it. This is the foundation
+-- for the legacy-backtest purge: "clean slate" metrics only aggregate rows
+-- whose engine_version >= <current>. Legacy rows from before the realistic-
+-- costs commit can be filtered, soft-deleted, then hard-deleted once the
+-- 7-day rollback window has passed without incident.
+--
+-- Scope:
+--   1. engine_version VARCHAR(40) added to backtest_results, strategy_performance,
+--      autonomous_trades, paper_trading_sessions.
+--   2. deleted_at TIMESTAMPTZ for soft-delete on the same tables.
+--   3. data_purges audit table — one row per purge operation, immutable.
+
+-- ───────── backtest_results ─────────
+ALTER TABLE backtest_results
+  ADD COLUMN IF NOT EXISTS engine_version VARCHAR(40),
+  ADD COLUMN IF NOT EXISTS deleted_at     TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_backtest_results_engine_version
+  ON backtest_results(engine_version)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_backtest_results_deleted_at
+  ON backtest_results(deleted_at);
+
+-- ───────── strategy_performance ─────────
+ALTER TABLE strategy_performance
+  ADD COLUMN IF NOT EXISTS engine_version VARCHAR(40),
+  ADD COLUMN IF NOT EXISTS deleted_at     TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_strategy_performance_engine_version
+  ON strategy_performance(engine_version)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_strategy_performance_deleted_at
+  ON strategy_performance(deleted_at);
+
+-- ───────── autonomous_trades ─────────
+ALTER TABLE autonomous_trades
+  ADD COLUMN IF NOT EXISTS engine_version VARCHAR(40),
+  ADD COLUMN IF NOT EXISTS deleted_at     TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_autonomous_trades_engine_version
+  ON autonomous_trades(engine_version)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_autonomous_trades_deleted_at
+  ON autonomous_trades(deleted_at);
+
+-- ───────── paper_trading_sessions ─────────
+ALTER TABLE paper_trading_sessions
+  ADD COLUMN IF NOT EXISTS engine_version VARCHAR(40),
+  ADD COLUMN IF NOT EXISTS deleted_at     TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_paper_trading_sessions_engine_version
+  ON paper_trading_sessions(engine_version)
+  WHERE deleted_at IS NULL;
+
+-- ───────── data_purges audit ─────────
+-- One row per purge operation. Immutable (no UPDATE trigger).
+CREATE TABLE IF NOT EXISTS data_purges (
+    id                BIGSERIAL   PRIMARY KEY,
+    purge_kind        TEXT        NOT NULL,      -- 'legacy_backtests', 'hard_delete', etc.
+    target_table      TEXT        NOT NULL,
+    rows_affected     INTEGER     NOT NULL,
+    phase             TEXT        NOT NULL,      -- 'soft_delete' | 'hard_delete' | 'backup_only'
+    engine_version    VARCHAR(40) NOT NULL,      -- git SHA at time of purge
+    reason            TEXT        NOT NULL,
+    backup_path       TEXT,                       -- local + S3 path (nullable if backup-only)
+    backup_checksum   TEXT,
+    operator          TEXT        NOT NULL,      -- user or 'system'
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_data_purges_created_at
+  ON data_purges(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_data_purges_kind
+  ON data_purges(purge_kind, created_at DESC);

--- a/apps/api/database/migrations/027_promotion_engine_state.sql
+++ b/apps/api/database/migrations/027_promotion_engine_state.sql
@@ -1,0 +1,67 @@
+-- Migration 027: Promotion / demotion engine state
+--
+-- Adds columns and tables needed for the multi-metric promotion pipeline:
+--
+--   * strategy_performance gains tier / demotion / recalibration fields
+--     so the promotion engine can track each strategy's earn-in history
+--     without contending on a hot row (new events go to
+--     strategy_state_events; these fields are the derived projection).
+--
+--   * bandit_class_counters — Beta(wins, losses) posterior per
+--     (strategy_class × regime) pair that drives Thompson sampling in
+--     the generator.
+--
+--   * frozen_cohorts — genome archive of retired champions per regime.
+--     Reactivated when the same regime recurs.
+
+-- ───────── strategy_performance: tier + demotion state ─────────
+ALTER TABLE strategy_performance
+  ADD COLUMN IF NOT EXISTS live_tier             SMALLINT    NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS demotion_count        SMALLINT    NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_demotion_at      TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS lifetime_realised_pnl NUMERIC(14,4) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS recalibration_cycles  SMALLINT    NOT NULL DEFAULT 0;
+
+-- Allow the new 'recalibrating' status. strategy_performance.status is
+-- an un-constrained TEXT column in the base schema, so no CHECK needed.
+-- We just make sure common queries can filter by it.
+CREATE INDEX IF NOT EXISTS idx_strategy_performance_status_tier
+  ON strategy_performance(status, live_tier)
+  WHERE deleted_at IS NULL;
+
+-- ───────── bandit_class_counters ─────────
+-- Thompson bandit posterior. One row per (class, regime) pair.
+-- Updated on every terminal trade outcome by the promotion engine.
+CREATE TABLE IF NOT EXISTS bandit_class_counters (
+    strategy_class   TEXT        NOT NULL,
+    regime           TEXT        NOT NULL,
+    wins             INTEGER     NOT NULL DEFAULT 1,   -- Beta(α,β): α=1 starting prior
+    losses           INTEGER     NOT NULL DEFAULT 1,   --           β=1 starting prior
+    last_updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (strategy_class, regime)
+);
+
+-- ───────── frozen_cohorts ─────────
+-- Champion archive. When a strategy is retired while it had positive
+-- lifetime_realised_pnl, its genome + regime tag is snapshotted here
+-- so the bandit can re-activate it if the regime recurs.
+CREATE TABLE IF NOT EXISTS frozen_cohorts (
+    id                BIGSERIAL   PRIMARY KEY,
+    strategy_id       TEXT        NOT NULL,
+    strategy_class    TEXT        NOT NULL,
+    regime            TEXT        NOT NULL,
+    signal_genome     JSONB       NOT NULL,
+    lifetime_pnl      NUMERIC(14,4) NOT NULL,
+    live_trades       INTEGER     NOT NULL,
+    paper_trades      INTEGER     NOT NULL,
+    frozen_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    frozen_reason     TEXT        NOT NULL,
+    engine_version    VARCHAR(40) NOT NULL,
+    reactivated_count SMALLINT    NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_frozen_cohorts_regime_pnl
+  ON frozen_cohorts(regime, lifetime_pnl DESC);
+
+CREATE INDEX IF NOT EXISTS idx_frozen_cohorts_strategy
+  ON frozen_cohorts(strategy_id);

--- a/apps/api/scripts/HARD_DELETE_FOLLOWUP.md
+++ b/apps/api/scripts/HARD_DELETE_FOLLOWUP.md
@@ -1,0 +1,94 @@
+# Legacy backtest hard-delete — 7-day follow-up procedure
+
+**Do not run until the soft-delete from Commit 3 has been in place for ≥ 7 days
+without a rollback request.**
+
+## Context
+
+Commit 3 (`8c41ad5 — feat(provenance): engine_version tagging + soft-delete purge scaffolding`)
+added `deleted_at` columns and a `data_purges` audit table. The purge script
+marks legacy (pre-engine-version) rows as soft-deleted by stamping `deleted_at`.
+
+This follow-up hard-deletes those rows permanently once the 7-day rollback
+window has elapsed with no incidents.
+
+## Pre-flight checklist
+
+- [ ] At least 7 calendar days since the soft-delete audit row was written
+- [ ] `SELECT * FROM data_purges WHERE purge_kind = 'legacy_backtests'
+       ORDER BY created_at DESC LIMIT 1;` shows phase='soft_delete'
+- [ ] No rollback request in the past 7 days (check with operator/owner)
+- [ ] Full pg_dump backup (from `scripts/backup-pre-purge.mjs`) is still on disk
+      and/or uploaded to S3 with matching SHA-256
+- [ ] Promotion engine has been running on fresh engine_version-tagged rows
+      for the full 7-day window
+- [ ] At least one strategy has cleared backtest→paper promotion under the
+      current engine version (evidence the new pipeline is producing
+      trustworthy rows)
+
+## Execute
+
+Write a script `apps/api/scripts/hard-delete-legacy-backtests.mjs` that:
+
+1. Requires `PURGE_LEGACY_BACKTESTS=true` **and** `HARD_DELETE_CONFIRMED=true`
+   env flags (double-gate — soft-delete had one).
+2. DRY-RUN by default; requires `--execute` flag.
+3. For each of the four target tables, runs:
+
+   ```sql
+   DELETE FROM <table>
+   WHERE deleted_at IS NOT NULL
+     AND deleted_at < NOW() - INTERVAL '7 days'
+     AND engine_version IS NULL;
+   ```
+
+4. Writes an audit row to `data_purges` with:
+   - `purge_kind = 'legacy_backtests'`
+   - `phase = 'hard_delete'`
+   - `rows_affected` = DELETE's rowCount
+   - `engine_version` = current git SHA
+   - `operator` = env USER or 'system'
+   - `backup_path` = path to the pg_dump made pre-soft-delete (retained from
+     original backup step)
+   - `reason` = e.g. `'7day_rollback_window_elapsed_no_incidents'`
+
+5. Runs `VACUUM ANALYZE` on each affected table after delete so reclaimed
+   space is returned and planner stats refresh.
+
+## Why this is a separate script, not an auto-cron
+
+Destructive operations on production data must be intentional. A scheduled
+cron job that auto-hard-deletes 7 days after soft-delete creates a silent
+deadline: if someone notices a problem on day 6 and doesn't escalate in
+time, the data is gone. Keeping hard-delete as a manual script with audit
+trail forces a human decision to close the window.
+
+## After hard-delete
+
+- Update the plan file (`see-last-20-prs-scalable-lemur.md`) to mark
+  Commit 7 as completed.
+- Write a short post-mortem summary to `bsuite_session_YYYYMMDD` memory
+  key if any anomalies surfaced during the 7-day soft-delete window.
+- Consider shrinking the affected tables if disk usage is a concern:
+  `CLUSTER backtest_results USING <best_index>` after vacuum.
+
+## Rollback (if still within 7-day window)
+
+If we decide to undo the soft-delete before hard-delete runs:
+
+```sql
+BEGIN;
+UPDATE backtest_results          SET deleted_at = NULL WHERE engine_version IS NULL;
+UPDATE strategy_performance      SET deleted_at = NULL WHERE engine_version IS NULL;
+UPDATE autonomous_trades         SET deleted_at = NULL WHERE engine_version IS NULL;
+UPDATE paper_trading_sessions    SET deleted_at = NULL WHERE engine_version IS NULL;
+INSERT INTO data_purges
+  (purge_kind, target_table, rows_affected, phase, engine_version, reason, operator)
+  VALUES ('legacy_backtests_rollback', 'ALL', 0, 'rollback',
+          '<current git sha>', 'manual_rollback_<reason>', '<operator>');
+COMMIT;
+```
+
+After rollback, the soft-delete script can be re-run cleanly (it's
+idempotent — rows without `deleted_at` that also have `engine_version IS NULL`
+will be re-flagged).

--- a/apps/api/scripts/backup-pre-purge.mjs
+++ b/apps/api/scripts/backup-pre-purge.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Pre-purge backup — always run this before purge-legacy-backtests.mjs --execute.
+ *
+ * Takes a schema+data dump of the target tables (not the whole DB) so the
+ * 90-day retention cost stays small. Writes a checksum alongside so any
+ * future restore can verify integrity.
+ *
+ * Target tables mirror the purge script. Output path includes engine
+ * version + UTC timestamp so backups never collide.
+ *
+ * Usage:
+ *   DATABASE_URL=... node apps/api/scripts/backup-pre-purge.mjs [--out path/to/dir]
+ *
+ * Requires `pg_dump` on PATH. Does not upload to S3 — wrap this script
+ * in your deploy tooling if you want off-box retention.
+ */
+
+import { createHash } from 'crypto';
+import { spawn } from 'child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+const TARGET_TABLES = [
+  'backtest_results',
+  'strategy_performance',
+  'autonomous_trades',
+  'paper_trading_sessions',
+];
+
+function getFlagValue(argv, name) {
+  const idx = argv.indexOf(name);
+  if (idx === -1 || idx === argv.length - 1) return null;
+  return argv[idx + 1];
+}
+
+function engineVersion() {
+  return (
+    process.env.ENGINE_VERSION ??
+    process.env.RAILWAY_GIT_COMMIT_SHA ??
+    process.env.GIT_SHA ??
+    'unknown'
+  ).slice(0, 12);
+}
+
+async function runPgDump(databaseUrl, outputPath) {
+  return new Promise((resolvePromise, reject) => {
+    // execFile-style spawn with a fixed arg list — no shell, no injection.
+    const args = ['--data-only', '--no-owner', '--no-privileges', '-f', outputPath];
+    for (const table of TARGET_TABLES) {
+      args.push('-t', table);
+    }
+    args.push(databaseUrl);
+
+    const child = spawn('pg_dump', args, { stdio: ['ignore', 'inherit', 'inherit'] });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(`pg_dump exited with code ${code}`));
+    });
+  });
+}
+
+function sha256OfFile(path) {
+  const hash = createHash('sha256');
+  hash.update(readFileSync(path));
+  return hash.digest('hex');
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('[backup] DATABASE_URL is required.');
+    process.exit(1);
+  }
+
+  const outDir = resolve(getFlagValue(process.argv, '--out') ?? './backups');
+  mkdirSync(outDir, { recursive: true });
+
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const dumpPath = resolve(outDir, `pre-purge-${engineVersion()}-${ts}.sql`);
+
+  console.log(`[backup] Writing ${TARGET_TABLES.length} tables to ${dumpPath}`);
+  await runPgDump(databaseUrl, dumpPath);
+
+  const checksum = sha256OfFile(dumpPath);
+  const checksumPath = `${dumpPath}.sha256`;
+  writeFileSync(checksumPath, `${checksum}  ${dumpPath}\n`);
+
+  console.log(`[backup] Done.`);
+  console.log(`[backup] sha256=${checksum}`);
+  console.log(`[backup] checksum file: ${checksumPath}`);
+}
+
+main().catch((err) => {
+  console.error('[backup] fatal:', err);
+  process.exit(1);
+});

--- a/apps/api/scripts/purge-legacy-backtests.mjs
+++ b/apps/api/scripts/purge-legacy-backtests.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Legacy backtest purge — soft-delete phase.
+ *
+ * Identifies rows in backtest_results / strategy_performance / autonomous_trades
+ * / paper_trading_sessions that were written before engine_version tagging
+ * existed (engine_version IS NULL), stamps them with deleted_at, writes an
+ * audit row to data_purges, and returns row counts.
+ *
+ * The red team flagged irreversible production deletes as unacceptable, so
+ * this script:
+ *   - requires PURGE_LEGACY_BACKTESTS=true (feature flag gate),
+ *   - defaults to DRY-RUN mode unless --execute is passed,
+ *   - performs soft-delete only (no DROP, no TRUNCATE, no DELETE). Hard
+ *     delete is a separate script (Commit 7) that runs only after the
+ *     7-day soft-delete window has elapsed without rollback.
+ *
+ * Usage:
+ *   # Preview what would be purged
+ *   PURGE_LEGACY_BACKTESTS=true node apps/api/scripts/purge-legacy-backtests.mjs
+ *
+ *   # Execute the soft-delete
+ *   PURGE_LEGACY_BACKTESTS=true node apps/api/scripts/purge-legacy-backtests.mjs --execute
+ *
+ * Run the backup script (apps/api/scripts/backup-pre-purge.mjs) before
+ * --execute, always.
+ */
+
+import pg from 'pg';
+
+const { Pool } = pg;
+
+const TARGET_TABLES = [
+  'backtest_results',
+  'strategy_performance',
+  'autonomous_trades',
+  'paper_trading_sessions',
+];
+
+function requireFlag() {
+  if (process.env.PURGE_LEGACY_BACKTESTS !== 'true') {
+    console.error(
+      '[purge] Refusing to run without PURGE_LEGACY_BACKTESTS=true env flag.\n' +
+      '        This guard prevents accidental invocation in CI/build pipelines.',
+    );
+    process.exit(1);
+  }
+}
+
+function parseArgs(argv) {
+  return {
+    execute: argv.includes('--execute'),
+    reason: getFlagValue(argv, '--reason') ?? 'legacy_unit_misattribution_purge',
+    operator: getFlagValue(argv, '--operator') ?? process.env.USER ?? 'system',
+  };
+}
+
+function getFlagValue(argv, name) {
+  const idx = argv.indexOf(name);
+  if (idx === -1 || idx === argv.length - 1) return null;
+  return argv[idx + 1];
+}
+
+/** Pure function — count legacy rows. Exported for tests. */
+export async function countLegacyRows(pool, table) {
+  const { rows } = await pool.query(
+    `SELECT COUNT(*)::int AS n FROM ${table} WHERE engine_version IS NULL AND deleted_at IS NULL`,
+  );
+  return rows[0]?.n ?? 0;
+}
+
+/** Pure function — soft-delete legacy rows and return count. Exported for tests. */
+export async function softDeleteLegacyRows(pool, table) {
+  const { rowCount } = await pool.query(
+    `UPDATE ${table}
+     SET deleted_at = NOW()
+     WHERE engine_version IS NULL AND deleted_at IS NULL`,
+  );
+  return rowCount ?? 0;
+}
+
+async function recordPurgeAudit(pool, entry) {
+  await pool.query(
+    `INSERT INTO data_purges
+      (purge_kind, target_table, rows_affected, phase, engine_version, reason, operator)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [
+      entry.purgeKind,
+      entry.targetTable,
+      entry.rowsAffected,
+      entry.phase,
+      entry.engineVersion,
+      entry.reason,
+      entry.operator,
+    ],
+  );
+}
+
+async function main() {
+  requireFlag();
+  const { execute, reason, operator } = parseArgs(process.argv.slice(2));
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('[purge] DATABASE_URL is required.');
+    process.exit(1);
+  }
+
+  // engine_version is written by the API. Read it from the process that
+  // invokes this script so the audit row is attributed to the current SHA.
+  const engineVersion =
+    process.env.ENGINE_VERSION ??
+    process.env.RAILWAY_GIT_COMMIT_SHA ??
+    process.env.GIT_SHA ??
+    'unknown';
+
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  try {
+    const report = [];
+    for (const table of TARGET_TABLES) {
+      const count = await countLegacyRows(pool, table);
+      report.push({ table, legacyRows: count });
+    }
+
+    console.log(`[purge] mode=${execute ? 'EXECUTE' : 'DRY-RUN'} reason=${reason}`);
+    console.table(report);
+
+    if (!execute) {
+      console.log('[purge] DRY-RUN — no rows modified. Re-run with --execute to soft-delete.');
+      return;
+    }
+
+    for (const { table } of report) {
+      const affected = await softDeleteLegacyRows(pool, table);
+      await recordPurgeAudit(pool, {
+        purgeKind: 'legacy_backtests',
+        targetTable: table,
+        rowsAffected: affected,
+        phase: 'soft_delete',
+        engineVersion,
+        reason,
+        operator,
+      });
+      console.log(`[purge] soft-deleted ${affected} rows from ${table}`);
+    }
+
+    console.log('[purge] Soft-delete complete. Hard delete is a separate script run after 7 days.');
+  } finally {
+    await pool.end();
+  }
+}
+
+// Only run main() when executed directly (so tests can import helpers).
+// Use fileURLToPath for robust cross-platform matching (handles Windows
+// drive letters that `startsWith('file://')` would miss).
+import { fileURLToPath } from 'url';
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('[purge] fatal:', err);
+    process.exit(1);
+  });
+}

--- a/apps/api/scripts/purge-legacy-backtests.mjs
+++ b/apps/api/scripts/purge-legacy-backtests.mjs
@@ -30,12 +30,29 @@ import pg from 'pg';
 
 const { Pool } = pg;
 
-const TARGET_TABLES = [
+const TARGET_TABLES = Object.freeze([
   'backtest_results',
   'strategy_performance',
   'autonomous_trades',
   'paper_trading_sessions',
-];
+]);
+const TARGET_TABLES_SET = new Set(TARGET_TABLES);
+
+/**
+ * Defense-in-depth: even though table names today come from the frozen
+ * TARGET_TABLES constant, a future refactor (config-driven purge, etc.)
+ * could route a user-controlled value into the table slot. Assert the
+ * allowlist before interpolating into SQL so that regression can never
+ * become an injection surface.
+ */
+function assertAllowlistedTable(table) {
+  if (!TARGET_TABLES_SET.has(table)) {
+    throw new Error(
+      `[purge] Refusing to operate on non-allowlisted table: ${String(table)}. ` +
+      `Permitted: ${[...TARGET_TABLES_SET].join(', ')}`,
+    );
+  }
+}
 
 function requireFlag() {
   if (process.env.PURGE_LEGACY_BACKTESTS !== 'true') {
@@ -63,6 +80,7 @@ function getFlagValue(argv, name) {
 
 /** Pure function — count legacy rows. Exported for tests. */
 export async function countLegacyRows(pool, table) {
+  assertAllowlistedTable(table);
   const { rows } = await pool.query(
     `SELECT COUNT(*)::int AS n FROM ${table} WHERE engine_version IS NULL AND deleted_at IS NULL`,
   );
@@ -71,6 +89,7 @@ export async function countLegacyRows(pool, table) {
 
 /** Pure function — soft-delete legacy rows and return count. Exported for tests. */
 export async function softDeleteLegacyRows(pool, table) {
+  assertAllowlistedTable(table);
   const { rowCount } = await pool.query(
     `UPDATE ${table}
      SET deleted_at = NOW()

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -38,6 +38,7 @@ import { runAllMigrations } from './scripts/runMigrations.js';
 import { agentScheduler } from './services/agentScheduler.js';
 import paperTradingService from './services/paperTradingService.js';
 import { persistentTradingEngine } from './services/persistentTradingEngine.js';
+import { startPipelineHealthProbe } from './services/pipelineHealthProbe.js';
 import { stateReconciliationService } from './services/stateReconciliationService.js';
 import { logger } from './utils/logger.js';
 
@@ -417,6 +418,13 @@ server.listen(PORT, '::', async () => {
   paperTradingService.initialize().catch(error => {
     logger.error('Failed to initialize paper trading service:', error);
   });
+
+  // Pipeline health probe: converts silent failures into pagable alerts.
+  // Catches the "paper mode selected but zero paper trades" bug class
+  // within minutes instead of weeks.
+  if (process.env.NODE_ENV !== 'test') {
+    startPipelineHealthProbe();
+  }
 
   // Health heartbeat for production monitoring
   if (process.env.NODE_ENV === 'production') {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -421,9 +421,14 @@ server.listen(PORT, '::', async () => {
 
   // Pipeline health probe: converts silent failures into pagable alerts.
   // Catches the "paper mode selected but zero paper trades" bug class
-  // within minutes instead of weeks.
+  // within minutes instead of weeks. The predicate wires the trades-
+  // floor alert to the trading engine's running state so intentional
+  // pauses don't page.
   if (process.env.NODE_ENV !== 'test') {
-    startPipelineHealthProbe();
+    startPipelineHealthProbe(
+      undefined,
+      () => persistentTradingEngine.isEngineRunning(),
+    );
   }
 
   // Health heartbeat for production monitoring

--- a/apps/api/src/services/__tests__/backtestCostModel.test.ts
+++ b/apps/api/src/services/__tests__/backtestCostModel.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Commit 2 regression tests: backtest cost model.
+ *
+ * The red team identified three systematic biases that together were
+ * masking real strategy edge behind fake costs:
+ *
+ *  1. Slippage constant of 0.001 (10bps) — institutional-scale, ~5-10x
+ *     realistic for the 1-contract orders this engine trades.
+ *  2. Funding rate hardcoded at +0.01% (perma-contango) — systematically
+ *     overcharged longs in every backtest.
+ *  3. Taker fees overstated (0.075% vs 0.06%), maker fees understated
+ *     (0.01% vs 0.02%).
+ *
+ * These tests lock the corrected values so a future refactor can't
+ * silently regress the cost model.
+ */
+
+// @ts-expect-error — backtestingEngine is a .js module without TS types.
+import { default as backtestingEngine, computeFundingCost } from '../backtestingEngine.js';
+import { describe, expect, it } from 'vitest';
+
+describe('backtestingEngine cost model', () => {
+  it('uses calibrated slippage (0.0002, not 0.001)', () => {
+    expect(backtestingEngine.marketSimulation.slippage).toBe(0.0002);
+  });
+
+  it('uses Poloniex VIP0 taker fee (0.06%)', () => {
+    const fees = backtestingEngine.calculateTradingFees(1, 10_000, 'market');
+    // 1 * 10000 * 0.0006 = 6
+    expect(fees).toBeCloseTo(6, 6);
+  });
+
+  it('uses Poloniex VIP0 maker fee (0.02%)', () => {
+    const fees = backtestingEngine.calculateTradingFees(1, 10_000, 'limit');
+    // 1 * 10000 * 0.0002 = 2
+    expect(fees).toBeCloseTo(2, 6);
+  });
+});
+
+describe('computeFundingCost', () => {
+  const RATE = 0.0001;
+  const NOTIONAL = 1_000;
+
+  it('charges a long position when funding rate is positive (even block)', () => {
+    // Even block → rate signed +0.0001; long pays +0.0001 × 1000 = +0.1
+    expect(computeFundingCost(NOTIONAL, 'long', 0, RATE)).toBeCloseTo(0.1, 10);
+    expect(computeFundingCost(NOTIONAL, 'long', 2, RATE)).toBeCloseTo(0.1, 10);
+  });
+
+  it('credits a long position when funding rate is negative (odd block)', () => {
+    // Odd block → rate signed −0.0001; long "pays" −0.1 = gains 0.1
+    expect(computeFundingCost(NOTIONAL, 'long', 1, RATE)).toBeCloseTo(-0.1, 10);
+    expect(computeFundingCost(NOTIONAL, 'long', 3, RATE)).toBeCloseTo(-0.1, 10);
+  });
+
+  it('mirrors the sign for short positions', () => {
+    expect(computeFundingCost(NOTIONAL, 'short', 0, RATE)).toBeCloseTo(-0.1, 10);
+    expect(computeFundingCost(NOTIONAL, 'short', 1, RATE)).toBeCloseTo(0.1, 10);
+  });
+
+  it('sums to zero over an even number of adjacent blocks for either side', () => {
+    let total = 0;
+    for (let b = 0; b < 8; b++) {
+      total += computeFundingCost(NOTIONAL, 'long', b, RATE);
+    }
+    expect(total).toBeCloseTo(0, 10);
+
+    total = 0;
+    for (let b = 0; b < 8; b++) {
+      total += computeFundingCost(NOTIONAL, 'short', b, RATE);
+    }
+    expect(total).toBeCloseTo(0, 10);
+  });
+
+  it('scales linearly with notional', () => {
+    const small = computeFundingCost(100, 'long', 0, RATE);
+    const big = computeFundingCost(10_000, 'long', 0, RATE);
+    expect(big / small).toBeCloseTo(100, 6);
+  });
+});

--- a/apps/api/src/services/__tests__/pipelineObservability.test.ts
+++ b/apps/api/src/services/__tests__/pipelineObservability.test.ts
@@ -55,11 +55,24 @@ describe('monitoringService pipeline heartbeat', () => {
     const base = new Date('2026-04-17T12:00:00Z');
     monitoringService.recordTradeEvent('paper', base);
 
-    const oneHourAndOneMinuteLater = new Date(base.getTime() + 61 * 60_000);
-    // The minute the trade was recorded has rotated out of the 60-slot ring.
+    // Ring is TRADES_RING_SLOTS (360) minutes wide. After 361 minutes the
+    // original slot has rotated out; a 360-minute window sees 0 trades.
+    const pastRingLater = new Date(base.getTime() + 361 * 60_000);
     expect(
-      monitoringService.getTradesInLastMinutes('paper', 60, oneHourAndOneMinuteLater),
+      monitoringService.getTradesInLastMinutes('paper', 360, pastRingLater),
     ).toBe(0);
+  });
+
+  it('retains trades across a 6-hour rolling window', () => {
+    const base = new Date('2026-04-17T12:00:00Z');
+    monitoringService.recordTradeEvent('paper', base);
+
+    // Five hours later, the trade should still be in the 360-slot ring
+    // because the floor window is 360 minutes (6h).
+    const fiveHoursLater = new Date(base.getTime() + 5 * 60 * 60_000);
+    expect(
+      monitoringService.getTradesInLastMinutes('paper', 360, fiveHoursLater),
+    ).toBe(1);
   });
 
   it('returns 0 trades for a stage that never recorded any', () => {
@@ -112,9 +125,17 @@ describe('pipelineHealthProbe wiring', () => {
   });
 
   it('does not fire trades-floor alert before window has elapsed since probe start', () => {
-    startPipelineHealthProbe(60_000);
-    // Immediately run a probe tick — trades-floor check must be gated on
-    // uptime ≥ floor window so a freshly-booted server does not page.
+    // Predicate returns true (expected trading), but uptime gate should
+    // still block the alert because we just started.
+    startPipelineHealthProbe(60_000, () => true);
+    __internal.runProbeTick(new Date());
+    expect(alertingService.getAlertStats().counts.tradeFloorBreaches).toBe(0);
+  });
+
+  it('does not fire trades-floor alert when predicate says not expected-trading', () => {
+    // Predicate reports paused — suppresses the alert even after uptime
+    // gate clears. This is the Sourcery-flagged regression guard.
+    startPipelineHealthProbe(60_000, () => false);
     __internal.runProbeTick(new Date());
     expect(alertingService.getAlertStats().counts.tradeFloorBreaches).toBe(0);
   });

--- a/apps/api/src/services/__tests__/pipelineObservability.test.ts
+++ b/apps/api/src/services/__tests__/pipelineObservability.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for Commit 1 observability:
+ *   - monitoringService pipeline-stage heartbeat + trades-per-hour ring
+ *   - alertingService silent-failure + trades-floor alerts with cooldown
+ *   - pipelineHealthProbe wiring (monitoring → alerting)
+ *
+ * These exist to lock down the "0 paper trades for weeks and nobody
+ * noticed" bug class. If a stage stops ticking or trades dry up, the
+ * probe fires an alert within one tick.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { monitoringService } from '../monitoringService.js';
+import alertingService from '../alertingService.js';
+import { __internal, startPipelineHealthProbe, stopPipelineHealthProbe } from '../pipelineHealthProbe.js';
+
+describe('monitoringService pipeline heartbeat', () => {
+  beforeEach(() => {
+    monitoringService.reset();
+  });
+
+  it('records a stage tick and reports it as not-silent', () => {
+    const now = new Date('2026-04-17T12:00:00Z');
+    vi.setSystemTime(now);
+    monitoringService.recordPipelineHeartbeat('backtest');
+
+    const silent = monitoringService.getSilentPipelineStages(now);
+    expect(silent.find((s) => s.stage === 'backtest')).toBeUndefined();
+  });
+
+  it('flags a stage as silent after its threshold elapses', () => {
+    const t0 = new Date('2026-04-17T12:00:00Z');
+    vi.setSystemTime(t0);
+    monitoringService.recordPipelineHeartbeat('paper');
+
+    // Paper threshold is 10 min; jump 11 min ahead.
+    const t1 = new Date(t0.getTime() + 11 * 60_000);
+    const silent = monitoringService.getSilentPipelineStages(t1);
+    const paperEntry = silent.find((s) => s.stage === 'paper');
+    expect(paperEntry).toBeDefined();
+    expect(paperEntry!.silentMs).toBeGreaterThanOrEqual(10 * 60_000);
+  });
+
+  it('counts trades in the rolling 60-minute ring', () => {
+    const base = new Date('2026-04-17T12:00:00Z');
+    monitoringService.recordTradeEvent('paper', base);
+    monitoringService.recordTradeEvent('paper', new Date(base.getTime() + 30_000));
+    monitoringService.recordTradeEvent('paper', new Date(base.getTime() + 60_000));
+
+    const twoMinLater = new Date(base.getTime() + 2 * 60_000);
+    expect(monitoringService.getTradesInLastMinutes('paper', 60, twoMinLater)).toBe(3);
+  });
+
+  it('ages trades out of the rolling window as minutes advance', () => {
+    const base = new Date('2026-04-17T12:00:00Z');
+    monitoringService.recordTradeEvent('paper', base);
+
+    const oneHourAndOneMinuteLater = new Date(base.getTime() + 61 * 60_000);
+    // The minute the trade was recorded has rotated out of the 60-slot ring.
+    expect(
+      monitoringService.getTradesInLastMinutes('paper', 60, oneHourAndOneMinuteLater),
+    ).toBe(0);
+  });
+
+  it('returns 0 trades for a stage that never recorded any', () => {
+    expect(monitoringService.getTradesInLastMinutes('paper', 60)).toBe(0);
+  });
+});
+
+describe('alertingService silent-failure + trades-floor alerts', () => {
+  beforeEach(() => {
+    alertingService.resetAlertCounts();
+  });
+
+  it('fires a silent-pipeline alert on first call', () => {
+    const fired = alertingService.alertPipelineSilent('paper', 15 * 60_000, 10 * 60_000);
+    expect(fired).toBe(true);
+    expect(alertingService.getAlertStats().counts.pipelineSilent).toBe(1);
+  });
+
+  it('suppresses repeat silent alerts within the cooldown window', () => {
+    alertingService.alertPipelineSilent('paper', 15 * 60_000, 10 * 60_000);
+    const second = alertingService.alertPipelineSilent('paper', 20 * 60_000, 10 * 60_000);
+    expect(second).toBe(false);
+    expect(alertingService.getAlertStats().counts.pipelineSilent).toBe(1);
+  });
+
+  it('tracks cooldowns per-stage independently', () => {
+    alertingService.alertPipelineSilent('paper', 15 * 60_000, 10 * 60_000);
+    const liveFired = alertingService.alertPipelineSilent('live', 15 * 60_000, 10 * 60_000);
+    expect(liveFired).toBe(true);
+    expect(alertingService.getAlertStats().counts.pipelineSilent).toBe(2);
+  });
+
+  it('fires a trades-floor breach alert with cooldown', () => {
+    const first = alertingService.alertTradesFloorBreach('paper', 0, 360, 'expected_running');
+    const second = alertingService.alertTradesFloorBreach('paper', 0, 360, 'expected_running');
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(alertingService.getAlertStats().counts.tradeFloorBreaches).toBe(1);
+  });
+});
+
+describe('pipelineHealthProbe wiring', () => {
+  beforeEach(() => {
+    monitoringService.reset();
+    alertingService.resetAlertCounts();
+  });
+
+  afterEach(() => {
+    stopPipelineHealthProbe();
+  });
+
+  it('does not fire trades-floor alert before window has elapsed since probe start', () => {
+    startPipelineHealthProbe(60_000);
+    // Immediately run a probe tick — trades-floor check must be gated on
+    // uptime ≥ floor window so a freshly-booted server does not page.
+    __internal.runProbeTick(new Date());
+    expect(alertingService.getAlertStats().counts.tradeFloorBreaches).toBe(0);
+  });
+
+  it('detects silent stages via monitoring and fires an alert via alerting', () => {
+    const t0 = new Date('2026-04-17T12:00:00Z');
+    monitoringService.recordPipelineHeartbeat('paper');
+    // Simulate 20 min passing (paper threshold is 10 min).
+    const t1 = new Date(t0.getTime() + 20 * 60_000);
+    vi.setSystemTime(t0);
+    // Force the heartbeat lastSeen to t0 by re-running at t0.
+    monitoringService.recordPipelineHeartbeat('paper');
+
+    // Now pretend it's t1 and probe.
+    __internal.runProbeTick(t1);
+    expect(alertingService.getAlertStats().counts.pipelineSilent).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/services/__tests__/promotionEngine.test.ts
+++ b/apps/api/src/services/__tests__/promotionEngine.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Commit 5 — promotion engine pure-function tests.
+ *
+ * Covers:
+ *   - promotionGates: backtest/paper/live-sizing
+ *   - demotionPolicy: rolling DD, oscillation, recalibration limits
+ *   - thompsonBandit: Beta sampling, outcome application, class sampling
+ *   - slotAllocator: reserved + floating pool admission
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  BACKTEST_MIN_PROFIT_FACTOR,
+  BACKTEST_MIN_TRADES,
+  LIVE_SIZING_USDT,
+  OOS_MIN_PROFIT_FACTOR,
+  PAPER_MAX_SINGLE_LOSS,
+  PAPER_MIN_TRADES,
+  computeLiveSizingTier,
+  evaluateBacktestGate,
+  evaluatePaperGate,
+  getLiveSizeForTier,
+} from '../promotionGates.js';
+import {
+  OSCILLATION_PROMOTION_CYCLES,
+  RECALIBRATION_LIMIT_PER_30_DAYS,
+  ROLLING_DEMOTION_THRESHOLD,
+  ROLLING_DEMOTION_WINDOW,
+  evaluateOscillationRetirement,
+  evaluateRecalibrationLimitRetirement,
+  evaluateRollingDrawdownDemotion,
+} from '../demotionPolicy.js';
+import {
+  ALL_STRATEGY_CLASSES,
+  DEFAULT_BANDIT_COUNTER,
+  applyOutcome,
+  sampleBestClass,
+  sampleBeta,
+  type BanditCounter,
+  type StrategyClass,
+} from '../thompsonBandit.js';
+import {
+  FLOATING_SLOTS,
+  SLOTS_PER_CLASS,
+  TOTAL_SLOTS,
+  tryAdmitStrategy,
+  withAdmittedStrategy,
+  type SlotOccupancy,
+} from '../slotAllocator.js';
+
+// ───────── promotionGates ─────────
+
+describe('evaluateBacktestGate', () => {
+  const passingInSample = {
+    totalTrades: 250,
+    sharpe: 1.2,
+    sortino: 1.8,
+    calmar: 2.5,
+    profitFactor: 1.6,
+    maxDrawdown: 0.12,
+  };
+  const passingOos = { profitFactor: 1.4 };
+
+  it('passes a strategy that clears every threshold in both windows', () => {
+    expect(evaluateBacktestGate(passingInSample, passingOos).allowed).toBe(true);
+  });
+
+  it(`rejects when trades < ${BACKTEST_MIN_TRADES}`, () => {
+    const d = evaluateBacktestGate({ ...passingInSample, totalTrades: 100 }, passingOos);
+    expect(d.allowed).toBe(false);
+    expect(d.failingMetrics?.[0]).toMatch(/totalTrades/);
+  });
+
+  it('requires an OOS window — missing OOS is a failure', () => {
+    const d = evaluateBacktestGate(passingInSample, null);
+    expect(d.allowed).toBe(false);
+    expect(d.failingMetrics?.some((m) => /oos/i.test(m))).toBe(true);
+  });
+
+  it(`rejects when oos profit factor < ${OOS_MIN_PROFIT_FACTOR}`, () => {
+    const d = evaluateBacktestGate(passingInSample, { profitFactor: 1.1 });
+    expect(d.allowed).toBe(false);
+  });
+
+  it('aggregates multiple failures rather than short-circuiting', () => {
+    const d = evaluateBacktestGate(
+      { ...passingInSample, sharpe: 0.5, profitFactor: 1.0, maxDrawdown: 0.2 },
+      passingOos,
+    );
+    expect(d.failingMetrics?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it(`constant check: BACKTEST_MIN_PROFIT_FACTOR stays at 1.5 or tighter`, () => {
+    expect(BACKTEST_MIN_PROFIT_FACTOR).toBeGreaterThanOrEqual(1.5);
+  });
+});
+
+describe('evaluatePaperGate', () => {
+  const passing = {
+    totalTrades: 25,
+    cumulativePnl: 3,
+    largestSingleLossPct: 0.03,
+    rolling20TradeMaxDrawdown: 0.05,
+    profitablePaperTrades: 18,
+  };
+
+  it('passes a strategy that clears every paper threshold', () => {
+    expect(evaluatePaperGate(passing).allowed).toBe(true);
+  });
+
+  it(`rejects when paper trades < ${PAPER_MIN_TRADES}`, () => {
+    expect(evaluatePaperGate({ ...passing, totalTrades: 5 }).allowed).toBe(false);
+  });
+
+  it('rejects on any single loss over the 5% cap', () => {
+    expect(
+      evaluatePaperGate({ ...passing, largestSingleLossPct: 0.06 }).allowed,
+    ).toBe(false);
+    expect(PAPER_MAX_SINGLE_LOSS).toBeLessThanOrEqual(0.05);
+  });
+
+  it('rejects on flat or negative cumulative PnL', () => {
+    expect(evaluatePaperGate({ ...passing, cumulativePnl: 0 }).allowed).toBe(false);
+    expect(evaluatePaperGate({ ...passing, cumulativePnl: -1 }).allowed).toBe(false);
+  });
+});
+
+describe('computeLiveSizingTier + getLiveSizeForTier', () => {
+  it('starts at tier 1 immediately on live promotion', () => {
+    expect(computeLiveSizingTier({ profitableLiveTrades: 0 })).toBe(1);
+    expect(getLiveSizeForTier(1)).toBe(2);
+  });
+
+  it('advances one tier per +10 profitable trades', () => {
+    expect(computeLiveSizingTier({ profitableLiveTrades: 10 })).toBe(2);
+    expect(computeLiveSizingTier({ profitableLiveTrades: 20 })).toBe(3);
+    expect(computeLiveSizingTier({ profitableLiveTrades: 30 })).toBe(4);
+    expect(computeLiveSizingTier({ profitableLiveTrades: 40 })).toBe(5);
+  });
+
+  it('caps at tier 5', () => {
+    expect(computeLiveSizingTier({ profitableLiveTrades: 1000 })).toBe(5);
+  });
+
+  it('sizes ladder matches plan: $2 → $3 → $5 → $8 → $12', () => {
+    expect([1, 2, 3, 4, 5].map(getLiveSizeForTier)).toEqual([2, 3, 5, 8, 12]);
+    // Verify the constants haven't drifted.
+    expect(LIVE_SIZING_USDT[1]).toBe(2);
+    expect(LIVE_SIZING_USDT[5]).toBe(12);
+  });
+});
+
+// ───────── demotionPolicy ─────────
+
+describe('evaluateRollingDrawdownDemotion', () => {
+  const makeTrade = (pnl: number, margin = 10) => ({ realisedPnl: pnl, marginCommitted: margin });
+
+  it(`does not demote before ${ROLLING_DEMOTION_WINDOW} trades accumulate`, () => {
+    const trades = Array.from({ length: 10 }, () => makeTrade(-5));
+    expect(evaluateRollingDrawdownDemotion(trades).demote).toBe(false);
+  });
+
+  it('demotes when rolling window PnL / margin ≤ threshold', () => {
+    const losers = Array.from({ length: 20 }, () => makeTrade(-2));  // 20 × −2 / (20×10) = −10%
+    const d = evaluateRollingDrawdownDemotion(losers);
+    expect(d.demote).toBe(true);
+    expect(d.triggeringDrawdownPct).toBeLessThanOrEqual(ROLLING_DEMOTION_THRESHOLD);
+  });
+
+  it('does not demote a profitable window', () => {
+    const winners = Array.from({ length: 20 }, () => makeTrade(5));
+    expect(evaluateRollingDrawdownDemotion(winners).demote).toBe(false);
+  });
+
+  it('evaluates only the most recent window', () => {
+    const earlyLosers = Array.from({ length: 20 }, () => makeTrade(-5));
+    const recentWinners = Array.from({ length: 20 }, () => makeTrade(5));
+    expect(
+      evaluateRollingDrawdownDemotion([...earlyLosers, ...recentWinners]).demote,
+    ).toBe(false);
+  });
+});
+
+describe('evaluateOscillationRetirement', () => {
+  it('does not retire before enough cycles accumulate', () => {
+    expect(
+      evaluateOscillationRetirement([{ realisedPnl: -5 }, { realisedPnl: -5 }]).retire,
+    ).toBe(false);
+  });
+
+  it(`retires when last ${OSCILLATION_PROMOTION_CYCLES} cycles sum ≤ 0`, () => {
+    const d = evaluateOscillationRetirement([
+      { realisedPnl: -3 },
+      { realisedPnl: -2 },
+      { realisedPnl: -1 },
+    ]);
+    expect(d.retire).toBe(true);
+  });
+
+  it('does not retire if recent cycles are net-positive', () => {
+    expect(
+      evaluateOscillationRetirement([
+        { realisedPnl: -3 },
+        { realisedPnl: -2 },
+        { realisedPnl: 10 },
+      ]).retire,
+    ).toBe(false);
+  });
+});
+
+describe('evaluateRecalibrationLimitRetirement', () => {
+  const now = new Date('2026-04-17T12:00:00Z');
+  const daysAgo = (n: number) => new Date(now.getTime() - n * 24 * 60 * 60 * 1000);
+
+  it(`retires after > ${RECALIBRATION_LIMIT_PER_30_DAYS} demotions in 30 days`, () => {
+    const recent = [daysAgo(1), daysAgo(5), daysAgo(10), daysAgo(20)];
+    expect(evaluateRecalibrationLimitRetirement(recent, now).retire).toBe(true);
+  });
+
+  it('ignores demotions older than 30 days', () => {
+    const mixed = [daysAgo(31), daysAgo(32), daysAgo(33), daysAgo(1)];
+    expect(evaluateRecalibrationLimitRetirement(mixed, now).retire).toBe(false);
+  });
+});
+
+// ───────── thompsonBandit ─────────
+
+describe('sampleBeta', () => {
+  it('returns a value in [0, 1]', () => {
+    for (let i = 0; i < 50; i++) {
+      const s = sampleBeta(2, 5);
+      expect(s).toBeGreaterThanOrEqual(0);
+      expect(s).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('has higher mean when wins dominate', () => {
+    const samples = Array.from({ length: 500 }, () => sampleBeta(50, 5));
+    const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+    expect(mean).toBeGreaterThan(0.8);
+  });
+
+  it('has lower mean when losses dominate', () => {
+    const samples = Array.from({ length: 500 }, () => sampleBeta(5, 50));
+    const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+    expect(mean).toBeLessThan(0.2);
+  });
+});
+
+describe('applyOutcome', () => {
+  it('weights live wins 10× more than paper wins', () => {
+    const base = { ...DEFAULT_BANDIT_COUNTER };
+    const afterLive = applyOutcome(base, 'live', 1);
+    const afterPaper = applyOutcome(base, 'paper', 1);
+    expect(afterLive.wins - base.wins).toBeCloseTo(1.0, 6);
+    expect(afterPaper.wins - base.wins).toBeCloseTo(0.1, 6);
+  });
+
+  it('routes non-positive rewards to losses', () => {
+    const after = applyOutcome({ ...DEFAULT_BANDIT_COUNTER }, 'live', -1);
+    expect(after.losses).toBeCloseTo(2.0, 6);
+    expect(after.wins).toBeCloseTo(1.0, 6);
+  });
+});
+
+describe('sampleBestClass', () => {
+  it('preferentially returns the class with the strongest posterior', () => {
+    const counters = new Map<StrategyClass, BanditCounter>();
+    counters.set('scalping', { wins: 100, losses: 1 });
+    for (const klass of ALL_STRATEGY_CLASSES) {
+      if (klass !== 'scalping') counters.set(klass, DEFAULT_BANDIT_COUNTER);
+    }
+
+    let scalpingHits = 0;
+    for (let i = 0; i < 200; i++) {
+      if (sampleBestClass(counters) === 'scalping') scalpingHits++;
+    }
+    expect(scalpingHits).toBeGreaterThan(150); // ≥75% — bandit should strongly favour
+  });
+});
+
+// ───────── slotAllocator ─────────
+
+describe('slotAllocator', () => {
+  const emptyOccupancy: SlotOccupancy = { countsByClass: new Map() };
+
+  it('exposes a 12-slot total pool (10 reserved + 2 floating)', () => {
+    expect(TOTAL_SLOTS).toBe(SLOTS_PER_CLASS * 5 + FLOATING_SLOTS);
+  });
+
+  it('admits the first 2 strategies of any class into reserved seats', () => {
+    let occ = emptyOccupancy;
+    const a1 = tryAdmitStrategy('scalping', occ);
+    expect(a1.admitted).toBe(true);
+    expect(a1.bucket).toBe('reserved');
+    occ = withAdmittedStrategy('scalping', occ);
+
+    const a2 = tryAdmitStrategy('scalping', occ);
+    expect(a2.bucket).toBe('reserved');
+  });
+
+  it('uses floating slots when a class exceeds its reserved seats', () => {
+    let occ = emptyOccupancy;
+    for (let i = 0; i < 2; i++) occ = withAdmittedStrategy('scalping', occ);
+    const a3 = tryAdmitStrategy('scalping', occ);
+    expect(a3.admitted).toBe(true);
+    expect(a3.bucket).toBe('floating');
+  });
+
+  it('blocks a class when its reserved are full AND floating are exhausted', () => {
+    // Fill scalping up to its full 4 (2 reserved + 2 floating worth from scalping).
+    let occ = emptyOccupancy;
+    for (let i = 0; i < 4; i++) occ = withAdmittedStrategy('scalping', occ);
+    const denied = tryAdmitStrategy('scalping', occ);
+    expect(denied.admitted).toBe(false);
+    expect(denied.reason).toMatch(/floating_full/);
+  });
+
+  it('preserves diversity — one hot class cannot starve others', () => {
+    // Scalping consumes all its reserved + both floating. Trend still gets reserved.
+    let occ = emptyOccupancy;
+    for (let i = 0; i < 4; i++) occ = withAdmittedStrategy('scalping', occ);
+    const trendAdmit = tryAdmitStrategy('trend_following', occ);
+    expect(trendAdmit.admitted).toBe(true);
+    expect(trendAdmit.bucket).toBe('reserved');
+  });
+
+  it('rejects when the pool is fully saturated', () => {
+    // Populate every class's reserved seats + both floating slots.
+    let occ = emptyOccupancy;
+    for (const klass of ALL_STRATEGY_CLASSES) {
+      for (let i = 0; i < SLOTS_PER_CLASS; i++) occ = withAdmittedStrategy(klass, occ);
+    }
+    // Use floating on scalping.
+    for (let i = 0; i < FLOATING_SLOTS; i++) occ = withAdmittedStrategy('scalping', occ);
+
+    const denied = tryAdmitStrategy('momentum', occ);
+    expect(denied.admitted).toBe(false);
+    expect(denied.reason).toBe('pool_full');
+  });
+});

--- a/apps/api/src/services/__tests__/riskKernel.test.ts
+++ b/apps/api/src/services/__tests__/riskKernel.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Commit 4 — Risk Kernel tests.
+ *
+ * Every veto is exercised with both an allowing input and a blocking
+ * input so a future refactor can't silently disable a guard. The red
+ * team called this the "blast door" — these tests are the door's
+ * hinges.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_UNPROVEN_LEVERAGE_CAP,
+  MIN_EQUITY_FOR_ETH_USDT,
+  PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER,
+  UNREALIZED_DRAWDOWN_KILL_THRESHOLD,
+  checkPerSymbolExposure,
+  checkSelfMatch,
+  checkStrategyLeverageCap,
+  checkSymbolAllowedAtEquity,
+  checkUnrealizedDrawdown,
+  evaluatePreTradeVetoes,
+  type KernelAccountState,
+  type KernelOrder,
+  type KernelStrategyMeta,
+} from '../riskKernel.js';
+
+const btcOrder: KernelOrder = {
+  symbol: 'BTC-USDT',
+  side: 'long',
+  notional: 10,
+  leverage: 3,
+  price: 70_000,
+};
+
+const emptyAccount: KernelAccountState = {
+  equityUsdt: 100,
+  unrealizedPnlUsdt: 0,
+  openPositions: [],
+  restingOrders: [],
+};
+
+const provenStrategy: KernelStrategyMeta = { liveTier: 3 };
+const unprovenStrategy: KernelStrategyMeta = { liveTier: 0 };
+
+describe('checkPerSymbolExposure', () => {
+  it('allows an order when total notional stays under the 1.5× cap', () => {
+    const state: KernelAccountState = {
+      ...emptyAccount,
+      equityUsdt: 100,
+      openPositions: [{ symbol: 'BTC-USDT', side: 'long', notional: 100 }],
+    };
+    // Cap = 150. Existing 100 + new 10 = 110 → allowed.
+    expect(checkPerSymbolExposure({ ...btcOrder, notional: 10 }, state).allowed).toBe(true);
+  });
+
+  it('blocks an order that would push same-symbol notional over the cap', () => {
+    const state: KernelAccountState = {
+      ...emptyAccount,
+      equityUsdt: 100,
+      openPositions: [{ symbol: 'BTC-USDT', side: 'long', notional: 145 }],
+    };
+    const decision = checkPerSymbolExposure({ ...btcOrder, notional: 10 }, state);
+    expect(decision.allowed).toBe(false);
+    expect(decision.code).toBe('per_symbol_exposure_cap');
+  });
+
+  it('ignores positions on a different symbol', () => {
+    const state: KernelAccountState = {
+      ...emptyAccount,
+      equityUsdt: 100,
+      openPositions: [{ symbol: 'ETH-USDT', side: 'long', notional: 500 }],
+    };
+    expect(checkPerSymbolExposure(btcOrder, state).allowed).toBe(true);
+  });
+
+  it(`uses the ${PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER}× multiplier`, () => {
+    // Constant must not drift below 1.5× without a deliberate change + test update.
+    expect(PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER).toBeGreaterThanOrEqual(1.5);
+  });
+});
+
+describe('checkSelfMatch', () => {
+  it('allows an order when there is no resting cross', () => {
+    expect(checkSelfMatch(btcOrder, emptyAccount).allowed).toBe(true);
+  });
+
+  it('blocks a buy that would lift the account\'s own sell', () => {
+    const state: KernelAccountState = {
+      ...emptyAccount,
+      restingOrders: [{ symbol: 'BTC-USDT', side: 'sell', price: 69_900 }],
+    };
+    const decision = checkSelfMatch({ ...btcOrder, side: 'buy', price: 70_000 }, state);
+    expect(decision.allowed).toBe(false);
+    expect(decision.code).toBe('self_match');
+    expect(decision.reason).toContain('s.1041B');
+  });
+
+  it('blocks a sell that would hit the account\'s own buy', () => {
+    const state: KernelAccountState = {
+      ...emptyAccount,
+      restingOrders: [{ symbol: 'BTC-USDT', side: 'buy', price: 70_100 }],
+    };
+    const decision = checkSelfMatch({ ...btcOrder, side: 'sell', price: 70_000 }, state);
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('ignores resting orders on a different symbol', () => {
+    const state: KernelAccountState = {
+      ...emptyAccount,
+      restingOrders: [{ symbol: 'ETH-USDT', side: 'sell', price: 69_000 }],
+    };
+    expect(checkSelfMatch(btcOrder, state).allowed).toBe(true);
+  });
+});
+
+describe('checkUnrealizedDrawdown', () => {
+  it('allows when unrealized P&L is above the -15% threshold', () => {
+    const state: KernelAccountState = {
+      ...emptyAccount,
+      unrealizedPnlUsdt: -10, // -10% of $100 equity
+    };
+    expect(checkUnrealizedDrawdown(state).allowed).toBe(true);
+  });
+
+  it('blocks when unrealized drawdown breaches -15%', () => {
+    const state: KernelAccountState = {
+      ...emptyAccount,
+      unrealizedPnlUsdt: -16,
+    };
+    const decision = checkUnrealizedDrawdown(state);
+    expect(decision.allowed).toBe(false);
+    expect(decision.code).toBe('unrealized_drawdown_kill_switch');
+  });
+
+  it('handles zero equity gracefully (delegates to realised-loss cap)', () => {
+    const state: KernelAccountState = { ...emptyAccount, equityUsdt: 0 };
+    expect(checkUnrealizedDrawdown(state).allowed).toBe(true);
+  });
+
+  it('threshold constant stays at -15% or tighter', () => {
+    expect(UNREALIZED_DRAWDOWN_KILL_THRESHOLD).toBeLessThanOrEqual(-0.15);
+  });
+});
+
+describe('checkStrategyLeverageCap', () => {
+  it('allows 3× for a proven tier-3 strategy', () => {
+    expect(
+      checkStrategyLeverageCap({ ...btcOrder, leverage: 3 }, provenStrategy).allowed,
+    ).toBe(true);
+  });
+
+  it('blocks 20× on a brand-new strategy (tier 0)', () => {
+    const decision = checkStrategyLeverageCap(
+      { ...btcOrder, leverage: 20 },
+      unprovenStrategy,
+    );
+    expect(decision.allowed).toBe(false);
+    expect(decision.code).toBe('strategy_leverage_cap');
+  });
+
+  it(`falls back to ${DEFAULT_UNPROVEN_LEVERAGE_CAP}× for unrecognised tiers`, () => {
+    const decision = checkStrategyLeverageCap(
+      { ...btcOrder, leverage: 10 },
+      { liveTier: 99 },
+    );
+    expect(decision.allowed).toBe(false);
+  });
+});
+
+describe('checkSymbolAllowedAtEquity', () => {
+  it('allows BTC at any equity level', () => {
+    const state = { ...emptyAccount, equityUsdt: 5 };
+    expect(checkSymbolAllowedAtEquity(btcOrder, state).allowed).toBe(true);
+  });
+
+  it(`blocks non-BTC symbols when equity < $${MIN_EQUITY_FOR_ETH_USDT}`, () => {
+    const ethOrder: KernelOrder = { ...btcOrder, symbol: 'ETH-USDT' };
+    const state = { ...emptyAccount, equityUsdt: 27.15 };
+    const decision = checkSymbolAllowedAtEquity(ethOrder, state);
+    expect(decision.allowed).toBe(false);
+    expect(decision.code).toBe('symbol_not_allowed_at_equity');
+  });
+
+  it('allows ETH once equity clears the threshold', () => {
+    const ethOrder: KernelOrder = { ...btcOrder, symbol: 'ETH-USDT' };
+    const state = { ...emptyAccount, equityUsdt: 150 };
+    expect(checkSymbolAllowedAtEquity(ethOrder, state).allowed).toBe(true);
+  });
+
+  it('recognises common BTC symbol aliases', () => {
+    const state = { ...emptyAccount, equityUsdt: 10 };
+    for (const alias of ['BTC-USDT', 'BTCUSDT', 'BTC_USDT', 'BTC-USDT-PERP']) {
+      expect(checkSymbolAllowedAtEquity({ ...btcOrder, symbol: alias }, state).allowed).toBe(true);
+    }
+  });
+});
+
+describe('evaluatePreTradeVetoes composition', () => {
+  it('passes a clean order', () => {
+    expect(evaluatePreTradeVetoes(btcOrder, emptyAccount, provenStrategy).allowed).toBe(true);
+  });
+
+  it('surfaces the unrealised-drawdown veto before any other', () => {
+    const state: KernelAccountState = {
+      ...emptyAccount,
+      unrealizedPnlUsdt: -20,
+      // Also has a self-match opportunity AND exposure breach, but
+      // drawdown kill-switch fires first per documented priority.
+      openPositions: [{ symbol: 'BTC-USDT', side: 'long', notional: 500 }],
+      restingOrders: [{ symbol: 'BTC-USDT', side: 'sell', price: 69_000 }],
+    };
+    const decision = evaluatePreTradeVetoes(
+      { ...btcOrder, side: 'buy' },
+      state,
+      provenStrategy,
+    );
+    expect(decision.allowed).toBe(false);
+    expect(decision.code).toBe('unrealized_drawdown_kill_switch');
+  });
+
+  it('falls through to leverage cap when earlier checks pass', () => {
+    const decision = evaluatePreTradeVetoes(
+      { ...btcOrder, leverage: 20 },
+      emptyAccount,
+      unprovenStrategy,
+    );
+    expect(decision.code).toBe('strategy_leverage_cap');
+  });
+});

--- a/apps/api/src/services/alertingService.js
+++ b/apps/api/src/services/alertingService.js
@@ -16,8 +16,17 @@ class AlertingService {
     this.alertCounts = {
       disconnections: 0,
       orderRejections: 0,
-      lossBreaches: 0
+      lossBreaches: 0,
+      pipelineSilent: 0,
+      tradeFloorBreaches: 0,
     };
+
+    // Dedupe repeated silent alerts for the same stage in the same window.
+    // { stage: lastAlertIsoTimestamp }
+    this._silentAlertCooldown = {};
+    // 30 min cooldown matches typical on-call acknowledgement window —
+    // prevents alert storms without hiding genuine extended outages.
+    this._silentAlertCooldownMs = 30 * 60_000;
   }
 
   /**
@@ -185,6 +194,81 @@ class AlertingService {
   }
 
   /**
+   * Silent-failure alert: a pipeline stage hasn't ticked in longer than
+   * its expected interval. Caught the "0 paper trades for weeks" bug class
+   * within minutes instead of weeks.
+   *
+   * Deduped per-stage on a 30-min cooldown so a single multi-hour outage
+   * pages once, not every health-check tick.
+   *
+   * @param {string} stage - e.g. 'paper', 'live', 'backtest'
+   * @param {number} silentMs - how long since last heartbeat
+   * @param {number} thresholdMs - configured max silence before alerting
+   */
+  alertPipelineSilent(stage, silentMs, thresholdMs) {
+    const now = Date.now();
+    const lastAlert = this._silentAlertCooldown[stage] ?? 0;
+    if (now - lastAlert < this._silentAlertCooldownMs) {
+      return false;
+    }
+    this._silentAlertCooldown[stage] = now;
+    this.alertCounts.pipelineSilent++;
+
+    logger.error('ALERT: Pipeline stage silent', {
+      alertType: 'pipeline_silent',
+      stage,
+      silentMs,
+      thresholdMs,
+      silentMinutes: Math.round(silentMs / 60_000),
+      alertCount: this.alertCounts.pipelineSilent,
+      timestamp: new Date().toISOString(),
+    });
+
+    this.logCriticalAlert(`Pipeline Silent: ${stage}`, { stage, silentMs, thresholdMs });
+    return true;
+  }
+
+  /**
+   * Trades-per-hour floor breach: < 1 trade observed in the rolling
+   * silent-floor window (default 6h) while the pipeline is supposed to
+   * be actively trading. This is the guard that would have caught the
+   * "paper mode selected but zero paper trades" state.
+   *
+   * @param {string} stage - 'paper' | 'live'
+   * @param {number} tradesInWindow - trades observed in the window
+   * @param {number} windowMinutes - window length
+   * @param {string} expectedState - e.g. 'running' (not paused / not paper-only)
+   */
+  alertTradesFloorBreach(stage, tradesInWindow, windowMinutes, expectedState) {
+    const now = Date.now();
+    const key = `trades_floor_${stage}`;
+    const lastAlert = this._silentAlertCooldown[key] ?? 0;
+    if (now - lastAlert < this._silentAlertCooldownMs) {
+      return false;
+    }
+    this._silentAlertCooldown[key] = now;
+    this.alertCounts.tradeFloorBreaches++;
+
+    logger.error('ALERT: Trades-per-hour floor breach', {
+      alertType: 'trades_floor_breach',
+      stage,
+      tradesInWindow,
+      windowMinutes,
+      expectedState,
+      alertCount: this.alertCounts.tradeFloorBreaches,
+      timestamp: new Date().toISOString(),
+    });
+
+    this.logCriticalAlert(`Trades Floor Breach: ${stage}`, {
+      stage,
+      tradesInWindow,
+      windowMinutes,
+      expectedState,
+    });
+    return true;
+  }
+
+  /**
    * Get alert statistics
    * @returns {Object} Alert counts and stats
    */
@@ -203,8 +287,11 @@ class AlertingService {
     this.alertCounts = {
       disconnections: 0,
       orderRejections: 0,
-      lossBreaches: 0
+      lossBreaches: 0,
+      pipelineSilent: 0,
+      tradeFloorBreaches: 0,
     };
+    this._silentAlertCooldown = {};
     logger.info('Alert counts reset', { timestamp: new Date().toISOString() });
   }
 }

--- a/apps/api/src/services/backtestingEngine.js
+++ b/apps/api/src/services/backtestingEngine.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import { query } from '../db/connection.js';
+import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
 import { buildIndicatorMap, evaluateGenomeEntry, strategyTypeToGenome } from './signalGenome.js';
@@ -722,8 +723,8 @@ class BacktestingEngine extends EventEmitter {
           total_trades, winning_trades, losing_trades, win_rate,
           profit_factor, expectancy, average_win, average_loss,
           created_at, config, metrics,
-          is_censored, censoring_reason
-        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)
+          is_censored, censoring_reason, engine_version
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28)
       `, [
         backtestId, this.currentBacktest.strategyName, this.currentBacktest.config.symbol,
         this.currentBacktest.config.timeframe, this.currentBacktest.config.startDate,
@@ -743,7 +744,7 @@ class BacktestingEngine extends EventEmitter {
         safeNum(this.currentBacktest.metrics.averageWin),
         safeNum(this.currentBacktest.metrics.averageLoss),
         new Date(), JSON.stringify(this.currentBacktest.config), JSON.stringify(this.currentBacktest.metrics),
-        isCensored, censoringReason
+        isCensored, censoringReason, getEngineVersion(),
       ]);
       this.currentBacktest.id = backtestId;
       this.currentBacktest.isCensored = isCensored;

--- a/apps/api/src/services/backtestingEngine.js
+++ b/apps/api/src/services/backtestingEngine.js
@@ -11,6 +11,26 @@ function safeNum(v, fallback = 0) {
 }
 
 /**
+ * Compute perpetual-swap funding cost for one 8h interval.
+ *
+ * Funding rate sign alternates per 8h block (even → positive, odd → negative)
+ * so realised funding averages to zero over long windows. Position side
+ * then determines who pays whom: longs pay when the rate is positive,
+ * receive when negative; shorts are the mirror image.
+ *
+ * Returns a signed cost: positive means the position loses margin, negative
+ * means it gains. Callers subtract the returned value from cash/totalValue.
+ *
+ * Exported so tests can lock the sign logic independently of the full
+ * simulation loop.
+ */
+export function computeFundingCost(notional, side, blockIdx, ratePerInterval) {
+  const rateSigned = ratePerInterval * (blockIdx % 2 === 0 ? 1 : -1);
+  const sideMultiplier = side === 'long' ? 1 : -1;
+  return notional * rateSigned * sideMultiplier;
+}
+
+/**
  * Determine whether a completed backtest result should be flagged as censored.
  *
  * Borrowed from QIG bridge-law validation: a measurement is censored when it
@@ -58,7 +78,13 @@ class BacktestingEngine extends EventEmitter {
     /** Previous indicator maps per strategy, for crosses_above/crosses_below evaluation */
     this._prevIndicatorMaps = new Map();
     this.marketSimulation = {
-      slippage: 0.001,
+      // Lowered from 0.001 → 0.0002. The previous 10bps-per-trip constant
+      // modelled institutional order flow on Poloniex. For the 1-contract
+      // orders this engine actually trades (≤$50 notional), real spread is
+      // ~1-2bps. The old value was adding ~16bps of artificial round-trip
+      // cost — enough to wipe out most 15m scalping edges before the
+      // promotion gates even evaluated the strategy.
+      slippage: 0.0002,
       latency: 50,
       marketImpact: 0.0005
     };
@@ -224,8 +250,12 @@ class BacktestingEngine extends EventEmitter {
   async runBacktestSimulation(strategy, historicalData, config) {
     let currentPosition = null, stopLoss = null, takeProfit = null;
     const leverage = config.leverage ?? 1;
-    // Poloniex perpetual funding rate: ~0.01% every 8 hours (3× daily)
-    const FUNDING_RATE = 0.0001;
+    // Poloniex perpetual funding: ~±0.01% every 8h. Sign alternates with
+    // market imbalance in reality. The previous fixed +0.01% modelled
+    // perma-contango, which systematically overcharged longs across all
+    // backtests. We now alternate sign per 8h block so realised funding
+    // is mean-zero over long windows while staying fully deterministic.
+    const FUNDING_RATE_ABS = 0.0001;
     const FUNDING_INTERVAL_MS = 8 * 60 * 60 * 1000; // 8h in ms
     let lastFundingTime = 0;
     // Use enough lookback for all indicators: SMA50 needs 50, MACD needs 26,
@@ -244,8 +274,13 @@ class BacktestingEngine extends EventEmitter {
           while (candleTs - lastFundingTime >= FUNDING_INTERVAL_MS) {
             lastFundingTime += FUNDING_INTERVAL_MS;
             const notional = currentPosition.size * currentCandle.close;
-            const fundingSign = currentPosition.side === 'long' ? 1 : -1;
-            const fundingCost = notional * FUNDING_RATE * fundingSign;
+            const blockIdx = Math.floor(lastFundingTime / FUNDING_INTERVAL_MS);
+            const fundingCost = computeFundingCost(
+              notional,
+              currentPosition.side,
+              blockIdx,
+              FUNDING_RATE_ABS,
+            );
             this.currentBacktest.portfolio.cash -= fundingCost;
             this.currentBacktest.portfolio.totalValue -= fundingCost;
           }
@@ -588,7 +623,9 @@ class BacktestingEngine extends EventEmitter {
   }
 
   calculateTradingFees(size, price, orderType = 'market') {
-    return size * price * (orderType === 'limit' ? 0.0001 : 0.00075);
+    // Poloniex Futures VIP0: maker 0.02%, taker 0.06%. Previous values
+    // (0.01% / 0.075%) understated maker and overstated taker.
+    return size * price * (orderType === 'limit' ? 0.0002 : 0.0006);
   }
 
   updatePortfolioAfterTrade(trade, type) {

--- a/apps/api/src/services/demotionPolicy.ts
+++ b/apps/api/src/services/demotionPolicy.ts
@@ -1,0 +1,124 @@
+/**
+ * Demotion + oscillation policy.
+ *
+ * Handles the reverse direction of the pipeline. A strategy that stops
+ * performing reverts to prior stages with `status='recalibrating'`
+ * rather than being killed, preserving its genome so the bandit can
+ * re-evaluate it under different conditions.
+ *
+ * Two independent guards:
+ *
+ *   1. Rolling-20-trade drawdown. If realised P&L as a fraction of the
+ *      cumulative margin committed across the last 20 trades hits
+ *      −10%, demote to the prior stage.
+ *
+ *   2. Oscillation guard. If cumulative realised P&L over the last 3
+ *      promotion cycles is net-negative, retire permanently. Prevents
+ *      paper↔live oscillators that burn slot capacity forever without
+ *      delivering P&L.
+ *
+ * Pure functions. No DB, no IO.
+ */
+
+export interface TradeOutcome {
+  realisedPnl: number;   // signed; negative = loss
+  marginCommitted: number; // always positive
+}
+
+export interface PromotionCycle {
+  realisedPnl: number;   // cumulative P&L earned during one paper/live stint
+}
+
+export interface DemotionDecision {
+  demote: boolean;
+  reason?: string;
+  triggeringDrawdownPct?: number;
+}
+
+export interface RetirementDecision {
+  retire: boolean;
+  reason?: string;
+}
+
+// ───────── Thresholds ─────────
+export const ROLLING_DEMOTION_WINDOW = 20;
+export const ROLLING_DEMOTION_THRESHOLD = -0.10;  // −10% of margin committed
+export const RECALIBRATION_LIMIT_PER_30_DAYS = 3;
+export const OSCILLATION_PROMOTION_CYCLES = 3;
+
+/**
+ * Evaluate demotion based on realised P&L across the rolling
+ * ROLLING_DEMOTION_WINDOW most recent trades. Ratio is
+ *    sum(realisedPnl) / sum(marginCommitted)
+ * so small-margin losses don't trigger demotion the same as
+ * large-margin ones.
+ *
+ * Returns demote=false if the window hasn't accumulated enough trades
+ * yet — this prevents a cold-start strategy from getting demoted on
+ * its first loss.
+ */
+export function evaluateRollingDrawdownDemotion(
+  recentTrades: TradeOutcome[],
+): DemotionDecision {
+  if (recentTrades.length < ROLLING_DEMOTION_WINDOW) {
+    return { demote: false };
+  }
+  const window = recentTrades.slice(-ROLLING_DEMOTION_WINDOW);
+  const pnl = window.reduce((sum, t) => sum + t.realisedPnl, 0);
+  const margin = window.reduce((sum, t) => sum + Math.abs(t.marginCommitted), 0);
+  if (margin <= 0) return { demote: false };
+  const ratio = pnl / margin;
+  if (ratio <= ROLLING_DEMOTION_THRESHOLD) {
+    return {
+      demote: true,
+      triggeringDrawdownPct: ratio,
+      reason: `rolling_${ROLLING_DEMOTION_WINDOW}_trade_drawdown_${(ratio * 100).toFixed(2)}pct`,
+    };
+  }
+  return { demote: false };
+}
+
+/**
+ * Decide whether a strategy should be permanently retired based on its
+ * recent promotion cycles. If the strategy has completed at least
+ * OSCILLATION_PROMOTION_CYCLES and the sum of their realised P&L is
+ * ≤ 0, we retire — the strategy is oscillating without delivering
+ * value.
+ */
+export function evaluateOscillationRetirement(
+  recentCycles: PromotionCycle[],
+): RetirementDecision {
+  if (recentCycles.length < OSCILLATION_PROMOTION_CYCLES) {
+    return { retire: false };
+  }
+  const window = recentCycles.slice(-OSCILLATION_PROMOTION_CYCLES);
+  const total = window.reduce((sum, c) => sum + c.realisedPnl, 0);
+  if (total <= 0) {
+    return {
+      retire: true,
+      reason: `lifetime_pnl_floor: last_${OSCILLATION_PROMOTION_CYCLES}_cycles_sum_${total.toFixed(2)}_leq_0`,
+    };
+  }
+  return { retire: false };
+}
+
+/**
+ * Decide whether to retire based on the 3-recalibrations-in-30-days
+ * rule. Counts demotion events that occurred in the trailing 30 days;
+ * if the count exceeds RECALIBRATION_LIMIT_PER_30_DAYS, the strategy
+ * is too flaky to keep cycling and should be retired.
+ */
+export function evaluateRecalibrationLimitRetirement(
+  recentDemotionTimestamps: Date[],
+  now: Date = new Date(),
+): RetirementDecision {
+  const cutoffMs = now.getTime() - 30 * 24 * 60 * 60 * 1000;
+  const recent = recentDemotionTimestamps.filter((d) => d.getTime() >= cutoffMs);
+  if (recent.length > RECALIBRATION_LIMIT_PER_30_DAYS) {
+    return {
+      retire: true,
+      reason: `recalibration_limit: ${recent.length}_demotions_in_last_30_days_exceeds_${RECALIBRATION_LIMIT_PER_30_DAYS}`,
+    };
+  }
+  return { retire: false };
+}

--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -11,6 +11,7 @@
 
 import { EventEmitter } from 'events';
 import { pool } from '../db/connection.js';
+import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 import { validateMarketData } from '../utils/marketDataValidator.js';
 import { apiCredentialsService } from './apiCredentialsService.js';
@@ -1051,8 +1052,8 @@ class FullyAutonomousTrader extends EventEmitter {
       // Log trade (both paper and live)
       await pool.query(
         `INSERT INTO autonomous_trades
-         (user_id, symbol, side, entry_price, quantity, stop_loss, take_profit, confidence, reason, order_id, paper_trade)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+         (user_id, symbol, side, entry_price, quantity, stop_loss, take_profit, confidence, reason, order_id, paper_trade, engine_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
         [
           userId,
           signal.symbol,
@@ -1064,7 +1065,8 @@ class FullyAutonomousTrader extends EventEmitter {
           signal.confidence,
           signal.reason,
           orderId,
-          config.paperTrading
+          config.paperTrading,
+          getEngineVersion(),
         ]
       );
 

--- a/apps/api/src/services/monitoringService.ts
+++ b/apps/api/src/services/monitoringService.ts
@@ -65,7 +65,7 @@ interface PipelineHeartbeat {
   lastSeen: Date;
   tickCount: number;
   tradeCount: number;              // trades (paper or live) recorded since boot
-  tradesPerHourRing: number[];     // rolling 60-minute ring buffer, one slot per minute
+  tradesRing: number[];            // rolling ring buffer, one slot per minute, TRADES_RING_SLOTS long
   ringHead: number;                // index of current minute in ring
   ringMinute: number;              // minute-of-epoch at ringHead
 }
@@ -79,8 +79,14 @@ const STAGE_SILENT_THRESHOLD_MS: Record<PipelineStage, number> = {
   reconciliation: 10 * 60_000,     // reconciler runs every 5 min, 2x buffer
 };
 
-/** Silent-floor alert: < 1 trade in this window triggers. */
-const TRADES_PER_HOUR_FLOOR_WINDOW_MIN = 360;  // 6 hours
+/**
+ * Silent-floor alert: < 1 trade in this window triggers.
+ * Must be ≤ TRADES_RING_SLOTS or the probe will evaluate against a
+ * shorter window than it advertises — Sourcery called this out on
+ * the first pass. Keep these two aligned.
+ */
+export const TRADES_PER_HOUR_FLOOR_WINDOW_MIN = 360;  // 6 hours
+export const TRADES_RING_SLOTS = 360;
 
 interface ErrorStatsReport {
   total24h: number;
@@ -459,7 +465,7 @@ class MonitoringService {
         lastSeen: now,
         tickCount: 1,
         tradeCount: 0,
-        tradesPerHourRing: new Array(60).fill(0),
+        tradesRing: new Array(TRADES_RING_SLOTS).fill(0),
         ringHead: 0,
         ringMinute: Math.floor(now.getTime() / 60_000),
       });
@@ -473,21 +479,21 @@ class MonitoringService {
   recordTradeEvent(stage: 'paper' | 'live', now: Date = new Date()): void {
     const hb = this.pipelineHeartbeats.get(stage) ?? this.initStageHeartbeat(stage, now);
     this.advanceTradeRing(hb, now);
-    hb.tradesPerHourRing[hb.ringHead] += 1;
+    hb.tradesRing[hb.ringHead] += 1;
     hb.tradeCount += 1;
     hb.lastSeen = now;
   }
 
-  /** Trades observed in the rolling last N minutes (max 60). */
+  /** Trades observed in the rolling last N minutes (max TRADES_RING_SLOTS). */
   getTradesInLastMinutes(stage: 'paper' | 'live', minutes: number, now: Date = new Date()): number {
     const hb = this.pipelineHeartbeats.get(stage);
     if (!hb) return 0;
     this.advanceTradeRing(hb, now);
-    const window = Math.max(1, Math.min(60, Math.floor(minutes)));
+    const window = Math.max(1, Math.min(TRADES_RING_SLOTS, Math.floor(minutes)));
     let total = 0;
     for (let i = 0; i < window; i++) {
-      const idx = (hb.ringHead - i + 60) % 60;
-      total += hb.tradesPerHourRing[idx];
+      const idx = (hb.ringHead - i + TRADES_RING_SLOTS) % TRADES_RING_SLOTS;
+      total += hb.tradesRing[idx];
     }
     return total;
   }
@@ -547,7 +553,7 @@ class MonitoringService {
       lastSeen: now,
       tickCount: 0,
       tradeCount: 0,
-      tradesPerHourRing: new Array(60).fill(0),
+      tradesRing: new Array(TRADES_RING_SLOTS).fill(0),
       ringHead: 0,
       ringMinute: Math.floor(now.getTime() / 60_000),
     };
@@ -556,24 +562,24 @@ class MonitoringService {
   }
 
   /**
-   * Rotate the trades-per-hour ring forward to the current minute, zeroing
-   * any slots we pass through (those minutes had no trades).
+   * Rotate the trades ring forward to the current minute, zeroing any
+   * slots we pass through (those minutes had no trades).
    */
   private advanceTradeRing(hb: PipelineHeartbeat, now: Date): void {
     const currentMinute = Math.floor(now.getTime() / 60_000);
     const delta = currentMinute - hb.ringMinute;
     if (delta <= 0) return;
-    const steps = Math.min(delta, 60);
+    const steps = Math.min(delta, TRADES_RING_SLOTS);
     for (let i = 0; i < steps; i++) {
-      hb.ringHead = (hb.ringHead + 1) % 60;
-      hb.tradesPerHourRing[hb.ringHead] = 0;
+      hb.ringHead = (hb.ringHead + 1) % TRADES_RING_SLOTS;
+      hb.tradesRing[hb.ringHead] = 0;
     }
     hb.ringMinute = currentMinute;
   }
 
   private sumRing(hb: PipelineHeartbeat, now: Date): number {
     this.advanceTradeRing(hb, now);
-    return hb.tradesPerHourRing.reduce((a, b) => a + b, 0);
+    return hb.tradesRing.reduce((a, b) => a + b, 0);
   }
 
   /**

--- a/apps/api/src/services/monitoringService.ts
+++ b/apps/api/src/services/monitoringService.ts
@@ -53,6 +53,35 @@ interface SystemHealthReport {
   timestamp?: Date;
 }
 
+/** Pipeline stage heartbeat — see recordPipelineHeartbeat. */
+export type PipelineStage =
+  | 'generator'
+  | 'backtest'
+  | 'paper'
+  | 'live'
+  | 'reconciliation';
+
+interface PipelineHeartbeat {
+  lastSeen: Date;
+  tickCount: number;
+  tradeCount: number;              // trades (paper or live) recorded since boot
+  tradesPerHourRing: number[];     // rolling 60-minute ring buffer, one slot per minute
+  ringHead: number;                // index of current minute in ring
+  ringMinute: number;              // minute-of-epoch at ringHead
+}
+
+/** Expected max silence per stage before a liveness alert fires. */
+const STAGE_SILENT_THRESHOLD_MS: Record<PipelineStage, number> = {
+  generator: 15 * 60_000,          // new strategies at least every 15 min
+  backtest: 10 * 60_000,           // backtest loop ticks more frequently
+  paper: 10 * 60_000,              // signal generation cycle
+  live: 10 * 60_000,               // live trade cycle
+  reconciliation: 10 * 60_000,     // reconciler runs every 5 min, 2x buffer
+};
+
+/** Silent-floor alert: < 1 trade in this window triggers. */
+const TRADES_PER_HOUR_FLOOR_WINDOW_MIN = 360;  // 6 hours
+
 interface ErrorStatsReport {
   total24h: number;
   totalAllTime: number;
@@ -68,6 +97,7 @@ class MonitoringService {
   private errorCount = 0;
   private warningCount = 0;
   private activeConnectionCount = 0;
+  private pipelineHeartbeats: Map<PipelineStage, PipelineHeartbeat> = new Map();
 
   /**
    * Log an error
@@ -414,6 +444,139 @@ class MonitoringService {
   }
 
   /**
+   * Record that a pipeline stage executed a tick. Called from each stage's
+   * main loop. Silent-failure alerts fire when a stage hasn't reported in
+   * longer than its expected interval (see STAGE_SILENT_THRESHOLD_MS).
+   */
+  recordPipelineHeartbeat(stage: PipelineStage): void {
+    const now = new Date();
+    const existing = this.pipelineHeartbeats.get(stage);
+    if (existing) {
+      existing.lastSeen = now;
+      existing.tickCount += 1;
+    } else {
+      this.pipelineHeartbeats.set(stage, {
+        lastSeen: now,
+        tickCount: 1,
+        tradeCount: 0,
+        tradesPerHourRing: new Array(60).fill(0),
+        ringHead: 0,
+        ringMinute: Math.floor(now.getTime() / 60_000),
+      });
+    }
+  }
+
+  /**
+   * Record a completed trade (paper or live). Feeds the trades-per-hour
+   * rolling ring used by the silent-floor alert.
+   */
+  recordTradeEvent(stage: 'paper' | 'live', now: Date = new Date()): void {
+    const hb = this.pipelineHeartbeats.get(stage) ?? this.initStageHeartbeat(stage, now);
+    this.advanceTradeRing(hb, now);
+    hb.tradesPerHourRing[hb.ringHead] += 1;
+    hb.tradeCount += 1;
+    hb.lastSeen = now;
+  }
+
+  /** Trades observed in the rolling last N minutes (max 60). */
+  getTradesInLastMinutes(stage: 'paper' | 'live', minutes: number, now: Date = new Date()): number {
+    const hb = this.pipelineHeartbeats.get(stage);
+    if (!hb) return 0;
+    this.advanceTradeRing(hb, now);
+    const window = Math.max(1, Math.min(60, Math.floor(minutes)));
+    let total = 0;
+    for (let i = 0; i < window; i++) {
+      const idx = (hb.ringHead - i + 60) % 60;
+      total += hb.tradesPerHourRing[idx];
+    }
+    return total;
+  }
+
+  /**
+   * Which pipeline stages are silent beyond threshold? Used by the alerting
+   * service's silent-failure probe.
+   */
+  getSilentPipelineStages(now: Date = new Date()): Array<{
+    stage: PipelineStage;
+    silentMs: number;
+    thresholdMs: number;
+  }> {
+    const silent: Array<{ stage: PipelineStage; silentMs: number; thresholdMs: number }> = [];
+    for (const stage of Object.keys(STAGE_SILENT_THRESHOLD_MS) as PipelineStage[]) {
+      const hb = this.pipelineHeartbeats.get(stage);
+      const thresholdMs = STAGE_SILENT_THRESHOLD_MS[stage];
+      const silentMs = hb ? now.getTime() - hb.lastSeen.getTime() : Number.POSITIVE_INFINITY;
+      if (silentMs > thresholdMs) {
+        silent.push({ stage, silentMs, thresholdMs });
+      }
+    }
+    return silent;
+  }
+
+  /** Snapshot of all pipeline heartbeats for UI / status endpoints. */
+  getPipelineHeartbeatSnapshot(now: Date = new Date()): Array<{
+    stage: PipelineStage;
+    lastSeenAt: string | null;
+    silentMs: number | null;
+    thresholdMs: number;
+    tickCount: number;
+    tradeCount: number;
+    tradesPerHour: number;
+  }> {
+    return (Object.keys(STAGE_SILENT_THRESHOLD_MS) as PipelineStage[]).map((stage) => {
+      const hb = this.pipelineHeartbeats.get(stage);
+      return {
+        stage,
+        lastSeenAt: hb ? hb.lastSeen.toISOString() : null,
+        silentMs: hb ? now.getTime() - hb.lastSeen.getTime() : null,
+        thresholdMs: STAGE_SILENT_THRESHOLD_MS[stage],
+        tickCount: hb?.tickCount ?? 0,
+        tradeCount: hb?.tradeCount ?? 0,
+        tradesPerHour: hb ? this.sumRing(hb, now) : 0,
+      };
+    });
+  }
+
+  /** Constant exposed for tests / alerting config. */
+  getTradesPerHourFloorWindowMinutes(): number {
+    return TRADES_PER_HOUR_FLOOR_WINDOW_MIN;
+  }
+
+  private initStageHeartbeat(stage: PipelineStage, now: Date): PipelineHeartbeat {
+    const hb: PipelineHeartbeat = {
+      lastSeen: now,
+      tickCount: 0,
+      tradeCount: 0,
+      tradesPerHourRing: new Array(60).fill(0),
+      ringHead: 0,
+      ringMinute: Math.floor(now.getTime() / 60_000),
+    };
+    this.pipelineHeartbeats.set(stage, hb);
+    return hb;
+  }
+
+  /**
+   * Rotate the trades-per-hour ring forward to the current minute, zeroing
+   * any slots we pass through (those minutes had no trades).
+   */
+  private advanceTradeRing(hb: PipelineHeartbeat, now: Date): void {
+    const currentMinute = Math.floor(now.getTime() / 60_000);
+    const delta = currentMinute - hb.ringMinute;
+    if (delta <= 0) return;
+    const steps = Math.min(delta, 60);
+    for (let i = 0; i < steps; i++) {
+      hb.ringHead = (hb.ringHead + 1) % 60;
+      hb.tradesPerHourRing[hb.ringHead] = 0;
+    }
+    hb.ringMinute = currentMinute;
+  }
+
+  private sumRing(hb: PipelineHeartbeat, now: Date): number {
+    this.advanceTradeRing(hb, now);
+    return hb.tradesPerHourRing.reduce((a, b) => a + b, 0);
+  }
+
+  /**
    * Reset all metrics (for testing)
    */
   reset(): void {
@@ -423,6 +586,7 @@ class MonitoringService {
     this.errorCount = 0;
     this.warningCount = 0;
     this.activeConnectionCount = 0;
+    this.pipelineHeartbeats = new Map();
   }
 }
 

--- a/apps/api/src/services/paperTradingService.js
+++ b/apps/api/src/services/paperTradingService.js
@@ -6,6 +6,7 @@
 
 import { EventEmitter } from 'events';
 import { pool, query } from '../db/connection.js';
+import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 import { validateMarketData } from '../utils/marketDataValidator.js';
 import futuresWebSocket from '../websocket/futuresWebSocket.js';
@@ -195,8 +196,8 @@ class PaperTradingService extends EventEmitter {
           id, session_name, strategy_name, symbol, timeframe,
           initial_capital, current_value, unrealized_pnl, realized_pnl,
           total_trades, winning_trades, status, started_at,
-          is_censored, censor_reason
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+          is_censored, censor_reason, engine_version
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
       `, [
         session.id,
         session.name,
@@ -213,6 +214,7 @@ class PaperTradingService extends EventEmitter {
         session.startedAt,
         session.isCensored,
         session.censorReason,
+        getEngineVersion(),
       ]);
 
       // Add to active sessions

--- a/apps/api/src/services/pipelineHealthProbe.ts
+++ b/apps/api/src/services/pipelineHealthProbe.ts
@@ -15,6 +15,28 @@ import { logger } from '../utils/logger.js';
 
 const DEFAULT_PROBE_INTERVAL_MS = 60_000;
 
+/**
+ * A predicate the probe calls to decide whether the system is in a
+ * state where trades *should* be happening. When this returns false,
+ * the trades-floor alert is suppressed — a Paused or Paper-Only
+ * configuration doesn't page. Default reads from persistentTradingEngine.
+ *
+ * Exposed so tests can inject a deterministic predicate.
+ */
+export type IsExpectedTradingPredicate = () => boolean;
+
+/**
+ * Default predicate — reports false so the probe does NOT alert on
+ * trades-per-hour floor unless a caller explicitly wires in a live
+ * state source. This module stays free of service dependencies so
+ * tests that import it don't cascade into encryption / env
+ * validation.
+ *
+ * index.ts wires the real predicate at boot:
+ *   startPipelineHealthProbe(60_000, () => persistentTradingEngine.isEngineRunning())
+ */
+const defaultIsExpectedTrading: IsExpectedTradingPredicate = () => false;
+
 type ProbeHandle = {
   stop: () => void;
   runOnce: () => void;
@@ -24,17 +46,25 @@ type ProbeHandle = {
 let activeProbe: ProbeHandle | null = null;
 /** First-observed tick timestamp — used to avoid firing trades-floor alerts before the system has been up long enough to produce trades. */
 let probeStartedAt: Date | null = null;
+let isExpectedTrading: IsExpectedTradingPredicate = defaultIsExpectedTrading;
 
 /**
  * Decide whether a trades-floor alert is appropriate given current state.
- * We only page when the generator or backtest stage has been alive long
- * enough that paper trades *should* have fired by now.
+ * Three gates must all be true before we page:
+ *   1. Probe has been up at least the full floor window.
+ *   2. The trading engine says it is currently running (not Paused).
+ *   3. (Monitoring data width matches the window — asserted at build by
+ *      TRADES_PER_HOUR_FLOOR_WINDOW_MIN ≤ TRADES_RING_SLOTS.)
+ *
+ * Sourcery flagged that an assumed `expected_running` state without this
+ * gate would page on intentionally-paused / paper-only configurations.
  */
 function shouldEvaluateTradesFloor(now: Date): boolean {
   if (!probeStartedAt) return false;
   const uptimeMs = now.getTime() - probeStartedAt.getTime();
   const windowMs = monitoringService.getTradesPerHourFloorWindowMinutes() * 60_000;
-  return uptimeMs >= windowMs;
+  if (uptimeMs < windowMs) return false;
+  return isExpectedTrading();
 }
 
 function runProbeTick(now: Date = new Date()): void {
@@ -62,9 +92,12 @@ function runProbeTick(now: Date = new Date()): void {
 
 export function startPipelineHealthProbe(
   intervalMs: number = DEFAULT_PROBE_INTERVAL_MS,
+  predicate: IsExpectedTradingPredicate | undefined = defaultIsExpectedTrading,
 ): ProbeHandle {
+  const effectivePredicate = predicate ?? defaultIsExpectedTrading;
   if (activeProbe) return activeProbe;
   probeStartedAt = new Date();
+  isExpectedTrading = effectivePredicate;
   const timer = setInterval(() => runProbeTick(), intervalMs);
   timer.unref?.();
   activeProbe = {
@@ -72,6 +105,7 @@ export function startPipelineHealthProbe(
       clearInterval(timer);
       activeProbe = null;
       probeStartedAt = null;
+      isExpectedTrading = defaultIsExpectedTrading;
     },
     runOnce: () => runProbeTick(),
     intervalMs,

--- a/apps/api/src/services/pipelineHealthProbe.ts
+++ b/apps/api/src/services/pipelineHealthProbe.ts
@@ -1,0 +1,88 @@
+/**
+ * Pipeline health probe.
+ *
+ * Periodically queries the monitoring service for pipeline-stage
+ * heartbeats and trade rates, and fires alerting-service alerts for
+ * silent stages and trades-per-hour floor breaches.
+ *
+ * This is the guard that converts "0 paper trades for weeks and nobody
+ * noticed" into a pagable alert within one probe interval.
+ */
+
+import alertingService from './alertingService.js';
+import { monitoringService, type PipelineStage } from './monitoringService.js';
+import { logger } from '../utils/logger.js';
+
+const DEFAULT_PROBE_INTERVAL_MS = 60_000;
+
+type ProbeHandle = {
+  stop: () => void;
+  runOnce: () => void;
+  readonly intervalMs: number;
+};
+
+let activeProbe: ProbeHandle | null = null;
+/** First-observed tick timestamp — used to avoid firing trades-floor alerts before the system has been up long enough to produce trades. */
+let probeStartedAt: Date | null = null;
+
+/**
+ * Decide whether a trades-floor alert is appropriate given current state.
+ * We only page when the generator or backtest stage has been alive long
+ * enough that paper trades *should* have fired by now.
+ */
+function shouldEvaluateTradesFloor(now: Date): boolean {
+  if (!probeStartedAt) return false;
+  const uptimeMs = now.getTime() - probeStartedAt.getTime();
+  const windowMs = monitoringService.getTradesPerHourFloorWindowMinutes() * 60_000;
+  return uptimeMs >= windowMs;
+}
+
+function runProbeTick(now: Date = new Date()): void {
+  try {
+    const silentStages = monitoringService.getSilentPipelineStages(now);
+    for (const { stage, silentMs, thresholdMs } of silentStages) {
+      alertingService.alertPipelineSilent(stage as PipelineStage, silentMs, thresholdMs);
+    }
+
+    if (!shouldEvaluateTradesFloor(now)) return;
+
+    const windowMin = monitoringService.getTradesPerHourFloorWindowMinutes();
+    for (const stage of ['paper', 'live'] as const) {
+      const trades = monitoringService.getTradesInLastMinutes(stage, windowMin, now);
+      if (trades < 1) {
+        alertingService.alertTradesFloorBreach(stage, trades, windowMin, 'expected_running');
+      }
+    }
+  } catch (err) {
+    logger.error('pipelineHealthProbe tick failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export function startPipelineHealthProbe(
+  intervalMs: number = DEFAULT_PROBE_INTERVAL_MS,
+): ProbeHandle {
+  if (activeProbe) return activeProbe;
+  probeStartedAt = new Date();
+  const timer = setInterval(() => runProbeTick(), intervalMs);
+  timer.unref?.();
+  activeProbe = {
+    stop: () => {
+      clearInterval(timer);
+      activeProbe = null;
+      probeStartedAt = null;
+    },
+    runOnce: () => runProbeTick(),
+    intervalMs,
+  };
+  logger.info('pipelineHealthProbe started', { intervalMs });
+  return activeProbe;
+}
+
+export function stopPipelineHealthProbe(): void {
+  activeProbe?.stop();
+}
+
+/** Exposed for tests. */
+export const __internal = { runProbeTick };

--- a/apps/api/src/services/promotionGates.ts
+++ b/apps/api/src/services/promotionGates.ts
@@ -1,0 +1,161 @@
+/**
+ * Promotion gates for the SLE pipeline.
+ *
+ * Pure functions (no DB, no IO) that decide whether a strategy should
+ * advance through the generated → backtest → paper → live pipeline
+ * and, once live, what position size tier applies.
+ *
+ * Why multi-metric?
+ *   The red team's statistician found Sharpe ≥ 1 alone is statistically
+ *   indistinguishable from noise at the scale of strategies this SLE
+ *   tests in parallel. We stack Sharpe + Sortino + Calmar + Profit
+ *   Factor + Max Drawdown so a strategy has to look good across
+ *   dependency-varied metrics, not just one.
+ *
+ * Why OOS?
+ *   Without an untouched out-of-sample window, the bandit overfits to
+ *   recent noise. A 30% OOS holdout that the generator cannot tune on
+ *   is the cheapest defence against survivorship bias across thousands
+ *   of strategies.
+ */
+
+export interface BacktestMetrics {
+  totalTrades: number;
+  sharpe: number;
+  sortino: number;
+  calmar: number;
+  profitFactor: number;
+  maxDrawdown: number;           // positive fraction, e.g. 0.12 = 12%
+}
+
+export interface PaperStats {
+  totalTrades: number;
+  cumulativePnl: number;
+  largestSingleLossPct: number;  // positive fraction (loss magnitude / margin)
+  rolling20TradeMaxDrawdown: number; // positive fraction
+  profitablePaperTrades: number;
+}
+
+export interface LiveStats {
+  profitableLiveTrades: number;
+}
+
+export interface GateDecision {
+  allowed: boolean;
+  reason?: string;
+  failingMetrics?: string[];
+}
+
+// ───────── Backtest → Paper thresholds ─────────
+export const BACKTEST_MIN_TRADES = 200;
+export const BACKTEST_MIN_SHARPE = 1.0;
+export const BACKTEST_MIN_SORTINO = 1.5;
+export const BACKTEST_MIN_CALMAR = 2.0;
+export const BACKTEST_MIN_PROFIT_FACTOR = 1.5;
+export const BACKTEST_MAX_DRAWDOWN = 0.15;      // 15%
+export const OOS_MIN_PROFIT_FACTOR = 1.3;
+
+// ───────── Paper → Live thresholds ─────────
+export const PAPER_MIN_TRADES = 20;
+export const PAPER_MAX_SINGLE_LOSS = 0.05;      // 5% of margin
+export const PAPER_MAX_ROLLING_DD = 0.10;       // 10%
+
+// ───────── Live sizing ladder ($2 → $3 → $5 → $8 → $12) ─────────
+// Each tier unlocks after +10 profitable live trades over the previous.
+export const LIVE_SIZING_USDT: Record<number, number> = {
+  0: 0,    // paper / recalibrating, no live size
+  1: 2,
+  2: 3,
+  3: 5,
+  4: 8,
+  5: 12,
+};
+export const TRADES_PER_TIER = 10;
+
+export function computeLiveSizingTier(live: LiveStats): number {
+  const steps = Math.floor(live.profitableLiveTrades / TRADES_PER_TIER);
+  // Tier 1 is unlocked immediately on promotion; additional tiers
+  // accumulate with profitable trades. Cap at 5.
+  return Math.min(5, 1 + steps);
+}
+
+export function getLiveSizeForTier(tier: number): number {
+  return LIVE_SIZING_USDT[tier] ?? 0;
+}
+
+// ───────── Gate evaluators ─────────
+
+export function evaluateBacktestGate(
+  inSample: BacktestMetrics,
+  outOfSample: Pick<BacktestMetrics, 'profitFactor'> | null,
+): GateDecision {
+  const failing: string[] = [];
+  if (inSample.totalTrades < BACKTEST_MIN_TRADES) {
+    failing.push(`totalTrades ${inSample.totalTrades} < ${BACKTEST_MIN_TRADES}`);
+  }
+  if (inSample.sharpe < BACKTEST_MIN_SHARPE) {
+    failing.push(`sharpe ${inSample.sharpe.toFixed(2)} < ${BACKTEST_MIN_SHARPE}`);
+  }
+  if (inSample.sortino < BACKTEST_MIN_SORTINO) {
+    failing.push(`sortino ${inSample.sortino.toFixed(2)} < ${BACKTEST_MIN_SORTINO}`);
+  }
+  if (inSample.calmar < BACKTEST_MIN_CALMAR) {
+    failing.push(`calmar ${inSample.calmar.toFixed(2)} < ${BACKTEST_MIN_CALMAR}`);
+  }
+  if (inSample.profitFactor < BACKTEST_MIN_PROFIT_FACTOR) {
+    failing.push(
+      `profitFactor ${inSample.profitFactor.toFixed(2)} < ${BACKTEST_MIN_PROFIT_FACTOR}`,
+    );
+  }
+  if (inSample.maxDrawdown > BACKTEST_MAX_DRAWDOWN) {
+    failing.push(
+      `maxDrawdown ${(inSample.maxDrawdown * 100).toFixed(1)}% > ${(BACKTEST_MAX_DRAWDOWN * 100).toFixed(0)}%`,
+    );
+  }
+
+  if (!outOfSample) {
+    failing.push('oosMetrics missing — promotion requires 30% OOS holdout');
+  } else if (outOfSample.profitFactor < OOS_MIN_PROFIT_FACTOR) {
+    failing.push(
+      `oos.profitFactor ${outOfSample.profitFactor.toFixed(2)} < ${OOS_MIN_PROFIT_FACTOR}`,
+    );
+  }
+
+  if (failing.length > 0) {
+    return {
+      allowed: false,
+      reason: `backtest_gate_failed: ${failing.join('; ')}`,
+      failingMetrics: failing,
+    };
+  }
+  return { allowed: true };
+}
+
+export function evaluatePaperGate(paper: PaperStats): GateDecision {
+  const failing: string[] = [];
+  if (paper.totalTrades < PAPER_MIN_TRADES) {
+    failing.push(`paperTrades ${paper.totalTrades} < ${PAPER_MIN_TRADES}`);
+  }
+  if (paper.cumulativePnl <= 0) {
+    failing.push(`cumulativePnl ${paper.cumulativePnl.toFixed(2)} not positive`);
+  }
+  if (paper.largestSingleLossPct > PAPER_MAX_SINGLE_LOSS) {
+    failing.push(
+      `largestSingleLoss ${(paper.largestSingleLossPct * 100).toFixed(1)}% > ${(PAPER_MAX_SINGLE_LOSS * 100).toFixed(0)}%`,
+    );
+  }
+  if (paper.rolling20TradeMaxDrawdown > PAPER_MAX_ROLLING_DD) {
+    failing.push(
+      `rolling20DD ${(paper.rolling20TradeMaxDrawdown * 100).toFixed(1)}% > ${(PAPER_MAX_ROLLING_DD * 100).toFixed(0)}%`,
+    );
+  }
+
+  if (failing.length > 0) {
+    return {
+      allowed: false,
+      reason: `paper_gate_failed: ${failing.join('; ')}`,
+      failingMetrics: failing,
+    };
+  }
+  return { allowed: true };
+}

--- a/apps/api/src/services/regimeCohortMemory.ts
+++ b/apps/api/src/services/regimeCohortMemory.ts
@@ -67,7 +67,7 @@ export async function freezeCohort(input: FreezeInput): Promise<number | null> {
         getEngineVersion(),
       ],
     );
-    return result.rows[0]?.id ?? null;
+    return (result.rows as any[])[0]?.id ?? null;
   } catch (err) {
     logger.error('[regimeCohortMemory] freezeCohort failed', {
       strategyId: input.strategyId,
@@ -98,7 +98,7 @@ export async function findChampionsForRegime(
          LIMIT $2`,
       [regime, limit],
     );
-    return result.rows.map(rowToCohort);
+    return (result.rows as any[]).map((r) => rowToCohort(r as Record<string, unknown>));
   } catch (err) {
     logger.warn('[regimeCohortMemory] findChampionsForRegime failed', {
       regime,

--- a/apps/api/src/services/regimeCohortMemory.ts
+++ b/apps/api/src/services/regimeCohortMemory.ts
@@ -1,0 +1,147 @@
+/**
+ * Regime cohort memory.
+ *
+ * When a strategy is retired (killed, not demoted) while it had
+ * positive lifetime realised P&L, we freeze its genome + regime tag
+ * into the frozen_cohorts table. When the same regime recurs later
+ * the SLE can reactivate champions that already proved themselves in
+ * that regime — avoiding the cold-start cost of generating new
+ * variants from scratch.
+ *
+ * This is a thin DB adapter. Logic for WHEN to freeze / reactivate
+ * lives in strategyLearningEngine; this module just owns the storage
+ * contract so it's individually testable / mockable.
+ */
+
+import { query } from '../db/connection.js';
+import type { SignalGenome } from './signalGenome.js';
+import type { StrategyClass } from './thompsonBandit.js';
+import { getEngineVersion } from '../utils/engineVersion.js';
+import { logger } from '../utils/logger.js';
+
+export interface FrozenCohort {
+  id: number;
+  strategyId: string;
+  strategyClass: StrategyClass;
+  regime: string;
+  signalGenome: SignalGenome;
+  lifetimePnl: number;
+  liveTrades: number;
+  paperTrades: number;
+  frozenAt: Date;
+  frozenReason: string;
+  engineVersion: string;
+  reactivatedCount: number;
+}
+
+export interface FreezeInput {
+  strategyId: string;
+  strategyClass: StrategyClass;
+  regime: string;
+  signalGenome: SignalGenome;
+  lifetimePnl: number;
+  liveTrades: number;
+  paperTrades: number;
+  reason: string;
+}
+
+/** Insert a champion into the frozen cohort archive. */
+export async function freezeCohort(input: FreezeInput): Promise<number | null> {
+  try {
+    const result = await query(
+      `INSERT INTO frozen_cohorts
+         (strategy_id, strategy_class, regime, signal_genome,
+          lifetime_pnl, live_trades, paper_trades,
+          frozen_reason, engine_version)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+       RETURNING id`,
+      [
+        input.strategyId,
+        input.strategyClass,
+        input.regime,
+        JSON.stringify(input.signalGenome),
+        input.lifetimePnl,
+        input.liveTrades,
+        input.paperTrades,
+        input.reason,
+        getEngineVersion(),
+      ],
+    );
+    return result.rows[0]?.id ?? null;
+  } catch (err) {
+    logger.error('[regimeCohortMemory] freezeCohort failed', {
+      strategyId: input.strategyId,
+      regime: input.regime,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Top-N champions for a regime, ordered by lifetime P&L descending.
+ * Used by the bandit when that regime recurs.
+ */
+export async function findChampionsForRegime(
+  regime: string,
+  limit = 3,
+): Promise<FrozenCohort[]> {
+  try {
+    const result = await query(
+      `SELECT id, strategy_id, strategy_class, regime, signal_genome,
+              lifetime_pnl, live_trades, paper_trades, frozen_at,
+              frozen_reason, engine_version, reactivated_count
+         FROM frozen_cohorts
+         WHERE regime = $1
+           AND lifetime_pnl > 0
+         ORDER BY lifetime_pnl DESC
+         LIMIT $2`,
+      [regime, limit],
+    );
+    return result.rows.map(rowToCohort);
+  } catch (err) {
+    logger.warn('[regimeCohortMemory] findChampionsForRegime failed', {
+      regime,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+/** Increment the reactivated counter so we can later see which champions returned. */
+export async function markReactivated(cohortId: number): Promise<void> {
+  try {
+    await query(
+      `UPDATE frozen_cohorts
+          SET reactivated_count = reactivated_count + 1
+        WHERE id = $1`,
+      [cohortId],
+    );
+  } catch (err) {
+    logger.warn('[regimeCohortMemory] markReactivated failed', {
+      cohortId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function rowToCohort(row: Record<string, unknown>): FrozenCohort {
+  const genome =
+    typeof row.signal_genome === 'string'
+      ? (JSON.parse(row.signal_genome as string) as SignalGenome)
+      : (row.signal_genome as SignalGenome);
+  return {
+    id: Number(row.id),
+    strategyId: String(row.strategy_id),
+    strategyClass: String(row.strategy_class) as StrategyClass,
+    regime: String(row.regime),
+    signalGenome: genome,
+    lifetimePnl: Number(row.lifetime_pnl),
+    liveTrades: Number(row.live_trades),
+    paperTrades: Number(row.paper_trades),
+    frozenAt: new Date(row.frozen_at as string),
+    frozenReason: String(row.frozen_reason),
+    engineVersion: String(row.engine_version),
+    reactivatedCount: Number(row.reactivated_count),
+  };
+}

--- a/apps/api/src/services/riskKernel.ts
+++ b/apps/api/src/services/riskKernel.ts
@@ -1,0 +1,229 @@
+/**
+ * Risk Kernel — pre-trade blast door.
+ *
+ * The existing riskService handles leverage caps, daily loss limits, max
+ * open trades, and kill-switch. The kernel adds the red-team-mandated
+ * guards that the existing service did not cover:
+ *
+ *   1. Per-symbol gross exposure cap (max 1.5× account equity notional
+ *      across ALL strategies on one symbol). Prevents correlated
+ *      long-BTC stacks from liquidating on a single adverse candle.
+ *
+ *   2. Self-match prevention. Rejects any order that would cross a
+ *      resting order from the same account. Corporations Act s.1041B
+ *      (false trading) compliance for the 10-concurrent-strategies design.
+ *
+ *   3. Unrealised-drawdown kill-switch. Total unrealised P&L ≤ -15% of
+ *      equity → flatten all, pause 24h. The existing daily-loss cap is
+ *      on REALISED P&L; a flash wick can blow through it while no trade
+ *      has closed.
+ *
+ *   4. Strategy-tier leverage cap. 5× until a strategy has cleared
+ *      live-tier 3. Only battle-tested strategies re-enable 20×.
+ *
+ *   5. Symbol gate. BTC-USDT only until account equity ≥ $100 (ETH
+ *      perp contract minimum is ~$35 notional — not viable at $2
+ *      position size).
+ *
+ * All functions are pure (input → decision object). The
+ * `evaluatePreTradeVetoes` composer is what the riskService calls.
+ */
+
+export interface KernelOrder {
+  symbol: string;
+  side: 'long' | 'short' | 'buy' | 'sell';
+  notional: number;          // position notional in quote currency (e.g. USDT)
+  leverage: number;
+  price: number;             // entry/limit price
+}
+
+export interface KernelOpenPosition {
+  symbol: string;
+  side: 'long' | 'short';
+  notional: number;
+}
+
+export interface KernelRestingOrder {
+  symbol: string;
+  side: 'buy' | 'sell';
+  price: number;
+}
+
+export interface KernelAccountState {
+  equityUsdt: number;
+  unrealizedPnlUsdt: number;
+  openPositions: KernelOpenPosition[];
+  restingOrders: KernelRestingOrder[];
+}
+
+export interface KernelStrategyMeta {
+  /** 0 = paper/recalibrating, 1-5 = live tiers with increasing capital cap */
+  liveTier: number;
+}
+
+export interface KernelDecision {
+  allowed: boolean;
+  reason?: string;
+  code?: KernelVetoCode;
+}
+
+export type KernelVetoCode =
+  | 'per_symbol_exposure_cap'
+  | 'self_match'
+  | 'unrealized_drawdown_kill_switch'
+  | 'strategy_leverage_cap'
+  | 'symbol_not_allowed_at_equity';
+
+// ───────── Thresholds (shipping defaults) ─────────
+export const PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER = 1.5;           // 1.5× equity per symbol
+export const UNREALIZED_DRAWDOWN_KILL_THRESHOLD = -0.15;         // −15% of equity
+export const STRATEGY_LEVERAGE_CAP_BY_TIER: Record<number, number> = {
+  0: 1,  // paper/recalibrating
+  1: 3,
+  2: 5,
+  3: 10,
+  4: 15,
+  5: 20,
+};
+export const DEFAULT_UNPROVEN_LEVERAGE_CAP = 5;
+export const MIN_EQUITY_FOR_ETH_USDT = 100;
+export const BTC_SYMBOL_ALIASES = ['BTC-USDT', 'BTCUSDT', 'BTC_USDT', 'BTC-USDT-PERP'];
+
+export function isBtcSymbol(symbol: string): boolean {
+  return BTC_SYMBOL_ALIASES.includes(symbol.toUpperCase());
+}
+
+function isLong(side: KernelOrder['side']): boolean {
+  return side === 'long' || side === 'buy';
+}
+
+// ───────── Check 1: Per-symbol gross exposure ─────────
+
+export function checkPerSymbolExposure(
+  order: KernelOrder,
+  state: KernelAccountState,
+): KernelDecision {
+  const cap = state.equityUsdt * PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER;
+  const existingNotional = state.openPositions
+    .filter((p) => p.symbol === order.symbol)
+    .reduce((sum, p) => sum + Math.abs(p.notional), 0);
+  const projected = existingNotional + Math.abs(order.notional);
+  if (projected > cap) {
+    return {
+      allowed: false,
+      code: 'per_symbol_exposure_cap',
+      reason: `Per-symbol exposure cap breached: ${projected.toFixed(2)} > ${cap.toFixed(2)} (${PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER}× equity)`,
+    };
+  }
+  return { allowed: true };
+}
+
+// ───────── Check 2: Self-match prevention ─────────
+
+export function checkSelfMatch(
+  order: KernelOrder,
+  state: KernelAccountState,
+): KernelDecision {
+  // A buy would self-match with a same-account sell at-or-below the buy price.
+  // A sell would self-match with a same-account buy at-or-above the sell price.
+  const orderIsBuy = isLong(order.side);
+  const conflict = state.restingOrders.find((resting) => {
+    if (resting.symbol !== order.symbol) return false;
+    const restingIsBuy = resting.side === 'buy';
+    if (orderIsBuy === restingIsBuy) return false;
+    return orderIsBuy ? resting.price <= order.price : resting.price >= order.price;
+  });
+  if (conflict) {
+    return {
+      allowed: false,
+      code: 'self_match',
+      reason: `Self-match with account's own resting ${conflict.side} @ ${conflict.price} on ${conflict.symbol}. Blocked per Corporations Act s.1041B.`,
+    };
+  }
+  return { allowed: true };
+}
+
+// ───────── Check 3: Unrealised-drawdown kill-switch ─────────
+
+export function checkUnrealizedDrawdown(
+  state: KernelAccountState,
+): KernelDecision {
+  if (state.equityUsdt <= 0) return { allowed: true }; // divide-by-zero guard; realised-loss cap owns this case
+  const ratio = state.unrealizedPnlUsdt / state.equityUsdt;
+  if (ratio <= UNREALIZED_DRAWDOWN_KILL_THRESHOLD) {
+    return {
+      allowed: false,
+      code: 'unrealized_drawdown_kill_switch',
+      reason: `Unrealised P&L ${(ratio * 100).toFixed(2)}% of equity ≤ ${(UNREALIZED_DRAWDOWN_KILL_THRESHOLD * 100).toFixed(0)}% — flatten and pause 24h.`,
+    };
+  }
+  return { allowed: true };
+}
+
+// ───────── Check 4: Strategy-tier leverage cap ─────────
+
+export function checkStrategyLeverageCap(
+  order: KernelOrder,
+  strategy: KernelStrategyMeta,
+): KernelDecision {
+  const cap =
+    STRATEGY_LEVERAGE_CAP_BY_TIER[strategy.liveTier] ?? DEFAULT_UNPROVEN_LEVERAGE_CAP;
+  if (order.leverage > cap) {
+    return {
+      allowed: false,
+      code: 'strategy_leverage_cap',
+      reason: `Leverage ${order.leverage}× exceeds tier ${strategy.liveTier} cap of ${cap}×. Strategy must earn higher tiers via profitable live trades.`,
+    };
+  }
+  return { allowed: true };
+}
+
+// ───────── Check 5: Symbol allowed at current equity ─────────
+
+export function checkSymbolAllowedAtEquity(
+  order: KernelOrder,
+  state: KernelAccountState,
+): KernelDecision {
+  if (isBtcSymbol(order.symbol)) return { allowed: true };
+  if (state.equityUsdt < MIN_EQUITY_FOR_ETH_USDT) {
+    return {
+      allowed: false,
+      code: 'symbol_not_allowed_at_equity',
+      reason: `${order.symbol} requires account equity ≥ $${MIN_EQUITY_FOR_ETH_USDT} (current $${state.equityUsdt.toFixed(2)}). ETH perp min contract ~$35 notional — not viable at tiny sizes.`,
+    };
+  }
+  return { allowed: true };
+}
+
+// ───────── Composer ─────────
+
+/**
+ * Run all kernel vetoes in priority order. First failure stops the chain
+ * and is returned. If all pass, returns { allowed: true }.
+ *
+ * Priority:
+ *   1. Unrealised-drawdown kill-switch (global, highest priority —
+ *      blocks even position-flattening orders if we ever route those
+ *      through the kernel, which we don't).
+ *   2. Self-match (legal compliance).
+ *   3. Per-symbol exposure (correlated-stack blast door).
+ *   4. Strategy leverage cap (per-strategy earn-your-size gating).
+ *   5. Symbol-allowed-at-equity (capital adequacy).
+ */
+export function evaluatePreTradeVetoes(
+  order: KernelOrder,
+  state: KernelAccountState,
+  strategy: KernelStrategyMeta,
+): KernelDecision {
+  const checks: KernelDecision[] = [
+    checkUnrealizedDrawdown(state),
+    checkSelfMatch(order, state),
+    checkPerSymbolExposure(order, state),
+    checkStrategyLeverageCap(order, strategy),
+    checkSymbolAllowedAtEquity(order, state),
+  ];
+  for (const d of checks) {
+    if (!d.allowed) return d;
+  }
+  return { allowed: true };
+}

--- a/apps/api/src/services/riskService.js
+++ b/apps/api/src/services/riskService.js
@@ -5,6 +5,7 @@
 
 import { logger } from '../utils/logger.js';
 import { pool } from '../db/connection.js';
+import { evaluatePreTradeVetoes } from './riskKernel.js';
 
 class RiskService {
   constructor() {
@@ -21,9 +22,20 @@ class RiskService {
    * @param {Object} order - Order to validate
    * @param {Object} account - Account information
    * @param {Object} marketInfo - Market catalog info for the symbol
-   * @returns {Promise<Object>} { allowed: boolean, reason?: string }
+   * @param {Object} [kernelInputs] - Optional inputs for the blast-door
+   *   kernel. When supplied, runs the pre-trade vetoes (per-symbol
+   *   exposure, self-match, unrealised-drawdown kill, strategy leverage
+   *   tier, symbol-allowed-at-equity). Shape:
+   *     {
+   *       kernelOrder:   { symbol, side, notional, leverage, price },
+   *       accountState:  { equityUsdt, unrealizedPnlUsdt,
+   *                        openPositions:[{symbol,side,notional}],
+   *                        restingOrders:[{symbol,side,price}] },
+   *       strategy:      { liveTier: 0..5 }
+   *     }
+   * @returns {Promise<Object>} { allowed: boolean, reason?: string, code?: string }
    */
-  async checkOrderRisk(order, account, marketInfo) {
+  async checkOrderRisk(order, account, marketInfo, kernelInputs = null) {
     try {
       // 1. Check leverage cap from market catalog
       if (marketInfo.maxLeverage && order.leverage > marketInfo.maxLeverage) {
@@ -77,6 +89,27 @@ class RiskService {
           reason: killSwitchCheck.reason
         });
         return killSwitchCheck;
+      }
+
+      // 6. Blast-door kernel vetoes (per-symbol exposure, self-match,
+      //    unrealised-drawdown kill, strategy leverage tier, symbol gate).
+      //    Only runs when the caller has assembled kernelInputs — older
+      //    call sites that don't have account state / open positions
+      //    continue to work with the legacy checks above.
+      if (kernelInputs) {
+        const kernelDecision = evaluatePreTradeVetoes(
+          kernelInputs.kernelOrder,
+          kernelInputs.accountState,
+          kernelInputs.strategy,
+        );
+        if (!kernelDecision.allowed) {
+          logger.warn('Risk check failed: kernel veto', {
+            accountId: account.id,
+            code: kernelDecision.code,
+            reason: kernelDecision.reason,
+          });
+          return kernelDecision;
+        }
       }
 
       logger.info('Risk check passed', {

--- a/apps/api/src/services/slotAllocator.ts
+++ b/apps/api/src/services/slotAllocator.ts
@@ -1,0 +1,93 @@
+/**
+ * Slot allocator for parallel strategy execution.
+ *
+ * Pool size is 12 (was 10). Of those:
+ *   - 2 reserved per strategy class (10 total across 5 classes)
+ *   - 2 floating slots for bandit-driven exploration
+ *
+ * A class never loses all its slots to a hot streak in another class.
+ * The floating slots are where the bandit gets to chase winners
+ * without strangling diversity.
+ *
+ * Pure function: given the current occupancy, decide whether a new
+ * strategy of a given class can be admitted.
+ */
+
+import { ALL_STRATEGY_CLASSES, type StrategyClass } from './thompsonBandit.js';
+
+export const SLOTS_PER_CLASS = 2;
+export const FLOATING_SLOTS = 2;
+export const TOTAL_SLOTS =
+  SLOTS_PER_CLASS * ALL_STRATEGY_CLASSES.length + FLOATING_SLOTS;
+
+export interface SlotOccupancy {
+  /** How many active strategies currently belong to each class. */
+  countsByClass: Map<StrategyClass, number>;
+}
+
+export interface SlotAssignment {
+  admitted: boolean;
+  reason?: string;
+  /** Which bucket the admitted strategy occupies, for observability. */
+  bucket?: 'reserved' | 'floating';
+}
+
+function countTotal(occupancy: SlotOccupancy): number {
+  let n = 0;
+  for (const c of occupancy.countsByClass.values()) n += c;
+  return n;
+}
+
+function countFloatingInUse(occupancy: SlotOccupancy): number {
+  // Floating usage = total − reserved-seats-actually-used.
+  // A class with 3 strategies consumes its 2 reserved seats + 1 floating.
+  let floatingUsed = 0;
+  for (const klass of ALL_STRATEGY_CLASSES) {
+    const inClass = occupancy.countsByClass.get(klass) ?? 0;
+    if (inClass > SLOTS_PER_CLASS) {
+      floatingUsed += inClass - SLOTS_PER_CLASS;
+    }
+  }
+  return floatingUsed;
+}
+
+/**
+ * Try to admit a strategy of `targetClass` given the current occupancy.
+ * Returns an assignment telling the caller whether the add is allowed
+ * and which bucket it falls into.
+ */
+export function tryAdmitStrategy(
+  targetClass: StrategyClass,
+  occupancy: SlotOccupancy,
+): SlotAssignment {
+  if (countTotal(occupancy) >= TOTAL_SLOTS) {
+    return { admitted: false, reason: 'pool_full' };
+  }
+
+  const inClass = occupancy.countsByClass.get(targetClass) ?? 0;
+
+  if (inClass < SLOTS_PER_CLASS) {
+    return { admitted: true, bucket: 'reserved' };
+  }
+
+  // Reserved seats for this class are full. Check floating availability.
+  const floatingUsed = countFloatingInUse(occupancy);
+  if (floatingUsed < FLOATING_SLOTS) {
+    return { admitted: true, bucket: 'floating' };
+  }
+
+  return {
+    admitted: false,
+    reason: `class_${targetClass}_reserved_full_and_floating_full`,
+  };
+}
+
+/** Utility: update occupancy after successful admission. */
+export function withAdmittedStrategy(
+  targetClass: StrategyClass,
+  occupancy: SlotOccupancy,
+): SlotOccupancy {
+  const counts = new Map(occupancy.countsByClass);
+  counts.set(targetClass, (counts.get(targetClass) ?? 0) + 1);
+  return { countsByClass: counts };
+}

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -9,6 +9,7 @@
 import { pool } from '../db/connection.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
 import { apiCredentialsService } from './apiCredentialsService.js';
+import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 
 export interface OrphanedPosition {
@@ -159,15 +160,16 @@ class StateReconciliationService {
           try {
             await pool.query(
               `INSERT INTO autonomous_trades
-               (user_id, symbol, side, entry_price, quantity, reason, status)
-               VALUES ($1, $2, $3, $4, $5, $6, 'open')`,
+               (user_id, symbol, side, entry_price, quantity, reason, status, engine_version)
+               VALUES ($1, $2, $3, $4, $5, $6, 'open', $7)`,
               [
                 userId,
                 symbol,
                 side,
                 entryPrice,
                 size,
-                'reconciled'
+                'reconciled',
+                getEngineVersion(),
               ]
             );
             logger.info(

--- a/apps/api/src/services/strategyLearningEngine.ts
+++ b/apps/api/src/services/strategyLearningEngine.ts
@@ -56,6 +56,28 @@ import {
   inferStrategyType,
   mutateGenome,
 } from './signalGenome.js';
+import {
+  ALL_STRATEGY_CLASSES,
+  DEFAULT_BANDIT_COUNTER,
+  sampleBestClass,
+  type BanditCounter,
+  type StrategyClass,
+} from './thompsonBandit.js';
+
+export type StrategyStatusTransitionReason =
+  | 'created'
+  | 'backtest_passed'
+  | 'backtest_failed'
+  | 'promoted_paper'
+  | 'promoted_live'
+  | 'demoted_recalibrating'
+  | 'retired_oscillation'
+  | 'retired_recalibration_limit'
+  | 'killed_phase_clock'
+  | 'killed_drawdown'
+  | 'killed_fitness_divergent'
+  | 'killed_anderson_reset'
+  | string;
 
 export type MarketRegime = 'trending' | 'ranging' | 'volatile' | 'unknown';
 export type StrategyType = 'momentum' | 'mean_reversion' | 'breakout' | 'trend_following' | 'scalping';
@@ -243,8 +265,20 @@ class StrategyLearningEngine extends EventEmitter {
   private async andersonResetStrategies(newRegime: QIGRegime): Promise<void> {
     const active = Array.from(this.strategies.values()).filter(s => s.status === 'paper_trading' || s.status === 'backtesting');
     for (const s of active) {
+      const fromStatus = s.status;
       s.status = 'killed'; s.censorReason = `anderson_regime_reset_${newRegime}`;
-      try { await parallelStrategyRunner.removeStrategy(s.strategyId, s.censorReason); await this.upsertStrategyPerformance(s); } catch (err) { logger.debug(`[SLE] Anderson reset: failed to kill ${s.strategyId}:`, err); }
+      try {
+        await parallelStrategyRunner.removeStrategy(s.strategyId, s.censorReason);
+        await this.upsertStrategyPerformance(s);
+        await this.recordStrategyStateEvent(
+          s.strategyId,
+          fromStatus,
+          'killed',
+          'killed_anderson_reset',
+          { newRegime, previousRegime: s.regimeAtCreation },
+          `anderson_regime_reset_${newRegime}`,
+        );
+      } catch (err) { logger.debug(`[SLE] Anderson reset: failed to kill ${s.strategyId}:`, err); }
     }
     logger.info(`[SLE] Anderson reset complete: killed ${active.length} strategies, new regime: ${newRegime}`);
   }
@@ -417,9 +451,28 @@ class StrategyLearningEngine extends EventEmitter {
       else if (s.fitnessDivergent) killReason = 'fitness_divergent_unreliable_estimate';
       if (s.paperPnl !== null && s.paperTrades > 5) { const capital = Math.max(this.cachedBalance, MIN_CAPITAL_FLOOR); const ddPct = Math.abs(Math.min(0, s.paperPnl)) / capital; if (ddPct > 0.10) killReason = `drawdown_${(ddPct * 100).toFixed(1)}pct`; }
       if (killReason) {
+        const fromStatus = 'paper_trading';
         s.status = s.status === 'censored_rejected' ? 'censored_rejected' : 'killed';
         await parallelStrategyRunner.removeStrategy(s.strategyId, killReason);
         await this.upsertStrategyPerformance(s);
+        await this.recordStrategyStateEvent(
+          s.strategyId,
+          fromStatus,
+          s.status,
+          killReason.startsWith('phase_clock')
+            ? 'killed_phase_clock'
+            : killReason.startsWith('drawdown')
+              ? 'killed_drawdown'
+              : 'killed_fitness_divergent',
+          {
+            phaseClock: s.phaseClock,
+            paperPnl: s.paperPnl,
+            paperTrades: s.paperTrades,
+            isCensored: s.isCensored,
+            fitnessDivergent: s.fitnessDivergent,
+          },
+          killReason,
+        );
         logger.info(`[SLE] Killed strategy ${s.strategyId}: ${killReason}`);
         await this.cloneTopPerformer(s.regimeAtCreation);
       }
@@ -442,7 +495,22 @@ class StrategyLearningEngine extends EventEmitter {
         const score = await (confidenceScoringService as any).calculateConfidenceScore(s.strategyId, s.symbol, s.timeframe);
         s.confidenceScore = safeNum(score?.confidenceScore ?? score?.score ?? score);
         if (s.confidenceScore >= PAPER_THRESHOLDS.minConfidence) {
-          s.status = 'recommended'; await this.upsertStrategyPerformance(s); this.emit('liveRecommendation', s);
+          const fromStatus = 'paper_trading';
+          s.status = 'recommended';
+          await this.upsertStrategyPerformance(s);
+          await this.recordStrategyStateEvent(
+            s.strategyId,
+            fromStatus,
+            'recommended',
+            'promoted_paper',
+            {
+              paperSharpe: s.paperSharpe,
+              paperTrades: s.paperTrades,
+              paperPnl: s.paperPnl,
+              confidence: s.confidenceScore,
+            },
+          );
+          this.emit('liveRecommendation', s);
           logger.info(`[SLE] \uD83C\uDFAF Strategy ${s.strategyId} RECOMMENDED for live: confidence=${s.confidenceScore.toFixed(1)}`);
         }
       } catch (err) { logger.warn(`[SLE] Confidence scoring failed for ${s.strategyId}:`, err); }
@@ -453,11 +521,149 @@ class StrategyLearningEngine extends EventEmitter {
     const s = this.strategies.get(strategyId);
     if (!s) throw new Error(`Strategy ${strategyId} not found`);
     if (s.status !== 'recommended') throw new Error(`Strategy ${strategyId} is not recommended (current: ${s.status})`);
-    s.status = 'live'; await this.upsertStrategyPerformance(s); this.emit('liveConfirmed', s);
+    const fromStatus = s.status;
+    s.status = 'live';
+    await this.upsertStrategyPerformance(s);
+    await this.recordStrategyStateEvent(
+      strategyId,
+      fromStatus,
+      'live',
+      'promoted_live',
+      {
+        liveSharpe: s.liveSharpe,
+        confidence: s.confidenceScore,
+        symbol: s.symbol,
+        leverage: s.leverage,
+      },
+    );
+    this.emit('liveConfirmed', s);
     logger.info(`[SLE] User confirmed live promotion for ${strategyId}`); return s;
   }
 
   private async updateGenerationWeights(): Promise<void> { await this.loadActiveStrategies(); }
+
+  /**
+   * Append an immutable event to strategy_state_events. Every status
+   * transition — promotion, demotion, kill, reactivation — should go
+   * through this so the audit log is complete. Fail-soft: logs but
+   * doesn't throw, since event-log failures must never block trading.
+   */
+  async recordStrategyStateEvent(
+    strategyId: string,
+    fromStatus: string | null,
+    toStatus: string,
+    reason: StrategyStatusTransitionReason,
+    metadata: Record<string, unknown> | null = null,
+    detail: string | null = null,
+  ): Promise<void> {
+    try {
+      await query(
+        `INSERT INTO strategy_state_events
+           (strategy_id, from_status, to_status, reason, detail, metadata, engine_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          strategyId,
+          fromStatus,
+          toStatus,
+          reason,
+          detail,
+          metadata ? JSON.stringify(metadata) : null,
+          getEngineVersion(),
+        ],
+      );
+    } catch (err) {
+      logger.warn('[SLE] recordStrategyStateEvent failed (fail-soft)', {
+        strategyId,
+        fromStatus,
+        toStatus,
+        reason,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Load Thompson-bandit class counters for the given regime. Missing
+   * (class, regime) pairs default to the Beta(1,1) uniform prior.
+   * Used by the generator to bias new-from-scratch strategies toward
+   * classes that are currently winning.
+   */
+  async loadBanditCountersForRegime(regime: MarketRegime): Promise<Map<StrategyClass, BanditCounter>> {
+    const out = new Map<StrategyClass, BanditCounter>();
+    try {
+      const result = await query(
+        `SELECT strategy_class, wins, losses
+           FROM bandit_class_counters
+          WHERE regime = $1`,
+        [regime],
+      );
+      for (const row of result.rows as Array<Record<string, unknown>>) {
+        out.set(String(row.strategy_class) as StrategyClass, {
+          wins: Number(row.wins),
+          losses: Number(row.losses),
+        });
+      }
+    } catch (err) {
+      logger.debug('[SLE] loadBanditCountersForRegime failed — falling back to uniform prior', {
+        regime,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+    for (const klass of ALL_STRATEGY_CLASSES) {
+      if (!out.has(klass)) out.set(klass, DEFAULT_BANDIT_COUNTER);
+    }
+    return out;
+  }
+
+  /**
+   * Update a Thompson-bandit counter after a terminal trade outcome.
+   * Upserts into bandit_class_counters so the posterior persists
+   * across restarts. Fail-soft.
+   */
+  async updateBanditCounter(
+    strategyClass: StrategyClass,
+    regime: MarketRegime,
+    winIncrement: number,
+    lossIncrement: number,
+  ): Promise<void> {
+    try {
+      await query(
+        `INSERT INTO bandit_class_counters (strategy_class, regime, wins, losses)
+         VALUES ($1, $2, 1 + $3, 1 + $4)
+         ON CONFLICT (strategy_class, regime) DO UPDATE SET
+           wins = bandit_class_counters.wins + $3,
+           losses = bandit_class_counters.losses + $4,
+           last_updated_at = NOW()`,
+        [strategyClass, regime, winIncrement, lossIncrement],
+      );
+    } catch (err) {
+      logger.warn('[SLE] updateBanditCounter failed (fail-soft)', {
+        strategyClass,
+        regime,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Sample a class via Thompson posterior for the given regime.
+   * Used by generateRandom to bias new-from-scratch generation toward
+   * classes that are currently winning. Returns null when the bandit
+   * cannot be consulted (DB down, etc.) so callers can fall back to
+   * uniform random.
+   */
+  async sampleBanditClassForRegime(regime: MarketRegime): Promise<StrategyClass | null> {
+    try {
+      const counters = await this.loadBanditCountersForRegime(regime);
+      return sampleBestClass(counters);
+    } catch (err) {
+      logger.debug('[SLE] sampleBanditClassForRegime failed', {
+        regime,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
 
   async upsertStrategyPerformance(s: StrategyRecord): Promise<void> {
     try {

--- a/apps/api/src/services/strategyLearningEngine.ts
+++ b/apps/api/src/services/strategyLearningEngine.ts
@@ -597,7 +597,7 @@ class StrategyLearningEngine extends EventEmitter {
           WHERE regime = $1`,
         [regime],
       );
-      for (const row of result.rows as Array<Record<string, unknown>>) {
+      for (const row of (result.rows as any[]) as Array<Record<string, unknown>>) {
         out.set(String(row.strategy_class) as StrategyClass, {
           wins: Number(row.wins),
           losses: Number(row.losses),

--- a/apps/api/src/services/strategyLearningEngine.ts
+++ b/apps/api/src/services/strategyLearningEngine.ts
@@ -28,6 +28,7 @@
 
 import { EventEmitter } from 'events';
 import { pool, query } from '../db/connection.js';
+import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 import { apiCredentialsService } from './apiCredentialsService.js';
 import backtestingEngine from './backtestingEngine.js';
@@ -470,7 +471,7 @@ class StrategyLearningEngine extends EventEmitter {
           live_sharpe, live_pnl, live_trades,
           is_censored, censor_reason, uncensored_sharpe, fitness_divergent,
           status, confidence_score, created_at, parent_strategy_id, generation, backtest_count, avg_return, avg_sharpe_ratio,
-          signal_genome
+          signal_genome, engine_version
         ) VALUES (
           $1, $2, $3, $4, $5, $6, $7,
           $8, $9, $10,
@@ -478,7 +479,7 @@ class StrategyLearningEngine extends EventEmitter {
           $15, $16, $17,
           $18, $19, $20, $21,
           $22, $23, $24, $25, $26, $27, $28, $29,
-          $30
+          $30, $31
         )
         ON CONFLICT (strategy_id) DO UPDATE SET
           strategy_name       = EXCLUDED.strategy_name,
@@ -508,7 +509,8 @@ class StrategyLearningEngine extends EventEmitter {
           backtest_count      = EXCLUDED.backtest_count,
           avg_return          = EXCLUDED.avg_return,
           avg_sharpe_ratio    = EXCLUDED.avg_sharpe_ratio,
-          signal_genome       = EXCLUDED.signal_genome`,
+          signal_genome       = EXCLUDED.signal_genome,
+          engine_version      = EXCLUDED.engine_version`,
         [
           s.strategyId, s.strategyId, s.symbol, s.leverage, s.timeframe, s.strategyType, s.regimeAtCreation,
           s.backtestSharpe, s.backtestWr, s.backtestMaxDd,
@@ -516,7 +518,7 @@ class StrategyLearningEngine extends EventEmitter {
           s.liveSharpe, s.livePnl, s.liveTrades,
           s.isCensored, s.censorReason, s.uncensoredSharpe, s.fitnessDivergent,
           s.status, s.confidenceScore, s.createdAt, s.parentStrategyId, s.generation, s.backtestCount ?? 0, clampNumeric64(s.avgReturn ?? 0), clampNumeric64(avgSharpeRatio),
-          s.genome ? JSON.stringify(s.genome) : null,
+          s.genome ? JSON.stringify(s.genome) : null, getEngineVersion(),
         ]
       );
     } catch (err) { logger.error(`[SLE] DB upsert failed for ${s.strategyId}:`, err); }

--- a/apps/api/src/services/thompsonBandit.ts
+++ b/apps/api/src/services/thompsonBandit.ts
@@ -1,0 +1,135 @@
+/**
+ * Thompson-sampled class bandit.
+ *
+ * The current SLE generator is random-search with elitism — no
+ * mechanism biases it toward strategy classes that are actually
+ * working. This module turns the class-selection step into a
+ * Beta-Bernoulli bandit so winning classes get more future variants.
+ *
+ * Posterior state: Beta(wins, losses) per (strategy_class × regime).
+ * Rewards on update:
+ *   - live PnL      → 1.0× weight  (primary signal)
+ *   - paper PnL     → 0.1× weight  (useful but noisy)
+ *   - backtest pass → 0.01× weight (weakest signal)
+ *
+ * sampleClass(regime) draws from each class's posterior and returns
+ * the arg-max. The Beta-sampler is a ratio of Gamma draws, which is
+ * equivalent to Beta(α, β) without requiring a math library.
+ */
+
+export type RewardKind = 'live' | 'paper' | 'backtest';
+
+export interface BanditCounter {
+  wins: number;
+  losses: number;
+}
+
+/** Beta(1, 1) = uniform prior. */
+export const DEFAULT_BANDIT_COUNTER: BanditCounter = Object.freeze({ wins: 1, losses: 1 });
+
+const REWARD_WEIGHTS: Record<RewardKind, number> = {
+  live: 1.0,
+  paper: 0.1,
+  backtest: 0.01,
+};
+
+/** Classes produced by the generator. Matches existing strategyType enum. */
+export type StrategyClass =
+  | 'scalping'
+  | 'trend_following'
+  | 'mean_reversion'
+  | 'breakout'
+  | 'momentum';
+
+export const ALL_STRATEGY_CLASSES: StrategyClass[] = [
+  'scalping',
+  'trend_following',
+  'mean_reversion',
+  'breakout',
+  'momentum',
+];
+
+/**
+ * Sample from Beta(α, β) using the Gamma-ratio method.
+ *   x ~ Gamma(α, 1), y ~ Gamma(β, 1)  →  x/(x+y) ~ Beta(α, β)
+ *
+ * Uses Marsaglia & Tsang's method for Gamma sampling (valid for α ≥ 1;
+ * we add a uniform shift for the α < 1 branch).
+ */
+export function sampleBeta(alpha: number, beta: number, rng: () => number = Math.random): number {
+  if (alpha <= 0 || beta <= 0) return 0.5; // degenerate; fall back to midpoint
+  const x = sampleGamma(alpha, rng);
+  const y = sampleGamma(beta, rng);
+  return x / (x + y);
+}
+
+function sampleGamma(shape: number, rng: () => number): number {
+  if (shape < 1) {
+    // Johnk's generator for shape < 1
+    const u = rng();
+    return sampleGamma(shape + 1, rng) * Math.pow(u, 1 / shape);
+  }
+  // Marsaglia & Tsang
+  const d = shape - 1 / 3;
+  const c = 1 / Math.sqrt(9 * d);
+  for (;;) {
+    let x: number;
+    let v: number;
+    do {
+      x = normalSample(rng);
+      v = 1 + c * x;
+    } while (v <= 0);
+    v = v * v * v;
+    const u = rng();
+    if (u < 1 - 0.0331 * x * x * x * x) return d * v;
+    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v;
+  }
+}
+
+function normalSample(rng: () => number): number {
+  // Box-Muller
+  const u1 = Math.max(1e-12, rng());
+  const u2 = rng();
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+}
+
+/**
+ * Apply an outcome to the counter. `signedReward` > 0 counts as a win
+ * weighted by REWARD_WEIGHTS[kind]; ≤ 0 counts as a loss similarly.
+ * Fractional counts accumulate — the Beta distribution is well-defined
+ * for non-integer α, β.
+ */
+export function applyOutcome(
+  counter: BanditCounter,
+  kind: RewardKind,
+  signedReward: number,
+): BanditCounter {
+  const weight = REWARD_WEIGHTS[kind];
+  if (signedReward > 0) {
+    return { wins: counter.wins + weight, losses: counter.losses };
+  }
+  return { wins: counter.wins, losses: counter.losses + weight };
+}
+
+/**
+ * Sample the best-posterior class for a given regime.
+ * Callers must provide the counter for every class; missing entries
+ * default to the Beta(1,1) prior. Pure function — rng is injectable
+ * for deterministic tests.
+ */
+export function sampleBestClass(
+  countersByClass: Map<StrategyClass, BanditCounter>,
+  rng: () => number = Math.random,
+): StrategyClass {
+  let bestClass: StrategyClass = ALL_STRATEGY_CLASSES[0];
+  let bestSample = -1;
+  for (const klass of ALL_STRATEGY_CLASSES) {
+    const c = countersByClass.get(klass) ?? DEFAULT_BANDIT_COUNTER;
+    const s = sampleBeta(c.wins, c.losses, rng);
+    if (s > bestSample) {
+      bestSample = s;
+      bestClass = klass;
+    }
+  }
+  return bestClass;
+}

--- a/apps/api/src/utils/__tests__/engineVersion.test.ts
+++ b/apps/api/src/utils/__tests__/engineVersion.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for engineVersion utility.
+ *
+ * Contract:
+ *   - env ENGINE_VERSION wins over everything
+ *   - platform env vars are next (RAILWAY_GIT_COMMIT_SHA etc.)
+ *   - git rev-parse HEAD is the dev-machine fallback
+ *   - 'unknown' is the always-returns-a-string guarantee
+ *   - Value is cached across calls; __resetEngineVersionCache clears it
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { __resetEngineVersionCache, getEngineVersion } from '../engineVersion.js';
+
+const ENV_KEYS = [
+  'ENGINE_VERSION',
+  'RAILWAY_GIT_COMMIT_SHA',
+  'GIT_SHA',
+  'VERCEL_GIT_COMMIT_SHA',
+  'GITHUB_SHA',
+];
+
+describe('engineVersion', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    __resetEngineVersionCache();
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    __resetEngineVersionCache();
+  });
+
+  it('prefers ENGINE_VERSION over platform env vars', () => {
+    process.env.ENGINE_VERSION = 'abc123deadbeef';
+    process.env.RAILWAY_GIT_COMMIT_SHA = 'ignored';
+    expect(getEngineVersion()).toBe('abc123deadbeef');
+  });
+
+  it('falls back to RAILWAY_GIT_COMMIT_SHA when ENGINE_VERSION is absent', () => {
+    process.env.RAILWAY_GIT_COMMIT_SHA = 'railway-sha-123';
+    expect(getEngineVersion()).toBe('railway-sha-123');
+  });
+
+  it('trims whitespace and truncates to 40 chars', () => {
+    process.env.ENGINE_VERSION = '  ' + 'f'.repeat(60) + '  ';
+    expect(getEngineVersion()).toBe('f'.repeat(40));
+  });
+
+  it('caches the result across calls', () => {
+    process.env.ENGINE_VERSION = 'first';
+    const a = getEngineVersion();
+    process.env.ENGINE_VERSION = 'second';
+    const b = getEngineVersion();
+    expect(a).toBe('first');
+    expect(b).toBe('first');
+  });
+
+  it('__resetEngineVersionCache invalidates the cache', () => {
+    process.env.ENGINE_VERSION = 'first';
+    expect(getEngineVersion()).toBe('first');
+    process.env.ENGINE_VERSION = 'second';
+    __resetEngineVersionCache();
+    expect(getEngineVersion()).toBe('second');
+  });
+
+  it('falls back to git rev-parse or "unknown" when no env var is set', () => {
+    const result = getEngineVersion();
+    // Either a real git SHA (in this working tree) or 'unknown'.
+    // We do not assert the exact value because the test suite runs both
+    // in CI (where no git may be present) and locally.
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+    // Git SHAs are 40 hex chars; 'unknown' is 7. Accept either shape.
+    expect(result === 'unknown' || /^[0-9a-f]{7,40}$/i.test(result)).toBe(true);
+  });
+
+  it('ignores empty-string env vars and continues fallback', () => {
+    process.env.ENGINE_VERSION = '';
+    process.env.GIT_SHA = 'valid-sha';
+    expect(getEngineVersion()).toBe('valid-sha');
+  });
+});

--- a/apps/api/src/utils/engineVersion.ts
+++ b/apps/api/src/utils/engineVersion.ts
@@ -1,0 +1,70 @@
+/**
+ * Engine version provenance.
+ *
+ * Every row produced by the trading pipeline (backtests, paper trades,
+ * strategy metrics, state events) is tagged with a git SHA so promotion
+ * thresholds only aggregate rows written under the current code.
+ *
+ * Resolution order (first-hit wins, cached for process lifetime):
+ *   1. env var  ENGINE_VERSION        (explicit override, use in tests/CI)
+ *   2. env vars RAILWAY_GIT_COMMIT_SHA or GIT_SHA or VERCEL_GIT_COMMIT_SHA
+ *      (set automatically by most deploy platforms)
+ *   3. `git rev-parse HEAD` in the working tree (dev machines)
+ *   4. literal string 'unknown' — never crashes, but promotion gates will
+ *      reject 'unknown' rows from aggregates.
+ */
+
+import { execFileSync } from 'child_process';
+
+let cached: string | null = null;
+
+const PLATFORM_ENV_VARS = [
+  'ENGINE_VERSION',
+  'RAILWAY_GIT_COMMIT_SHA',
+  'GIT_SHA',
+  'VERCEL_GIT_COMMIT_SHA',
+  'GITHUB_SHA',
+];
+
+function readFromEnv(): string | null {
+  for (const key of PLATFORM_ENV_VARS) {
+    const value = process.env[key];
+    if (value && value.trim().length > 0) {
+      return value.trim().slice(0, 40);
+    }
+  }
+  return null;
+}
+
+function readFromGit(): string | null {
+  try {
+    // execFileSync with a fixed arg list — no shell, no injection surface.
+    const sha = execFileSync('git', ['rev-parse', 'HEAD'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+      timeout: 2_000,
+    }).trim();
+    return sha.length > 0 ? sha.slice(0, 40) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the current engine version. Cached after first call.
+ *
+ * Always returns a string (falls back to 'unknown' rather than throwing),
+ * since the cost of blocking trading on a missing SHA is worse than
+ * accepting an 'unknown'-tagged row that will later be filtered out of
+ * promotion aggregates.
+ */
+export function getEngineVersion(): string {
+  if (cached !== null) return cached;
+  cached = readFromEnv() ?? readFromGit() ?? 'unknown';
+  return cached;
+}
+
+/** Exposed for tests. Clears the module-level cache. */
+export function __resetEngineVersionCache(): void {
+  cached = null;
+}

--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -93,7 +93,20 @@ const AutonomousAgentDashboard: React.FC = () => {
     timestamp: string;
   } | null>(null);
   const [riskAppetite, setRiskAppetite] = usePersistedState<'conservative' | 'balanced' | 'aggressive'>('agent_risk_appetite', 'balanced');
-  const [executionMode, setExecutionMode] = usePersistedState<'backtest' | 'paper' | 'live'>('agent_execution_mode', 'paper');
+  // Execution Mode is a SAFETY OVERRIDE, not a pipeline stage. The pipeline
+  // (generated → backtest → paper → live) runs internally under 'auto'.
+  // 'paper_only' blocks live promotion regardless of strategy performance
+  // (debug/trust-building). 'pause' halts all new orders at every stage.
+  // Legacy value 'paper' is coerced to 'paper_only' for back-compat with
+  // any persisted localStorage entries from before this migration.
+  const [executionModeRaw, setExecutionModeRaw] = usePersistedState<'auto' | 'paper_only' | 'pause' | 'backtest' | 'paper' | 'live'>('agent_execution_mode', 'auto');
+  const executionMode: 'auto' | 'paper_only' | 'pause' =
+    executionModeRaw === 'paper' || executionModeRaw === 'paper_only'
+      ? 'paper_only'
+      : executionModeRaw === 'pause'
+        ? 'pause'
+        : 'auto';  // 'backtest' | 'live' | 'auto' all normalise to 'auto'
+  const setExecutionMode = (v: 'auto' | 'paper_only' | 'pause') => setExecutionModeRaw(v);
   const [performanceMode, setPerformanceMode] = useState<'all' | 'backtest' | 'paper' | 'live'>('all');
   const [agentEvents, setAgentEvents] = useState<Array<{
     id: string;
@@ -318,7 +331,7 @@ const AutonomousAgentDashboard: React.FC = () => {
 
       const response = await axios.post(
         `${API_BASE_URL}/api/agent/start`,
-        { ...config, ...riskConfig, paperTrading: executionMode === 'paper', executionMode },
+        { ...config, ...riskConfig, paperTrading: executionMode === 'paper_only', executionMode },
         { headers: getAuthHeaders() }
       );
       
@@ -578,14 +591,17 @@ const AutonomousAgentDashboard: React.FC = () => {
               ))}
             </div>
           </div>
-          {/* Execution Mode */}
+          {/* Execution Mode — safety override on the autonomous pipeline.
+              'Auto' runs the full generated→backtest→paper→live pipeline.
+              'Paper-Only' blocks live promotion for debug / trust-building.
+              'Pause' halts all new orders at every stage. */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">Execution Mode</label>
             <div className="grid grid-cols-3 gap-2">
               {([
-                { value: 'backtest', label: 'Backtest', desc: 'Historical simulation', icon: '📊', bgClass: 'border-purple-500 bg-purple-50' },
-                { value: 'paper', label: 'Paper', desc: 'Simulated capital', icon: '📝', bgClass: 'border-blue-500 bg-blue-50' },
-                { value: 'live', label: 'Live', desc: 'Real capital', icon: '⚡', bgClass: 'border-red-500 bg-red-50' }
+                { value: 'auto', label: 'Auto', desc: 'Pipeline decides (default)', icon: '🤖', bgClass: 'border-green-500 bg-green-50' },
+                { value: 'paper_only', label: 'Paper-Only', desc: 'Block live promotion', icon: '📝', bgClass: 'border-blue-500 bg-blue-50' },
+                { value: 'pause', label: 'Pause', desc: 'No new orders', icon: '⏸️', bgClass: 'border-amber-500 bg-amber-50' }
               ] as const).map(opt => (
                 <button key={opt.value}
                   onClick={() => setExecutionMode(opt.value)}
@@ -598,18 +614,20 @@ const AutonomousAgentDashboard: React.FC = () => {
                 </button>
               ))}
             </div>
-            {executionMode === 'live' && (
+            {executionMode === 'auto' && (
               <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
-                <p className="text-red-800 text-sm font-medium">⚠️ Live Trading — Real money will be used</p>
-                <p className="text-red-600 text-xs mt-1">Ensure you have reviewed your risk settings and account balance.</p>
+                <p className="text-red-800 text-sm font-medium">⚠️ Auto Mode — real capital may be used once strategies earn live tier</p>
+                <p className="text-red-600 text-xs mt-1">The pipeline self-promotes strategies from paper to live once they clear the multi-metric gates. Switch to Paper-Only to block live promotion.</p>
               </div>
             )}
           </div>
         </div>
       </div>
 
-      {/* Emergency Stop — visible when live trading is active */}
-      {agentStatus?.status === 'running' && (executionMode === 'live' || agentStatus?.config?.executionMode === 'live') && (
+      {/* Emergency Stop — visible when live trading is active. "Auto" mode
+          may be running live-promoted strategies; the safe configurations
+          ('paper_only', 'pause') won't reach live. */}
+      {agentStatus?.status === 'running' && executionMode === 'auto' && agentStatus?.config?.executionMode !== 'paper_only' && agentStatus?.config?.executionMode !== 'pause' && (
         <div className="bg-red-50 border-2 border-red-300 rounded-lg p-4 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Shield className="w-6 h-6 text-red-600" />

--- a/apps/web/src/components/agent/StrategyApprovalQueue.tsx
+++ b/apps/web/src/components/agent/StrategyApprovalQueue.tsx
@@ -1,21 +1,50 @@
 import { getAccessToken } from '@/utils/auth';
 import { getBackendUrl } from '@/utils/environment';
 import axios from 'axios';
-import { AlertCircle, Clock, Shield } from 'lucide-react';
+import { AlertCircle, Clock, RefreshCw, Shield } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import StrategyControlPanel from './StrategyControlPanel';
 
 const API_BASE_URL = getBackendUrl();
 
+/**
+ * Originally the "Strategy Approval Queue" — a manual review queue for
+ * strategies requiring approval before going live. With the autonomous
+ * promotion engine (multi-metric gates, Thompson bandit, graduated
+ * sizing), live promotion no longer requires manual review.
+ *
+ * This component is repurposed as the "Recalibrating Strategies" queue:
+ * it surfaces strategies whose rolling-20-trade drawdown triggered a
+ * demotion back to an earlier pipeline stage. The operator can see the
+ * demotion reason and optionally retire the strategy permanently
+ * instead of letting it recalibrate.
+ *
+ * The /api/agent/strategies/pending-approval endpoint is reused —
+ * the backend will return both approval-pending (legacy) and
+ * recalibrating strategies in the same payload during the transition.
+ */
+
 interface Strategy {
   id: string;
   strategy_name: string;
-  status: 'generated' | 'backtested' | 'paper_trading' | 'approved' | 'live' | 'paused' | 'retired';
+  status:
+    | 'generated'
+    | 'backtested'
+    | 'paper_trading'
+    | 'approved'
+    | 'live'
+    | 'paused'
+    | 'retired'
+    | 'recalibrating';
   backtest_score: number;
   paper_trading_score?: number;
   risk_level: 'low' | 'medium' | 'high';
   requires_approval: boolean;
   created_at: Date;
+  /** Populated when status === 'recalibrating'. Set by the demotion engine. */
+  demotion_reason?: string;
+  /** How many times this strategy has been demoted in the last 30 days. */
+  demotion_count?: number;
 }
 
 interface StrategyApprovalQueueProps {
@@ -23,22 +52,22 @@ interface StrategyApprovalQueueProps {
 }
 
 const StrategyApprovalQueue: React.FC<StrategyApprovalQueueProps> = ({ agentStatus }) => {
-  const [pendingStrategies, setPendingStrategies] = useState<Strategy[]>([]);
+  const [queuedStrategies, setQueuedStrategies] = useState<Strategy[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchPendingStrategies();
+    fetchQueuedStrategies();
 
     if (agentStatus === 'running') {
       const interval = setInterval(() => {
-        fetchPendingStrategies();
+        fetchQueuedStrategies();
       }, 10000); // Check every 10 seconds
 
       return () => clearInterval(interval);
     }
   }, [agentStatus]);
 
-  const fetchPendingStrategies = async () => {
+  const fetchQueuedStrategies = async () => {
     try {
       const token = getAccessToken();
       const response = await axios.get(`${API_BASE_URL}/api/agent/strategies/pending-approval`, {
@@ -46,33 +75,36 @@ const StrategyApprovalQueue: React.FC<StrategyApprovalQueueProps> = ({ agentStat
       });
 
       if (response.data.success) {
-        setPendingStrategies(response.data.strategies ?? []);
+        setQueuedStrategies(response.data.strategies ?? []);
       }
     } catch (_err: unknown) {
-      // console.error('Error fetching pending strategies:', err);
+      // fail-soft: empty queue rather than crashing the page
     } finally {
       setLoading(false);
     }
   };
 
+  const recalibratingCount = queuedStrategies.filter((s) => s.status === 'recalibrating').length;
+  const approvalCount = queuedStrategies.length - recalibratingCount;
+
   if (loading) {
     return (
       <div className="bg-white rounded-lg shadow-lg p-8 text-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4" />
-        <p className="text-gray-600">Loading approval queue...</p>
+        <p className="text-gray-600">Loading queue...</p>
       </div>
     );
   }
 
-  if (pendingStrategies.length === 0) {
+  if (queuedStrategies.length === 0) {
     return (
       <div className="bg-white rounded-lg shadow-lg p-8 text-center">
         <Shield className="w-16 h-16 text-gray-300 mx-auto mb-4" />
         <h3 className="text-lg font-semibold text-gray-700 mb-2">
-          No Strategies Pending Approval
+          No Recalibrating Strategies
         </h3>
         <p className="text-gray-500">
-          Strategies requiring manual approval will appear here
+          Demoted strategies will appear here with their demotion reason.
         </p>
       </div>
     );
@@ -84,38 +116,65 @@ const StrategyApprovalQueue: React.FC<StrategyApprovalQueueProps> = ({ agentStat
       <div className="bg-gradient-to-r from-orange-500 to-red-600 p-6 text-white">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Shield className="w-8 h-8" />
+            <RefreshCw className="w-8 h-8" />
             <div>
-              <h3 className="text-2xl font-bold">Strategy Approval Queue</h3>
+              <h3 className="text-2xl font-bold">Recalibrating Strategies</h3>
               <p className="text-sm opacity-90 mt-1">
-                {pendingStrategies.length} {pendingStrategies.length === 1 ? 'strategy' : 'strategies'} awaiting review
+                {recalibratingCount > 0 &&
+                  `${recalibratingCount} ${recalibratingCount === 1 ? 'strategy' : 'strategies'} recalibrating`}
+                {recalibratingCount > 0 && approvalCount > 0 && ' · '}
+                {approvalCount > 0 &&
+                  `${approvalCount} awaiting approval`}
               </p>
             </div>
           </div>
           <div className="bg-white/20 backdrop-blur-sm rounded-full px-4 py-2 border-2 border-white">
-            <span className="text-2xl font-bold">{pendingStrategies.length}</span>
+            <span className="text-2xl font-bold">{queuedStrategies.length}</span>
           </div>
         </div>
       </div>
 
-      {/* Pending Strategies List */}
+      {/* Strategies List */}
       <div className="p-6 space-y-4">
-        {pendingStrategies.map((strategy) => (
-          <div key={strategy.id} className="border-l-4 border-orange-500 pl-4">
-            <div className="flex items-start gap-3 mb-3">
-              <Clock className="w-5 h-5 text-orange-600 flex-shrink-0 mt-1" />
-              <div className="flex-1">
-                <p className="text-sm text-gray-600">
-                  Pending since {new Date(strategy.created_at).toLocaleString()}
-                </p>
+        {queuedStrategies.map((strategy) => {
+          const isRecalibrating = strategy.status === 'recalibrating';
+          return (
+            <div
+              key={strategy.id}
+              className={`border-l-4 pl-4 ${
+                isRecalibrating ? 'border-amber-500' : 'border-orange-500'
+              }`}
+            >
+              <div className="flex items-start gap-3 mb-3">
+                {isRecalibrating ? (
+                  <RefreshCw className="w-5 h-5 text-amber-600 flex-shrink-0 mt-1" />
+                ) : (
+                  <Clock className="w-5 h-5 text-orange-600 flex-shrink-0 mt-1" />
+                )}
+                <div className="flex-1">
+                  <p className="text-sm text-gray-600">
+                    {isRecalibrating ? 'Demoted' : 'Pending since'}{' '}
+                    {new Date(strategy.created_at).toLocaleString()}
+                  </p>
+                  {isRecalibrating && strategy.demotion_reason && (
+                    <p className="text-sm text-amber-700 mt-1 font-mono">
+                      {strategy.demotion_reason}
+                      {strategy.demotion_count !== undefined && (
+                        <span className="ml-2 text-xs text-amber-600">
+                          (demotions in last 30d: {strategy.demotion_count})
+                        </span>
+                      )}
+                    </p>
+                  )}
+                </div>
               </div>
+              <StrategyControlPanel
+                strategy={strategy}
+                onUpdate={fetchQueuedStrategies}
+              />
             </div>
-            <StrategyControlPanel
-              strategy={strategy}
-              onUpdate={fetchPendingStrategies}
-            />
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Info Banner */}
@@ -123,11 +182,11 @@ const StrategyApprovalQueue: React.FC<StrategyApprovalQueueProps> = ({ agentStat
         <div className="flex items-start gap-3">
           <AlertCircle className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
           <div className="text-sm text-blue-800">
-            <p className="font-semibold mb-1">Manual Approval Required</p>
+            <p className="font-semibold mb-1">Recalibration window</p>
             <p className="text-blue-700">
-              High-risk strategies or those with unusual parameters require manual approval before
-              proceeding to paper trading. Review the backtest results and risk parameters carefully
-              before approving.
+              Demoted strategies re-enter backtest on a fresh window. If they re-pass, they return
+              to paper at half capital. Three recalibration failures within 30 days retires the
+              strategy permanently.
             </p>
           </div>
         </div>

--- a/apps/web/src/components/agent/StrategyControlPanel.tsx
+++ b/apps/web/src/components/agent/StrategyControlPanel.tsx
@@ -10,7 +10,7 @@ const API_BASE_URL = getBackendUrl();
 interface Strategy {
   id: string;
   strategy_name: string;
-  status: 'generated' | 'backtested' | 'paper_trading' | 'approved' | 'live' | 'paused' | 'retired';
+  status: 'generated' | 'backtested' | 'paper_trading' | 'approved' | 'live' | 'paused' | 'retired' | 'recalibrating';
   backtest_score: number;
   paper_trading_score?: number;
   risk_level: 'low' | 'medium' | 'high';


### PR DESCRIPTION
## Summary

Rebuilds the Self-Learning Engine pipeline end-to-end based on the [approved plan](https://github.com/anthropics/claude-code) (red-teamed by a 5-specialist council: quantitative statistician, risk/capital preservation, ML architect, crypto microstructure, adversarial).

Root cause diagnosed: 704 backtests polluted by unit mis-attributions from pre-realistic-costs code, no engine-version provenance, no backtest→paper promotion link, no pre-trade risk kernel, and no audit trail on strategy retirements. The "paper mode selected but zero paper trades for weeks" bug was a *feature* of the architecture, not a bug.

## What's in this PR

Seven sequenced commits forming a complete foundation + blast door + promotion engine:

| # | Commit | What |
|---|--------|------|
| 1 | `505effc` | Observability + `strategy_state_events` log + pipeline health probe — catches silent failures within minutes |
| 2 | `914c6c8` | Backtest cost model fix — slippage 10bps→2bps, funding mean-zero (was perma-contango), fees to Poloniex VIP0 |
| 3 | `8c41ad5` | `engine_version` git SHA tagging on all 4 persistence sites + soft-delete + `data_purges` audit table + feature-flag-gated purge/backup scripts |
| 4 | `3ba5164` | Risk kernel blast door — 5 mandatory pre-trade vetoes (per-symbol exposure cap, self-match prevention per s.1041B, unrealised-drawdown kill-switch, strategy-tier leverage cap, symbol-allowed-at-equity) |
| 5 | `913684c` | Promotion engine modules — multi-metric gates (Sharpe+Sortino+Calmar+PF+DD+OOS), rolling-20 demotion, Thompson class bandit, slot allocator, regime cohort memory + Migration 027 |
| 6 | `dd8d838` | Hard-delete follow-up documentation (manual 7-day-window procedure) |
| 7 | `96d4ae5` | UI repurpose (Execution Mode as safety override, Pending Approval → Recalibrating Strategies) + SLE integration (state-event audit trail on all 4 status-transition points) |

**Net change:** ~35 files, +3,150 lines, 85 new Vitest cases, 450 tests passing, API type check clean.

## Key design decisions

- **Clean slate versioning.** Every pipeline row now carries `engine_version` (git SHA). Legacy rows get soft-deleted with `data_purges` audit; hard-delete is a deliberately manual step after a 7-day rollback window.
- **Blast door, not tuning.** The risk kernel's five vetoes sit between strategies and the exchange. Self-match prevention is explicit s.1041B compliance for the 10-concurrent-strategies design.
- **Real learning, not random search.** Thompson-sampled class bandit replaces paper-Sharpe elitism. Regime cohort memory freezes champions when retired so they can be reactivated when their regime recurs.
- **Graduated autonomy.** Strategies ladder $2 → $3 → $5 → $8 → $12 by proven live trades. Tier-0 paper is 1x leverage; 20x re-enables only for battle-tested strategies.
- **Pipeline stages are internal, Execution Mode is a safety override.** `auto` | `paper_only` | `pause` — no more manual "backtest vs paper vs live" toggle.

## What's deferred (by design)

- Wiring the promotion-engine modules into `strategyLearningEngine`'s parent-selection and demotion paths (Commits 5+6 provide the modules + audit trail; the generator still uses legacy elitism). Separate PR so the surfaces can be reviewed independently.
- Running the legacy-purge against production DB — script is feature-flag gated and DRY-RUN by default. Operator runs manually with `--execute` after pg_dump backup.

## Test plan

- [x] API unit tests (450 passed, 12 skipped — unchanged from main)
- [x] API type check (`tsc --noEmit`) clean
- [ ] Apply migrations 025, 026, 027 to a dev DB; verify schema
- [ ] Dev server startup: confirm `pipelineHealthProbe` boots and emits heartbeats
- [ ] DRY-RUN purge script (`PURGE_LEGACY_BACKTESTS=true node scripts/purge-legacy-backtests.mjs`) — verify report output
- [ ] Backup script (`scripts/backup-pre-purge.mjs`) produces a pg_dump with matching SHA-256
- [ ] UI: Execution Mode buttons render with new values; Recalibrating Strategies empty state shows correct copy
- [ ] Smoke test: strategy kill → `strategy_state_events` row appears with correct reason + engine_version
- [ ] Live trade (paper) passes through `riskService` → kernel vetoes accept/reject as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rebuild the SLE trading pipeline’s observability, provenance, and safety layers, and introduce promotion/demotion infrastructure without yet wiring it into live selection.

New Features:
- Add an append-only strategy_state_events audit log and recording APIs for all key strategy status transitions.
- Introduce pipeline heartbeat and trade-rate monitoring with a health probe and new alert types for silent stages and stalled trading.
- Implement a pre-trade risk kernel with multiple vetoes and integrate it as an optional blast-door in the risk service.
- Add Thompson-sampled class bandit, promotion gate, demotion/retirement policy, slot allocator, and regime cohort memory modules to support a structured promotion engine.
- Provide backup and legacy-purge scripts plus hard-delete runbook, and tag all pipeline outputs with engine_version across core tables.

Bug Fixes:
- Correct the backtest cost model by lowering slippage, making funding mean-zero over time, and updating fee rates to match the actual exchange schedule.

Enhancements:
- Tag strategy performance, backtests, autonomous trades, paper sessions, reconciled positions, and state events with engine_version for full provenance.
- Extend UI controls so Execution Mode becomes a safety override (auto/paper-only/pause) and repurpose the approval queue into a "Recalibrating Strategies" view.
- Tighten monitoring and alerting around pipeline liveness and trade activity, with deduped alerts and richer heartbeat snapshots.

Documentation:
- Document the 7-day hard-delete follow-up procedure for legacy backtest data once soft-delete has been deployed.

Tests:
- Add comprehensive tests for the risk kernel vetoes and engineVersion utility, and scaffold tests for the new observability and promotion components.