### PR TITLE
fix(reconciler): cover liveSignal users + normalize side + time-bound stacking guard

### DIFF
--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -311,19 +311,32 @@ export class LiveSignalEngine extends EventEmitter {
       return;
     }
 
-    // 2c. Stacking guard: if we already have an open autonomous_trade
-    //      row on this symbol from the live-signal engine, don't stack.
-    //      Market orders on the same side accumulate into one net
-    //      Poloniex position — the exposure cap catches the extreme,
-    //      but we'd still burn fees stacking 60x/hour into the same
-    //      trade. Let existing position play out; managePositions or
-    //      the SL/TP exit will flip the DB row to 'closed' and free
-    //      this symbol for a fresh signal.
+    // 2c. Stacking guard: if we already have a RECENT open
+    //      autonomous_trade row on this symbol from the live-signal
+    //      engine, don't stack. Market orders on the same side
+    //      accumulate into one net Poloniex position — the exposure
+    //      cap catches the extreme, but we'd still burn fees stacking
+    //      60x/hour into the same trade. Let the existing position
+    //      play out; managePositions or the SL/TP exit will flip the
+    //      DB row to 'closed' and free this symbol for a fresh signal.
+    //
+    //      Time-bounded (60 min): the 2026-04-18 phantom-rows incident
+    //      had 6 rows stuck in status='open' for 12+ hours because
+    //      order_id was never captured; the guard read them as "open
+    //      positions" and silently blocked every signal. The periodic
+    //      reconciler (stateReconciliationService) now catches
+    //      phantoms within 60s, but this 60-min window is a belt on top
+    //      of those braces — if reconciliation is itself broken, we
+    //      still resume trading within an hour rather than indefinitely.
+    //      ATR-scaled stops/takes resolve most real trades in tens of
+    //      minutes; anything open >1h is outside our strategy envelope.
     const openCheck = await pool.query(
       `SELECT 1 FROM autonomous_trades
         WHERE symbol = $1
           AND status = 'open'
           AND reason LIKE 'live_signal|%'
+          AND (entry_time > NOW() - INTERVAL '60 minutes'
+               OR (entry_time IS NULL AND created_at > NOW() - INTERVAL '60 minutes'))
         LIMIT 1`,
       [symbol],
     );

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -186,12 +186,20 @@ class StateReconciliationService {
       }
 
       // ── 6. Ghost detection: in DB but not on exchange ────────────────────────
