### PR TITLE
fix(live-signal): row-ID dedup in bandit reconciler (batch-close repeat-feed)

### DIFF
--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -163,6 +163,21 @@ export class LiveSignalEngine extends EventEmitter {
   private tickMs = DEFAULT_TICK_MS;
   /** Latest close time already processed by the bandit reconciler. */
   private lastReconcileAt: Date = new Date(Date.now() - 60 * 60_000);  // look back 1h on boot
+  /**
+   * Row IDs already fed to the bandit. Prevents re-feeding the same
+   * closed trade when multiple rows share an exit_time (e.g. kill-
+   * switch flatten closing 5 positions in one transaction all got
+   * exit_time=NOW(); millisecond-precision JS Date vs microsecond-
+   * precision Postgres timestamp lets the `> lastReconcileAt` filter
+   * mis-match-match on the next tick).
+   *
+   * Bounded to the 500 most-recent IDs via FIFO eviction — keeps
+   * memory flat while covering the window needed for close→tick
+   * cycles (liveSignal runs 60s, so 500 entries covers 8h+ of trades).
+   */
+  private processedBanditIds: Set<string> = new Set();
+  private processedBanditIdsOrder: string[] = [];
+  private static readonly PROCESSED_BANDIT_IDS_MAX = 500;
 
   async start(options: StartOptions = {}): Promise<void> {
     this.symbols = options.symbols ?? [...DEFAULT_WATCH_SYMBOLS];
@@ -314,7 +329,7 @@ export class LiveSignalEngine extends EventEmitter {
   private async reconcileClosedTrades(): Promise<void> {
     try {
       const result = await pool.query(
-        `SELECT symbol, reason, pnl, exit_time, exit_price, entry_price, quantity, exit_reason, leverage
+        `SELECT id, symbol, reason, pnl, exit_time, exit_price, entry_price, quantity, exit_reason, leverage
            FROM autonomous_trades
           WHERE status = 'closed'
             AND exit_time > $1
@@ -325,6 +340,18 @@ export class LiveSignalEngine extends EventEmitter {
       );
       const rows = (result.rows as Array<Record<string, unknown>>) ?? [];
       for (const row of rows) {
+        // Row-ID dedup: Postgres timestamps have microsecond precision
+        // and JS Date only millisecond precision, so `exit_time >
+        // lastReconcileAt` can re-match the same row if the timestamp
+        // has sub-ms digits lost on the round-trip. Additionally, batch
+        // closes (e.g. kill-switch flatten) give multiple rows the
+        // identical exit_time=NOW() — those would all re-feed every
+        // tick without this guard. 2026-04-20 incident: 5 bulk-closed
+        // rows fed the bandit 5 losses per tick for an unbounded time.
+        const rowId = String(row.id ?? '');
+        if (rowId && this.processedBanditIds.has(rowId)) {
+          continue;
+        }
         const reason = String(row.reason ?? '');
         const keyMatch = reason.match(/key=([^|]+)/);
         const regimeMatch = reason.match(/regime=([^|]+)/);
@@ -386,6 +413,18 @@ export class LiveSignalEngine extends EventEmitter {
             exitReason,
             pnl,
           });
+        }
+
+        // Mark this row as processed regardless of which branch we took
+        // — even skipped rows shouldn't be revisited. FIFO-bound the
+        // Set so memory stays flat over long uptimes.
+        if (rowId) {
+          this.processedBanditIds.add(rowId);
+          this.processedBanditIdsOrder.push(rowId);
+          if (this.processedBanditIdsOrder.length > LiveSignalEngine.PROCESSED_BANDIT_IDS_MAX) {
+            const evicted = this.processedBanditIdsOrder.shift();
+            if (evicted) this.processedBanditIds.delete(evicted);
+          }
         }
 
         if (closedAt > this.lastReconcileAt) {


### PR DESCRIPTION
## Summary
Post-deploy verification of PR #513 exposed a new bandit-poisoning path. The 5 emergency-flatten rows were re-fed to the Thompson posterior on every tick:
\`\`\`
losses": 66 → 71 → 76 → 81 ...
\`\`\`

## Root cause
\`reconcileClosedTrades\` dedupes via \`WHERE exit_time > $1\` where \$1 is \`this.lastReconcileAt\` (JS \`Date\`). Postgres stores timestamps with microsecond precision; JS \`Date\` only milliseconds. A row with \`exit_time=00:03:57.010159\` becomes \`lastReconcileAt=00:03:57.010\` on the JS side, and the next query with \`> 00:03:57.010\` still matches \`.010159\`.

Additionally, **batch closes** (kill-switch auto-flatten, bulk manual UPDATE) give multiple rows identical \`exit_time=NOW()\`. Even with perfect precision the same second's rows would re-feed if only the last one's timestamp was cached.

## Fix
In-memory \`Set<row.id>\` of recently-processed rows, FIFO-bounded to 500 entries (~8h+ of trades at 60s cadence). Check before bandit update; mark after. Memory stays flat; duplicate-feed becomes impossible regardless of timestamp precision.

## Test plan
- [ ] Post-deploy: bandit counters stay stable (no growth) while no new trades fire
- [ ] If a new trade fires and closes, bandit updates ONCE for that trade's row.id

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent the bandit reconciler from re-processing already-closed trades whose timestamps cause them to be repeatedly selected on each tick.

Bug Fixes:
- Avoid repeated bandit updates for the same closed trade rows when timestamp precision and batch closes cause rows to be re-selected across ticks.

Enhancements:
- Track a bounded in-memory set of recently processed trade row IDs to deduplicate bandit reconciliation while keeping memory usage stable.