### PR TITLE
feat(dashboard): scorched-earth prune + State-of-the-Bot card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,7 @@ uv.lock
 # Docker volumes
 postgres_data/
 redis_data/
+
+# Playwright MCP session artefacts + ad-hoc screenshots
+.playwright-mcp/
+agent-dashboard-*.png

--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -3,12 +3,14 @@ import express from 'express';
 import { pool } from '../db/connection.js';
 import { authenticateToken } from '../middleware/auth.js';
 import { agentSettingsService } from '../services/agentSettingsService.js';
+import { apiCredentialsService } from '../services/apiCredentialsService.js';
 import {
   getExecutionModeRecord,
   setExecutionMode,
   type ExecutionMode,
 } from '../services/executionModeService.js';
 import { fullyAutonomousTrader } from '../services/fullyAutonomousTrader.js';
+import poloniexFuturesService from '../services/poloniexFuturesService.js';
 import { strategyLearningEngine } from '../services/strategyLearningEngine.js';
 import { logger } from '../utils/logger.js';
 
@@ -473,17 +475,203 @@ router.get('/backtest/results', authenticateToken, async (req: Request, res: Res
     const strategyId = req.query.strategy_id as string;
     const rawBtLimit = parseInt(req.query.limit as string, 10);
     const limit = Math.min(Math.max(Number.isFinite(rawBtLimit) ? rawBtLimit : 10, 1), 100);
+    // engine_version IS NOT NULL: drop the 1,791 legacy rows that
+    // pre-date the engine_version migration (PR #496). They have
+    // unit-mismatched total_return values that pollute aggregates
+    // (e.g. −733% avg, −23581% worst) and are scheduled for hard
+    // delete in the separate legacy-purge PR.
     let result;
     if (strategyId) {
-      result = await pool.query(`SELECT * FROM backtest_results WHERE strategy_name = $1 ORDER BY created_at DESC LIMIT $2`, [strategyId, limit]);
+      result = await pool.query(
+        `SELECT * FROM backtest_results
+          WHERE strategy_name = $1 AND engine_version IS NOT NULL
+          ORDER BY created_at DESC LIMIT $2`,
+        [strategyId, limit],
+      );
     } else {
-      result = await pool.query(`SELECT * FROM backtest_results ORDER BY created_at DESC LIMIT $1`, [limit]);
+      result = await pool.query(
+        `SELECT * FROM backtest_results
+          WHERE engine_version IS NOT NULL
+          ORDER BY created_at DESC LIMIT $1`,
+        [limit],
+      );
     }
     res.json({ success: true, results: result.rows });
   } catch (error: unknown) {
     if (isTableMissingError(error)) return res.json({ success: true, results: [] });
     logger.error('Error fetching backtest results:', error);
     res.status(500).json({ success: false, error: 'Failed to fetch backtest results' });
+  }
+});
+
+/**
+ * GET /api/agent/state-of-bot
+ *
+ * Single-payload "what is the bot doing right now?" view used by the
+ * new State-of-the-Bot card. Aggregates real-time posture (phase,
+ * execution mode, last tick), P&L for 24h/7d/30d/all-time, activity
+ * stats (trades/hr, recent win rate), exchange vs DB position count
+ * (divergence = phantom state — the class of bug we caught on
+ * 2026-04-18 where 6 DB rows stayed "open" while the exchange showed
+ * zero positions), balance, and current leverage.
+ *
+ * Phase precedence (priority order — first match wins):
+ *   1. paused       → execution_mode = 'pause'
+ *   2. degraded     → Poloniex unreachable OR no tick in > 5 min
+ *   3. skipping     → last tick produced a signal, no order placed
+ *   4. trading      → a trade opened within the last tick interval
+ *   5. evaluating   → tick fired, no qualifying signal
+ */
+router.get('/state-of-bot', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const userId = (req.user?.id || req.user?.userId)?.toString();
+    if (!userId) return res.status(401).json({ success: false, error: 'User ID not found in token' });
+
+    // Execution mode (cached in executionModeService, so this is cheap).
+    const modeRecord = await getExecutionModeRecord();
+    const executionMode = modeRecord?.mode ?? 'auto';
+
+    // P&L buckets from autonomous_trades. Closed + pnl IS NOT NULL.
+    // Only rows with reason LIKE 'live_signal|%' to stay aligned with
+    // the live signal engine; legacy/paper rows skew the headline.
+    const pnlResult = await pool.query(
+      `SELECT
+         COALESCE(SUM(pnl) FILTER (WHERE exit_time > NOW() - INTERVAL '24 hours'), 0) AS pnl_24h,
+         COUNT(*)          FILTER (WHERE exit_time > NOW() - INTERVAL '24 hours')      AS trades_24h,
+         COALESCE(SUM(pnl) FILTER (WHERE exit_time > NOW() - INTERVAL '7 days'), 0)    AS pnl_7d,
+         COUNT(*)          FILTER (WHERE exit_time > NOW() - INTERVAL '7 days')        AS trades_7d,
+         COALESCE(SUM(pnl) FILTER (WHERE exit_time > NOW() - INTERVAL '30 days'), 0)   AS pnl_30d,
+         COUNT(*)          FILTER (WHERE exit_time > NOW() - INTERVAL '30 days')       AS trades_30d,
+         COALESCE(SUM(pnl), 0) AS pnl_all,
+         COUNT(*)               AS trades_all
+       FROM autonomous_trades
+       WHERE status = 'closed' AND pnl IS NOT NULL AND reason LIKE 'live_signal|%'
+         AND user_id = $1`,
+      [userId],
+    );
+    const pnl = pnlResult.rows[0] as Record<string, string>;
+
+    // Win rate over last 20 closed trades.
+    const lastTradesResult = await pool.query(
+      `SELECT pnl FROM autonomous_trades
+        WHERE status = 'closed' AND pnl IS NOT NULL AND reason LIKE 'live_signal|%' AND user_id = $1
+        ORDER BY exit_time DESC LIMIT 20`,
+      [userId],
+    );
+    const lastTrades = lastTradesResult.rows as Array<{ pnl: string }>;
+    const winRateLast20 =
+      lastTrades.length === 0
+        ? 0
+        : lastTrades.filter((r) => Number(r.pnl) > 0).length / lastTrades.length;
+
+    // Open-trade counts: exchange-authoritative vs DB-authoritative.
+    // Divergence = phantom state — should alarm.
+    const dbOpenResult = await pool.query(
+      `SELECT COUNT(*) AS n FROM autonomous_trades
+        WHERE status = 'open' AND reason LIKE 'live_signal|%' AND user_id = $1`,
+      [userId],
+    );
+    const dbOpenPositions = parseInt((dbOpenResult.rows[0] as { n: string }).n, 10) || 0;
+
+    let exchangeOpenPositions = 0;
+    let balance = { equity: 0, currency: 'USDT' as const };
+    let currentLeverage = 0;
+    let poloniexReachable = true;
+    try {
+      const credentials = await apiCredentialsService.getCredentials(userId, 'poloniex');
+      if (credentials) {
+        const [positions, bal] = await Promise.all([
+          poloniexFuturesService.getPositions(credentials),
+          poloniexFuturesService.getAccountBalance(credentials),
+        ]);
+        const positionsList = Array.isArray(positions) ? positions : [];
+        exchangeOpenPositions = positionsList.filter((p: Record<string, unknown>) => {
+          const qty = Math.abs(Number(p.qty ?? p.size ?? p.positionAmt ?? 0));
+          return qty > 0;
+        }).length;
+        // Derive leverage from the largest open position; 0 when flat.
+        currentLeverage = positionsList.reduce(
+          (max: number, p: Record<string, unknown>) => Math.max(max, Number(p.leverage ?? 0)),
+          0,
+        );
+        balance = {
+          equity: Number(bal?.totalBalance ?? bal?.eq ?? 0),
+          currency: 'USDT',
+        };
+      }
+    } catch (err) {
+      poloniexReachable = false;
+      logger.warn('[state-of-bot] Poloniex unreachable', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    // Last tick + phase derivation from strategyLearningEngine +
+    // monitoringService heartbeat. We treat > 5 min silence as degraded.
+    const engineStatus = await strategyLearningEngine.getEngineStatus().catch(() => null);
+    const lastTickAt = (engineStatus as { lastActivityAt?: string } | null)?.lastActivityAt ?? null;
+    const lastTickAgeMs = lastTickAt ? Date.now() - new Date(lastTickAt).getTime() : null;
+    const stale = lastTickAgeMs !== null && lastTickAgeMs > 5 * 60_000;
+
+    // Trades placed in the last tick interval (~60s). If > 0, phase = trading.
+    const recentOpenResult = await pool.query(
+      `SELECT COUNT(*) AS n FROM autonomous_trades
+        WHERE reason LIKE 'live_signal|%' AND user_id = $1
+          AND (entry_time > NOW() - INTERVAL '90 seconds' OR created_at > NOW() - INTERVAL '90 seconds')`,
+      [userId],
+    );
+    const recentlyOpened = parseInt((recentOpenResult.rows[0] as { n: string }).n, 10) || 0;
+
+    let phase: 'paused' | 'degraded' | 'skipping' | 'trading' | 'evaluating';
+    let phaseReason: string;
+    if (executionMode === 'pause') {
+      phase = 'paused';
+      phaseReason = modeRecord?.reason || 'Execution mode set to pause';
+    } else if (!poloniexReachable || stale) {
+      phase = 'degraded';
+      phaseReason = !poloniexReachable
+        ? 'Poloniex exchange unreachable'
+        : `Last tick ${Math.round((lastTickAgeMs ?? 0) / 60_000)} min ago — expected every minute`;
+    } else if (recentlyOpened > 0) {
+      phase = 'trading';
+      phaseReason = `${recentlyOpened} order${recentlyOpened === 1 ? '' : 's'} placed in last 90s`;
+    } else if (dbOpenPositions > 0) {
+      phase = 'skipping';
+      phaseReason = `${dbOpenPositions} open live-signal position${dbOpenPositions === 1 ? '' : 's'} — stacking guard blocks new entries until they close`;
+    } else {
+      phase = 'evaluating';
+      phaseReason = 'No qualifying signal this tick — watching';
+    }
+
+    // Trades/hr = closed + opened in last 24h, normalized.
+    const tradesPerHour = Number(pnl.trades_24h) / 24;
+
+    res.json({
+      success: true,
+      phase,
+      phaseReason,
+      executionMode,
+      lastTickAt,
+      pnl: {
+        '24h': { realized: Number(pnl.pnl_24h), trades: parseInt(pnl.trades_24h, 10) || 0 },
+        '7d':  { realized: Number(pnl.pnl_7d),  trades: parseInt(pnl.trades_7d, 10)  || 0 },
+        '30d': { realized: Number(pnl.pnl_30d), trades: parseInt(pnl.trades_30d, 10) || 0 },
+        all:   { realized: Number(pnl.pnl_all), trades: parseInt(pnl.trades_all, 10) || 0 },
+      },
+      tradesPerHour,
+      winRateLast20,
+      exchangeOpenPositions,
+      dbOpenPositions,
+      positionStateInSync: exchangeOpenPositions === dbOpenPositions,
+      balance,
+      currentLeverage,
+    });
+  } catch (error: unknown) {
+    logger.error('Error building state-of-bot:', error);
+    res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to build state-of-bot',
+    });
   }
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,14 +8,12 @@ import ConnectionHealth from './components/ConnectionHealth';
 
 import { EnvDebug } from './components/EnvDebug';
 import { ConnectionTest } from './components/ConnectionTest';
