### PR TITLE
fix(poloniex): setLeverage body uses lever/mgnMode per v3 docs

### DIFF
--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -354,9 +354,37 @@ class PoloniexFuturesService {
   /**
    * Set leverage for a position
    * Endpoint: POST /v3/position/leverage
+   *
+   * Poloniex V3 expects `lever` (stringified) NOT `leverage`, plus `mgnMode`
+   * (CROSS|ISOLATED). In one-way/`BOTH` position mode, `posSide` is optional
+   * but if supplied must be `BOTH`. Sending `{ symbol, leverage }` as we did
+   * previously produced `{ code: 400, msg: "Param error lever" }` on the
+   * live API (Railway prod, 2026-04-19), which caused every live tick to
+   * log a (non-fatal) leverage-set failure right before order placement.
+   *
+   * The web UI already used the correct shape — see
+   * apps/web/src/context/FuturesContext.tsx::setLeverage which posts
+   * `{ symbol, lever, mgnMode }`. This brings the server-side call in line.
+   *
+   * @param {Object} credentials
+   * @param {string} symbol             e.g. 'BTC_USDT_PERP'
+   * @param {number|string} leverage    numeric leverage (2..125)
+   * @param {Object} [opts]
+   * @param {'CROSS'|'ISOLATED'} [opts.mgnMode='CROSS']  margin mode;
+   *   defaults to CROSS per shared/constants.ts::FUTURES_DEFAULTS
+   *   and the agent dashboard default.
+   * @param {'LONG'|'SHORT'|'BOTH'} [opts.posSide]  position side; omitted
+   *   by default since the account runs in one-way (BOTH) mode.
    */
-  async setLeverage(credentials, symbol, leverage) {
-    const body = { symbol, leverage };
+  async setLeverage(credentials, symbol, leverage, opts = {}) {
+    const body = {
+      symbol,
+      lever: String(leverage),
+      mgnMode: opts.mgnMode || 'CROSS',
+    };
+    if (opts.posSide) {
+      body.posSide = opts.posSide;
+    }
     return this.makeRequest(credentials, 'POST', '/position/leverage', body);
   }
 

--- a/apps/api/src/tests/poloniexFuturesService.setLeverage.test.js
+++ b/apps/api/src/tests/poloniexFuturesService.setLeverage.test.js
@@ -1,0 +1,102 @@
+/**
+ * Locks the exact body shape sent to POST /v3/position/leverage.
+ *
+ * Why this test exists:
+ *   Poloniex V3 returns `{ code: 400, msg: "Param error lever" }` when the
+ *   body uses `leverage`. The correct field name is `lever` (stringified),
+ *   alongside `mgnMode` (CROSS|ISOLATED) and optional `posSide`. Prior to
+ *   this fix every live-signal tick logged a non-fatal setLeverage failure
+ *   right before order placement — noisy and hid the real failure mode if
+ *   the exchange ever started rejecting orders because leverage was stale.
+ *
+ *   See:
+ *     - apps/web/src/context/FuturesContext.tsx::setLeverage (already used
+ *       `{ symbol, lever, mgnMode }` on the client side)
+ *     - shared/constants.ts::FUTURES_DEFAULTS.marginMode = 'CROSS'
+ *     - docs/archive/historical/POLONIEX_V3_API_FIXES.md (confirms v3 uses
+ *       `lever` and `mgnMode` in responses)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import poloniexFuturesService from '../services/poloniexFuturesService.js';
+
+describe('PoloniexFuturesService.setLeverage body shape', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends { symbol, lever: String(leverage), mgnMode: "CROSS" } by default', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({ lever: '5', mgnMode: 'CROSS' });
+
+    await poloniexFuturesService.setLeverage(
+      { apiKey: 'k', apiSecret: 's' },
+      'BTC_USDT_PERP',
+      5,
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [, method, endpoint, body] = spy.mock.calls[0];
+    expect(method).toBe('POST');
+    expect(endpoint).toBe('/position/leverage');
+    expect(body).toEqual({
+      symbol: 'BTC_USDT_PERP',
+      lever: '5',
+      mgnMode: 'CROSS',
+    });
+    // Critical: must NOT send the `leverage` field — that is what produced
+    // "Param error lever" on the live API.
+    expect(body).not.toHaveProperty('leverage');
+    // posSide should be omitted in one-way/BOTH mode unless explicitly set.
+    expect(body).not.toHaveProperty('posSide');
+  });
+
+  it('stringifies numeric leverage', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({});
+
+    await poloniexFuturesService.setLeverage(
+      { apiKey: 'k', apiSecret: 's' },
+      'ETH_USDT_PERP',
+      20,
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(typeof body.lever).toBe('string');
+    expect(body.lever).toBe('20');
+  });
+
+  it('honors opts.mgnMode override', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({});
+
+    await poloniexFuturesService.setLeverage(
+      { apiKey: 'k', apiSecret: 's' },
+      'BTC_USDT_PERP',
+      3,
+      { mgnMode: 'ISOLATED' },
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body.mgnMode).toBe('ISOLATED');
+  });
+
+  it('includes posSide only when explicitly provided', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({});
+
+    await poloniexFuturesService.setLeverage(
+      { apiKey: 'k', apiSecret: 's' },
+      'BTC_USDT_PERP',
+      10,
+      { posSide: 'LONG' },
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body.posSide).toBe('LONG');
+  });
+});


### PR DESCRIPTION
## Summary

Live Railway logs post-PR #506 (which unmasked application-level errors on HTTP 200 responses) showed every live-signal tick logging:

```
Poloniex API response received {"endpoint":"/v3/position/leverage","status":200,"hasData":true,"dataKeys":["code","msg"],"bodyCode":400,"bodyMsg":"Param error lever"}
```

HTTP 200 with `{ code: 400, msg: "Param error lever" }`. The error message names the field exactly — Poloniex v3 expects **`lever`** (stringified), not `leverage`. It also expects **`mgnMode`** (CROSS | ISOLATED) alongside it.

Root cause: `apps/api/src/services/poloniexFuturesService.js::setLeverage` was sending `{ symbol, leverage }`.

## What changed

- `apps/api/src/services/poloniexFuturesService.js::setLeverage` now sends:
  ```js
  { symbol, lever: String(leverage), mgnMode: 'CROSS' }
  ```
  - `lever` stringified (matches Poloniex v3 convention — see docs/archive/historical/POLONIEX_V3_API_FIXES.md line 144 which shows `lever: "30"` in get-leverages responses)
  - `mgnMode` defaults to `CROSS` per `shared/constants.ts::FUTURES_DEFAULTS.marginMode` and the agent dashboard default (`apps/web/src/components/agent/AutonomousAgentDashboard.tsx:194`)
  - `posSide` omitted by default (one-way / `BOTH` mode), overridable via opts
- Existing 3-arg signature `(credentials, symbol, leverage)` unchanged — added **optional** 4th `opts` parameter `{ mgnMode?, posSide? }` which is non-breaking. Callers at `fullyAutonomousTrader.ts:977` and `liveSignalEngine.ts:745` continue to work as-is.
- New Vitest `apps/api/src/tests/poloniexFuturesService.setLeverage.test.js` (4 tests) locks the body shape so this never drifts again.

## Evidence

### 1. Corroborating docs (fetched from Poloniex v3 API docs, `/v3/futures/api/trade/place-multiple-orders`)

> **mgnMode** — Required. String. Allowed values: `CROSS`, `ISOLATED`.
> "Margin mode `CROSS`、`ISOLATED`, Required in LONG/SHORT mode, linked with posSide in buy/sell mode, either fill in all or leave them blank"
>
> **posSide** — String. Allowed values: `LONG`, `SHORT`, `BOTH`.
> "Position side, this parameter is not mandatory in `BOTH` mode. If you pass it through, the only valid value is `BOTH`."

(The dedicated `/v3/futures/api/position/set-leverage` doc page is a JS-rendered SPA and could not be fetched via `WebFetch` — only the navigation shell comes through. The field-naming conventions in the place-orders docs plus the explicit `Param error lever` from the live API, plus the internal archived `docs/archive/historical/POLONIEX_V3_API_FIXES.md` which shows `lever` / `mgnMode` in v3 responses, plus the fact that the web-side client at `apps/web/src/context/FuturesContext.tsx:118` already posts `{ symbol, lever, mgnMode }` — all converge on the same shape.)

### 2. Pre-existing correct usage in the web tier (already worked before this fix)

`apps/web/src/context/FuturesContext.tsx:118`:
```ts
await api.setLeverage({ symbol, lever: leverage, mgnMode: marginMode });
```
The server-side service was the only place still sending the old `leverage` field. This PR closes that gap.

### 3. Live API curl — BLOCKED by IP allowlist

I ran a probe script (`apps/api/scripts/test-setleverage.mjs`, since deleted per task constraint) that attempted five body shapes against `https://api.poloniex.com/v3/position/leverage` using the provided prod key. All five returned `HTTP 401 { "code": 401, "message": "Illegal of ip" }` — the API key is locked to Railway egress IPs, so direct verification from a developer workstation isn't possible.

```
=== A: { symbol, leverage } (current broken) ===
http status: 401 — {"code":401,"message":"Illegal of ip"}
=== B: { symbol, lever: num } ===
http status: 401 — {"code":401,"message":"Illegal of ip"}
=== C: { symbol, lever: "5" } ===
http status: 401 — {"code":401,"message":"Illegal of ip"}
=== D: { symbol, lever: "5", mgnMode: CROSS } ===
http status: 401 — {"code":401,"message":"Illegal of ip"}
=== E: { symbol, lever: "5", mgnMode: CROSS, posSide: BOTH } ===
http status: 401 — {"code":401,"message":"Illegal of ip"}
```

**Final verification** must be the next Railway deploy — `Param error lever` should disappear from the logs and be replaced by `bodyCode: 200`. The non-fatal catch on the caller side means this is safe to roll out even if some other v3 quirk surfaces: the order-placement path keeps working, we just get one more iteration of log signal.

### 4. Test results

```
$ yarn vitest run src/tests/poloniexFuturesService.setLeverage.test.js
 ✓ src/tests/poloniexFuturesService.setLeverage.test.js (4 tests) 5ms
   Tests  4 passed (4)

$ yarn test:run
   Test Files  33 passed | 1 skipped (34)
        Tests  530 passed | 12 skipped (542)

$ npx tsc -p apps/api/tsconfig.json --noEmit
(clean, no output)
```

The existing `poloniexFuturesService.test.js` also still passes — its stdout now confirms the new signed body:
```
Signature message: POST
/v3/position/leverage
requestBody={"symbol":"BTC_USDT_PERP","lever":"10","mgnMode":"CROSS"}&signTimestamp=...
```

## Files changed

| File | Change |
|---|---|
| `apps/api/src/services/poloniexFuturesService.js` | Fixed `setLeverage` body shape; added optional `opts` parameter with `mgnMode`/`posSide` overrides |
| `apps/api/src/tests/poloniexFuturesService.setLeverage.test.js` | New Vitest (4 tests) locking the body shape |

Diff stat: `2 files changed, 132 insertions(+), 2 deletions(-)`

## Test plan

- [x] `yarn vitest run src/tests/poloniexFuturesService.setLeverage.test.js` — 4/4 pass
- [x] `yarn test:run` — 530 pass, 12 pre-existing skips, no regressions
- [x] `npx tsc -p apps/api/tsconfig.json --noEmit` — clean
- [ ] Post-deploy: Railway logs show `bodyCode: 200` for `/v3/position/leverage` (not 400)
- [ ] Post-deploy: `Param error lever` no longer appears in any live-tick log

## Constraints honored

- Did not modify the `setLeverage` signature for existing callers (added an **optional** 4th arg)
- Deleted the one-off probe script before commit
- Did not merge — left open for human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align Poloniex futures leverage-setting with the v3 API by correcting the request payload and adding coverage to prevent regressions.

Bug Fixes:
- Fix Poloniex leverage API calls by sending `lever` and `mgnMode` instead of the incorrect `leverage` field, eliminating `Param error lever` responses.

Enhancements:
- Extend the Poloniex futures `setLeverage` service to accept an optional options object for overriding margin mode and position side without breaking existing callers.

Tests:
- Add dedicated tests for the Poloniex futures `setLeverage` method to lock in the expected request body shape.