### PR TITLE
fix(live): prevent stacking + capture Poloniex ordId

### DIFF
--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -311,6 +311,27 @@ export class LiveSignalEngine extends EventEmitter {
       return;
     }
 
+    // 2c. Stacking guard: if we already have an open autonomous_trade
+    //      row on this symbol from the live-signal engine, don't stack.
+    //      Market orders on the same side accumulate into one net
+    //      Poloniex position — the exposure cap catches the extreme,
+    //      but we'd still burn fees stacking 60x/hour into the same
+    //      trade. Let existing position play out; managePositions or
+    //      the SL/TP exit will flip the DB row to 'closed' and free
+    //      this symbol for a fresh signal.
+    const openCheck = await pool.query(
+      `SELECT 1 FROM autonomous_trades
+        WHERE symbol = $1
+          AND status = 'open'
+          AND reason LIKE 'live_signal|%'
+        LIMIT 1`,
+      [symbol],
+    );
+    if ((openCheck.rowCount ?? 0) > 0) {
+      logger.debug(`[LiveSignal] ${symbol} has open live_signal trade — skipping new entry`);
+      return;
+    }
+
     // 3. Translate signal to a KernelOrder shape.
     const atr = this.computeATR(ohlcv, ATR_PERIOD);
     const order = this.buildOrder(symbol, signal, currentPrice, atr);
@@ -612,9 +633,17 @@ export class LiveSignalEngine extends EventEmitter {
         type: 'market',
         size: quantity,
       });
-      orderId = exchangeOrder?.orderId ?? exchangeOrder?.id;
+      // Poloniex v3 futures returns the exchange order id as `ordId`.
+      // Keep `orderId`/`id` fallbacks so mocked tests + any future
+      // adapter variants still work without changing this line.
+      orderId =
+        exchangeOrder?.ordId ??
+        exchangeOrder?.orderId ??
+        exchangeOrder?.id ??
+        exchangeOrder?.clientOid;
       logger.info('[LiveSignal] exchange order placed', {
         orderId,
+        rawResponseKeys: exchangeOrder ? Object.keys(exchangeOrder) : [],
         symbol: order.symbol,
         side: exchangeSide,
         size: quantity,


### PR DESCRIPTION
## Summary
Observed immediately after #498: every 60s tick placed a new market buy on BTC+ETH. Same-side market orders accumulate into one net Poloniex position, but DB fills with phantom 'open' rows and we burn fees.

- **Stacking guard**: skip the tick if there's already an open \`live_signal|%\` row on that symbol. Lets existing trade play out via SL/TP or managePositions before fresh entry.
- **Poloniex ordId**: v3 futures returns \`ordId\` (not \`orderId\`/\`id\`). Now falls back through \`ordId → orderId → id → clientOid\` and logs \`rawResponseKeys\` so future shape drift is visible.

## Test plan
- [ ] After deploy + resume (\`execution_mode=auto\`): first tick places order, subsequent ticks log \`has open live_signal trade — skipping\`
- [ ] \`[LiveSignal] exchange order placed\` log shows a non-empty orderId
- [ ] \`autonomous_trades.order_id\` column populated on new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent repeated live-signal entries from stacking on the same symbol and ensure Poloniex futures order IDs are correctly captured and logged.

Bug Fixes:
- Skip creating a new live-signal autonomous trade when an open live_signal trade already exists for the same symbol, avoiding stacked entries and redundant fees.
- Capture Poloniex v3 futures order IDs using ordId with fallbacks and log response keys so live trades consistently persist a valid exchange order ID.