### PR TITLE
fix(poloniex): placeOrder body matches v3 spec (sz/mgnMode/posSide + UPPER)

### DIFF
--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -712,9 +712,11 @@ export class LiveSignalEngine extends EventEmitter {
     // produces 0 contracts and we skip. The fullyAutonomousTrader path
     // already uses this pattern.
     let formattedSize = quantity;
+    let symbolLotSize = 0;
     try {
       const precisions = await getPrecisions(order.symbol);
       if (precisions.lotSize && precisions.lotSize > 0) {
+        symbolLotSize = precisions.lotSize;
         formattedSize = Math.floor(quantity / precisions.lotSize) * precisions.lotSize;
       }
     } catch (err) {
@@ -769,6 +771,7 @@ export class LiveSignalEngine extends EventEmitter {
         side: exchangeSide,
         type: 'market',
         size: formattedSize,
+        lotSize: symbolLotSize,
       });
       // Poloniex v3 futures returns the exchange order id as `ordId`.
       // Keep `orderId`/`id` fallbacks so mocked tests + any future
@@ -800,15 +803,20 @@ export class LiveSignalEngine extends EventEmitter {
     // 3. Best-effort exchange-side SL + TP (reduce-only). Failures
     //    are logged but don't roll back — the server-side managed
     //    loop handles SL/TP as a fallback.
-    if (stopLoss > 0 && Number.isFinite(stopLoss)) {
+    // Stop-market trigger orders currently fall back to MARKET in the
+    // placeOrder body mapping — they aren't true trigger orders until we
+    // wire the dedicated Poloniex v3 trigger-order endpoint. Skipping
+    // SL/TP exchange-side placement for now; managePositions in the
+    // trader loop catches SL/TP on the backend side. Leaving the block
+    // for future re-enablement once the trigger endpoint is plumbed.
+    if (false && stopLoss > 0 && Number.isFinite(stopLoss)) {
       try {
         await poloniexFuturesService.placeOrder(credentials, {
           symbol: order.symbol,
           side: closeSide,
           type: 'stop_market',
           size: formattedSize,
-          stopPrice: stopLoss,
-          stopPriceType: 'TP',
+          lotSize: symbolLotSize,
           reduceOnly: true,
         });
       } catch (slErr) {
@@ -817,15 +825,14 @@ export class LiveSignalEngine extends EventEmitter {
         });
       }
     }
-    if (takeProfit > 0 && Number.isFinite(takeProfit)) {
+    if (false && takeProfit > 0 && Number.isFinite(takeProfit)) {
       try {
         await poloniexFuturesService.placeOrder(credentials, {
           symbol: order.symbol,
           side: closeSide,
           type: 'stop_market',
           size: formattedSize,
-          stopPrice: takeProfit,
-          stopPriceType: 'TP',
+          lotSize: symbolLotSize,
           reduceOnly: true,
         });
       } catch (tpErr) {

--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -516,34 +516,76 @@ class PoloniexFuturesService {
   /**
    * Place a futures order
    * Endpoint: POST /v3/trade/order
+   *
+   * Poloniex v3 Futures body schema (verified against
+   * https://api-docs.poloniex.com/v3/futures/api/trade/place-order
+   * on 2026-04-19 after production Param error surfaced via PR #506):
+   *
+   *   Required: symbol, side (UPPER), mgnMode, posSide, type (UPPER), sz
+   *   sz is a STRING, in CONTRACTS (not base asset). Caller is
+   *   responsible for converting base-asset quantity → contracts via
+   *   marketCatalog.lotSize (1 contract = lotSize base units).
+   *   Optional: clOrdId, px (limit only), reduceOnly, timeInForce,
+   *   stpMode, and trigger-order-specific fields.
+   *
+   * Caller still passes the ergonomic shape (`side: 'buy'`,
+   * `type: 'market'`, `size: <base asset>`); this method normalises
+   * to v3 wire form. `lotSize` in the optional 4th arg (or the
+   * catalog lookup) tells us how to convert size → sz.
    */
-  async placeOrder(credentials, orderData) {
+  async placeOrder(credentials, orderData, opts = {}) {
+    // Normalise side + type to UPPER per v3 spec.
+    const side = String(orderData.side ?? '').toUpperCase();
+    const typeRaw = String(orderData.type ?? 'market').toLowerCase();
+    const typeUpper = typeRaw === 'market' ? 'MARKET'
+      : typeRaw === 'limit' ? 'LIMIT'
+      : typeRaw === 'limit_maker' ? 'LIMIT_MAKER'
+      // stop_market / stop_limit — historical names; map conservatively to MARKET.
+      // If the caller wanted a true trigger order, they should be using the
+      // dedicated trigger endpoint, not this one.
+      : typeRaw === 'stop_market' ? 'MARKET'
+      : typeRaw === 'stop_limit' ? 'LIMIT'
+      : typeRaw.toUpperCase();
+
+    // Convert size (base asset) → sz (contracts). lotSize is the size of one
+    // contract in base-asset units. e.g. BTC_USDT_PERP lotSize = 0.001 means
+    // 1 contract = 0.001 BTC; if caller wants 0.001 BTC exposure, pass
+    // size=0.001 and lotSize=0.001 → sz=1.
+    const lotSize = Number(opts.lotSize ?? orderData.lotSize ?? 0);
+    let szContracts;
+    if (lotSize > 0 && Number.isFinite(Number(orderData.size))) {
+      szContracts = Math.round(Number(orderData.size) / lotSize);
+    } else {
+      // Fallback: caller already passed contract count (integer). Don't
+      // silently mangle; just pass through. If Poloniex rejects with
+      // "Param error sz" it's the caller's problem to pass lotSize.
+      szContracts = Math.round(Number(orderData.size));
+    }
+
     const body = {
-      clientOid: orderData.clientOid || this.generateClientOrderId(),
+      clOrdId: orderData.clientOid || orderData.clOrdId || this.generateClientOrderId(),
       symbol: orderData.symbol,
-      side: orderData.side, // 'buy' or 'sell'
-      type: orderData.type, // 'limit', 'market', 'stop_limit', 'stop_market'
-      size: orderData.size,
-      price: orderData.price,
-      timeInForce: orderData.timeInForce || 'GTC',
-      postOnly: orderData.postOnly || false,
-      hidden: orderData.hidden || false,
-      iceberg: orderData.iceberg || false,
-      visibleSize: orderData.visibleSize,
-      stopPrice: orderData.stopPrice,
-      stopPriceType: orderData.stopPriceType || 'TP',
-      reduceOnly: orderData.reduceOnly || false,
-      closeOrder: orderData.closeOrder || false,
-      forceHold: orderData.forceHold || false
+      side,                                                      // 'BUY' | 'SELL'
+      mgnMode: (opts.mgnMode ?? orderData.mgnMode ?? 'CROSS').toUpperCase(),
+      posSide: (opts.posSide ?? orderData.posSide ?? 'BOTH').toUpperCase(),
+      type: typeUpper,                                           // 'MARKET' | 'LIMIT' | 'LIMIT_MAKER'
+      sz: String(szContracts),                                   // STRING, in contracts
     };
-    
-    // Remove undefined values
+
+    // Limit-only fields
+    if (typeUpper === 'LIMIT' || typeUpper === 'LIMIT_MAKER') {
+      if (orderData.price !== undefined) body.px = String(orderData.price);
+      if (orderData.timeInForce) body.timeInForce = orderData.timeInForce;
+    }
+    if (orderData.reduceOnly) body.reduceOnly = true;
+
+    // Remove undefined values defensively.
     Object.keys(body).forEach(key => {
       if (body[key] === undefined) {
         delete body[key];
       }
     });
-    
+
     const result = await this.makeRequest(credentials, 'POST', '/trade/order', body);
     apiCache.invalidatePrefix('GET:/account/balance');
     apiCache.invalidatePrefix('GET:/trade/position');


### PR DESCRIPTION
## Summary
setLeverage fix in PR #508 unmasked the same class of bug in placeOrder — every Poloniex v3 POST body we construct has wrong param names, lowercase enums, and missing required fields.

## Live proof
After PR #510 deploy + LIVE_LEVERAGE=16:
- ✅ setLeverage NOW returns \`bodyCode: 200, bodyMsg: "Success"\` (PR #508 working)
- ✅ placeOrder reaches Poloniex with \`formattedSize: 0.001\` (1 lot)
- ❌ Poloniex returns \`bodyCode: 400, bodyMsg: "Param error sz"\`

## Root cause (per v3 docs)
Poloniex v3 placeOrder requires:
- \`sz\` (not \`size\`), STRING, in **contracts** not base asset
- \`side\`: UPPER (\`BUY\`/\`SELL\`)
- \`type\`: UPPER (\`MARKET\`/\`LIMIT\`/\`LIMIT_MAKER\`)
- \`mgnMode\`: required (\`CROSS\`/\`ISOLATED\`)
- \`posSide\`: required (\`BOTH\` in one-way mode)
- \`clOrdId\`: not \`clientOid\`
- \`px\`: not \`price\` (limit only)

Our previous body was basically the old v2 shape with camelCase. None of it matches.

## Fix
Rewrote \`placeOrder\` body to v3 spec. Caller passes \`lotSize\` alongside \`size\` (base asset); we convert to contract count via round(size/lotSize). liveSignalEngine updated to pass it.

## Side note on SL/TP
The two follow-on \`stop_market\` calls in liveSignalEngine are gated behind \`if (false)\` in this PR — v3's \`/trade/order\` endpoint doesn't accept stop-market as a type; true trigger orders need the dedicated trigger endpoint (future PR). managePositions handles SL/TP backend-side until then.

## Test plan
- [ ] Post-deploy: logs show \`[LiveSignal] exchange order placed\` with non-empty ordId
- [ ] \`autonomous_trades.order_id\` populated
- [ ] Poloniex balance \`im\` > 0 (margin committed = real position)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align Poloniex v3 futures order placement with the documented API schema and adjust live signal order placement to supply correct contract sizing while temporarily disabling exchange-side SL/TP orders.

Bug Fixes:
- Correct Poloniex futures placeOrder request body to use v3 field names, uppercase enums, required margin/position fields, and contract-based size values instead of the legacy v2 shape.

Enhancements:
- Normalize order side/type and contract size conversion inside placeOrder, allowing callers to pass ergonomic parameters plus lot size metadata.
- Update liveSignalEngine to fetch symbol lot size, format order quantities accordingly, and pass lot size into Poloniex futures order placement.
- Comment out SL/TP follow-on stop-market orders in liveSignalEngine pending wiring of the dedicated Poloniex v3 trigger-order endpoint, delegating SL/TP handling to the backend management loop.