### PR TITLE
fix(live+pause): close schema drift + wire header Pause/Stop

### DIFF
--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -122,9 +122,13 @@ router.post('/stop', authenticateToken, async (req: Request, res: Response) => {
   try {
     const userId = (req.user?.id || req.user?.userId)?.toString();
     if (!userId) return res.status(401).json({ success: false, error: 'User ID not found in token' });
-    // Only stop the per-user trader — SLE is global and must not be stopped per-user
+    // Global halt: flip execution mode to 'pause' so the risk kernel
+    // vetoes every order submission (liveSignalEngine, fullyAutonomousTrader,
+    // paperTradingService all cascade through this one switch).
+    const operator = (req.user?.email || req.user?.id || req.user?.userId || 'header_stop').toString();
+    await setExecutionMode('pause', operator, 'Header Stop button');
     try { await fullyAutonomousTrader.disableAutonomousTrading(userId); } catch { /* may not be enabled */ }
-    res.json({ success: true, message: 'Agent stopped successfully' });
+    res.json({ success: true, message: 'Agent stopped successfully', mode: 'pause' });
   } catch (error: unknown) {
     logger.error('Error stopping agent:', error);
     res.status(500).json({ success: false, error: error instanceof Error ? error.message : 'Failed to stop agent' });
@@ -135,9 +139,11 @@ router.post('/pause', authenticateToken, async (req: Request, res: Response) => 
   try {
     const userId = (req.user?.id || req.user?.userId)?.toString();
     if (!userId) return res.status(401).json({ success: false, error: 'User ID not found in token' });
-    // Only disable per-user trader — SLE is global and must not be stopped per-user
-    try { await fullyAutonomousTrader.disableAutonomousTrading(userId); } catch { /* may not be enabled */ }
-    res.json({ success: true, message: 'Agent paused successfully' });
+    // Global halt — same as /stop but keeps the per-user trader state
+    // alive so it resumes cleanly on /resume.
+    const operator = (req.user?.email || req.user?.id || req.user?.userId || 'header_pause').toString();
+    await setExecutionMode('pause', operator, 'Header Pause button');
+    res.json({ success: true, message: 'Agent paused successfully', mode: 'pause' });
   } catch (error: unknown) {
     logger.error('Error pausing agent:', error);
     res.status(500).json({ success: false, error: error instanceof Error ? error.message : 'Failed to pause agent' });
@@ -148,8 +154,10 @@ router.post('/resume', authenticateToken, async (req: Request, res: Response) =>
   try {
     const userId = (req.user?.id || req.user?.userId)?.toString();
     if (!userId) return res.status(401).json({ success: false, error: 'User ID not found in token' });
+    const operator = (req.user?.email || req.user?.id || req.user?.userId || 'header_resume').toString();
+    await setExecutionMode('auto', operator, 'Header Resume button');
     await strategyLearningEngine.start();
-    res.json({ success: true, message: 'Agent resumed successfully' });
+    res.json({ success: true, message: 'Agent resumed successfully', mode: 'auto' });
   } catch (error: unknown) {
     logger.error('Error resuming agent:', error);
     res.status(500).json({ success: false, error: error instanceof Error ? error.message : 'Failed to resume agent' });
@@ -162,11 +170,22 @@ router.get('/status', authenticateToken, async (req: Request, res: Response) => 
     if (!userId) return res.status(401).json({ success: false, error: 'User ID not found in token' });
     const sleStatus = await strategyLearningEngine.getEngineStatus();
     const traderStatus = await fullyAutonomousTrader.getStatus(userId);
+    const execMode = await getExecutionModeRecord();
+    // Resolve a single user-facing status. When execution mode is
+    // paused, surface that as the dominant state even if the SLE
+    // generation loop happens to be mid-tick — this is what the
+    // header Pause/Stop buttons advertise.
+    const running = traderStatus.isRunning || sleStatus.isRunning;
+    let status: 'running' | 'paused' | 'stopped';
+    if (execMode?.mode === 'pause') status = 'paused';
+    else if (running) status = 'running';
+    else status = 'stopped';
     res.json({
       success: true,
       status: {
         id: userId,
-        status: traderStatus.isRunning || sleStatus.isRunning ? 'running' : 'stopped',
+        status,
+        executionMode: execMode?.mode ?? null,
         startedAt: null,
         sle: sleStatus,
         trader: traderStatus

--- a/apps/api/src/routes/autonomousTrader.ts
+++ b/apps/api/src/routes/autonomousTrader.ts
@@ -123,9 +123,9 @@ router.get('/status', authenticateToken, async (req: Request, res: Response) => 
         quantity: parseFloat(trade.quantity),
         pnl: trade.pnl ? parseFloat(trade.pnl) : null,
         status: trade.status,
-        exitReason: trade.close_reason,
-        entryTime: trade.created_at,
-        exitTime: trade.closed_at,
+        exitReason: trade.exit_reason,
+        entryTime: trade.entry_time ?? trade.created_at,
+        exitTime: trade.exit_time,
         confidence: trade.confidence ? parseFloat(trade.confidence) : null,
         reason: trade.reason
       }))
@@ -245,9 +245,9 @@ router.get('/trades', authenticateToken, async (req: Request, res: Response) => 
         takeProfit: trade.take_profit ? parseFloat(trade.take_profit) : null,
         pnl: trade.pnl ? parseFloat(trade.pnl) : null,
         status: trade.status,
-        exitReason: trade.close_reason,
-        entryTime: trade.created_at,
-        exitTime: trade.closed_at,
+        exitReason: trade.exit_reason,
+        entryTime: trade.entry_time ?? trade.created_at,
+        exitTime: trade.exit_time,
         confidence: trade.confidence ? parseFloat(trade.confidence) : null,
         reason: trade.reason
       }))

--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -1194,8 +1194,8 @@ class FullyAutonomousTrader extends EventEmitter {
         );
         for (const symbol of inDbNotExchange) {
           await pool.query(
-            `UPDATE autonomous_trades SET status = 'closed', closed_at = NOW(),
-             close_reason = 'reconciliation: position not found on exchange'
+            `UPDATE autonomous_trades SET status = 'closed', exit_time = NOW(),
+             exit_reason = 'reconciliation: position not found on exchange'
              WHERE user_id = $1 AND symbol = $2 AND status = 'open' AND paper_trade = false`,
             [userId, symbol]
           );
@@ -1311,7 +1311,7 @@ class FullyAutonomousTrader extends EventEmitter {
       try {
         await pool.query(
           `UPDATE autonomous_trades
-           SET status = 'closed', close_reason = $3, closed_at = NOW(),
+           SET status = 'closed', exit_reason = $3, exit_time = NOW(),
                exit_price = $4, pnl = $5
            WHERE user_id = $1 AND symbol = $2 AND status = 'open'`,
           [userId, symbol, reason, exitPrice, pnl]
@@ -1320,7 +1320,7 @@ class FullyAutonomousTrader extends EventEmitter {
         // Columns may not exist yet — fall back to basic update
         await pool.query(
           `UPDATE autonomous_trades
-           SET status = 'closed', close_reason = $3, closed_at = NOW()
+           SET status = 'closed', exit_reason = $3, exit_time = NOW()
            WHERE user_id = $1 AND symbol = $2 AND status = 'open'`,
           [userId, symbol, reason]
         );
@@ -1348,7 +1348,7 @@ class FullyAutonomousTrader extends EventEmitter {
       // Update all open trades in DB
       await pool.query(
         `UPDATE autonomous_trades
-         SET status = 'closed', close_reason = 'trading_disabled', closed_at = NOW()
+         SET status = 'closed', exit_reason = 'trading_disabled', exit_time = NOW()
          WHERE user_id = $1 AND status = 'open'`,
         [userId]
       );

--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -194,12 +194,12 @@ export class LiveSignalEngine extends EventEmitter {
   private async reconcileClosedTrades(): Promise<void> {
     try {
       const result = await pool.query(
-        `SELECT symbol, reason, pnl, closed_at, exit_price, entry_price, quantity
+        `SELECT symbol, reason, pnl, exit_time, exit_price, entry_price, quantity
            FROM autonomous_trades
           WHERE status = 'closed'
-            AND closed_at > $1
+            AND exit_time > $1
             AND reason LIKE 'live_signal|%'
-          ORDER BY closed_at ASC
+          ORDER BY exit_time ASC
           LIMIT 100`,
         [this.lastReconcileAt],
       );
@@ -211,7 +211,7 @@ export class LiveSignalEngine extends EventEmitter {
         const signalKey = keyMatch?.[1];
         const regime = regimeMatch?.[1];
         const pnl = Number(row.pnl ?? 0);
-        const closedAt = row.closed_at ? new Date(row.closed_at as string) : new Date();
+        const closedAt = row.exit_time ? new Date(row.exit_time as string) : new Date();
 
         if (signalKey && regime) {
           await this.recordTradeOutcome(signalKey, regime, pnl);
@@ -316,9 +316,11 @@ export class LiveSignalEngine extends EventEmitter {
     const order = this.buildOrder(symbol, signal, currentPrice, atr);
     if (!order) return;
 
-    // 4. Fetch live account state for the kernel.
-    const accountState = await this.loadAccountState(symbol);
-    if (!accountState) return;
+    // 4. Fetch live account state for the kernel (also returns
+    //    userId + credentials so we can submit the order downstream
+    //    without another DB round-trip).
+    const accountCtx = await this.loadAccountContext(symbol);
+    if (!accountCtx) return;
     const symbolMaxLeverage = (await getMaxLeverage(symbol)) ?? order.leverage;
     const mode = await getCurrentExecutionMode();
     const context: KernelContext = {
@@ -328,7 +330,7 @@ export class LiveSignalEngine extends EventEmitter {
     };
 
     // 5. Blast-door kernel vetoes.
-    const decision = evaluatePreTradeVetoes(order, accountState, context);
+    const decision = evaluatePreTradeVetoes(order, accountCtx.state, context);
     if (!decision.allowed) {
       logger.info('[LiveSignal] kernel veto', {
         symbol,
@@ -345,7 +347,7 @@ export class LiveSignalEngine extends EventEmitter {
 
     // 6. Submit. The existing poloniexFuturesService handles the
     //    actual exchange call; ml-worker never touches the exchange.
-    await this.submitOrder(order, signal, atr);
+    await this.submitOrder(order, signal, atr, accountCtx.userId, accountCtx.credentials);
   }
 
   private normaliseSignal(s: unknown): 'BUY' | 'SELL' | 'HOLD' {
@@ -494,11 +496,21 @@ export class LiveSignalEngine extends EventEmitter {
   }
 
   /**
-   * Assemble the KernelAccountState the kernel needs. Uses the
-   * authenticated Poloniex account (there's exactly one on this
-   * platform at the moment).
+   * Assemble the KernelAccountState the kernel needs + return the
+   * operating userId and credentials so the caller can also submit
+   * orders and record DB rows without re-loading credentials.
+   *
+   * Uses the authenticated Poloniex account (there's exactly one on
+   * this platform at the moment).
    */
-  private async loadAccountState(symbol: string): Promise<KernelAccountState | null> {
+  private async loadAccountContext(symbol: string): Promise<
+    | {
+        state: KernelAccountState;
+        userId: string;
+        credentials: { apiKey: string; apiSecret: string; passphrase?: string };
+      }
+    | null
+  > {
     try {
       const userRow = await pool.query(
         `SELECT user_id FROM user_api_credentials WHERE exchange = 'poloniex' LIMIT 1`,
@@ -523,10 +535,14 @@ export class LiveSignalEngine extends EventEmitter {
       })).filter((p) => p.symbol.length > 0);
 
       return {
-        equityUsdt,
-        unrealizedPnlUsdt,
-        openPositions,
-        restingOrders: [],  // Not needed for market orders; self-match prevention still runs
+        state: {
+          equityUsdt,
+          unrealizedPnlUsdt,
+          openPositions,
+          restingOrders: [],  // Not needed for market orders; self-match prevention still runs
+        },
+        userId,
+        credentials,
       };
     } catch (err) {
       logger.warn(`[LiveSignal] ${symbol} — failed to load account state`, {
@@ -537,12 +553,26 @@ export class LiveSignalEngine extends EventEmitter {
   }
 
   /**
-   * Write the order to the DB + hand off to the exchange adapter +
-   * publish an outcome event for ml-worker training. Intentionally
-   * does NOT block on the fill — the order-status reconciler picks
-   * up fills/partials asynchronously.
+   * Place the order on the exchange, persist it to the DB, and
+   * publish an outcome event for ml-worker training. Sequence:
+   *
+   *   1. Set per-symbol leverage on the exchange.
+   *   2. Submit the market order (size in base units).
+   *   3. Best-effort place reduce-only exchange-side SL + TP.
+   *   4. INSERT the row into autonomous_trades with the returned
+   *      orderId so positionManagement can close against it later.
+   *
+   * Fail-soft: an exchange error is logged and recorded to the
+   * outcome event; we still record a DB row only on successful
+   * placement so the reconciler doesn't see phantom opens.
    */
-  private async submitOrder(order: KernelOrder, signal: LiveSignalTick, atr: number): Promise<void> {
+  private async submitOrder(
+    order: KernelOrder,
+    signal: LiveSignalTick,
+    atr: number,
+    userId: string,
+    credentials: { apiKey: string; apiSecret: string; passphrase?: string },
+  ): Promise<void> {
     const quantity = order.notional / order.price;
     const stopLoss = order.side === 'long'
       ? order.price - atr * ATR_STOP_MULTIPLIER
@@ -550,6 +580,8 @@ export class LiveSignalEngine extends EventEmitter {
     const takeProfit = order.side === 'long'
       ? order.price + atr * ATR_TAKE_PROFIT_MULTIPLIER
       : order.price - atr * ATR_TAKE_PROFIT_MULTIPLIER;
+    const exchangeSide = order.side === 'long' ? 'buy' : 'sell';
+    const closeSide = order.side === 'long' ? 'sell' : 'buy';
 
     logger.info('[LiveSignal] submitting order', {
       order,
@@ -560,39 +592,121 @@ export class LiveSignalEngine extends EventEmitter {
       signal,
     });
 
+    // 1. Leverage — non-fatal if exchange rejects; order still proceeds.
     try {
-      // Encode bandit key + regime into the reason column so the
-      // close-hook can look them up cheaply (no schema change needed
-      // for this iteration). Format: live_signal|key=...|regime=...|src=...
+      await poloniexFuturesService.setLeverage(credentials, order.symbol, order.leverage);
+    } catch (levErr) {
+      logger.warn('[LiveSignal] setLeverage failed (non-fatal)', {
+        symbol: order.symbol,
+        leverage: order.leverage,
+        err: levErr instanceof Error ? levErr.message : String(levErr),
+      });
+    }
+
+    // 2. Market order — this is the point of no return.
+    let orderId: string | undefined;
+    try {
+      const exchangeOrder = await poloniexFuturesService.placeOrder(credentials, {
+        symbol: order.symbol,
+        side: exchangeSide,
+        type: 'market',
+        size: quantity,
+      });
+      orderId = exchangeOrder?.orderId ?? exchangeOrder?.id;
+      logger.info('[LiveSignal] exchange order placed', {
+        orderId,
+        symbol: order.symbol,
+        side: exchangeSide,
+        size: quantity,
+      });
+    } catch (err) {
+      logger.error('[LiveSignal] exchange placeOrder failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      await this.publishOutcomeEvent({
+        symbol: order.symbol,
+        phase: 'rejected',
+        reason: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    // 3. Best-effort exchange-side SL + TP (reduce-only). Failures
+    //    are logged but don't roll back — the server-side managed
+    //    loop handles SL/TP as a fallback.
+    if (stopLoss > 0 && Number.isFinite(stopLoss)) {
+      try {
+        await poloniexFuturesService.placeOrder(credentials, {
+          symbol: order.symbol,
+          side: closeSide,
+          type: 'stop_market',
+          size: quantity,
+          stopPrice: stopLoss,
+          stopPriceType: 'TP',
+          reduceOnly: true,
+        });
+      } catch (slErr) {
+        logger.warn('[LiveSignal] SL placement failed (non-fatal)', {
+          err: slErr instanceof Error ? slErr.message : String(slErr),
+        });
+      }
+    }
+    if (takeProfit > 0 && Number.isFinite(takeProfit)) {
+      try {
+        await poloniexFuturesService.placeOrder(credentials, {
+          symbol: order.symbol,
+          side: closeSide,
+          type: 'stop_market',
+          size: quantity,
+          stopPrice: takeProfit,
+          stopPriceType: 'TP',
+          reduceOnly: true,
+        });
+      } catch (tpErr) {
+        logger.warn('[LiveSignal] TP placement failed (non-fatal)', {
+          err: tpErr instanceof Error ? tpErr.message : String(tpErr),
+        });
+      }
+    }
+
+    // 4. Persist. Encode bandit key + regime into `reason` so the
+    //    close-hook can look them up cheaply (no schema change).
+    //    Format: live_signal|key=...|regime=...|src=...
+    try {
       const reasonEncoded =
         `live_signal|key=${signal.signalKey}|regime=${signal.regime}|src=${signal.reason}`;
       await pool.query(
         `INSERT INTO autonomous_trades
-           (symbol, side, entry_price, quantity, stop_loss, take_profit,
-            confidence, reason, paper_trade, engine_version)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+           (user_id, symbol, side, entry_price, quantity, leverage,
+            stop_loss, take_profit, confidence, reason, order_id,
+            paper_trade, engine_version)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
         [
+          userId,
           order.symbol,
-          order.side === 'long' ? 'buy' : 'sell',
+          exchangeSide,
           order.price,
           quantity,
+          order.leverage,
           stopLoss,
           takeProfit,
           signal.effectiveStrength,
           reasonEncoded,
+          orderId ?? null,
           false,
           getEngineVersion(),
         ],
       );
       monitoringService.recordTradeEvent('live');
     } catch (err) {
-      logger.error('[LiveSignal] DB insert failed', {
+      logger.error('[LiveSignal] DB insert failed after exchange placement', {
+        orderId,
         err: err instanceof Error ? err.message : String(err),
       });
     }
 
-    // Fire-and-forget outcome event (initial — fills will be reported
-    // by the reconciler when they land).
+    // Fire-and-forget outcome event (fills will be reported by the
+    // reconciler when they land).
     await this.publishOutcomeEvent({
       symbol: order.symbol,
       signal: signal.signal,
@@ -601,6 +715,7 @@ export class LiveSignalEngine extends EventEmitter {
       phase: 'submitted',
       price: order.price,
       quantity,
+      orderId,
     });
   }
 

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -208,8 +208,8 @@ class StateReconciliationService {
             await pool.query(
               `UPDATE autonomous_trades
                SET status = 'closed',
-                   close_reason = 'reconciled_not_on_exchange',
-                   closed_at = NOW()
+                   exit_reason = 'reconciled_not_on_exchange',
+                   exit_time = NOW()
                WHERE id = $1`,
               [dbTrade.id]
             );

--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -243,6 +243,16 @@ const AutonomousAgentDashboard: React.FC = () => {
     };
   }, []);
 
+  // Re-fetch timeline events whenever the user changes the filter pill
+  // (All / trade decision / state change / risk action / health alert /
+  // error). Without this the filter only took effect on the next
+  // running-polling tick — so from the user's perspective the buttons
+  // looked dead when the agent was stopped.
+  useEffect(() => {
+    fetchEvents();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventFilter]);
+
   // Polling interval — adjusts based on agent status with exponential backoff on errors
   useEffect(() => {
     const isActive = agentStatus?.status === 'running';
@@ -1104,7 +1114,7 @@ const AutonomousAgentDashboard: React.FC = () => {
       </div>
 
       {/* Performance Analytics */}
-      <PerformanceAnalytics agentStatus={agentStatus?.status} />
+      <PerformanceAnalytics agentStatus={agentStatus?.status} performanceMode={performanceMode} />
 
       {/* Agent Activity Timeline */}
       <div className="bg-white rounded-lg shadow-lg overflow-hidden">

--- a/apps/web/src/components/agent/PerformanceAnalytics.tsx
+++ b/apps/web/src/components/agent/PerformanceAnalytics.tsx
@@ -30,11 +30,19 @@ interface PerformanceData {
 interface PerformanceAnalyticsProps {
   agentStatus?: string;
   timeRange?: '24h' | '7d' | '30d' | 'all';
+  /**
+   * Execution-mode filter from the parent's Performance Mode tabs.
+   * The backend accepts 'paper' | 'live' (derived from order_id prefix)
+   * and treats anything else as "all modes combined". Passing this
+   * makes the tabs functional rather than decorative.
+   */
+  performanceMode?: 'all' | 'backtest' | 'paper' | 'live';
 }
 
-const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({ 
+const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
   agentStatus,
-  timeRange = '7d'
+  timeRange = '7d',
+  performanceMode = 'all'
 }) => {
   const [data, setData] = useState<PerformanceData | null>(null);
   const [selectedRange, setSelectedRange] = useState(timeRange);
@@ -42,7 +50,7 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
 
   useEffect(() => {
     fetchPerformanceData();
-    
+
     if (agentStatus === 'running') {
       const interval = setInterval(() => {
         fetchPerformanceData();
@@ -50,13 +58,20 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
 
       return () => clearInterval(interval);
     }
-  }, [agentStatus, selectedRange]);
+  }, [agentStatus, selectedRange, performanceMode]);
 
   const fetchPerformanceData = async () => {
     try {
       const token = getAccessToken();
+      // The backend supports mode=paper|live; any other value (incl.
+      // 'all' and 'backtest') yields combined results — backtest data
+      // lives in a separate table served by BacktestResultsVisualization.
+      const modeParam =
+        performanceMode === 'paper' || performanceMode === 'live'
+          ? `&mode=${performanceMode}`
+          : '';
       const response = await axios.get(
-        `${API_BASE_URL}/api/agent/performance?range=${selectedRange}`,
+        `${API_BASE_URL}/api/agent/performance?range=${selectedRange}${modeParam}`,
         { headers: { Authorization: `Bearer ${token}` } }
       );
       


### PR DESCRIPTION
## Summary
Three post-merge fixes on top of #497:

- **Schema drift:** prod \`autonomous_trades\` uses \`exit_time\`/\`exit_reason\`, not \`closed_at\`/\`close_reason\`. Every reconcile tick was erroring; live INSERTs were failing on \`user_id\` NOT NULL. Fixed in liveSignalEngine, fullyAutonomousTrader, stateReconciliationService, autonomousTrader route.
- **liveSignalEngine actually places exchange orders now.** Previous version wrote a DB row but never called \`poloniexFuturesService.placeOrder\`. Now: setLeverage → market order → reduce-only SL/TP → DB row with returned orderId + user_id + leverage.
- **Header Pause/Stop now halt live trading.** They only disabled the per-user trader; the risk kernel cascades off \`execution_mode\` which they never touched. Now Pause/Stop set \`execution_mode=pause\` (cascades through every order path); Resume sets \`auto\`.
- **GET /agent/status** returns \`executionMode\` and a \`'paused'\` top-level state so the header reflects the real posture.

## Test plan
- [ ] After deploy: no more \`column "closed_at" does not exist\` errors in logs
- [ ] After deploy: no more \`null value in column "user_id"\` violations
- [ ] With \`LIVE_SIGNAL_EXECUTE=true\`: \`[LiveSignal] exchange order placed\` log line appears with a real orderId
- [ ] First $2 live order visible on Poloniex Futures account
- [ ] Header Pause button → execution_mode=pause → subsequent liveSignal ticks veto with \`execution_mode_paused\`
- [ ] Header Resume button → trading resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align live trading, reconciliation, and status reporting with production schema while wiring live execution and global pause/resume controls.

New Features:
- Enable liveSignalEngine to place real exchange orders, including leverage setup, market entry, optional SL/TP, and persistence of order metadata for reconciliation.
- Expose global execution mode and a derived paused/running/stopped status from GET /agent/status so the UI reflects the trading posture.
- Make header Pause/Stop/Resume controls drive the global execution mode to halt or resume all automated trading paths.

Bug Fixes:
- Fix schema drift in autonomous_trades usage by switching from closed_at/close_reason to exit_time/exit_reason and using entry_time where available.
- Ensure autonomous_trades inserts include user_id and exchange order identifiers to prevent NOT NULL violations and orphaned trades in reconciliation.

Enhancements:
- Refine reconciliation paths in fullyAutonomousTrader and stateReconciliationService to set exit_time/exit_reason consistently when closing trades.