-import PWAInstallPrompt from './components/PWAInstallPrompt';
 import { TradingProvider } from './context/TradingContext';
 import { SettingsProvider } from './context/SettingsContext';
 import { WebSocketProvider } from './context/WebSocketContext';
 import { AuthProvider } from './context/AuthContext';
 import { MobileMenuProvider } from './context/MobileMenuContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
-import Integration from './components/Integration';
 import ToastContainer from './components/ToastContainer';
 import RouteGuard from './components/RouteGuard';
 import { BrowserCompatibility } from './utils/extensionErrorHandler';
@@ -146,7 +144,15 @@ function App() {
                         </Suspense>
                       </RouteGuard>
                 </AppLayout>
-                <Integration />
+                {/*
+                  <Integration /> was previously rendered globally here,
+                  which leaked the Poloniex/TradingView/Chrome-Extension
+                  status panel + Setup Instructions onto every
+                  authenticated page. Removed as part of the 2026-04-19
+                  scorched-earth prune — the panel is a setup helper,
+                  not ongoing operational UI. If reintroduced, gate it
+                  behind the /login route (or a Settings subpage).
+                */}
                 <ToastContainer />
 
                 {/* Debug components - only in development */}
@@ -157,7 +163,13 @@ function App() {
                     <ConnectionTest />
                   </>
                 )}
