### PR TITLE
Silence pipeline-alert false positives: wire heartbeats + Option C trades-floor predicate

### DIFF
--- a/apps/api/database/migrations/028_promoted_paper_at_index.sql
+++ b/apps/api/database/migrations/028_promoted_paper_at_index.sql
@@ -1,0 +1,14 @@
+-- Migration 028: partial index supporting the trades-floor probe's
+-- shouldExpectPaperTrades() lookup.
+--
+-- The probe runs every 60s. Its query takes MAX(promoted_paper_at) over
+-- strategy_performance rows where deleted_at IS NULL. Without this
+-- index PG does a partial sequential scan — cheap today but unpredictable
+-- as the table grows. Sourcery flagged the DB-load profile on PR #489.
+--
+-- Partial index (promoted_paper_at IS NOT NULL) keeps the index small;
+-- DESC order matches the MAX access pattern.
+
+CREATE INDEX IF NOT EXISTS idx_strategy_performance_promoted_paper_at
+  ON strategy_performance(promoted_paper_at DESC)
+  WHERE deleted_at IS NULL AND promoted_paper_at IS NOT NULL;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -40,6 +40,7 @@ import paperTradingService from './services/paperTradingService.js';
 import { persistentTradingEngine } from './services/persistentTradingEngine.js';
 import { startPipelineHealthProbe } from './services/pipelineHealthProbe.js';
 import { stateReconciliationService } from './services/stateReconciliationService.js';
+import { shouldExpectPaperTrades } from './services/tradingStateProbe.js';
 import { logger } from './utils/logger.js';
 
 // Import environment configuration (dotenv.config() is called inside env.ts)
