### PR TITLE
Wire UI Execution Mode buttons to the server-side endpoint

### DIFF
--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -93,12 +93,17 @@ const AutonomousAgentDashboard: React.FC = () => {
     timestamp: string;
   } | null>(null);
   const [riskAppetite, setRiskAppetite] = usePersistedState<'conservative' | 'balanced' | 'aggressive'>('agent_risk_appetite', 'balanced');
-  // Execution Mode is a SAFETY OVERRIDE, not a pipeline stage. The pipeline
-  // (generated → backtest → paper → live) runs internally under 'auto'.
-  // 'paper_only' blocks live promotion regardless of strategy performance
-  // (debug/trust-building). 'pause' halts all new orders at every stage.
-  // Legacy value 'paper' is coerced to 'paper_only' for back-compat with
-  // any persisted localStorage entries from before this migration.
+  // Execution Mode is a SAFETY OVERRIDE enforced by the server-side risk
+  // kernel. The UI fetches it on mount and pushes updates via PUT; the
+  // cache in localStorage is just an optimistic UI value so the buttons
+  // feel responsive before the PUT completes.
+  //
+  // 'auto'        — pipeline decides; live trading permitted
+  // 'paper_only'  — kernel blocks all live orders; paper continues
+  // 'pause'       — kernel blocks ALL new orders at every stage
+  //
+  // Legacy localStorage values ('paper' | 'backtest' | 'live') coerce to
+  // the nearest valid server-side mode.
   const [executionModeRaw, setExecutionModeRaw] = usePersistedState<'auto' | 'paper_only' | 'pause' | 'backtest' | 'paper' | 'live'>('agent_execution_mode', 'auto');
   const executionMode: 'auto' | 'paper_only' | 'pause' =
     executionModeRaw === 'paper' || executionModeRaw === 'paper_only'
@@ -106,7 +111,55 @@ const AutonomousAgentDashboard: React.FC = () => {
       : executionModeRaw === 'pause'
         ? 'pause'
         : 'auto';  // 'backtest' | 'live' | 'auto' all normalise to 'auto'
-  const setExecutionMode = (v: 'auto' | 'paper_only' | 'pause') => setExecutionModeRaw(v);
+  const [executionModeUpdating, setExecutionModeUpdating] = useState(false);
+
+  /** PUT the new mode to the server and reflect the returned value. */
+  const setExecutionMode = useCallback(async (v: 'auto' | 'paper_only' | 'pause') => {
+    // Optimistic local update so the button highlight is instant.
+    setExecutionModeRaw(v);
+    setExecutionModeUpdating(true);
+    try {
+      const token = getAccessToken();
+      const response = await axios.put(
+        `${API_BASE_URL}/api/agent/execution-mode`,
+        { mode: v, reason: 'ui_toggle' },
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      if (response.data?.success && response.data?.mode) {
+        setExecutionModeRaw(response.data.mode);
+      }
+    } catch (err) {
+      // Revert the optimistic update if the server rejected.
+      console.error('Failed to update execution mode', err);
+      // Best-effort refetch of the authoritative value.
+      try {
+        const token = getAccessToken();
+        const response = await axios.get(`${API_BASE_URL}/api/agent/execution-mode`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (response.data?.mode) setExecutionModeRaw(response.data.mode);
+      } catch {
+        // swallow; UI will show the last good value
+      }
+    } finally {
+      setExecutionModeUpdating(false);
+    }
+  }, [setExecutionModeRaw]);
+
+  /** Pull server-authoritative mode on mount so UI matches reality. */
+  useEffect(() => {
+    (async () => {
+      try {
+        const token = getAccessToken();
+        const response = await axios.get(`${API_BASE_URL}/api/agent/execution-mode`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (response.data?.mode) setExecutionModeRaw(response.data.mode);
+      } catch (err) {
+        // Endpoint may be missing in older backends; keep localStorage value.
+      }
+    })();
+  }, [setExecutionModeRaw]);
   const [performanceMode, setPerformanceMode] = useState<'all' | 'backtest' | 'paper' | 'live'>('all');
   const [agentEvents, setAgentEvents] = useState<Array<{
     id: string;
@@ -605,7 +658,7 @@ const AutonomousAgentDashboard: React.FC = () => {
               ] as const).map(opt => (
                 <button key={opt.value}
                   onClick={() => setExecutionMode(opt.value)}
-                  disabled={agentStatus?.status === 'running'}
+                  disabled={executionModeUpdating}
                   className={`p-3 rounded-lg border-2 text-left transition-all disabled:opacity-50 ${
                     executionMode === opt.value ? opt.bgClass : 'border-gray-200 hover:border-gray-300'
                   }`}>


### PR DESCRIPTION
The Auto / Paper-Only / Pause buttons on the Autonomous Agent dashboard were localStorage-only — the server-side risk kernel kept reading the `agent_execution_mode` singleton (seeded 'auto'), so clicking 'Pause' did not actually pause anything.

## Fix

- **On mount:** `GET /api/agent/execution-mode` → populate UI from server truth
- **On click:** `PUT /api/agent/execution-mode` with `{mode, reason}` → kernel picks up the new mode within one cache TTL (30s)
- **Optimistic update pattern:** localStorage flips immediately for instant highlight; server response reconciles; rejected updates revert via a GET
- **Enabled during run:** flipped `disabled={agentStatus?.status === 'running'}` → `disabled={executionModeUpdating}`. Pausing while running is the whole point of the override.

## Other buttons — already correctly wired
- Start → `POST /api/agent/start`
- Stop → `POST /api/agent/stop`
- Pause → `POST /api/agent/pause`
- Resume → `POST /api/agent/resume`

Untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire the Autonomous Agent dashboard execution mode controls to the server-side endpoint and align the UI state with the backend risk kernel.

Bug Fixes:
- Ensure execution mode changes (Auto / Paper-Only / Pause) actually affect server-side behavior instead of only updating localStorage.

Enhancements:
- Load the authoritative execution mode from the backend on mount and reconcile optimistic local updates with server responses.
- Allow execution mode toggling while the agent is running, using an in-flight update flag to manage button disabled state.