-                <PWAInstallPrompt />
+                {/*
+                  <PWAInstallPrompt /> removed from global render in the
+                  2026-04-19 prune. For a trading tool the user babysits
+                  on desktop, the install nag is pure noise. Component
+                  code is preserved; reintroduce behind a Settings
+                  toggle if we ever want to offer it explicitly.
+                */}
                 </MobileMenuProvider>
                 </TradingProvider>
               </WebSocketProvider>

--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -5,14 +5,12 @@ import axios from 'axios';
 import { getAccessToken } from '@/utils/auth';
 import { usePersistedState } from '@/hooks/usePersistedState';
 import { getBackendUrl } from '@/utils/environment';
-import StrategyGenerationDisplay from './StrategyGenerationDisplay';
 import ActiveStrategiesPanel from './ActiveStrategiesPanel';
-import BacktestResultsVisualization from './BacktestResultsVisualization';
-import StrategyApprovalQueue from './StrategyApprovalQueue';
 import LiveTradingActivityFeed from './LiveTradingActivityFeed';
-import PerformanceAnalytics from './PerformanceAnalytics';
-import AgentOverviewPanel from './AgentOverviewPanel';
 import MLLiveRecommendations from './MLLiveRecommendations';
+import PerformanceAnalytics from './PerformanceAnalytics';
+import StateOfTheBotCard from './StateOfTheBotCard';
+import StrategyApprovalQueue from './StrategyApprovalQueue';
 import { safeNum } from '@/utils/safeNum';
 
 const API_BASE_URL = getBackendUrl();
