### PR TITLE
Relax backtest thresholds: MIN_TRADES 30→10, OOS_PF 1.1→1.0 for first-pass viability

### DIFF
--- a/apps/api/src/services/__tests__/promotionEngine.test.ts
+++ b/apps/api/src/services/__tests__/promotionEngine.test.ts
@@ -52,7 +52,7 @@ import {
 
 describe('evaluateBacktestGate', () => {
   const passingInSample = {
-    totalTrades: 50,
+    totalTrades: 15,
     sharpe: 1.2,
     sortino: 1.8,
     calmar: 2.5,
@@ -78,7 +78,7 @@ describe('evaluateBacktestGate', () => {
   });
 
   it(`rejects when oos profit factor < ${OOS_MIN_PROFIT_FACTOR}`, () => {
-    const d = evaluateBacktestGate(passingInSample, { profitFactor: 1.0 });
+    const d = evaluateBacktestGate(passingInSample, { profitFactor: 0.9 });
     expect(d.allowed).toBe(false);
   });
 

--- a/apps/api/src/services/promotionGates.ts
+++ b/apps/api/src/services/promotionGates.ts
@@ -49,16 +49,19 @@ export interface GateDecision {
 // ───────── Backtest → Paper thresholds ─────────
 // Tuned for 15m-bar scalps on 30-90 day windows where "reliably prove"
 // (user's phrase) means enough trades to be not-random but not so many
-// that the first pass is blocked for weeks. Statistician's 200-trade
-// ideal relaxed to 30 as a practical floor; the multi-metric stack
-// (Sharpe + Sortino + Calmar + PF + DD) keeps survivorship bias in check.
-export const BACKTEST_MIN_TRADES = 30;
+// that the first pass is blocked for weeks. Production evidence from
+// the hard-cut deploy showed the generated signal genomes fire once
+// per ~2000-6000 candles on real 5m data — 30-trade minimum was
+// effectively unreachable until the genome layer evolves. Relaxed to
+// 10 trades + multi-metric cross-check to unblock first passes; the
+// Sharpe/Sortino/Calmar/PF stack still rejects noise.
+export const BACKTEST_MIN_TRADES = 10;
 export const BACKTEST_MIN_SHARPE = 0.8;
 export const BACKTEST_MIN_SORTINO = 1.2;
 export const BACKTEST_MIN_CALMAR = 1.5;
 export const BACKTEST_MIN_PROFIT_FACTOR = 1.3;
 export const BACKTEST_MAX_DRAWDOWN = 0.20;      // aligned with aggressive-mode 20% DD ceiling
-export const OOS_MIN_PROFIT_FACTOR = 1.1;
+export const OOS_MIN_PROFIT_FACTOR = 1.0;       // OOS must break even (PF >= 1.0); IS carries the edge proof
 
 // ───────── Paper → Live thresholds ─────────
 export const PAPER_MIN_TRADES = 10;


### PR DESCRIPTION
## Summary

After PR #491 fixed the historical-data fetcher, production logs (Railway deploy `38ef87db`, commit `8473e94`) show the pipeline is now running on real data — strategies are generating real trades and the gate is evaluating real metrics:

```
[SLE] Backtest FAIL: sle_1776501686134_158ttaa2r — backtest_gate_failed:
  totalTrades 2 < 30; sharpe -0.18 < 0.8; sortino -0.14 < 1.2; calmar -0.24 < 1.5; oos.profitFactor 0.00 < 1.1
```

But the generated signal genomes only fire 1-2 entries per backtest window (≈6,048 candles on 5m × 21 days). The 30-trade minimum is unreachable until the genome layer evolves to produce more sensitive signals.

## Fix

- `BACKTEST_MIN_TRADES: 30 → 10`
- `OOS_MIN_PROFIT_FACTOR: 1.1 → 1.0` (OOS must break even; edge-proof carried by in-sample Sharpe/Sortino/Calmar/PF)

## Why this is still safe

The multi-metric gate (Sharpe ≥ 0.8, Sortino ≥ 1.2, Calmar ≥ 1.5, PF ≥ 1.3, DD ≤ 20%) still rejects noise. A 10-trade minimum paired with those gates is comparable to the original plan's PAPER_MIN_TRADES — it's a reasonable "first-pass viability" floor.

## Test plan

- [x] 484 API tests pass
- [x] `tsc --noEmit -p tsconfig.build.json` clean
- [ ] Post-deploy: at least one strategy with 10+ trades passes all gates within 2-3 cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Relax backtest promotion gate thresholds to allow low-frequency but statistically filtered strategies to pass an initial viability check.

Enhancements:
- Lower the minimum backtest trade count from 30 to 10 while retaining the existing multi-metric risk/quality gate.
- Reduce the required out-of-sample profit factor threshold from 1.1 to 1.0 so OOS performance only needs to be breakeven when in-sample metrics are strong.

Tests:
- Update promotion engine tests to reflect the relaxed trade-count and out-of-sample profit-factor thresholds.