### PR TITLE
Fix phantom-column SQL + silent-stage false positives from prod logs

### DIFF
--- a/apps/api/src/services/monitoringService.ts
+++ b/apps/api/src/services/monitoringService.ts
@@ -70,12 +70,26 @@ interface PipelineHeartbeat {
   ringMinute: number;              // minute-of-epoch at ringHead
 }
 
-/** Expected max silence per stage before a liveness alert fires. */
+/**
+ * Expected max silence per stage before a liveness alert fires.
+ *
+ * The SLE main loop runs every 30 minutes — each cycle emits one
+ * generator + one backtest heartbeat, then the loop sleeps. Thresholds
+ * must exceed that interval or the alert fires every cycle gap (false
+ * positive we observed in production as alertCount:12+ on generator).
+ *
+ * Set to 45 min = 30 min cycle + 15 min buffer for straggling cycles
+ * (heavy backtest, DB contention, etc.). A genuine stall — SLE loop
+ * dies or hangs — shows up as >>45 min silence.
+ *
+ * Paper / live / reconciliation tick on their own faster cadence
+ * (market events / 5-min reconcile loop) so tighter thresholds stay.
+ */
 const STAGE_SILENT_THRESHOLD_MS: Record<PipelineStage, number> = {
-  generator: 15 * 60_000,          // new strategies at least every 15 min
-  backtest: 10 * 60_000,           // backtest loop ticks more frequently
-  paper: 10 * 60_000,              // signal generation cycle
-  live: 10 * 60_000,               // live trade cycle
+  generator: 45 * 60_000,          // 30-min cycle + 15-min buffer
+  backtest: 45 * 60_000,           // same — both tick once per cycle
+  paper: 10 * 60_000,              // paper loop runs on market ticks
+  live: 10 * 60_000,               // live order path runs on signals
   reconciliation: 10 * 60_000,     // reconciler runs every 5 min, 2x buffer
 };
 

--- a/apps/api/src/services/strategyLearningEngine.ts
+++ b/apps/api/src/services/strategyLearningEngine.ts
@@ -767,6 +767,19 @@ class StrategyLearningEngine extends EventEmitter {
    * Fetch the strategy's most-recent trade outcomes for the rolling-
    * drawdown check. Returns an empty array if unavailable — the
    * demotion policy treats "not enough data" as "don't demote."
+   *
+   * Schema notes:
+   *   - paper_trading_positions uses realized_pnl (American), not
+   *     realised_pnl. Keep the SQL canonical; the TypeScript side
+   *     uses the British spelling by convention.
+   *   - strategy_name lives on paper_trading_sessions, not the
+   *     position rows — JOIN through.
+   *   - There is no margin_committed column. Position notional
+   *     (size × entry_price) is used as the denominator for the
+   *     drawdown-ratio calculation. That's gross exposure; for the
+   *     demotion policy's "sum(pnl) / sum(committed)" ratio this is
+   *     the right number.
+   *   - exit_time is the closed timestamp, not closed_at.
    */
   private async loadRecentTradeOutcomes(
     strategyId: string,
@@ -774,16 +787,19 @@ class StrategyLearningEngine extends EventEmitter {
   ): Promise<TradeOutcome[]> {
     try {
       const result = await query(
-        `SELECT realised_pnl, margin_committed
-           FROM paper_trading_positions
-          WHERE strategy_name = $1 AND status = 'closed'
-          ORDER BY closed_at DESC
+        `SELECT p.realized_pnl AS realized_pnl,
+                (p.size * p.entry_price) AS notional
+           FROM paper_trading_positions p
+           JOIN paper_trading_sessions s ON p.session_id = s.id
+          WHERE s.strategy_name = $1
+            AND p.status = 'closed'
+          ORDER BY p.exit_time DESC
           LIMIT $2`,
         [strategyId, limit],
       );
       return ((result.rows as any[]) ?? []).map((r) => ({
-        realisedPnl: safeNum(r.realised_pnl),
-        marginCommitted: Math.max(0.0001, safeNum(r.margin_committed, 1)),
+        realisedPnl: safeNum(r.realized_pnl),
+        marginCommitted: Math.max(0.0001, safeNum(r.notional, 1)),
       })).reverse(); // oldest first so rolling window sees trailing trades
     } catch (err) {
       logger.debug('[SLE] loadRecentTradeOutcomes failed (fail-soft):', err);


### PR DESCRIPTION
Two production bugs from Railway logs of `c2177b62`:

- **`ERROR: column "realised_pnl" does not exist`** — my British/American spelling mix in `loadRecentTradeOutcomes`. Rewrote the query with `realized_pnl`, JOIN through `paper_trading_sessions` for `strategy_name`, and `size × entry_price` as the drawdown denominator since there's no `margin_committed` column.
- **Pipeline-silent false positives every cycle** — thresholds (15/10 min) were shorter than the 30-min SLE cycle, guaranteed alert every gap. Raised `generator` and `backtest` to 45 min (cycle + buffer). Paper/live/reconciliation untouched.

Third recurrence of the PR #487 schema-drift bug class. The CI guard from the original plan would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix SLE trade outcome loading to match the actual paper trading schema and adjust monitoring silence thresholds to align with the 30-minute learning engine cycle.

Bug Fixes:
- Correct trade outcome query to use the existing realized PnL column, join via sessions for strategy names, and derive position notional as the drawdown denominator.
- Increase generator and backtest pipeline silence thresholds to prevent spurious liveness alerts on normal 30-minute cycles.

Enhancements:
- Add inline schema and monitoring behavior documentation to clarify SLE trade outcome assumptions and heartbeat thresholds.