### PR TITLE
fix(poloniex): throw on application-level error codes in response body

### DIFF
--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -180,16 +180,44 @@ class PoloniexFuturesService {
           }
         });
         const response = await axios(config);
-        
+
+        // Poloniex V3 API envelope: { code: 200, data: {...}, msg: "Success" }.
+        // A non-200 body code is an application error even when HTTP is 200 —
+        // most commonly seen on POST /v3/trade/order where HTTP returns 200
+        // but the body is { code: <non-200>, msg: "<reason>" } with no data.
+        // Previously we silently returned that error object as if it were the
+        // result, causing the exchange-order placeOrder path to look successful
+        // while actually failing (diagnosed 2026-04-19: every liveSignal tick
+        // was "placing" an order that never executed, then the reconciler was
+        // closing the phantom DB row seconds later).
+        const bodyCode = response?.data?.code;
+        const bodyMsg = response?.data?.msg;
+        const isApplicationError =
+          bodyCode !== undefined &&
+          bodyCode !== null &&
+          bodyCode !== 200 &&
+          bodyCode !== 0 &&
+          String(bodyCode) !== 'SUCCESS';
+
         logger.info('Poloniex API response received', {
           endpoint: requestPath,
           status: response.status,
           hasData: !!response.data,
-          dataKeys: response.data ? Object.keys(response.data) : []
+          dataKeys: response.data ? Object.keys(response.data) : [],
+          bodyCode,
+          bodyMsg,
         });
-        
-        // Poloniex V3 API returns: { code: 200, data: {...}, msg: "Success" }
-        // Extract the data field if present, otherwise return the full response
+
+        if (isApplicationError) {
+          const err = new Error(`Poloniex ${requestPath} returned code=${bodyCode}: ${bodyMsg ?? 'no message'}`);
+          // Attach context so callers that care (submitOrder) can surface it.
+          err.poloniexCode = bodyCode;
+          err.poloniexMsg = bodyMsg;
+          err.endpoint = requestPath;
+          throw err;
+        }
+
+        // Extract the data field if present, otherwise return the full response.
         let result;
         if (response.data && typeof response.data === 'object' && 'data' in response.data) {
           result = response.data.data;


### PR DESCRIPTION
## Summary
**Discovered during post-deploy verification of PRs #504/#505.** The prod bot has been \"placing orders\" every 60 seconds since the scorched-earth prune shipped — but **none of them were actually reaching Poloniex**. Every row inserted into \`autonomous_trades\` with empty \`order_id\`, and the reconciler closed it within 5 seconds as \`reconciled_not_on_exchange\`.

## Root cause
Poloniex v3 returns HTTP 200 with a body-level error code on failures:
\`\`\`json
{ "code": <non-200>, "msg": "<reason>" }
\`\`\`
no \`data\` field. Happens on \`POST /v3/trade/order\` for insufficient balance, invalid size, leverage conflicts, etc.

\`poloniexFuturesService.makeRequest\` was silently returning that error object as if it were the success result:
\`\`\`js
if (response.data && 'data' in response.data) {
  result = response.data.data;
} else {
  result = response.data;   // ← returns { code, msg } on error
}
\`\`\`

Downstream \`submitOrder\` saw \`exchangeOrder\` with no \`.ordId\`/\`.orderId\` → logged \`orderId: undefined\` but continued as if the order placed. DB row got no \`order_id\`, no actual exchange position. Reconciler cleaned up 5s later. Infinite loop, no trading.

## Fix
Detect \`response.data.code !== 200/0/'SUCCESS'\` and throw with \`code\` + \`msg\` attached. \`submitOrder\`'s existing try/catch catches it, logs the real reason, records a \`phase='rejected'\` outcome event.

Also widened the INFO log to always include \`bodyCode\`/\`bodyMsg\` for visibility on successful requests too.

## Test plan
- [ ] After deploy: look for \`[LiveSignal] exchange placeOrder failed\` log lines with the real Poloniex \`msg\` (insufficient balance, min order size, etc.)
- [ ] \`autonomous_trades\` stops getting phantom \`reconciled_not_on_exchange\` rows every minute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle Poloniex V3 application-level error codes in successful HTTP responses so failed orders are surfaced as errors instead of being treated as successful results.

Bug Fixes:
- Treat non-success Poloniex V3 body codes as application errors and throw, preventing phantom successful order placements when the API actually rejected the request.

Enhancements:
- Log Poloniex API response body code and message for better observability of both successful and failed requests.