### PR TITLE
fix(live-signal): round quantity to symbol lot-size before placeOrder

### DIFF
--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -40,7 +40,7 @@ import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 import { apiCredentialsService } from './apiCredentialsService.js';
 import { getCurrentExecutionMode } from './executionModeService.js';
-import { getMaxLeverage } from './marketCatalog.js';
+import { getMaxLeverage, getPrecisions } from './marketCatalog.js';
 import mlPredictionService from './mlPredictionService.js';
 import { monitoringService } from './monitoringService.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
@@ -693,9 +693,47 @@ export class LiveSignalEngine extends EventEmitter {
     const exchangeSide = order.side === 'long' ? 'buy' : 'sell';
     const closeSide = order.side === 'long' ? 'sell' : 'buy';
 
+    // Round quantity to the symbol's lot-size step. Poloniex v3 rejects
+    // sub-lot orders with `Param error sz` — diagnosed 2026-04-19 when
+    // the PR #506 error surfacer finally showed the real reason every
+    // tick's "exchange order placed" was actually failing silently.
+    // At $2 notional × 3x leverage = $6, which is below 1 BTC contract
+    // (~$7.6) and well below 1 ETH contract (~$23.6) — so lot rounding
+    // produces 0 contracts and we skip. The fullyAutonomousTrader path
+    // already uses this pattern.
+    let formattedSize = quantity;
+    try {
+      const precisions = await getPrecisions(order.symbol);
+      if (precisions.lotSize && precisions.lotSize > 0) {
+        formattedSize = Math.floor(quantity / precisions.lotSize) * precisions.lotSize;
+      }
+    } catch (err) {
+      logger.warn('[LiveSignal] getPrecisions failed, using raw quantity', {
+        symbol: order.symbol,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+    if (formattedSize <= 0) {
+      logger.info('[LiveSignal] size below lot minimum — skipping', {
+        symbol: order.symbol,
+        rawQuantity: quantity,
+        notionalUsdt: order.notional,
+        hint: 'Raise LIVE_POSITION_USDT or use higher leverage to clear min contract notional',
+      });
+      await this.publishOutcomeEvent({
+        symbol: order.symbol,
+        phase: 'skipped',
+        reason: 'size_below_lot_minimum',
+        rawQuantity: quantity,
+        notionalUsdt: order.notional,
+      });
+      return;
+    }
+
     logger.info('[LiveSignal] submitting order', {
       order,
-      quantity,
+      rawQuantity: quantity,
+      formattedSize,
       stopLoss,
       takeProfit,
       atr,
@@ -720,7 +758,7 @@ export class LiveSignalEngine extends EventEmitter {
         symbol: order.symbol,
         side: exchangeSide,
         type: 'market',
-        size: quantity,
+        size: formattedSize,
       });
       // Poloniex v3 futures returns the exchange order id as `ordId`.
       // Keep `orderId`/`id` fallbacks so mocked tests + any future
@@ -735,7 +773,7 @@ export class LiveSignalEngine extends EventEmitter {
         rawResponseKeys: exchangeOrder ? Object.keys(exchangeOrder) : [],
         symbol: order.symbol,
         side: exchangeSide,
-        size: quantity,
+        size: formattedSize,
       });
     } catch (err) {
       logger.error('[LiveSignal] exchange placeOrder failed', {
@@ -758,7 +796,7 @@ export class LiveSignalEngine extends EventEmitter {
           symbol: order.symbol,
           side: closeSide,
           type: 'stop_market',
-          size: quantity,
+          size: formattedSize,
           stopPrice: stopLoss,
           stopPriceType: 'TP',
           reduceOnly: true,
@@ -775,7 +813,7 @@ export class LiveSignalEngine extends EventEmitter {
           symbol: order.symbol,
           side: closeSide,
           type: 'stop_market',
-          size: quantity,
+          size: formattedSize,
           stopPrice: takeProfit,
           stopPriceType: 'TP',
           reduceOnly: true,
@@ -806,7 +844,7 @@ export class LiveSignalEngine extends EventEmitter {
           order.symbol,
           exchangeSide,
           order.price,
-          quantity,
+          formattedSize,
           order.leverage,
           stopLoss,
           takeProfit,
@@ -834,7 +872,7 @@ export class LiveSignalEngine extends EventEmitter {
       reason: signal.reason,
       phase: 'submitted',
       price: order.price,
-      quantity,
+      quantity: formattedSize,
       orderId,
     });
   }


### PR DESCRIPTION
## Summary
Finally nails the "orders not executing" root cause, surfaced by PR #506's error-code unmasking.

## What was actually happening
Every 60s for hours: \`[LiveSignal] exchange order placed\` INFO log, DB row inserted with empty \`order_id\`, reconciler closed it as \`reconciled_not_on_exchange\` 5s later. Loop repeat. Zero actual trades on Poloniex.

The hidden Poloniex response:
\`\`\`
POST /v3/trade/order → 200 { code: 400, msg: "Param error sz" }
\`\`\`

Reason: the raw quantity computed as \`notional / price\` is sub-lot-size for every symbol at \$2 position × 3x leverage = \$6 notional:

| Symbol | 1 contract | Min notional | Our notional | Contracts |
|---|---|---|---|---|
| BTC_USDT_PERP | ~0.0001 BTC at \$76k | ~\$7.6 | \$6 | 0 (rejected) |
| ETH_USDT_PERP | ~0.01 ETH at \$2360 | ~\$23.6 | \$6 | 0 (rejected) |

## Fix
Matches the existing \`fullyAutonomousTrader\` pattern:
1. \`marketCatalog.getPrecisions(symbol)\` before place.
2. \`formattedSize = floor(quantity / lotSize) * lotSize\`.
3. If \`formattedSize <= 0\` → log and skip with a \`size_below_lot_minimum\` outcome event. No point attempting an unplaceable order.
4. Use \`formattedSize\` for market order, SL, TP, DB \`quantity\` column, and submitted outcome event — everything downstream reflects the actual exchange size.

## Honest consequence
At current \$27 equity + \$2 position + 3x leverage, **both BTC and ETH are below minimum and no orders will place.** That is the correct behavior — don't try to trade something unplaceable. To actually trade:
- BTC: raise \`LIVE_POSITION_USDT\` to ~\$3 + 5x leverage = \$15 notional (2 BTC contracts), or stay at \$2 and use 10x (\$20 notional = 2 BTC contracts)
- ETH: needs ~\$24 notional which at \$2 position implies 12x leverage. Skip ETH until account is bigger or lift position to \$5+.

User knob decision — post-merge you can set \`LIVE_POSITION_USDT\` via Railway env.

## Test plan
- [ ] After deploy, for BTC+ETH at current sizing: \`[LiveSignal] size below lot minimum — skipping\` log every minute instead of phantom order attempts
- [ ] After raising LIVE_POSITION_USDT or leverage: real orderId in \`[LiveSignal] exchange order placed\` + non-empty \`order_id\` in autonomous_trades + actual Poloniex position visible via getPositions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle Poloniex lot-size constraints in live signal order placement to prevent silently rejected trades and ensure downstream state reflects actual executable size.

Bug Fixes:
- Round live signal order quantities to the symbol lot-size step before submitting to Poloniex to avoid `Param error sz` rejections and phantom 'placed' orders.
- Skip placing live trades whose computed size falls below the exchange lot-size minimum, emitting a structured outcome event instead.

Enhancements:
- Log both raw and formatted order sizes and include additional context when lot-size lookup fails, improving observability of live signal order placement behavior.