+      // Normalize both DB and exchange sides to long/short so liveSignalEngine
+      // rows (stored as buy/sell) compare correctly against the exchange
+      // (long/short). Without this normalization, every live-signal row was
+      // treated as a ghost-not-on-exchange because 'buy' !== 'long'.
+      const normalizeSide = (s: string): 'long' | 'short' =>
+        s === 'buy' || s === 'long' ? 'long' : 'short';
+
       for (const dbTrade of dbTrades) {
+        const dbSide = normalizeSide(dbTrade.side);
         const matched = exchangePositions.some(exPos => {
           const exSymbol: string = exPos.symbol ?? exPos.instId ?? '';
           const exQty = parseFloat(exPos.qty ?? exPos.availQty ?? '0');
           const exSide = exQty > 0 ? 'long' : 'short';
-          return exSymbol === dbTrade.symbol && exSide === dbTrade.side;
+          return exSymbol === dbTrade.symbol && exSide === dbSide;
         });
 
         if (!matched) {
@@ -256,25 +264,66 @@ class StateReconciliationService {
   }
 
   /**
-   * Run reconciliation for all users with an active autonomous trading config.
+   * Run reconciliation for every user who is currently "live" in some sense:
+   *
+   *   1. Users with an active autonomous_trading_configs row (legacy path).
+   *   2. Users with any open live_signal trade in autonomous_trades (the
+   *      liveSignalEngine path, which doesn't require autonomous_trading_configs).
+   *
+   * Without (2) we get the exact bug from 2026-04-18: 6 DB rows stuck in
+   * status='open' for 12h with no exchange position, and the 60s reconciler
+   * never touched them because autonomous_trading_configs was empty.
+   *
+   * Dedupe across both sets so a user with both an active config AND open
+   * live-signal trades only reconciles once per tick.
    */
   async reconcileAllActive(): Promise<void> {
     monitoringService.recordPipelineHeartbeat('reconciliation');
     try {
-      const activeConfigs = await pool.query(
-        `SELECT DISTINCT user_id FROM autonomous_trading_configs WHERE enabled = true`
-      );
+      const userIds = new Set<string>();
 
-      for (const row of activeConfigs.rows) {
-        const result = await this.reconcile(String(row.user_id));
+      // Source 1: active autonomous_trading_configs
+      try {
+        const activeConfigs = await pool.query(
+          `SELECT DISTINCT user_id FROM autonomous_trading_configs WHERE enabled = true`,
+        );
+        for (const row of activeConfigs.rows as Array<{ user_id: string }>) {
+          userIds.add(String(row.user_id));
+        }
+      } catch (err) {
+        logger.warn('[RECONCILE] autonomous_trading_configs lookup failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      // Source 2: users with an open live-signal trade. This is the
+      // liveSignalEngine's footprint — if phantom rows accumulate here,
+      // the stacking guard freezes all future entries until reconciler
+      // catches them. Covering this surface is the whole point of P2.
+      try {
+        const liveSignalUsers = await pool.query(
+          `SELECT DISTINCT user_id FROM autonomous_trades
+            WHERE status = 'open' AND reason LIKE 'live_signal|%'`,
+        );
+        for (const row of liveSignalUsers.rows as Array<{ user_id: string }>) {
+          userIds.add(String(row.user_id));
+        }
+      } catch (err) {
+        logger.warn('[RECONCILE] live-signal-users lookup failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      for (const userId of userIds) {
+        const result = await this.reconcile(userId);
         if (result.orphans.length > 0 || result.ghosts.length > 0) {
           logger.warn(
-            `[RECONCILE] State drift detected for user ${row.user_id}`,
+            `[RECONCILE] State drift detected for user ${userId}`,
             {
               orphans: result.orphans.length,
               ghosts: result.ghosts.length,
-              balanceDrift: result.balanceDrift
-            }
+              balanceDrift: result.balanceDrift,
+            },
           );
         }
       }

--- a/docs/superpowers/specs/2026-04-19-periodic-reconciler-design.md
+++ b/docs/superpowers/specs/2026-04-19-periodic-reconciler-design.md
@@ -1,0 +1,114 @@
+# Periodic Reconciler + Time-Bounded Stacking Guard (P2)
+
+## Context
+
+On 2026-04-18 the autonomous trading bot submitted 6 live orders that either never filled on Poloniex (due to the `ordId` vs `orderId` bug) or filled and closed without our reconciler catching the close. Result: 6 `autonomous_trades` rows stayed `status='open'` for 12+ hours while the actual Poloniex account held zero positions.
+
+The stacking guard added in PR #499 (designed to prevent the bot from placing a second order while an existing live-signal trade was still open) correctly read those 6 rows and correctly blocked every new signal for 12 hours — but because the DB was lying about reality, the guard silently killed all trading activity. The bug was only caught when the user asked "what is this thing doing?" and we manually queried the exchange to see the 0-position reality.
+
+## Goals
+
+1. **Prevent recurrence.** Any phantom DB `open` row older than N minutes that has no matching exchange position must auto-close so the stacking guard releases.
+2. **Prevent the next class of this bug too.** Divergence between DB `status='open'` count and exchange-position count for any symbol should be automatically resolved on a cadence, not require human intervention.
+3. **Keep the fix local.** No schema change, no migration, no change to the order-placement path. Pure defensive addition.
+
+## Non-goals
+
+- Retroactively reconciling paper trades (separate table `paper_trades`, different close logic).
+- Fixing the root `ordId` capture bug — already done in PR #499.
+- P&L math correctness (that's P3).
+
+## Design
+
+### Periodic reconciler service
+
+New function in `apps/api/src/services/stateReconciliationService.ts`:
+
+```ts
+async function reconcileLiveSignalPositions(): Promise<ReconcileReport> { ... }
+```
+
+Runs every **5 minutes** via `setInterval` started in `apps/api/src/index.ts` after backend boot, gated on `NODE_ENV !== 'test'`.
+
+Algorithm:
+
+1. Pull all `autonomous_trades` rows where `status='open' AND reason LIKE 'live_signal|%'`, grouped by `(user_id, symbol)`.
+2. For each `user_id`:
+   - Load credentials via `apiCredentialsService.getCredentials(userId, 'poloniex')`.
+   - Call `poloniexFuturesService.getPositions(credentials)` → `Map<symbol, netQty>`.
+3. For each `(user_id, symbol)` with DB `open` rows:
+   - If exchange has **zero** open qty on that symbol → **all DB rows for that symbol are phantoms.** Close them with:
+     ```sql
+     UPDATE autonomous_trades
+     SET status = 'closed',
+         exit_time = NOW(),
+         exit_reason = 'reconciled_phantom_no_exchange_position',
+         pnl = COALESCE(pnl, 0)
+     WHERE id = ANY($1)
+     ```
+   - If exchange has **some** open qty on that symbol → leave DB rows alone. (We conservatively assume the position is real; the managePositions loop owns closing them.)
+4. Emit a `strategy_state_events` row per reconciled symbol so audit trail exists.
+5. Log summary: `[Reconciler] closed N phantom rows across M symbols in ${elapsed}ms`.
+
+**Safety properties:**
+
+- Fail-soft: any Poloniex error aborts the cycle without touching DB (we'd rather re-check in 5 minutes than wrongly close a real position).
+- Idempotent: running it twice in a row with no state change is a no-op.
+- Per-user isolation: one user's credentials failure doesn't block reconciling others.
+
+### Time-bounded stacking guard
+
+Second layer of defense in `liveSignalEngine.ts::processSymbol`. Currently the guard unconditionally skips when any `status='open'` row exists for the symbol. Tighten:
+
+```ts
+const OPEN_TRADE_MAX_AGE_MS = 60 * 60_000;  // 60 minutes
+
+// Existing query, plus created_at filter:
+const openCheck = await pool.query(
+  `SELECT 1 FROM autonomous_trades
+    WHERE symbol = $1
+      AND status = 'open'
+      AND reason LIKE 'live_signal|%'
+      AND (entry_time > NOW() - INTERVAL '60 minutes' OR created_at > NOW() - INTERVAL '60 minutes')
+    LIMIT 1`,
+  [symbol],
+);
+```
+
+A DB row older than 60 minutes with no exchange position is **either:**
+
+- A phantom the reconciler hasn't caught yet (reconciler runs every 5 min, so worst case is a 5-min window where both this guard and reconciler disagree — fine, bias to conservative)
+- A real position that's been open for >1 hour, in which case the stacking guard would still veto correctly if the reconciler confirms it's real (exchange position present), OR the reconciler would close it.
+
+The 60-minute window is deliberately generous. ATR-scaled stop/take-profit targets should resolve most trades within tens of minutes; anything open > 1 hour is outside our strategy envelope and should not block new entries indefinitely.
+
+### Wire-up in `index.ts`
+
+```ts
+import { reconcileLiveSignalPositions } from './services/stateReconciliationService.js';
+
+// Already started:  liveSignalEngine.start(...)
+// Add:
+if (process.env.NODE_ENV !== 'test') {
+  setInterval(() => {
+    reconcileLiveSignalPositions().catch((err) => {
+      logger.error('[Reconciler] tick failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }, 5 * 60_000).unref?.();
+  logger.info('[Reconciler] periodic reconciler started', { intervalMs: 300_000 });
+}
+```
+
+## Verification plan
+
+1. Unit test: `reconcileLiveSignalPositions` with mocked `poloniexFuturesService.getPositions` returning `[]` → asserts all `status='open'` live-signal rows flip to `closed` with the reconciled reason.
+2. Unit test: same, but Poloniex returns one position with qty > 0 → those rows stay open.
+3. Integration smoke: insert a phantom row via SQL, wait 5 minutes (or trigger the interval manually), confirm row is closed.
+4. Production: deploy, confirm `[Reconciler]` log line appears every 5 minutes. If we reach a phantom state again, count how long until auto-recovery.
+
+## Follow-ups (still not in this PR)
+
+- P3 P&L math audit — decimal vs percent, short sign, leverage.
+- Alert/page when reconciler detects divergence above a threshold (e.g. > 3 phantom rows in one cycle).


### PR DESCRIPTION
## Summary
Prevents recurrence of the 2026-04-18 phantom-rows incident (6 \`autonomous_trades\` rows stayed \`status='open'\` for 12+ hours while the exchange held zero positions; stacking guard silently froze all trading).

Three defensive changes:

1. **\`reconcileAllActive()\` now covers liveSignal users.** Unions \`autonomous_trading_configs.enabled=true\` users (legacy — empty in prod) with users who have any open \`live_signal|%\` trade. The 60s reconciler was previously blind to the liveSignalEngine path.

2. **Ghost detection normalizes side.** DB stores \`buy\`/\`sell\` (as written by liveSignalEngine); exchange returns \`long\`/\`short\`. Previously every live-signal row was wrongly classified as "not on exchange" because \`'buy' !== 'long'\`. Normalize both to \`long\`/\`short\` before comparison.

3. **Stacking guard is time-bounded.** \`liveSignalEngine.processSymbol\` now only considers rows opened within the last 60 minutes when deciding whether to skip for an existing open position. Real ATR-scaled trades resolve in tens of minutes; anything open >1h is almost certainly a phantom the reconciler hasn't caught yet. Belt on top of the reconciler's braces.

## Test plan
- [ ] Post-deploy: \`[RECONCILE]\` log line appears every 60s and now includes the Poloniex user's ID even with empty \`autonomous_trading_configs\`
- [ ] If a phantom row appears, reconciler closes it within 60s with \`exit_reason='reconciled_not_on_exchange'\`
- [ ] Manual: insert a fake \`status='open' reason='live_signal|...'\` row via SQL, watch reconciler close it on next tick
- [ ] If reconciler is down, trading resumes within 60 minutes of last opened row via time-bounded guard

## Follow-up
- P3: P&L math audit (short-side sign, decimal/percent consistency, leverage as bandit dimension)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend periodic reconciliation and live signal handling to prevent phantom open trades from blocking trading and to better align database state with exchange positions.

Bug Fixes:
- Ensure ghost trade detection normalizes trade side between database (buy/sell) and exchange (long/short) to correctly identify missing positions.
- Include users with open live-signal trades in the periodic reconciliation pass so their stale open rows are detected and corrected.
- Limit the live-signal stacking guard to only consider open trades from the last 60 minutes so stale phantom rows cannot indefinitely block new entries.

Documentation:
- Add a design spec describing the periodic reconciler and time-bounded stacking guard, including incident context, goals, design details, and verification plan.