### PR TITLE
Seed anchor strategies to break the random-genome cold start

### DIFF
--- a/apps/api/src/services/__tests__/anchorStrategies.test.ts
+++ b/apps/api/src/services/__tests__/anchorStrategies.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Anchor-strategy sanity tests.
+ *
+ * Anchors are the cold-start cure for the SLE pipeline — they must be
+ * well-formed SignalGenome objects that the backtest engine can
+ * actually execute. These tests lock the contract so a genome refactor
+ * can't silently break anchors.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ANCHOR_STRATEGIES, getAnchorsForRegime } from '../anchorStrategies.js';
+
+describe('anchor strategies', () => {
+  it('exposes at least 3 seed strategies', () => {
+    expect(ANCHOR_STRATEGIES.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('every anchor has a stable anchor_ prefixed id', () => {
+    for (const a of ANCHOR_STRATEGIES) {
+      expect(a.id).toMatch(/^anchor_/);
+    }
+  });
+
+  it('every anchor has a valid (non-empty) genome with both long and short conditions', () => {
+    for (const a of ANCHOR_STRATEGIES) {
+      const hasLong = a.genome.entryConditions.some((c) => c.side === 'long' || c.side === 'both');
+      const hasShort = a.genome.entryConditions.some((c) => c.side === 'short' || c.side === 'both');
+      expect(hasLong, `${a.id} missing long entry`).toBe(true);
+      expect(hasShort, `${a.id} missing short entry`).toBe(true);
+    }
+  });
+
+  it('every anchor has sane risk parameters', () => {
+    for (const a of ANCHOR_STRATEGIES) {
+      expect(a.genome.stopLossPercent).toBeGreaterThan(0);
+      expect(a.genome.stopLossPercent).toBeLessThan(0.05);
+      expect(a.genome.takeProfitPercent).toBeGreaterThan(a.genome.stopLossPercent);
+      expect(a.genome.takeProfitPercent).toBeLessThan(0.10);
+      expect(a.genome.positionSizeFraction).toBeGreaterThan(0);
+      expect(a.genome.positionSizeFraction).toBeLessThanOrEqual(0.10);
+    }
+  });
+
+  it('every anchor targets a supported symbol and timeframe', () => {
+    const supportedSymbols = new Set([
+      'BTC_USDT_PERP',
+      'ETH_USDT_PERP',
+      'SOL_USDT_PERP',
+      'XRP_USDT_PERP',
+    ]);
+    const supportedTfs = new Set(['5m', '15m', '1h', '4h']);
+    for (const a of ANCHOR_STRATEGIES) {
+      expect(supportedSymbols.has(a.symbol), `${a.id} bad symbol`).toBe(true);
+      expect(supportedTfs.has(a.timeframe), `${a.id} bad timeframe`).toBe(true);
+    }
+  });
+
+  it('covers at least two regimes so anchors work in multiple markets', () => {
+    const regimes = new Set(ANCHOR_STRATEGIES.map((a) => a.regimeAffinity));
+    expect(regimes.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('getAnchorsForRegime filters by regime affinity', () => {
+    const trending = getAnchorsForRegime('trending');
+    const ranging = getAnchorsForRegime('ranging');
+    expect(trending.length).toBeGreaterThan(0);
+    expect(ranging.length).toBeGreaterThan(0);
+    // At least one anchor is trending-only so the two sets differ.
+    expect(trending.map((a) => a.id).sort()).not.toEqual(ranging.map((a) => a.id).sort());
+  });
+
+  it('getAnchorsForRegime("unknown") returns all anchors', () => {
+    expect(getAnchorsForRegime('unknown').length).toBe(ANCHOR_STRATEGIES.length);
+  });
+
+  it('anchor leverages are reasonable (≤10x) for the per-symbol kernel cap', () => {
+    for (const a of ANCHOR_STRATEGIES) {
+      expect(a.leverage).toBeGreaterThan(0);
+      expect(a.leverage).toBeLessThanOrEqual(10);
+    }
+  });
+});

--- a/apps/api/src/services/anchorStrategies.ts
+++ b/apps/api/src/services/anchorStrategies.ts
@@ -1,0 +1,171 @@
+/**
+ * Anchor strategies — hand-crafted SignalGenome seeds.
+ *
+ * Production evidence after the hard-cut pipeline came online showed
+ * the random-genome generator produces strategies that trade like
+ * coin flips (sharpe ≈ 0). The Thompson bandit can't bias toward
+ * winners because there are no winners to learn from — a classic
+ * cold-start problem for a random-search system.
+ *
+ * Anchors solve the cold-start by seeding the bandit with known
+ * classical patterns. They go through the same multi-metric
+ * promotion gate as everything else; anchors that pass on current
+ * data proceed to paper → live like any other strategy. Anchors
+ * that fail get retired same as a generated variant.
+ *
+ * The role of an anchor is NOT to be the final live strategy —
+ * it's to give the bandit and the genome-mutator a real winning
+ * distribution to warp toward.
+ *
+ * Every anchor is a pair (long + short conditions) because user
+ * requirement: "check that it is trading on a sell ... the system
+ * needs to account for making money that way too."
+ */
+
+import type {
+  SignalCondition,
+  SignalGenome,
+} from './signalGenome.js';
+import type { MarketRegime, StrategyType } from './strategyLearningEngine.js';
+
+export interface AnchorStrategyDef {
+  /** Stable ID — prefix 'anchor_' keeps them identifiable in strategy_performance. */
+  id: string;
+  /** Human-readable description for logs / observability. */
+  name: string;
+  /** Classical pattern family — maps to existing StrategyType union. */
+  strategyType: StrategyType;
+  /** Symbol the anchor was tuned for. */
+  symbol: string;
+  /** Timeframe the anchor was tuned for. */
+  timeframe: string;
+  /** Leverage the anchor requests (kernel still caps at per-symbol exchange max). */
+  leverage: number;
+  /** Hand-tuned genome — not evolved. */
+  genome: SignalGenome;
+  /** Regime where this anchor expects to perform best. */
+  regimeAffinity: MarketRegime;
+}
+
+// ───────── Anchor 1: Trend-pullback scalper ─────────
+// Long: uptrend (ema20 > ema50) + RSI pullback (<45) → enter on bounce.
+// Short: downtrend + RSI retrace (>55) → enter on failed rally.
+// Classical pattern that fires multiple times per week in trending regimes.
+const TREND_PULLBACK_ENTRY: SignalCondition[] = [
+  // LONG side — uptrend pullback
+  { indicator: 'ema_cross_9_20', comparator: '>', threshold: 0, side: 'long' },
+  { indicator: 'sma_cross_20_50', comparator: '>', threshold: 0, side: 'long' },
+  { indicator: 'rsi', comparator: '<', threshold: 45, side: 'long' },
+  // SHORT side — downtrend rally
+  { indicator: 'ema_cross_9_20', comparator: '<', threshold: 0, side: 'short' },
+  { indicator: 'sma_cross_20_50', comparator: '<', threshold: 0, side: 'short' },
+  { indicator: 'rsi', comparator: '>', threshold: 55, side: 'short' },
+];
+
+const TREND_PULLBACK_EXIT: SignalCondition[] = [
+  // Long exits when trend flips or RSI gets overbought
+  { indicator: 'ema_cross_9_20', comparator: '<', threshold: 0, side: 'long' },
+  { indicator: 'rsi', comparator: '>', threshold: 70, side: 'long' },
+  // Short exits when trend flips or RSI gets oversold
+  { indicator: 'ema_cross_9_20', comparator: '>', threshold: 0, side: 'short' },
+  { indicator: 'rsi', comparator: '<', threshold: 30, side: 'short' },
+];
+
+// ───────── Anchor 2: Bollinger mean-reversion ─────────
+// Long: price near lower band (bb_position < 0.1) + RSI oversold.
+// Short: price near upper band (bb_position > 0.9) + RSI overbought.
+// Fires on extreme moves, catches snapback bounces. Works in ranging regimes.
+const MEAN_REV_ENTRY: SignalCondition[] = [
+  { indicator: 'bb_position', comparator: '<', threshold: 0.15, side: 'long' },
+  { indicator: 'rsi', comparator: '<', threshold: 32, side: 'long' },
+  { indicator: 'bb_position', comparator: '>', threshold: 0.85, side: 'short' },
+  { indicator: 'rsi', comparator: '>', threshold: 68, side: 'short' },
+];
+
+const MEAN_REV_EXIT: SignalCondition[] = [
+  // Exit at the BB mid (bb_position ≈ 0.5)
+  { indicator: 'bb_position', comparator: '>', threshold: 0.5, side: 'long' },
+  { indicator: 'bb_position', comparator: '<', threshold: 0.5, side: 'short' },
+];
+
+// ───────── Anchor 3: MACD momentum ─────────
+// Long: MACD histogram crosses above 0 within an uptrending SMA structure.
+// Short: MACD histogram crosses below 0 in a downtrending structure.
+// Fires at momentum inflections; catches early breakouts.
+const MACD_MOMENTUM_ENTRY: SignalCondition[] = [
+  { indicator: 'macd_histogram', comparator: 'crosses_above', threshold: 0, side: 'long' },
+  { indicator: 'sma_cross_20_50', comparator: '>', threshold: 0, side: 'long' },
+  { indicator: 'macd_histogram', comparator: 'crosses_below', threshold: 0, side: 'short' },
+  { indicator: 'sma_cross_20_50', comparator: '<', threshold: 0, side: 'short' },
+];
+
+const MACD_MOMENTUM_EXIT: SignalCondition[] = [
+  { indicator: 'macd_histogram', comparator: 'crosses_below', threshold: 0, side: 'long' },
+  { indicator: 'macd_histogram', comparator: 'crosses_above', threshold: 0, side: 'short' },
+];
+
+export const ANCHOR_STRATEGIES: AnchorStrategyDef[] = [
+  {
+    id: 'anchor_trend_pullback_btc_15m',
+    name: 'Trend-pullback scalper (BTC 15m)',
+    strategyType: 'trend_following',
+    symbol: 'BTC_USDT_PERP',
+    timeframe: '15m',
+    leverage: 3,
+    regimeAffinity: 'trending',
+    genome: {
+      entryConditions: TREND_PULLBACK_ENTRY,
+      exitConditions: TREND_PULLBACK_EXIT,
+      stopLossPercent: 0.015,      // 1.5% — tight on a scalp
+      takeProfitPercent: 0.030,    // 3% — 2:1 reward-to-risk
+      positionSizeFraction: 0.05,  // 5% of allocated capital
+    },
+  },
+  {
+    id: 'anchor_mean_rev_eth_15m',
+    name: 'Bollinger mean-reversion (ETH 15m)',
+    strategyType: 'mean_reversion',
+    symbol: 'ETH_USDT_PERP',
+    timeframe: '15m',
+    leverage: 3,
+    regimeAffinity: 'ranging',
+    genome: {
+      entryConditions: MEAN_REV_ENTRY,
+      exitConditions: MEAN_REV_EXIT,
+      stopLossPercent: 0.010,      // 1% — mean-reverts should bounce fast
+      takeProfitPercent: 0.020,    // 2% — 2:1
+      positionSizeFraction: 0.05,
+    },
+  },
+  {
+    id: 'anchor_macd_momentum_btc_1h',
+    name: 'MACD momentum (BTC 1h)',
+    strategyType: 'momentum',
+    symbol: 'BTC_USDT_PERP',
+    timeframe: '1h',
+    leverage: 3,
+    regimeAffinity: 'trending',
+    genome: {
+      entryConditions: MACD_MOMENTUM_ENTRY,
+      exitConditions: MACD_MOMENTUM_EXIT,
+      stopLossPercent: 0.020,      // 2% — 1h bars are wider
+      takeProfitPercent: 0.040,    // 4% — 2:1
+      positionSizeFraction: 0.05,
+    },
+  },
+];
+
+/**
+ * Return anchor strategies whose regime-affinity matches the current
+ * regime. Anchors tuned for other regimes are skipped so we don't
+ * pollute the gate with strategies that aren't expected to work right
+ * now. All three regimes see at least one anchor.
+ */
+export function getAnchorsForRegime(regime: MarketRegime): AnchorStrategyDef[] {
+  // 'unknown' regime gets all anchors — we don't know what's working
+  // yet, so let the gate decide.
+  if (regime === 'unknown') return [...ANCHOR_STRATEGIES];
+  return ANCHOR_STRATEGIES.filter(
+    (a) => a.regimeAffinity === regime || a.regimeAffinity === 'unknown',
+  );
+}

--- a/apps/api/src/services/strategyLearningEngine.ts
+++ b/apps/api/src/services/strategyLearningEngine.ts
@@ -74,6 +74,11 @@ import {
   evaluateRollingDrawdownDemotion,
   type TradeOutcome,
 } from './demotionPolicy.js';
+import {
+  ANCHOR_STRATEGIES,
+  getAnchorsForRegime,
+  type AnchorStrategyDef,
+} from './anchorStrategies.js';
 
 export type StrategyStatusTransitionReason =
   | 'created'
@@ -330,6 +335,16 @@ class StrategyLearningEngine extends EventEmitter {
    * collapses to uniform class sampling — the generator still produces
    * 6 variants per cycle so there's no dead zone.
    *
+   * Additionally, ANCHOR STRATEGIES (hand-crafted seeds in
+   * anchorStrategies.ts) are always injected when their affine regime
+   * matches and they're not already active. Anchors solve the cold-
+   * start problem: without real winners the bandit has nothing to
+   * bias toward, and the random-genome generator produces Sharpe ≈ 0
+   * strategies. Anchors are tuned classical patterns that should
+   * produce > 10 trades with positive expectancy on crypto 15m/1h
+   * data, giving the bandit a real winning distribution to warp
+   * toward.
+   *
    * Old elitism-on-paper_sharpe-DESC is gone. No 30% fallback — the
    * bandit is the whole story.
    */
@@ -338,7 +353,31 @@ class StrategyLearningEngine extends EventEmitter {
     const banditCounters = await this.loadBanditCountersForRegime(regime);
     const allParents = await this.loadBestPerformers(regime, 20);
     const variants: StrategyRecord[] = [];
-    for (let i = 0; i < 6; i++) {
+
+    // Inject anchor strategies first — they're the cold-start cure.
+    // An anchor is re-queued whenever it's NOT currently active in
+    // any stage (backtesting/paper_trading/recommended/live). That
+    // lets a failed anchor be re-tested the next cycle with the
+    // most recent data (market conditions may have shifted).
+    const activeIds = new Set(
+      Array.from(this.strategies.values())
+        .filter((s) =>
+          s.status === 'backtesting' ||
+          s.status === 'paper_trading' ||
+          s.status === 'recalibrating' ||
+          s.status === 'recommended' ||
+          s.status === 'live',
+        )
+        .map((s) => s.strategyId),
+    );
+    for (const anchor of getAnchorsForRegime(regime)) {
+      if (activeIds.has(anchor.id)) continue;
+      variants.push(this.anchorToStrategyRecord(anchor, regime));
+    }
+
+    // Top-up the cycle with evolved variants so total is 6.
+    const evolvedCount = Math.max(0, 6 - variants.length);
+    for (let i = 0; i < evolvedCount; i++) {
       // Sample the preferred class for this variant (Thompson draw —
       // independent draws across the 6 variants give natural diversity
       // while still biasing toward winning classes).
@@ -368,6 +407,35 @@ class StrategyLearningEngine extends EventEmitter {
     }
     logger.info(`[SLE] Generated ${variants.length} variants for regime '${regime}'`);
     return variants;
+  }
+
+  /**
+   * Convert an AnchorStrategyDef into a StrategyRecord that the
+   * backtest pipeline can consume. Uses the anchor's stable ID (not
+   * a generated one) so the same anchor can be re-tested each cycle
+   * without creating duplicate DB rows.
+   */
+  private anchorToStrategyRecord(
+    anchor: AnchorStrategyDef,
+    regime: MarketRegime,
+  ): StrategyRecord {
+    return {
+      strategyId: anchor.id,
+      symbol: anchor.symbol,
+      leverage: anchor.leverage,
+      timeframe: anchor.timeframe,
+      strategyType: anchor.strategyType,
+      genome: anchor.genome,
+      regimeAtCreation: regime,
+      backtestSharpe: null, backtestWr: null, backtestMaxDd: null,
+      paperSharpe: null, paperWr: null, paperPnl: null, paperTrades: 0,
+      liveSharpe: null, livePnl: null, liveTrades: 0,
+      isCensored: false, censorReason: null, uncensoredSharpe: null, fitnessDivergent: false,
+      status: 'backtesting', confidenceScore: null, createdAt: new Date(),
+      parentStrategyId: null, generation: this.generationCount,
+      backtestCount: 0, avgReturn: 0, avgSharpeRatio: 0,
+      equityCurve: [], lastEquitySlope: 0, phaseClock: 0,
+    };
   }
 
   /**

--- a/apps/api/src/services/strategyLearningEngine.ts
+++ b/apps/api/src/services/strategyLearningEngine.ts
@@ -355,23 +355,33 @@ class StrategyLearningEngine extends EventEmitter {
     const variants: StrategyRecord[] = [];
 
     // Inject anchor strategies first — they're the cold-start cure.
-    // An anchor is re-queued whenever it's NOT currently active in
-    // any stage (backtesting/paper_trading/recommended/live). That
-    // lets a failed anchor be re-tested the next cycle with the
-    // most recent data (market conditions may have shifted).
+    // An anchor is re-queued whenever it's NOT currently already
+    // somewhere in the pipeline. The "active" filter includes
+    // recalibrating too: those are being re-tested by their own
+    // recalibration path, so re-injecting them would cause a double-
+    // backtest in the same cycle. We only re-queue anchors whose
+    // lifecycle has ended (killed / retired / absent).
+    const activeStatuses: StrategyStatus[] = [
+      'backtesting',
+      'paper_trading',
+      'recalibrating',
+      'recommended',
+      'live',
+    ];
     const activeIds = new Set(
       Array.from(this.strategies.values())
-        .filter((s) =>
-          s.status === 'backtesting' ||
-          s.status === 'paper_trading' ||
-          s.status === 'recalibrating' ||
-          s.status === 'recommended' ||
-          s.status === 'live',
-        )
+        .filter((s) => activeStatuses.includes(s.status))
         .map((s) => s.strategyId),
     );
-    for (const anchor of getAnchorsForRegime(regime)) {
-      if (activeIds.has(anchor.id)) continue;
+    // Cap anchors at the total batch size (6). If the anchor list ever
+    // grows beyond 6, the generator stops being a "6 variants per cycle"
+    // system, which would break the budgeting assumptions in
+    // parallelStrategyRunner and in the backtest-stall alert math.
+    const ANCHORS_PER_CYCLE_CAP = 6;
+    const anchorsToInject = getAnchorsForRegime(regime)
+      .filter((a) => !activeIds.has(a.id))
+      .slice(0, ANCHORS_PER_CYCLE_CAP);
+    for (const anchor of anchorsToInject) {
       variants.push(this.anchorToStrategyRecord(anchor, regime));
     }
 


### PR DESCRIPTION
## Summary

Production logs after PRs #490-492 (hard-cut + data-fetcher + threshold-relax) showed the infrastructure is working correctly — but the **random-genome generator** produces strategies that trade ~10 times per window with `sharpe ≈ 0`. The Thompson bandit has no winners to learn from; the cold-start self-perpetuates.

This PR seeds three hand-crafted classical patterns as anchors:

| Anchor | Symbol × TF | Pattern | Regime |
|--------|-------------|---------|--------|
| Trend-pullback scalper | BTC × 15m | EMA cross + RSI pullback, both sides | trending |
| Bollinger mean-reversion | ETH × 15m | BB extreme + RSI extreme, both sides | ranging |
| MACD momentum | BTC × 1h | MACD cross + SMA trend filter, both sides | trending |

Each anchor trades **both long and short** (addresses the user's explicit "check that it is trading on a sell — the system needs to account for making money that way too" requirement).

## How seeding works

`strategyLearningEngine.generateVariants`:
1. Check which anchors match the current regime (`getAnchorsForRegime`).
2. Any anchor not currently active in the pipeline is prepended to the 6-variant list.
3. Remaining slots filled by evolved variants (Thompson bandit + crossover + mutate).
4. Anchors use stable IDs (`anchor_...`) so they upsert cleanly and can be re-tested each cycle against fresh data.

## Why this unblocks the pipeline

Anchors are not meant to be the final live strategies — they're a **winning distribution** the bandit can warp toward. Once 1-2 anchors pass the backtest gate on current market data:
- They populate `bandit_class_counters` with real wins per (class × regime).
- Thompson sampling biases toward those classes for generated variants.
- Mutations of the winning anchor parents explore the neighborhood.
- Within a few generations the pipeline has a real leaderboard, not random noise.

## Test plan

- [x] 9 anchor-specific tests (ID format, genome well-formedness, both-sides trading, risk-parameter sanity, regime filtering)
- [x] Full API suite: 493 passed
- [x] `tsc --noEmit -p tsconfig.build.json` clean
- [ ] Post-deploy: Generation N logs should show anchors being backtested; at least one should produce sharpe > 0.8 within 2-3 cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Seed hand-crafted anchor trading strategies into the strategy learning engine to address cold-start issues and provide the bandit with stable, regime-aware baseline strategies.

New Features:
- Introduce three predefined anchor strategy definitions with long and short signal genomes for specific symbols, timeframes, and market regimes.
- Add regime-aware selection of anchor strategies so appropriate anchors are considered based on current market conditions.

Enhancements:
- Update the strategy learning engine to inject eligible anchor strategies into each generation cycle before filling remaining slots with evolved variants.

Tests:
- Add unit tests for anchor strategies to validate ID format, genome structure, regime filtering, and basic sanity of the configurations.