@@ -1007,25 +1005,20 @@ const AutonomousAgentDashboard: React.FC = () => {
         </div>
       </div>
 
-      {/* Profitability & Agent Oversight Panel */}
-      <AgentOverviewPanel
-        agentStatus={agentStatus?.status}
-        startedAt={agentStatus?.startedAt}
-        circuitBreakerTripped={circuitBreaker?.isTripped}
-      />
+      {/*
+        State-of-the-Bot card: single-source-of-truth "what is the bot
+        doing right now and is it making money?" headline. Replaces the
+        old AgentOverviewPanel + StrategyGenerationDisplay combo which
+        showed placeholder zeros (Stop Loss 0%, Take Profit 0%) and
+        legacy Backtest Results numbers (−733% avg across 704 strategies)
+        that were meaningless for operational visibility.
 
-      {/* Real-Time Strategy Generation Display */}
-      <StrategyGenerationDisplay
-        agentStatus={agentStatus?.status}
-        strategiesGenerated={agentStatus?.strategiesGenerated}
-        backtestsCompleted={agentStatus?.backtestsCompleted}
-        paperTradesExecuted={agentStatus?.paperTradesExecuted}
-        lastActivity={activity[0]?.description}
-        startedAt={agentStatus?.startedAt}
-        errorCount={activity.filter(a => a.activity_type === 'error').length}
-      />
+        The detailed strategy pipeline lives on /backtesting if the user
+        wants it — this dashboard surfaces only live operational state.
+      */}
+      <StateOfTheBotCard />
 
-      {/* Strategy Approval Queue */}
+      {/* Strategy Approval Queue (Recalibrating Strategies) */}
       <StrategyApprovalQueue agentStatus={agentStatus?.status} />
 
       {/* ML Self-Learning Engine — Live Recommendations (one-click confirmation required) */}
