### PR TITLE
fix(live-signal): make leverage configurable via LIVE_LEVERAGE env

### DIFF
--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -78,6 +78,16 @@ const OHLCV_TIMEFRAME = '15m';
 /** Live position sizing (USDT notional) — graduated ladder. */
 const INITIAL_POSITION_USDT = Number(process.env.LIVE_POSITION_USDT) || 2;
 
+/**
+ * Base leverage applied to the order before the symbol-max catalog cap.
+ * At small account sizes the critical constraint is lot-size × price —
+ * e.g. BTC lotSize=0.001 @ $75k = $75 minNotional per lot. A $5 position
+ * at 3x leverage is only $15 notional, which rounds to 0 lots. Higher
+ * leverage is how a $27 account ever places a compliant BTC order.
+ * Risk kernel still caps at symbolMaxLeverage (100× BTC, varies by alt).
+ */
+const DEFAULT_LEVERAGE = Number(process.env.LIVE_LEVERAGE) || 3;
+
 /** ATR-scaling: stop = ATR × this, take-profit = ATR × this × 2. */
 const ATR_STOP_MULTIPLIER = 1.5;
 const ATR_TAKE_PROFIT_MULTIPLIER = 3.0;
@@ -585,7 +595,7 @@ export class LiveSignalEngine extends EventEmitter {
    * posterior we update.
    */
   private prospectiveLeverage(): number {
-    return 3; // Conservative default; risk kernel caps at symbol max
+    return DEFAULT_LEVERAGE;
   }
 
   private buildOrder(


### PR DESCRIPTION
## Summary
Hard-coded 3x leverage in \`liveSignalEngine.prospectiveLeverage()\` means a \$27 account can never place a compliant BTC order:

- BTC \`lotSize = 0.001\` BTC
- BTC price ≈ \$75,000
- 1 lot = \$75 minNotional
- \$5 position × 3x = \$15 notional → rounds to 0 lots → skip every tick

Fix: replace the hardcoded \`return 3\` with \`return DEFAULT_LEVERAGE\` driven by \`LIVE_LEVERAGE\` env var (default 3 for backwards compat). Risk kernel still caps at per-symbol \`symbolMaxLeverage\` (100x for BTC).

## Unblock path
Set \`LIVE_LEVERAGE=15\` on Railway → \$5 × 15x = \$75 notional → 1 BTC contract → trades place.

## Test plan
- [ ] Post-deploy with LIVE_LEVERAGE=15: BTC logs \`exchange order placed\` with non-empty ordId
- [ ] \`autonomous_trades\` gets a row with populated \`order_id\`
- [ ] Poloniex position actually opens (verifiable via balance change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make live trading leverage configurable via environment variable instead of being hard-coded.

New Features:
- Allow configuration of base live trading leverage through the LIVE_LEVERAGE environment variable.

Enhancements:
- Document the rationale and constraints around default leverage and symbol-specific max leverage in the live signal engine.