### PR TITLE
Historical data fetcher: respect sTime/eTime + loop past 500-candle cap

### DIFF
--- a/apps/api/src/services/backtestingEngine.js
+++ b/apps/api/src/services/backtestingEngine.js
@@ -133,25 +133,25 @@ class BacktestingEngine extends EventEmitter {
    */
   async fetchHistoricalDataFromAPI(symbol, timeframe, startDate, endDate) {
     try {
-      // Calculate how many candles we need based on the time range and interval
-      const intervalSeconds = {
-        '1m': 60, '5m': 300, '15m': 900, '30m': 1800,
-        '1h': 3600, '1H': 3600, '2h': 7200,
-        '4h': 14400, '4H': 14400, '12h': 43200,
-        '1d': 86400, '1D': 86400
-      };
-      const seconds = intervalSeconds[timeframe] || 3600;
       const end = endDate instanceof Date ? endDate : new Date(endDate);
       const start = startDate instanceof Date ? startDate : new Date(startDate);
-      const rangeMs = end.getTime() - start.getTime();
-      const limit = Math.min(Math.ceil(rangeMs / (seconds * 1000)), 500);
-
-      // getHistoricalData handles interval format conversion, V3 array parsing,
-      // and non-array response guarding internally
-      const data = await poloniexFuturesService.getHistoricalData(symbol, timeframe, limit);
+      // Pass startTime/endTime explicitly so the fetcher returns candles
+      // IN the requested window (the IS or OOS slice), not "last N".
+      // The service will loop internally to cover windows larger than
+      // Poloniex's 500-per-call limit. limit below is only a per-call
+      // ceiling; the total fetched is determined by the time range.
+      const data = await poloniexFuturesService.getHistoricalData(
+        symbol,
+        timeframe,
+        500,
+        { startTime: start, endTime: end },
+      );
 
       if (!Array.isArray(data) || data.length === 0) {
-        logger.warn(`No historical data returned for ${symbol} (${timeframe}), limit=${limit}`);
+        logger.warn(`No historical data returned for ${symbol} (${timeframe})`, {
+          startDate: start.toISOString(),
+          endDate: end.toISOString(),
+        });
         return [];
       }
 

--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -743,10 +743,13 @@ class PoloniexFuturesService {
    * Get historical OHLCV data for ML training and analysis
    * @param {string} symbol - Trading symbol (e.g., 'BTCUSDTPERP')
    * @param {string} interval - Candle interval ('1m', '5m', '15m', '30m', '1h', '4h', '1d')
-   * @param {number} limit - Number of candles to fetch (max 1500)
+   * @param {number} limit - Number of candles to fetch (max 500 per call; loops to fill larger ranges)
+   * @param {Object} [opts] - Optional fetch options
+   * @param {Date|number} [opts.startTime] - Window start. When supplied with endTime, overrides the default "last N candles" behavior.
+   * @param {Date|number} [opts.endTime] - Window end. Defaults to now.
    * @returns {Promise<Array>} Array of OHLCV data [{timestamp, open, high, low, close, volume}]
    */
-  async getHistoricalData(symbol, interval = '1h', limit = 200) {
+  async getHistoricalData(symbol, interval = '1h', limit = 200, opts = {}) {
     try {
       // Map interval to Poloniex V3 format and seconds for time calculation
       const intervalMap = {
@@ -769,21 +772,45 @@ class PoloniexFuturesService {
         throw new Error(`Invalid interval: ${interval}. Use 1m, 5m, 15m, 30m, 1h, 2h, 4h, 12h, or 1d`);
       }
 
-      // Poloniex limits to 500 candles per request (not 1500)
-      const actualLimit = Math.min(limit, 500);
+      const POLONIEX_MAX_PER_CALL = 500;
+      const intervalMs = intervalConfig.seconds * 1000;
 
-      // Calculate time range
-      const endTime = Date.now();
-      const startTime = endTime - (intervalConfig.seconds * 1000 * actualLimit);
+      // Resolve time range. If caller supplied explicit startTime (e.g. the
+      // backtest walk-forward windows), honor it exactly. Otherwise fall
+      // back to "last N candles" for backward compat with the old callers.
+      const endTime = opts.endTime
+        ? (opts.endTime instanceof Date ? opts.endTime.getTime() : Number(opts.endTime))
+        : Date.now();
+      const explicitStart = opts.startTime != null
+        ? (opts.startTime instanceof Date ? opts.startTime.getTime() : Number(opts.startTime))
+        : null;
+      const cap = Math.min(limit, POLONIEX_MAX_PER_CALL);
+      const startTime = explicitStart ?? (endTime - intervalMs * cap);
 
-      // Fetch candles using V3 format
-      const params = {
-        limit: actualLimit,
-        sTime: Math.floor(startTime),
-        eTime: Math.floor(endTime)
-      };
-
-      const candles = await this.getKlines(symbol, intervalConfig.format, params);
+      // Compute candles needed in the window. Poloniex V3 returns up to 500
+      // per call, so when the window needs more we loop forward 500 at a
+      // time. This is the fix for the "fetcher ignored sTime and always
+      // returned last-N" bug that was producing 29-candle IS windows.
+      const totalNeeded = Math.ceil((endTime - startTime) / intervalMs);
+      const numCalls = Math.min(Math.ceil(totalNeeded / POLONIEX_MAX_PER_CALL), 50); // hard ceiling on call loops
+      let cursor = startTime;
+      const all = [];
+      for (let i = 0; i < numCalls; i++) {
+        const chunkEnd = Math.min(cursor + POLONIEX_MAX_PER_CALL * intervalMs, endTime);
+        const params = {
+          limit: POLONIEX_MAX_PER_CALL,
+          sTime: Math.floor(cursor),
+          eTime: Math.floor(chunkEnd),
+        };
+        const chunk = await this.getKlines(symbol, intervalConfig.format, params);
+        if (!chunk || !Array.isArray(chunk) || chunk.length === 0) break;
+        all.push(...chunk);
+        // Advance cursor just past the last received candle. If chunk
+        // length < 500 we assume no more data in that stride.
+        cursor = chunkEnd;
+        if (chunk.length < POLONIEX_MAX_PER_CALL) break;
+      }
+      const candles = all;
 
       // Transform to standard OHLCV format
       if (!candles || !Array.isArray(candles)) {

--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -743,7 +743,10 @@ class PoloniexFuturesService {
    * Get historical OHLCV data for ML training and analysis
    * @param {string} symbol - Trading symbol (e.g., 'BTCUSDTPERP')
    * @param {string} interval - Candle interval ('1m', '5m', '15m', '30m', '1h', '4h', '1d')
-   * @param {number} limit - Number of candles to fetch (max 500 per call; loops to fill larger ranges)
+   * @param {number} limit - Fallback candle count (per-call cap 500). Only used
+   *   to size the default "last N candles" window when opts.startTime is not
+   *   supplied. When opts.startTime is supplied, the window size is determined
+   *   by the time range and this value becomes a per-call hint.
    * @param {Object} [opts] - Optional fetch options
    * @param {Date|number} [opts.startTime] - Window start. When supplied with endTime, overrides the default "last N candles" behavior.
    * @param {Date|number} [opts.endTime] - Window end. Defaults to now.
@@ -773,26 +776,48 @@ class PoloniexFuturesService {
       }
 
       const POLONIEX_MAX_PER_CALL = 500;
+      const MAX_LOOP_CALLS = 50;  // safety ceiling — see MAX_TOTAL_CANDLES below
       const intervalMs = intervalConfig.seconds * 1000;
 
       // Resolve time range. If caller supplied explicit startTime (e.g. the
       // backtest walk-forward windows), honor it exactly. Otherwise fall
       // back to "last N candles" for backward compat with the old callers.
-      const endTime = opts.endTime
+      const rawEnd = opts.endTime != null
         ? (opts.endTime instanceof Date ? opts.endTime.getTime() : Number(opts.endTime))
         : Date.now();
-      const explicitStart = opts.startTime != null
+      const rawStart = opts.startTime != null
         ? (opts.startTime instanceof Date ? opts.startTime.getTime() : Number(opts.startTime))
         : null;
+      // Validate — NaN or inverted ranges would silently produce huge
+      // loops or empty results. Fail loudly.
+      if (!Number.isFinite(rawEnd)) {
+        throw new Error(`getHistoricalData: invalid opts.endTime (${String(opts.endTime)})`);
+      }
+      if (rawStart != null && !Number.isFinite(rawStart)) {
+        throw new Error(`getHistoricalData: invalid opts.startTime (${String(opts.startTime)})`);
+      }
+      if (rawStart != null && rawStart >= rawEnd) {
+        throw new Error(
+          `getHistoricalData: startTime (${rawStart}) must be < endTime (${rawEnd})`,
+        );
+      }
       const cap = Math.min(limit, POLONIEX_MAX_PER_CALL);
-      const startTime = explicitStart ?? (endTime - intervalMs * cap);
+      const endTime = rawEnd;
+      const startTime = rawStart ?? (endTime - intervalMs * cap);
 
       // Compute candles needed in the window. Poloniex V3 returns up to 500
       // per call, so when the window needs more we loop forward 500 at a
       // time. This is the fix for the "fetcher ignored sTime and always
       // returned last-N" bug that was producing 29-candle IS windows.
       const totalNeeded = Math.ceil((endTime - startTime) / intervalMs);
-      const numCalls = Math.min(Math.ceil(totalNeeded / POLONIEX_MAX_PER_CALL), 50); // hard ceiling on call loops
+      const callsNeeded = Math.ceil(totalNeeded / POLONIEX_MAX_PER_CALL);
+      const numCalls = Math.min(callsNeeded, MAX_LOOP_CALLS);
+      if (callsNeeded > MAX_LOOP_CALLS) {
+        logger.warn(
+          `getHistoricalData: window truncated — wanted ${callsNeeded} chunks for ${symbol} ${interval}, capped at ${MAX_LOOP_CALLS} (~${MAX_LOOP_CALLS * POLONIEX_MAX_PER_CALL} candles). Use a coarser timeframe or narrower window for full coverage.`,
+          { symbol, interval, callsNeeded, totalNeeded },
+        );
+      }
       let cursor = startTime;
       const all = [];
       for (let i = 0; i < numCalls; i++) {


### PR DESCRIPTION
## Summary

Production observation after PR #490's hard-cut deploy: strategies were getting `totalTrades: 0` on every backtest, so the multi-metric gate correctly rejected them all. But the gate wasn't the blocker — the data layer was.

### Root cause

[`poloniexFuturesService.getHistoricalData`](apps/api/src/services/poloniexFuturesService.js) hard-coded:

```js
const startTime = endTime - (intervalConfig.seconds * 1000 * actualLimit);
```

It **ignored** any caller's intent for an older time range. The in-sample walk-forward window asked for "57 days ago → 40 days ago" but got "last N candles ending now." The cache then filter-by-date-range returned a tiny random overlap (29-74 candles on 4h), never enough for a 50-bar-lookback strategy to produce even one trade.

### Fix

- `getHistoricalData` now takes `opts.startTime` / `opts.endTime`. When supplied, the fetcher honors them. Legacy callers without the option still get "last N candles" behavior.
- When the requested range exceeds Poloniex's 500-per-call cap, the fetcher loops 500 at a time until the window fills or an empty chunk signals no more data (max 50 chunks as a hard ceiling).
- `backtestingEngine.fetchHistoricalDataFromAPI` passes the backtest-engine's requested window through, removing the old `ceil(range/seconds)` limit calc that was also biasing toward last-N.

### Expected impact

First SLE cycle post-merge will run backtests against full IS (~40-day) and OOS (~17-day) windows with real data. For 1h+ timeframes, that's 500+ candles — enough for strategies to actually generate trades and for the promotion gate to evaluate real metrics.

## Test plan

- [x] 484 API tests pass
- [x] `tsc --noEmit -p tsconfig.build.json` clean
- [ ] After merge + deploy: Railway logs should show candle counts like `Loaded 960 historical data points for ETH_USDT_PERP` on 1h (40-day IS) instead of the current 29-74 range
- [ ] Generation N should show `backtest_pass > 0` for at least one strategy within 2-3 cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Honor explicit historical data time windows and support fetching large ranges beyond Poloniex’s per-call candle limit.

Bug Fixes:
- Respect caller-provided start and end times when fetching historical OHLCV data instead of always returning the latest candles.
- Ensure backtesting uses the intended in-sample and out-of-sample windows by passing the requested time range through to the historical data service.

Enhancements:
- Add looping in the Poloniex historical data fetcher to span large time ranges across multiple API calls while enforcing a per-call limit and safety cap.
- Improve backtesting API logging by including the requested start and end dates when no historical data is returned.