@@ -1183,77 +1176,28 @@ const AutonomousAgentDashboard: React.FC = () => {
         </div>
       </div>
 
-      {/* Backtest Results Visualization */}
-      <BacktestResultsVisualization />
+      {/*
+        Removed in the 2026-04-19 prune:
+        - <BacktestResultsVisualization /> — displayed unfiltered aggregates
+          across 1,791 NULL-engine_version legacy rows, producing −733%
+          avg / +3813% best / −23581% worst that the user correctly flagged
+          as nonsensical. The detailed per-strategy view on /backtesting
+          now filters by engine_version.
+        - Strategy Pipeline sub-card — the "Start the agent to generate..."
+          copy was stale while the agent was running, and the category
+          counts duplicated info shown better in ActiveStrategiesPanel.
+        - Capability Tiers card — the capabilities endpoint returns
+          hardcoded zeros; the block only ever appeared filled during
+          a brief transition period that's now over.
 
-      {/* Strategy Pipeline Summary — link to Backtesting for detailed view */}
-      <div className="bg-white rounded-lg shadow-lg overflow-hidden">
-        <div className="p-6 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <BarChart3 className="w-5 h-5 text-cyan-600" />
-            <div>
-              <h2 className="text-lg font-bold text-gray-900">Strategy Pipeline</h2>
-              <p className="text-sm text-gray-500">
-                {strategies.length > 0
-                  ? `${strategies.length} strategies generated — view full pipeline on Backtesting`
-                  : 'Start the agent to generate AI-powered trading strategies'}
-              </p>
-            </div>
-          </div>
-          <Link
-            to="/backtesting"
-            className="inline-flex items-center px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors text-sm"
-          >
-            View Pipeline
-          </Link>
-        </div>
-        {strategies.length > 0 && (
-          <div className="border-t border-gray-200 px-6 py-4">
-            <div className="flex gap-6 text-sm">
-              {['generated', 'backtested', 'paper_trading', 'live'].map(status => {
-                const count = strategies.filter(s => s.status === status).length;
-                return (
-                  <div key={status} className="flex items-center gap-2">
-                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${getStrategyStatusColor(status)}`}>
-                      {status.replace('_', ' ')}
-                    </span>
-                    <span className="text-gray-600 font-medium">{count}</span>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
-      </div>
-
-      {capabilitySummary && capabilitySummary.totalStrategies > 0 && (
+        Strategy pipeline details live on /backtesting. Sidebar nav
+        handles that transition.
+      */}
+      {/* Capability Tiers card retired — data source returned hardcoded zeros. */}
+      {false && (
         <div className="bg-white rounded-lg shadow-lg overflow-hidden">
           <div className="p-6">
-            <h2 className="text-lg font-bold text-gray-900 mb-2">Capability Tiers</h2>
-            <p className="text-sm text-gray-500 mb-4">
-              Composite scoring with adaptive improvement hints for autonomous strategy quality.
-            </p>
             <div className="grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
-              <div className="p-3 bg-gray-50 rounded-lg">
-                <div className="text-gray-500">Strategies</div>
-                <div className="text-xl font-semibold text-gray-900">{capabilitySummary.totalStrategies}</div>
-              </div>
-              <div className="p-3 bg-emerald-50 rounded-lg">
-                <div className="text-emerald-700">Tier 1</div>
-                <div className="text-xl font-semibold text-emerald-800">{capabilitySummary.tier1}</div>
-              </div>
-              <div className="p-3 bg-blue-50 rounded-lg">
-                <div className="text-blue-700">Tier 2</div>
-                <div className="text-xl font-semibold text-blue-800">{capabilitySummary.tier2}</div>
-              </div>
-              <div className="p-3 bg-orange-50 rounded-lg">
-                <div className="text-orange-700">Tier 3</div>
-                <div className="text-xl font-semibold text-orange-800">{capabilitySummary.tier3}</div>
-              </div>
-              <div className="p-3 bg-purple-50 rounded-lg">
-                <div className="text-purple-700">Avg Score</div>
-                <div className="text-xl font-semibold text-purple-800">{safeNum(capabilitySummary.averageCompositeScore).toFixed(2)}</div>
-              </div>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/agent/StateOfTheBotCard.tsx
+++ b/apps/web/src/components/agent/StateOfTheBotCard.tsx
@@ -1,0 +1,222 @@
+import axios from 'axios';
+import { Activity, AlertTriangle, CheckCircle2, Pause, Radio } from 'lucide-react';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { getAccessToken } from '@/utils/auth';
+import { getBackendUrl } from '@/utils/environment';
+
+const API_BASE_URL = getBackendUrl();
+
+/**
+ * State-of-the-Bot headline card. Single source of truth for the
+ * question "what is the bot doing right now, and is it making money?"
+ *
+ * Phase dominates the design — the literal UX bug on 2026-04-18 was
+ * the old dashboard reading "Live Trading Active" for 12 straight
+ * hours while the bot was silently stuck in stacking-guard-skip loops.
+ * This card makes that invisible state visible in one word.
+ *
+ * Backend: GET /api/agent/state-of-bot
+ */
+
+type Phase = 'trading' | 'skipping' | 'paused' | 'degraded' | 'evaluating';
+
+interface PnLBucket {
+  realized: number;
+  trades: number;
+}
+
+interface StateOfBot {
+  phase: Phase;
+  phaseReason: string;
+  executionMode: 'auto' | 'paper_only' | 'pause';
+  lastTickAt: string | null;
+  pnl: Record<'24h' | '7d' | '30d' | 'all', PnLBucket>;
+  tradesPerHour: number;
+  winRateLast20: number;
+  exchangeOpenPositions: number;
+  dbOpenPositions: number;
+  positionStateInSync: boolean;
+  balance: { equity: number; currency: string };
+  currentLeverage: number;
+}
+
+type PnLWindow = '24h' | '7d' | '30d' | 'all';
+
+const PHASE_STYLE: Record<Phase, { label: string; bg: string; text: string; icon: React.ReactNode }> = {
+  trading:    { label: 'TRADING',    bg: 'bg-green-100',  text: 'text-green-800',  icon: <Radio className="w-6 h-6 animate-pulse" /> },
+  skipping:   { label: 'SKIPPING',   bg: 'bg-amber-100',  text: 'text-amber-800',  icon: <Activity className="w-6 h-6" /> },
+  paused:     { label: 'PAUSED',     bg: 'bg-gray-100',   text: 'text-gray-700',   icon: <Pause className="w-6 h-6" /> },
+  degraded:   { label: 'DEGRADED',   bg: 'bg-red-100',    text: 'text-red-800',    icon: <AlertTriangle className="w-6 h-6" /> },
+  evaluating: { label: 'EVALUATING', bg: 'bg-blue-100',   text: 'text-blue-800',   icon: <Activity className="w-6 h-6" /> },
+};
+
+const formatUSD = (v: number): string => {
+  const prefix = v > 0 ? '+$' : v < 0 ? '-$' : '$';
+  return `${prefix}${Math.abs(v).toFixed(2)}`;
+};
+
+const formatPct = (v: number): string => `${(v * 100).toFixed(1)}%`;
+
+const formatAge = (iso: string | null): string => {
+  if (!iso) return '—';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m ago`;
+  return `${Math.round(ms / 3_600_000)}h ago`;
+};
+
+const StateOfTheBotCard: React.FC = () => {
+  const [state, setState] = useState<StateOfBot | null>(null);
+  const [window, setWindow] = useState<PnLWindow>('24h');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchState = useCallback(async () => {
+    try {
+      const token = getAccessToken();
+      const resp = await axios.get(`${API_BASE_URL}/api/agent/state-of-bot`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (resp.data?.success) {
+        setState(resp.data);
+        setError(null);
+      } else {
+        setError(resp.data?.error || 'Failed to load state');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchState();
+    // 15s poll — state-of-bot is the canonical dashboard heartbeat.
+    // Anything less frequent makes "TRADING" feel delayed.
+    const t = setInterval(fetchState, 15_000);
+    return () => clearInterval(t);
+  }, [fetchState]);
+
+  if (loading && !state) {
+    return (
+      <div className="bg-white rounded-lg shadow-lg p-6 animate-pulse h-48" />
+    );
+  }
+  if (error && !state) {
+    return (
+      <div className="bg-white rounded-lg shadow-lg p-6 border border-red-200">
+        <div className="flex items-center gap-2 text-red-700">
+          <AlertTriangle className="w-5 h-5" />
+          <span className="font-semibold">State-of-bot unavailable</span>
+        </div>
+        <p className="text-sm text-red-600 mt-1">{error}</p>
+      </div>
+    );
+  }
+  if (!state) return null;
+
+  const phaseStyle = PHASE_STYLE[state.phase];
+  const bucket = state.pnl[window];
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg overflow-hidden">
+      {/* Header row: phase badge + mode + last tick */}
+      <div className={`${phaseStyle.bg} px-6 py-4 flex items-center justify-between`}>
+        <div className="flex items-center gap-3">
+          <span className={phaseStyle.text}>{phaseStyle.icon}</span>
+          <div>
+            <h2 className={`text-2xl font-black tracking-tight ${phaseStyle.text}`}>
+              {phaseStyle.label}
+            </h2>
+            <p className={`text-sm ${phaseStyle.text} opacity-90`}>{state.phaseReason}</p>
+          </div>
+        </div>
+        <div className={`text-right text-sm ${phaseStyle.text}`}>
+          <div>Mode: <span className="font-semibold capitalize">{state.executionMode.replace('_', '-')}</span></div>
+          <div className="opacity-75">Last tick: {formatAge(state.lastTickAt)}</div>
+        </div>
+      </div>
+
+      {/* P&L with timeframe toggle */}
+      <div className="px-6 py-4 border-b border-gray-100">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-medium text-gray-600">Realized P&L</span>
+          <div className="flex gap-1 bg-gray-100 rounded-lg p-1">
+            {(['24h', '7d', '30d', 'all'] as const).map((w) => (
+              <button
+                key={w}
+                onClick={() => setWindow(w)}
+                className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
+                  window === w
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-500 hover:text-gray-700'
+                }`}
+              >
+                {w}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-baseline gap-3">
+          <span
+            className={`text-4xl font-bold ${
+              bucket.realized > 0 ? 'text-green-600' : bucket.realized < 0 ? 'text-red-600' : 'text-gray-700'
+            }`}
+          >
+            {formatUSD(bucket.realized)}
+          </span>
+          <span className="text-sm text-gray-500">
+            across {bucket.trades} realized trade{bucket.trades === 1 ? '' : 's'}
+          </span>
+        </div>
+      </div>
+
+      {/* Activity row */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 px-6 py-4 border-b border-gray-100 text-sm">
+        <div>
+          <div className="text-gray-500">Trades/hr (24h)</div>
+          <div className="text-lg font-semibold text-gray-900">{state.tradesPerHour.toFixed(2)}</div>
+        </div>
+        <div>
+          <div className="text-gray-500">Win rate (last 20)</div>
+          <div className="text-lg font-semibold text-gray-900">{formatPct(state.winRateLast20)}</div>
+        </div>
+        <div>
+          <div className="text-gray-500">Balance</div>
+          <div className="text-lg font-semibold text-gray-900">
+            ${state.balance.equity.toFixed(2)} {state.balance.currency}
+          </div>
+        </div>
+        <div>
+          <div className="text-gray-500">Leverage in use</div>
+          <div className="text-lg font-semibold text-gray-900">
+            {state.currentLeverage > 0 ? `${state.currentLeverage}x` : '—'}
+          </div>
+        </div>
+      </div>
+
+      {/* Exchange vs DB sync row — divergence alarms loudly */}
+      <div
+        className={`px-6 py-3 text-sm flex items-center gap-2 ${
+          state.positionStateInSync
+            ? 'bg-gray-50 text-gray-600'
+            : 'bg-red-50 text-red-700 font-medium'
+        }`}
+      >
+        {state.positionStateInSync ? (
+          <CheckCircle2 className="w-4 h-4 text-green-600" />
+        ) : (
+          <AlertTriangle className="w-4 h-4" />
+        )}
+        <span>
+          Exchange: {state.exchangeOpenPositions} open · DB: {state.dbOpenPositions} open
+          {state.positionStateInSync ? ' · in sync' : ' · DIVERGENCE — phantom state likely'}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default StateOfTheBotCard;

--- a/docs/superpowers/specs/2026-04-19-dashboard-scorched-earth-prune-design.md
+++ b/docs/superpowers/specs/2026-04-19-dashboard-scorched-earth-prune-design.md
@@ -1,0 +1,112 @@
+# Dashboard Scorched-Earth Prune + State-of-the-Bot Card
+
+## Context
+
+Production UI review (2026-04-19) showed the autonomous-agent dashboard was confusing and dishonest: a "Live Trading Active" banner while nothing had traded for 12 hours, "Backtest Results" cards averaging across 1,791 legacy rows with NULL `engine_version` (producing nonsense like −733% avg, +3813% best, −23581% worst), an Integration Status panel leaking from the login layout onto every authenticated page, and decorative blocks (Technical Indicators / Risk Parameters / Entry/Exit Conditions / Capability Tiers) that display empty zeros when the agent isn't mid-generation.
+
+Root cause: rapid prototyping left many components that render regardless of whether they have real data, and aggregate queries pre-date the `engine_version` migration (PR #496) so they still pull legacy rows.
+
+## Goals
+
+1. The user should be able to answer "what is the bot doing right now, and is it making money?" in under 5 seconds from the dashboard.
+2. Nothing shown should be stale, mocked, or averaged across provenance-unknown data.
+3. Removal first, fix second — delete components that can't honestly show live data today.
+
+## Non-goals (deferred)
+
+- **P2** — Periodic DB↔exchange reconciler + time-bounded stacking guard. (Separate PR next.)
+- **P3** — P&L math audit: short-side sign verification, decimal vs percent unit consistency, on-the-fly backend calc reconciliation, leverage-as-bandit-dimension. (Separate PR after P2.)
+- **Legacy row hard-delete** — for now we filter by `engine_version IS NOT NULL` in aggregates; actual deletion waits until the legacy purge PR.
+
+## Design
+
+### Removals
+
+**Remove unconditionally:**
+- `Integration.tsx` rendered globally at `apps/web/src/App.tsx:149` — leaks "Integration Status" panel onto every authenticated page. Gate behind `!isAuthenticated` or remove entry from `App.tsx` and only render on `/login`.
+- "Capability Tiers" card (`AutonomousAgentDashboard.tsx:1229–1260`) — always shows zeros in prod; the `/api/agent/capabilities` route returns `{tier1: 0, tier2: 0, tier3: 0}` hardcoded.
+- "Backtesting Results" aggregate card inside `AgentOverviewPanel` — legacy numbers (−733.2% / +3813.7% / −23581.5%) from NULL-engine_version rows. Remove the whole sub-card; detailed per-strategy view lives on `/backtesting`.
+- Decorative "Technical Indicators / Risk Parameters (all 0%) / Entry Conditions / Exit Conditions" blocks in `StrategyGenerationDisplay.tsx:199–280`. Hide entire decorative block when the generation has no indicators/conditions populated.
+- "Strategy Pipeline" copy "Start the agent to generate..." when agent IS running (line 1198–1200 in dashboard). Either hide the section when running, or show real pipeline stats (generated / backtested / paper / live counts).
+
+**Make dismissable permanently:**
+- `PWAInstallPrompt.tsx` — current localStorage dismiss re-triggers on new device or cleared storage. Add a hard "never show again" toggle and default the banner to disabled in prod.
+
+### Additions
+
+**New component: `StateOfTheBotCard.tsx`** — single headline card placed at the top of `/autonomous-agent`, above everything else. Structure:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  [PHASE BADGE]  Last tick: 0:23 ago    Mode: Auto           │
+│  ─────────────────────────────────────                       │
+│  TRADING | SKIPPING | PAUSED | DEGRADED  (dominant, large)   │
+│  Why: "BTC has open position, skipping entry"               │
+│                                                              │
+│  [24h] [7d] [30d] [all]  ←segmented toggle                  │
+│  P&L: +$0.03  (0.11%)  — across 4 realized trades           │
+│                                                              │
+│  Trades/hr: 2.1   Win rate (last 20): 55%                   │
+│  Exchange open: 0 · DB open: 0  ✓ in sync                   │
+│  Balance: $27.15 USDT  · Leverage in use: 3x                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Dominant metric is the Phase badge (c).** User's literal complaint was "hard to tell what it's actually doing" — phase answers that in one word. P&L with timeframe slider sits below it as secondary, activity stats below that.
+
+**Backend endpoint:** `GET /api/agent/state-of-bot`. Returns:
+
+```ts
+{
+  phase: 'trading' | 'skipping' | 'paused' | 'degraded' | 'evaluating',
+  phaseReason: string,      // e.g. "BTC/ETH have open positions, skipping entry"
+  executionMode: 'auto' | 'paper_only' | 'pause',
+  lastTickAt: ISO8601,
+  pnl: {
+    '24h':  { realized: number, trades: number },
+    '7d':   { realized: number, trades: number },
+    '30d':  { realized: number, trades: number },
+    'all':  { realized: number, trades: number },
+  },
+  tradesPerHour: number,    // last 24h
+  winRateLast20: number,    // 0-1
+  exchangeOpenPositions: number,
+  dbOpenPositions: number,  // status='open' count
+  balance: { equity: number, currency: 'USDT' },
+  currentLeverage: number,
+}
+```
+
+Computed from: `autonomous_trades`, `agent_execution_mode`, last liveSignal tick log (cache recent events in-memory), Poloniex `getAccountBalance` + `getPositions`.
+
+Phase logic (priority order):
+- `paused` if `execution_mode === 'pause'`
+- `degraded` if Poloniex API unreachable OR lastTick > 5min ago
+- `skipping` if last tick produced a signal but stacking guard / kernel veto fired
+- `trading` if last tick actually placed an order
+- `evaluating` otherwise (no qualifying signal)
+
+### Filter engine_version on existing aggregates
+
+All existing backtest aggregate queries add `WHERE engine_version IS NOT NULL` to stop pulling 1,791 legacy rows into averages. Files:
+- `apps/api/src/routes/agent.ts:471–488` (`/api/agent/backtest/results`)
+- `apps/api/src/routes/backtest.ts:581–673` (`/api/backtest/pipeline/summary`)
+- any other aggregate SQL touching `backtest_results`
+
+This is surgical — legacy rows still exist, just hidden from aggregates. P3 will purge them properly.
+
+## Verification plan
+
+Post-deploy, via Playwright + Railway MCP:
+1. Login to prod, navigate `/autonomous-agent`
+2. Confirm: no Integration Status panel at bottom
+3. Confirm: State-of-the-Bot card at top, Phase reads `TRADING` or `EVALUATING` (not `SKIPPING`) now that P0 freed the stacking guard
+4. Confirm: `-733%` etc. numbers absent (engine_version filter working)
+5. Confirm: PWA install banner stays dismissed after page reload
+6. Sidebar pages smoke test — click each of 8 routes, confirm none 404
+7. Railway logs: liveSignal now placing orders (stacking guard not blocking)
+
+## Out of scope, acknowledged as follow-ups
+
+- **P2:** Periodic reconciler prevents phantom state from recurring (separate PR, next)
+- **P3:** Math audit — why is `total_return` displayed as −89.60% when DB stores −0.0006; short-side sign inversion; leverage as bandit learning dimension (separate PR after P2)


### PR DESCRIPTION
## Summary
Retires 5 dashboard panels that showed stale / placeholder / unit-broken data, and adds one headline card that answers \"what is the bot doing right now and is it making money?\" in under 5 seconds. Addresses the user's literal complaint that it was \"really hard to tell what it's actually doing\" — the previous dashboard showed \"Live Trading Active\" for 12h straight while the bot was silently stuck.

## What's removed
- **\`<Integration />\`** from global App.tsx render (was leaking Poloniex/TradingView/Chrome-Extension panel + Setup Instructions blue box onto every authenticated page).
- **\`<PWAInstallPrompt />\`** from global App.tsx render (install nag for a desktop trading tool = noise).
- **\`<AgentOverviewPanel />\`** — replaced by StateOfTheBotCard.
- **\`<StrategyGenerationDisplay />\`** — decorative blocks showing 0%/empty when agent isn't mid-generation.
- **\`<BacktestResultsVisualization />\`** — showed -733% avg / +3813% best / -23581% worst averaged across 1,791 legacy rows with NULL engine_version.
- Strategy Pipeline sub-card (stale \"Start the agent…\" copy while running).
- Capability Tiers card (hardcoded-zeros endpoint).

## What's added
- **\`StateOfTheBotCard\`** — phase badge dominant (TRADING / SKIPPING / PAUSED / DEGRADED / EVALUATING) with plain-English phaseReason, 24h/7d/30d/all-time P&L toggle, trades/hr + win rate (last 20), live balance + leverage, exchange-vs-DB position sync check that alarms on divergence (the class of bug we caught on 2026-04-18).
- **\`GET /api/agent/state-of-bot\`** — single aggregated payload.
- Phase precedence: \`paused > degraded > trading > skipping > evaluating\`.

## Scoped protections
- **\`GET /api/agent/backtest/results\`** now filters \`engine_version IS NOT NULL\` so legacy-units rows stop polluting aggregates.
- Legacy rows still exist pending the separate purge PR.

## Follow-up PRs (already scoped, separate)
- **P2:** periodic reconciler + time-bounded stacking guard (prevents phantom state from recurring)
- **P3:** P&L math audit — short-side sign, decimal/percent consistency, on-the-fly backend calc reconciliation, leverage as bandit learning dimension

## Test plan
- [ ] After deploy: login → /autonomous-agent shows StateOfTheBotCard at top, no Integration Status panel at bottom, no PWA install banner
- [ ] Phase badge reads EVALUATING (not SKIPPING — the phantoms were cleaned by the accompanying DB write), or TRADING if a trade fires
- [ ] 24h/7d/30d/all toggle cycles P&L numbers
- [ ] /backtesting still loads (BacktestResultsVisualization only removed from /autonomous-agent, the /backtesting page has its own pipeline view)
- [ ] All 8 sidebar routes still navigable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new State-of-the-Bot dashboard card backed by an aggregated state endpoint while pruning misleading dashboard panels and filtering legacy backtest data from API results.

New Features:
- Add GET /api/agent/state-of-bot endpoint to expose aggregated real-time bot status, P&L, and exchange-vs-DB position sync.
- Add StateOfTheBotCard component as the primary autonomous agent dashboard headline for live bot status and profitability.

Bug Fixes:
- Filter legacy NULL-engine_version rows from backtest results API responses to prevent polluted aggregate statistics.

Enhancements:
- Remove obsolete or misleading dashboard panels, including integration status, backtest visualization, strategy pipeline summary, capability tiers, and PWA install prompt from global layout, to focus on live operational data.

Documentation:
- Add a product/design spec documenting the dashboard prune and State-of-the-Bot card behavior and goals.