@@ -421,13 +422,18 @@ server.listen(PORT, '::', async () => {
 
   // Pipeline health probe: converts silent failures into pagable alerts.
   // Catches the "paper mode selected but zero paper trades" bug class
-  // within minutes instead of weeks. The predicate wires the trades-
-  // floor alert to the trading engine's running state so intentional
-  // pauses don't page.
+  // within minutes instead of weeks. The predicate gates the trades-
+  // floor alert on BOTH the engine being up AND the pipeline having
+  // recently produced (or currently having) paper-eligible strategies —
+  // this suppresses the startup false-positive where alerting fires
+  // just because no strategy has cleared backtest yet.
   if (process.env.NODE_ENV !== 'test') {
     startPipelineHealthProbe(
       undefined,
-      () => persistentTradingEngine.isEngineRunning(),
+      async () => {
+        if (!persistentTradingEngine.isEngineRunning()) return false;
+        return shouldExpectPaperTrades();
+      },
     );
   }
 

--- a/apps/api/src/services/__tests__/pipelineObservability.test.ts
+++ b/apps/api/src/services/__tests__/pipelineObservability.test.ts
@@ -148,23 +148,23 @@ describe('pipelineHealthProbe wiring', () => {
     stopPipelineHealthProbe();
   });
 
-  it('does not fire trades-floor alert before window has elapsed since probe start', () => {
+  it('does not fire trades-floor alert before window has elapsed since probe start', async () => {
     // Predicate returns true (expected trading), but uptime gate should
     // still block the alert because we just started.
     startPipelineHealthProbe(60_000, () => true);
-    __internal.runProbeTick(new Date());
+    await __internal.runProbeTick(new Date());
     expect(alertingService.getAlertStats().counts.tradeFloorBreaches).toBe(0);
   });
 
-  it('does not fire trades-floor alert when predicate says not expected-trading', () => {
+  it('does not fire trades-floor alert when predicate says not expected-trading', async () => {
     // Predicate reports paused — suppresses the alert even after uptime
     // gate clears. This is the Sourcery-flagged regression guard.
     startPipelineHealthProbe(60_000, () => false);
-    __internal.runProbeTick(new Date());
+    await __internal.runProbeTick(new Date());
     expect(alertingService.getAlertStats().counts.tradeFloorBreaches).toBe(0);
   });
 
-  it('detects silent stages via monitoring and fires an alert via alerting', () => {
+  it('detects silent stages via monitoring and fires an alert via alerting', async () => {
     const t0 = new Date('2026-04-17T12:00:00Z');
     monitoringService.recordPipelineHeartbeat('paper');
     // Simulate 20 min passing (paper threshold is 10 min).
@@ -174,7 +174,30 @@ describe('pipelineHealthProbe wiring', () => {
     monitoringService.recordPipelineHeartbeat('paper');
 
     // Now pretend it's t1 and probe.
-    __internal.runProbeTick(t1);
+    await __internal.runProbeTick(t1);
     expect(alertingService.getAlertStats().counts.pipelineSilent).toBeGreaterThan(0);
+  });
+
+  it('skips overlapping ticks (re-entrancy guard)', async () => {
+    // Inject a predicate that never resolves so we can observe the
+    // guard behavior: a second tick called while the first is in
+    // flight should be skipped (not queued, not failed).
+    let release: () => void;
+    const block = new Promise<void>((res) => { release = res; });
+    startPipelineHealthProbe(60_000, async () => { await block; return false; });
+
+    // Fire-and-forget the first tick (don't await — it's stuck on `block`).
+    const first = __internal.runProbeTick(new Date());
+    // Second tick fires immediately; the guard should make it return
+    // quickly without waiting on the first.
+    await __internal.runProbeTick(new Date());
+
+    // Release the blocked first tick and await it so vitest doesn't
+    // warn about unhandled promises.
+    release!();
+    await first;
+    // No explicit assertion on the guard's internal state — the fact
+    // that the second tick resolved while the first was still pending
+    // is the proof.
   });
 });

--- a/apps/api/src/services/__tests__/pipelineObservability.test.ts
+++ b/apps/api/src/services/__tests__/pipelineObservability.test.ts
@@ -41,6 +41,30 @@ describe('monitoringService pipeline heartbeat', () => {
     expect(paperEntry!.silentMs).toBeGreaterThanOrEqual(10 * 60_000);
   });
 
+  it('does NOT flag never-seen stages as silent (prevents boot-time false positives)', () => {
+    // Reset ensures no stage has ticked yet.
+    monitoringService.reset();
+    // Probe runs immediately on boot — nothing should appear silent.
+    const silent = monitoringService.getSilentPipelineStages(new Date('2026-04-18T12:00:00Z'));
+    expect(silent).toEqual([]);
+  });
+
+  it('flags only seen-then-silent stages, not never-seen ones', () => {
+    monitoringService.reset();
+    const t0 = new Date('2026-04-17T12:00:00Z');
+    vi.setSystemTime(t0);
+    // Paper ticks once, generator never ticks.
+    monitoringService.recordPipelineHeartbeat('paper');
+
+    const t1 = new Date(t0.getTime() + 20 * 60_000);
+    const silent = monitoringService.getSilentPipelineStages(t1);
+    // Paper (seen, now silent) is flagged.
+    expect(silent.find((s) => s.stage === 'paper')).toBeDefined();
+    // Generator (never seen) is NOT flagged — the production alert-
+    // storm bug we fixed.
+    expect(silent.find((s) => s.stage === 'generator')).toBeUndefined();
+  });
+
   it('counts trades in the rolling 60-minute ring', () => {
     const base = new Date('2026-04-17T12:00:00Z');
     monitoringService.recordTradeEvent('paper', base);

--- a/apps/api/src/services/__tests__/tradingStateProbe.test.ts
+++ b/apps/api/src/services/__tests__/tradingStateProbe.test.ts
@@ -1,0 +1,78 @@
+/**
+ * tradingStateProbe — Option C predicate tests.
+ *
+ * The DB call is mocked via the db/connection module so we can exercise
+ * all three states (active strategies present, no active but recent
+ * promotion, nothing at all) without a real DB.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../db/connection.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../../db/connection.js';
+import {
+  TRADING_STATE_RECENT_PASS_WINDOW_MS,
+  shouldExpectPaperTrades,
+} from '../tradingStateProbe.js';
+
+const mockedQuery = query as unknown as ReturnType<typeof vi.fn>;
+
+describe('shouldExpectPaperTrades', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+  });
+  afterEach(() => {
+    mockedQuery.mockReset();
+  });
+
+  it('returns true when any strategy is active in paper/recommended/live', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ active_count: 3, last_paper_promo: null }],
+    });
+    expect(await shouldExpectPaperTrades()).toBe(true);
+  });
+
+  it('returns true when no active strategies but promotion was recent (<24h)', async () => {
+    const now = new Date('2026-04-18T12:00:00Z');
+    const oneHourAgo = new Date(now.getTime() - 60 * 60_000).toISOString();
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ active_count: 0, last_paper_promo: oneHourAgo }],
+    });
+    expect(await shouldExpectPaperTrades(now)).toBe(true);
+  });
+
+  it('returns false when no active strategies and last promotion was > 24h ago', async () => {
+    const now = new Date('2026-04-18T12:00:00Z');
+    const twoDaysAgo = new Date(
+      now.getTime() - 2 * TRADING_STATE_RECENT_PASS_WINDOW_MS,
+    ).toISOString();
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ active_count: 0, last_paper_promo: twoDaysAgo }],
+    });
+    expect(await shouldExpectPaperTrades(now)).toBe(false);
+  });
+
+  it('returns false when there has never been a paper promotion', async () => {
+    mockedQuery.mockResolvedValueOnce({
+      rows: [{ active_count: 0, last_paper_promo: null }],
+    });
+    expect(await shouldExpectPaperTrades()).toBe(false);
+  });
+
+  it('returns false on empty result set', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [] });
+    expect(await shouldExpectPaperTrades()).toBe(false);
+  });
+
+  it('fail-softs to false on DB error (no alert cascade on transient DB hiccup)', async () => {
+    mockedQuery.mockRejectedValueOnce(new Error('connection refused'));
+    expect(await shouldExpectPaperTrades()).toBe(false);
+  });
+
+  it('24h window constant matches the design decision', () => {
+    expect(TRADING_STATE_RECENT_PASS_WINDOW_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/apps/api/src/services/__tests__/tradingStateProbe.test.ts
+++ b/apps/api/src/services/__tests__/tradingStateProbe.test.ts
@@ -2,11 +2,16 @@
  * tradingStateProbe — Option C predicate tests.
  *
  * The DB call is mocked via the db/connection module so we can exercise
- * all three states (active strategies present, no active but recent
- * promotion, nothing at all) without a real DB.
+ * every branch (active strategies, no active but recent promotion,
+ * nothing at all) without a real DB.
+ *
+ * The implementation issues TWO queries: active-count first, then the
+ * MAX-promoted-at fallback only when active-count is zero. These tests
+ * mirror that by queuing responses in the order the implementation
+ * consumes them.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../db/connection.js', () => ({
   query: vi.fn(),
@@ -18,30 +23,28 @@ import {
   shouldExpectPaperTrades,
 } from '../tradingStateProbe.js';
 
-const mockedQuery = query as unknown as ReturnType<typeof vi.fn>;
+const mockedQuery = vi.mocked(query);
 
 describe('shouldExpectPaperTrades', () => {
   beforeEach(() => {
     mockedQuery.mockReset();
   });
-  afterEach(() => {
-    mockedQuery.mockReset();
-  });
 
-  it('returns true when any strategy is active in paper/recommended/live', async () => {
-    mockedQuery.mockResolvedValueOnce({
-      rows: [{ active_count: 3, last_paper_promo: null }],
-    });
+  it('returns true when any strategy is active (skips MAX query entirely)', async () => {
+    mockedQuery.mockResolvedValueOnce({ rows: [{ n: 3 }] });
     expect(await shouldExpectPaperTrades()).toBe(true);
+    // Short-circuit: MAX query never ran.
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
   });
 
   it('returns true when no active strategies but promotion was recent (<24h)', async () => {
     const now = new Date('2026-04-18T12:00:00Z');
     const oneHourAgo = new Date(now.getTime() - 60 * 60_000).toISOString();
-    mockedQuery.mockResolvedValueOnce({
-      rows: [{ active_count: 0, last_paper_promo: oneHourAgo }],
-    });
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] })
+      .mockResolvedValueOnce({ rows: [{ last_paper_promo: oneHourAgo }] });
     expect(await shouldExpectPaperTrades(now)).toBe(true);
+    expect(mockedQuery).toHaveBeenCalledTimes(2);
   });
 
   it('returns false when no active strategies and last promotion was > 24h ago', async () => {
@@ -49,21 +52,23 @@ describe('shouldExpectPaperTrades', () => {
     const twoDaysAgo = new Date(
       now.getTime() - 2 * TRADING_STATE_RECENT_PASS_WINDOW_MS,
     ).toISOString();
-    mockedQuery.mockResolvedValueOnce({
-      rows: [{ active_count: 0, last_paper_promo: twoDaysAgo }],
-    });
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] })
+      .mockResolvedValueOnce({ rows: [{ last_paper_promo: twoDaysAgo }] });
     expect(await shouldExpectPaperTrades(now)).toBe(false);
   });
 
   it('returns false when there has never been a paper promotion', async () => {
-    mockedQuery.mockResolvedValueOnce({
-      rows: [{ active_count: 0, last_paper_promo: null }],
-    });
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] })
+      .mockResolvedValueOnce({ rows: [{ last_paper_promo: null }] });
     expect(await shouldExpectPaperTrades()).toBe(false);
   });
 
   it('returns false on empty result set', async () => {
-    mockedQuery.mockResolvedValueOnce({ rows: [] });
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
     expect(await shouldExpectPaperTrades()).toBe(false);
   });
 

--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -14,6 +14,7 @@ import { pool } from '../db/connection.js';
 import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 import { validateMarketData } from '../utils/marketDataValidator.js';
+import { monitoringService } from './monitoringService.js';
 import { apiCredentialsService } from './apiCredentialsService.js';
 import backtestingEngine from './backtestingEngine.js';
 import { getPrecisions } from './marketCatalog.js';
@@ -844,6 +845,12 @@ class FullyAutonomousTrader extends EventEmitter {
     // Execute top signal
     const signal = signals[0];
 
+    // Heartbeat the appropriate stage so the silent-failure probe
+    // sees the dispatch loop as alive. Paper-mode signals feed the
+    // 'paper' stage (paperTradingService also heartbeats when it
+    // actually executes); live signals feed 'live'.
+    monitoringService.recordPipelineHeartbeat(config.paperTrading ? 'paper' : 'live');
+
     try {
       logger.info(`${config.paperTrading ? '[PAPER]' : '[LIVE]'} Executing signal for ${signal.symbol}: ${signal.action} at ${signal.entryPrice}`);
 
@@ -1082,6 +1089,9 @@ class FullyAutonomousTrader extends EventEmitter {
       });
 
       this.emit('trade_executed', { userId, signal, orderId, paperTrading: config.paperTrading });
+      // Feed the trades-per-hour rolling ring — this is the signal
+      // the silent-floor alert uses to verify the pipeline is alive.
+      monitoringService.recordTradeEvent(config.paperTrading ? 'paper' : 'live');
       logger.info(`${config.paperTrading ? '[PAPER]' : '[LIVE]'} Trade executed for user ${userId}: ${signal.symbol} ${signal.side}`);
 
     } catch (error) {

--- a/apps/api/src/services/monitoringService.ts
+++ b/apps/api/src/services/monitoringService.ts
@@ -501,6 +501,17 @@ class MonitoringService {
   /**
    * Which pipeline stages are silent beyond threshold? Used by the alerting
    * service's silent-failure probe.
+   *
+   * **Never-seen stages are NOT flagged.** A stage is silent only if it
+   * has ticked at least once AND has since gone quiet longer than its
+   * threshold. Otherwise a freshly-booted server pages on every stage
+   * that hasn't yet been wired to call recordPipelineHeartbeat — which
+   * is a class of alert that looked like a real outage in production
+   * (alertCount:161 over ~16h before being caught).
+   *
+   * The corresponding boot-time liveness concern ("a stage should have
+   * started but never did") is covered by the backend heartbeat emitted
+   * from index.ts, not by this probe.
    */
   getSilentPipelineStages(now: Date = new Date()): Array<{
     stage: PipelineStage;
@@ -510,8 +521,9 @@ class MonitoringService {
     const silent: Array<{ stage: PipelineStage; silentMs: number; thresholdMs: number }> = [];
     for (const stage of Object.keys(STAGE_SILENT_THRESHOLD_MS) as PipelineStage[]) {
       const hb = this.pipelineHeartbeats.get(stage);
+      if (!hb) continue;  // never reported — not silent, just unwired
       const thresholdMs = STAGE_SILENT_THRESHOLD_MS[stage];
-      const silentMs = hb ? now.getTime() - hb.lastSeen.getTime() : Number.POSITIVE_INFINITY;
+      const silentMs = now.getTime() - hb.lastSeen.getTime();
       if (silentMs > thresholdMs) {
         silent.push({ stage, silentMs, thresholdMs });
       }

--- a/apps/api/src/services/paperTradingService.js
+++ b/apps/api/src/services/paperTradingService.js
@@ -9,6 +9,7 @@ import { pool, query } from '../db/connection.js';
 import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 import { validateMarketData } from '../utils/marketDataValidator.js';
+import { monitoringService } from './monitoringService.js';
 import futuresWebSocket from '../websocket/futuresWebSocket.js';
 import backtestingEngine from './backtestingEngine.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
@@ -542,6 +543,9 @@ class PaperTradingService extends EventEmitter {
   async generateTradingSignals(session, marketData) {
     try {
       if (!session.strategy) return;
+      // Heartbeat: the paper stage is alive as long as an active session is
+      // evaluating signals against live market data.
+      monitoringService.recordPipelineHeartbeat('paper');
 
       // Get historical data for technical analysis
       const historicalData = await this.getHistoricalDataForSignal(session.symbol, session.timeframe);
@@ -622,6 +626,9 @@ class PaperTradingService extends EventEmitter {
         });
 
         logger.info(`📈 Executed entry signal for ${session.id}: ${signal.side} ${positionSize} at ${executionResult.executionPrice}`);
+        // Feed the trades-per-hour rolling ring so the silent-floor
+        // alert sees real activity.
+        monitoringService.recordTradeEvent('paper');
 
         this.emit('positionOpened', {
           sessionId: session.id,

--- a/apps/api/src/services/pipelineHealthProbe.ts
+++ b/apps/api/src/services/pipelineHealthProbe.ts
@@ -50,6 +50,13 @@ let activeProbe: ProbeHandle | null = null;
 /** First-observed tick timestamp — used to avoid firing trades-floor alerts before the system has been up long enough to produce trades. */
 let probeStartedAt: Date | null = null;
 let isExpectedTrading: IsExpectedTradingPredicate = defaultIsExpectedTrading;
+/**
+ * Re-entrancy guard. The probe tick is async (DB-backed predicate) and
+ * can legitimately take >60s under DB pressure; without this, overlapping
+ * ticks would pile up and inflate DB load on an already-struggling
+ * system. Sourcery flagged this on #489.
+ */
+let tickInFlight = false;
 
 /**
  * Decide whether a trades-floor alert is appropriate given current state.
@@ -72,6 +79,11 @@ async function shouldEvaluateTradesFloor(now: Date): Promise<boolean> {
 }
 
 async function runProbeTick(now: Date = new Date()): Promise<void> {
+  if (tickInFlight) {
+    logger.debug('pipelineHealthProbe tick skipped — previous tick still in flight');
+    return;
+  }
+  tickInFlight = true;
   try {
     const silentStages = monitoringService.getSilentPipelineStages(now);
     for (const { stage, silentMs, thresholdMs } of silentStages) {
@@ -91,6 +103,8 @@ async function runProbeTick(now: Date = new Date()): Promise<void> {
     logger.error('pipelineHealthProbe tick failed', {
       error: err instanceof Error ? err.message : String(err),
     });
+  } finally {
+    tickInFlight = false;
   }
 }
 
@@ -102,7 +116,10 @@ export function startPipelineHealthProbe(
   if (activeProbe) return activeProbe;
   probeStartedAt = new Date();
   isExpectedTrading = effectivePredicate;
-  const timer = setInterval(() => runProbeTick(), intervalMs);
+  // Explicit `void` so Node doesn't emit an unhandled-rejection warning
+  // if the tick rejects in a way the internal try/finally misses. The
+  // re-entrancy guard above already serialises overlapping ticks.
+  const timer = setInterval(() => { void runProbeTick(); }, intervalMs);
   timer.unref?.();
   activeProbe = {
     stop: () => {
@@ -110,8 +127,9 @@ export function startPipelineHealthProbe(
       activeProbe = null;
       probeStartedAt = null;
       isExpectedTrading = defaultIsExpectedTrading;
+      tickInFlight = false;
     },
-    runOnce: () => runProbeTick(),
+    runOnce: () => { void runProbeTick(); },
     intervalMs,
   };
   logger.info('pipelineHealthProbe started', { intervalMs });

--- a/apps/api/src/services/pipelineHealthProbe.ts
+++ b/apps/api/src/services/pipelineHealthProbe.ts
@@ -18,12 +18,16 @@ const DEFAULT_PROBE_INTERVAL_MS = 60_000;
 /**
  * A predicate the probe calls to decide whether the system is in a
  * state where trades *should* be happening. When this returns false,
- * the trades-floor alert is suppressed — a Paused or Paper-Only
- * configuration doesn't page. Default reads from persistentTradingEngine.
+ * the trades-floor alert is suppressed.
  *
- * Exposed so tests can inject a deterministic predicate.
+ * Returning a Promise is supported so the real predicate can query
+ * database state (option C in the design doc: "only alert once the
+ * pipeline has proven it *can* produce passing strategies").
+ *
+ * Default is sync `false` so tests / fresh boots stay silent unless a
+ * caller explicitly wires in a live state source.
  */
-export type IsExpectedTradingPredicate = () => boolean;
+export type IsExpectedTradingPredicate = () => boolean | Promise<boolean>;
 
 /**
  * Default predicate — reports false so the probe does NOT alert on
@@ -32,8 +36,7 @@ export type IsExpectedTradingPredicate = () => boolean;
  * tests that import it don't cascade into encryption / env
  * validation.
  *
- * index.ts wires the real predicate at boot:
- *   startPipelineHealthProbe(60_000, () => persistentTradingEngine.isEngineRunning())
+ * index.ts wires the real predicate at boot.
  */
 const defaultIsExpectedTrading: IsExpectedTradingPredicate = () => false;
 
@@ -59,22 +62,23 @@ let isExpectedTrading: IsExpectedTradingPredicate = defaultIsExpectedTrading;
  * Sourcery flagged that an assumed `expected_running` state without this
  * gate would page on intentionally-paused / paper-only configurations.
  */
-function shouldEvaluateTradesFloor(now: Date): boolean {
+async function shouldEvaluateTradesFloor(now: Date): Promise<boolean> {
   if (!probeStartedAt) return false;
   const uptimeMs = now.getTime() - probeStartedAt.getTime();
   const windowMs = monitoringService.getTradesPerHourFloorWindowMinutes() * 60_000;
   if (uptimeMs < windowMs) return false;
-  return isExpectedTrading();
+  const result = isExpectedTrading();
+  return result instanceof Promise ? await result : result;
 }
 
-function runProbeTick(now: Date = new Date()): void {
+async function runProbeTick(now: Date = new Date()): Promise<void> {
   try {
     const silentStages = monitoringService.getSilentPipelineStages(now);
     for (const { stage, silentMs, thresholdMs } of silentStages) {
       alertingService.alertPipelineSilent(stage as PipelineStage, silentMs, thresholdMs);
     }
 
-    if (!shouldEvaluateTradesFloor(now)) return;
+    if (!(await shouldEvaluateTradesFloor(now))) return;
 
     const windowMin = monitoringService.getTradesPerHourFloorWindowMinutes();
     for (const stage of ['paper', 'live'] as const) {

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -9,6 +9,7 @@
 import { pool } from '../db/connection.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
 import { apiCredentialsService } from './apiCredentialsService.js';
+import { monitoringService } from './monitoringService.js';
 import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 
@@ -258,6 +259,7 @@ class StateReconciliationService {
    * Run reconciliation for all users with an active autonomous trading config.
    */
   async reconcileAllActive(): Promise<void> {
+    monitoringService.recordPipelineHeartbeat('reconciliation');
     try {
       const activeConfigs = await pool.query(
         `SELECT DISTINCT user_id FROM autonomous_trading_configs WHERE enabled = true`

--- a/apps/api/src/services/strategyLearningEngine.ts
+++ b/apps/api/src/services/strategyLearningEngine.ts
@@ -33,6 +33,7 @@ import { logger } from '../utils/logger.js';
 import { apiCredentialsService } from './apiCredentialsService.js';
 import backtestingEngine from './backtestingEngine.js';
 import confidenceScoringService from './confidenceScoringService.js';
+import { monitoringService } from './monitoringService.js';
 import parallelStrategyRunner from './parallelStrategyRunner.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
 import {
@@ -217,11 +218,13 @@ class StrategyLearningEngine extends EventEmitter {
   private async runOneCycle(): Promise<void> {
     this.generationCount++;
     logger.info(`[SLE] === Generation ${this.generationCount} ===`);
+    monitoringService.recordPipelineHeartbeat('generator');
     await this.fetchActualBalance();
     parallelStrategyRunner.setBaseCapital(this.cachedBalance);
     const regime = await this.detectCurrentRegime();
     await this.checkQIGRegimeTransition();
     const newStrategies = await this.generateVariants(regime);
+    monitoringService.recordPipelineHeartbeat('backtest');
     const backtestPassed = await this.backtestVariants(newStrategies);
     for (const s of backtestPassed) { await this.promoteToParallelPaper(s); }
     await this.evaluatePaperSessions();

--- a/apps/api/src/services/tradingStateProbe.ts
+++ b/apps/api/src/services/tradingStateProbe.ts
@@ -27,28 +27,42 @@ import { logger } from '../utils/logger.js';
 export const TRADING_STATE_RECENT_PASS_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Cheap DB query — one row, two aggregate columns. Called every
- * 60s by the probe tick. Fails soft: returns false on any error so
- * a DB hiccup doesn't trigger a spurious alert cascade.
+ * Called every 60s by the probe tick. Split into two narrow queries so
+ * the expensive half (MAX(promoted_paper_at) over all rows) only runs
+ * in the uncommon "no active strategy" branch. Both queries hit
+ * partial indexes from migrations 027 and 028.
+ *
+ * Fails soft: returns false on any error so a DB hiccup doesn't
+ * trigger a spurious alert cascade.
  */
 export async function shouldExpectPaperTrades(
   now: Date = new Date(),
 ): Promise<boolean> {
   try {
-    const result = await query(
-      `SELECT
-         COUNT(*) FILTER (
-           WHERE status IN ('paper_trading', 'recommended', 'live')
-         )::int AS active_count,
-         MAX(promoted_paper_at) AS last_paper_promo
-       FROM strategy_performance
-       WHERE deleted_at IS NULL`,
+    // Query A: uses idx_strategy_performance_status_tier (partial,
+    // WHERE deleted_at IS NULL). Returns fast — in the steady state
+    // this is the only query that runs.
+    const activeResult = await query(
+      `SELECT COUNT(*)::int AS n
+         FROM strategy_performance
+        WHERE deleted_at IS NULL
+          AND status IN ('paper_trading', 'recommended', 'live')`,
     );
-    const row = (result.rows as any[])[0] ?? {};
-    const activeCount = Number(row.active_count ?? 0);
-    const lastPromo = row.last_paper_promo ? new Date(row.last_paper_promo as string) : null;
+    const activeCount = Number((activeResult.rows as any[])[0]?.n ?? 0);
     if (activeCount > 0) return true;
-    if (!lastPromo) return false;
+
+    // Query B: uses idx_strategy_performance_promoted_paper_at
+    // (migration 028, partial WHERE promoted_paper_at IS NOT NULL).
+    // Only runs when zero strategies are currently paper/live.
+    const promoResult = await query(
+      `SELECT MAX(promoted_paper_at) AS last_paper_promo
+         FROM strategy_performance
+        WHERE deleted_at IS NULL
+          AND promoted_paper_at IS NOT NULL`,
+    );
+    const rawPromo = (promoResult.rows as any[])[0]?.last_paper_promo;
+    if (!rawPromo) return false;
+    const lastPromo = new Date(rawPromo as string);
     return now.getTime() - lastPromo.getTime() < TRADING_STATE_RECENT_PASS_WINDOW_MS;
   } catch (err) {
     logger.debug('[tradingStateProbe] shouldExpectPaperTrades failed (fail-soft)', {

--- a/apps/api/src/services/tradingStateProbe.ts
+++ b/apps/api/src/services/tradingStateProbe.ts
@@ -1,0 +1,59 @@
+/**
+ * Trading-state probe — computes whether we should expect trades to be
+ * happening right now, so the trades-per-hour floor alert only fires
+ * when silence is genuinely unexpected.
+ *
+ * Decision rule (Option C from the design doc — user-picked on
+ * 2026-04-18 after production alert review):
+ *
+ *   expect_trading = TRUE if EITHER
+ *     (A) at least one strategy is in 'paper_trading' | 'recommended' | 'live', OR
+ *     (B) the most recent paper-promotion (`promoted_paper_at`) is
+ *         within the last 24h — strategies have recently been earning
+ *         their way forward, even if none are active at this instant.
+ *
+ * This silences the two false-positive modes we saw in production
+ * (alertCount:41 on a $27 account with no passing strategies) while
+ * keeping the alert loud if a pipeline that USED TO work has stopped.
+ *
+ * The complementary "generator is broken" failure mode (no strategy
+ * ever passes backtest) is intentionally NOT caught here — that's the
+ * job of a separate backtest-pass-rate metric and threshold.
+ */
+
+import { query } from '../db/connection.js';
+import { logger } from '../utils/logger.js';
+
+export const TRADING_STATE_RECENT_PASS_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Cheap DB query — one row, two aggregate columns. Called every
+ * 60s by the probe tick. Fails soft: returns false on any error so
+ * a DB hiccup doesn't trigger a spurious alert cascade.
+ */
+export async function shouldExpectPaperTrades(
+  now: Date = new Date(),
+): Promise<boolean> {
+  try {
+    const result = await query(
+      `SELECT
+         COUNT(*) FILTER (
+           WHERE status IN ('paper_trading', 'recommended', 'live')
+         )::int AS active_count,
+         MAX(promoted_paper_at) AS last_paper_promo
+       FROM strategy_performance
+       WHERE deleted_at IS NULL`,
+    );
+    const row = (result.rows as any[])[0] ?? {};
+    const activeCount = Number(row.active_count ?? 0);
+    const lastPromo = row.last_paper_promo ? new Date(row.last_paper_promo as string) : null;
+    if (activeCount > 0) return true;
+    if (!lastPromo) return false;
+    return now.getTime() - lastPromo.getTime() < TRADING_STATE_RECENT_PASS_WINDOW_MS;
+  } catch (err) {
+    logger.debug('[tradingStateProbe] shouldExpectPaperTrades failed (fail-soft)', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes three production-observed issues from the first 24h after #488 merged:

1. **Never-seen stages wrongly flagged as silent** (alertCount:161 before catching). `getSilentPipelineStages` used `Number.POSITIVE_INFINITY` as the "never ticked" silent duration, tripping every threshold. Fixed: unwired stages now skip the silent check — "unwired" is not "silent."

2. **Heartbeat recording was never actually called.** The probe was correct but every pipeline stage failed to call `recordPipelineHeartbeat()`, so everything looked silent during a healthy Gen 33. Wired the calls in the natural tick points:
   - [strategyLearningEngine.runOneCycle](apps/api/src/services/strategyLearningEngine.ts) → `'generator'` + `'backtest'`
   - [paperTradingService.generateTradingSignals](apps/api/src/services/paperTradingService.js) → `'paper'` heartbeat; `executeEntrySignal` → `recordTradeEvent('paper')`
   - [fullyAutonomousTrader.executeSignals](apps/api/src/services/fullyAutonomousTrader.ts) → `'paper' | 'live'` heartbeat + `recordTradeEvent` on successful order
   - [stateReconciliationService.reconcileAllActive](apps/api/src/services/stateReconciliationService.ts) → `'reconciliation'`

3. **Trades-floor alert pages on expected startup state** (alertCount:41). Old predicate only checked `isEngineRunning()`, which is true immediately after boot — so "no paper trades in 6h" fired even when NO strategy had ever cleared backtest. User picked **Option C** from the design options: alert only when the pipeline has proven it can produce passing strategies.

   New [`tradingStateProbe.shouldExpectPaperTrades()`](apps/api/src/services/tradingStateProbe.ts):
   ```
   expect = active_count(paper|recommended|live) > 0
            OR last_promoted_paper_at is within 24h
   ```
   Fail-soft to `false` on DB errors so a DB hiccup can't trigger a spurious alert cascade.

   Predicate type widened to `() => boolean | Promise<boolean>`; `runProbeTick` awaits it.

### What's intentionally NOT in this PR

The complementary "generator is broken, nothing ever passes backtest" failure mode (which Option C will silence if it happens from day 1) is deliberately NOT covered here. That's the job of a separate backtest-pass-rate metric + threshold — a follow-up PR.

## Test plan

- [x] 7 new Vitest cases for `tradingStateProbe` covering every Option-C branch, empty row, DB fail-soft, and the 24h constant lock
- [x] 2 new cases for never-seen-stage suppression (boot-time false positive + cohabitation with genuinely silent seen-stage)
- [x] Full API suite: 461 passed, 12 skipped (up from 452)
- [x] `tsc --noEmit -p tsconfig.build.json` clean
- [ ] Deploy to PR environment, watch logs for 1h, confirm alertCount stops climbing and new trade events are recorded as pipeline stages tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten pipeline health alerting to avoid startup false positives and ensure alerts reflect real silence by wiring heartbeats, refining silence detection, and gating trades-floor alerts on proven strategy activity.

New Features:
- Introduce a trading-state probe that determines when paper trades are expected based on active or recently promoted strategies.
- Support async predicates in the pipeline health probe so trading expectations can be derived from database-backed state.

Bug Fixes:
- Prevent never-seen pipeline stages from being flagged as silent, eliminating boot-time false-positive alerts.
- Ensure generator, backtest, paper, live, and reconciliation stages emit heartbeats and trade events so healthy pipelines are not misclassified as silent.
- Suppress trades-floor alerts on cold-start when no strategy has yet passed backtest, only alerting once the pipeline has demonstrated it can produce eligible strategies.
- Fail-soft trading-state evaluation to return false on database errors, avoiding spurious alert cascades during transient DB issues.

Enhancements:
- Gate trades-floor alerting on both the trading engine running and the trading-state probe’s expectation of paper trades.
- Refine monitoring documentation comments to clarify semantics of silent stages versus unwired stages.

Tests:
- Add comprehensive tests for the trading-state probe covering active strategies, recent promotions, empty results, DB failures, and the 24h window constant.
- Extend pipeline observability tests to verify never-seen stages are not flagged as silent and that only previously active stages are considered for silence detection.