### PR TITLE
feat(monkey): v0.2 unstick size gate via witness hook + leverage-aware sizing

### DIFF
--- a/apps/api/docs/poloniex-v3-LICENSE.md
+++ b/apps/api/docs/poloniex-v3-LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Poloniex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/api/docs/poloniex-v3-authentication.md
+++ b/apps/api/docs/poloniex-v3-authentication.md
@@ -1,0 +1,289 @@
+<!--
+Vendored from https://github.com/poloniex/polo-skills-hub/tree/master/skills/futures/references/authentication.md
+Commit: bca01fb370f2f6d30fddba5a5eb4467134238f49 (fetched 2026-04-20)
+License: MIT (see poloniex-v3-LICENSE.md)
+-->
+
+# Polo Spot Authentication
+
+All private API endpoints require signed requests using HMAC-SHA256.
+
+## Base URLs
+
+| Environment | URL |
+|-------------|-----|
+| Production | https://api.poloniex.com |
+
+## Environment Variables
+
+Configure your API credentials using environment variables:
+
+```bash
+export POLO_API_KEY="your_api_key"
+export POLO_SECRET_KEY="your_secret_key"
+```
+
+## Overview
+
+All private API requests must be authenticated by signing the request with your Secret Key. Each API Key has permission properties — ensure your API key has the required permissions (Read, Trade, Withdraw) for the operations you need.
+
+Authentication is done by sending required parameters in HTTP **headers** (not query parameters).
+
+## Required Headers for All Authenticated Requests
+
+Every authenticated request must include the following headers:
+
+* **key**: Your API Key (e.g., "A3xxxxxx-99xxxxxx-84xxxxxx-72xxxxxx")
+* **signTimestamp**: UTC timestamp in milliseconds (Unix epoch). Valid within 1 minute of server time.
+* **signature**: HMAC-SHA256 signature of the request (Base64-encoded)
+* **signatureMethod** (optional): Signature method, always "HmacSHA256"
+* **signatureVersion** (optional): Signature version, always "2"
+* **recvWindow** (optional): Duration in milliseconds for additional timing control
+
+### recvWindow Error Codes
+
+If `recvWindow` is specified, the request will be rejected if `(server_time - signTimestamp) > recvWindow`:
+
+* **400**: signTimestamp is more than 1 second from server time
+* **408**: Request timeout as recvWindow threshold has been breached
+
+## Signature Process
+
+### Step 1: Build the Pre-Sign String
+
+The pre-sign string format depends on the request method:
+
+#### GET Requests
+
+Concatenate the HTTP method, path, and sorted query parameters with `\n`:
+
+```
+GET\n
+/orders\n
+limit=5&signTimestamp=1659259836247&symbol=ETH_USDT
+```
+
+**Important**:
+- Sort all query parameters alphabetically by key name
+- Join parameters with `&`
+- Do NOT include the `signature` parameter itself
+- All parameters must be URL/UTF-8 encoded (space = "%20")
+
+#### POST/DELETE Requests with Body
+
+Concatenate the HTTP method, path, requestBody, and timestamp with `\n`:
+
+```
+DELETE\n
+/orders/cancelByIds\n
+requestBody={"orderIds":["1234567890"],"clientOrderIds":["myId-1"]}&signTimestamp=1631018760000
+```
+
+**Important**:
+- The body must be included as `requestBody=<json_string>` in the pre-sign string
+- Connect requestBody and signTimestamp with `&`
+
+#### POST/DELETE Requests without Body
+
+Concatenate the HTTP method, path, and timestamp with `\n`:
+
+```
+DELETE\n
+/orders/1\n
+signTimestamp=1631018760000
+```
+
+### Step 2: Generate Signature
+
+Sign the pre-sign string using HMAC-SHA256 with your Secret Key, then Base64-encode the result:
+
+```python
+import hmac
+import hashlib
+import base64
+
+signature = base64.b64encode(
+    hmac.new(
+        secret_key.encode('utf-8'),
+        presign_string.encode('utf-8'),
+        hashlib.sha256
+    ).digest()
+).decode('utf-8')
+```
+
+### Step 3: Send the Request
+
+Add all authentication parameters to the request **headers**, not the URL query string.
+
+**For GET requests:** Query parameters go in the URL, authentication goes in headers.
+
+```bash
+curl -X GET \
+  --header 'key: A3xxxxxx-99xxxxxx-84xxxxxx-72xxxxxx' \
+  --header 'signatureMethod: HmacSHA256' \
+  --header 'signatureVersion: 2' \
+  --header 'signTimestamp: 1631018760000' \
+  --header 'signature: 5g4Rx5A2bLyMWFgR3Aqp+B4w+iJkL7n5OD3SuYtCJK8=' \
+  'https://api.poloniex.com/orders?symbol=ETH_USDT&limit=5'
+```
+
+**For POST requests:** Authentication in headers, business parameters in JSON body.
+
+```bash
+curl -X POST \
+  --header 'Content-Type: application/json' \
+  --header 'key: A3xxxxxx-99xxxxxx-84xxxxxx-72xxxxxx' \
+  --header 'signatureMethod: HmacSHA256' \
+  --header 'signatureVersion: 2' \
+  --header 'signTimestamp: 1631018760000' \
+  --header 'signature: 5g4Rx5A2bLyMWFgR3Aqp+B4w+iJkL7n5OD3SuYtCJK8=' \
+  --data '{"symbol":"BTC_USDT","side":"BUY","type":"LIMIT","price":"30000","quantity":"0.001"}' \
+  'https://api.poloniex.com/orders'
+```
+
+## Request Method Summary
+
+| Method | Query Params in Signature | Body in Signature | Auth Location |
+|--------|---------------------------|-------------------|---------------|
+| GET | Yes (all params sorted) | N/A | Headers |
+| POST with body | No | Yes (as requestBody=...) | Headers |
+| POST without body | No | No (only timestamp) | Headers |
+| DELETE with body | No | Yes (as requestBody=...) | Headers |
+| DELETE without body | No | No (only timestamp) | Headers |
+
+## Additional Required Headers
+
+Include the following headers with every request:
+
+| Header | Value |
+|--------|-------|
+| `Content-Type` | `application/json` (for POST/DELETE requests with body) |
+| `User-Agent` | `polo-spot/1.0.0 (Skill)` |
+
+## Security Notes
+
+* **Never share your Secret Key** — Keep it secure at all times
+* **Use environment variables** — Store API credentials in `POLO_API_KEY` and `POLO_SECRET_KEY`
+* **Use IP whitelist** in Polo API settings for additional security
+* **Enable only required permissions** (Read, Trade; avoid Withdraw unless needed)
+* **Rotate keys periodically** — Update API keys regularly
+* **Monitor API usage** — Check for unauthorized access
+* **Timestamp validity** — Requests are valid within 1 minute of server time to prevent replay attacks
+* **Use HTTPS only** — All requests must use secure HTTPS protocol
+
+## Common Errors
+
+### Timestamp Outside Valid Window
+
+If you receive a timestamp error (400 or 408):
+
+1. Check server time via `GET /timestamp`
+2. Ensure your system clock is synchronized with UTC
+3. Verify the timestamp is in Unix milliseconds
+4. Timestamp must be within 1 minute of server time
+5. If using `recvWindow`, ensure it's set appropriately
+
+### Invalid Signature
+
+If signature validation fails:
+
+1. Verify the pre-sign string format: `METHOD\nPATH\nPARAMS`
+2. Ensure line breaks are `\n` (not `\r\n`)
+3. For GET requests: all query parameters must be sorted alphabetically and included
+4. For POST/DELETE with body: use `requestBody=<json>&signTimestamp=...` format
+5. For POST/DELETE without body: only include `signTimestamp=...`
+6. Verify the Secret Key is correct
+7. Ensure signature is Base64-encoded HMAC-SHA256 digest
+8. Check that authentication parameters are in **headers**, not query string
+
+## Example: Authenticated GET Request
+
+Request to get orders with symbol and limit:
+
+**Pre-sign string:**
+```
+GET\n
+/orders\n
+limit=5&signTimestamp=1659259836247&symbol=ETH_USDT
+```
+
+**Request:**
+```bash
+curl -X GET \
+  --header 'key: A3xxxxxx-99xxxxxx-84xxxxxx-72xxxxxx' \
+  --header 'signatureMethod: HmacSHA256' \
+  --header 'signatureVersion: 2' \
+  --header 'signTimestamp: 1659259836247' \
+  --header 'signature: 5g4Rx5A2bLyMWFgR3Aqp+B4w+iJkL7n5OD3SuYtCJK8=' \
+  'https://api.poloniex.com/orders?symbol=ETH_USDT&limit=5'
+```
+
+## Example: Authenticated POST Request with Body
+
+Request to create a limit order:
+
+**Pre-sign string:**
+```
+POST\n
+/orders\n
+requestBody={"symbol":"BTC_USDT","side":"BUY","type":"LIMIT","price":"30000","quantity":"0.001","timeInForce":"GTC"}&signTimestamp=1631018760000
+```
+
+**Request:**
+```bash
+curl -X POST \
+  --header 'Content-Type: application/json' \
+  --header 'key: A3xxxxxx-99xxxxxx-84xxxxxx-72xxxxxx' \
+  --header 'signatureMethod: HmacSHA256' \
+  --header 'signatureVersion: 2' \
+  --header 'signTimestamp: 1631018760000' \
+  --header 'signature: 4F65x5A2bLyMWVQj3Aqp+B4w+iJkL7n5OD3SuYtCJ9o=' \
+  --data '{"symbol":"BTC_USDT","side":"BUY","type":"LIMIT","price":"30000","quantity":"0.001","timeInForce":"GTC"}' \
+  'https://api.poloniex.com/orders'
+```
+
+## Example: Authenticated DELETE Request without Body
+
+Request to cancel order by ID:
+
+**Pre-sign string:**
+```
+DELETE\n
+/orders/1234567890\n
+signTimestamp=1631018760000
+```
+
+**Request:**
+```bash
+curl -X DELETE \
+  --header 'key: A3xxxxxx-99xxxxxx-84xxxxxx-72xxxxxx' \
+  --header 'signatureMethod: HmacSHA256' \
+  --header 'signatureVersion: 2' \
+  --header 'signTimestamp: 1631018760000' \
+  --header 'signature: xyz123...' \
+  'https://api.poloniex.com/orders/1234567890'
+```
+
+## Example: Authenticated DELETE Request with Body
+
+Request to cancel orders by IDs:
+
+**Pre-sign string:**
+```
+DELETE\n
+/orders/cancelByIds\n
+requestBody={"orderIds":["1234567890"],"clientOrderIds":["myId-1"]}&signTimestamp=1631018760000
+```
+
+**Request:**
+```bash
+curl -X DELETE \
+  --header 'Content-Type: application/json' \
+  --header 'key: A3xxxxxx-99xxxxxx-84xxxxxx-72xxxxxx' \
+  --header 'signatureMethod: HmacSHA256' \
+  --header 'signatureVersion: 2' \
+  --header 'signTimestamp: 1631018760000' \
+  --header 'signature: abc456...' \
+  --data '{"orderIds":["1234567890"],"clientOrderIds":["myId-1"]}' \
+  'https://api.poloniex.com/orders/cancelByIds'
+```

--- a/apps/api/docs/poloniex-v3-reference.md
+++ b/apps/api/docs/poloniex-v3-reference.md
@@ -1,0 +1,276 @@
+<!--
+Vendored from https://github.com/poloniex/polo-skills-hub/tree/master/skills/futures
+Commit: bca01fb370f2f6d30fddba5a5eb4467134238f49 (fetched 2026-04-20)
+License: MIT (see poloniex-v3-LICENSE.md)
+Refresh: gh api repos/poloniex/polo-skills-hub/contents/skills/futures/SKILL.md --jq '.content' | base64 -d
+-->
+
+---
+name: polo-futures
+description: Poloniex perpetual futures trading using the Poloniex Futures API. Authentication requires API key and secret key for certain endpoints. Supports mainnet.
+metadata:
+  version: 1.0.0
+  author: Poloniex
+license: MIT
+---
+
+# Poloniex Futures Skill
+
+Perpetual futures trading on Poloniex using authenticated and public API endpoints. Return the result in JSON format.
+
+## Base URLs
+
+* Production: https://api.poloniex.com
+
+## Quick Reference
+
+Complete API endpoints for Poloniex Futures. All endpoints use base URL `https://api.poloniex.com`.
+
+### Account
+| Endpoint | Description | Required | Optional | Authentication |
+|----------|-------------|----------|----------|----------------|
+| GET `/v3/account/balance` | Get Account Balance | None | None | Yes |
+| GET `/v3/account/bills` | Get Bills Details | None | None | Yes |
+
+### Order
+| Endpoint | Description | Required | Optional | Authentication |
+|----------|-------------|----------|----------|----------------|
+| POST `/v3/trade/order` | Place Order | symbol, side, mgnMode, posSide, type, sz | clOrdId, px, reduceOnly, timeInForce, stpMode | Yes |
+| POST `/v3/trade/orders` | Place Multiple Orders (max 10) | symbol, side, mgnMode, posSide, type, sz | clOrdId, px, reduceOnly, timeInForce, stpMode | Yes |
+| DELETE `/v3/trade/order` | Cancel Order | symbol | ordId, clOrdId | Yes |
+| DELETE `/v3/trade/batchOrders` | Cancel Multiple Orders (max 10) | symbol | ordIds, clOrdIds | Yes |
+| DELETE `/v3/trade/allOrders` | Cancel All Orders | None | symbol, side | Yes |
+| POST `/v3/trade/position` | Close At Market Price | symbol, mgnMode | posSide, clOrdId | Yes |
+| POST `/v3/trade/positionAll` | Close All At Market Price | None | None | Yes |
+| GET `/v3/trade/order/opens` | Get Current Orders | None | side, symbol, ordId, clOrdId, from, limit, direct | Yes |
+| GET `/v3/trade/order/trades` | Get Execution Details | None | side, symbol, ordId, clOrdId, sTime, eTime, from, limit, direct | Yes |
+| GET `/v3/trade/order/history` | Get Order History | None | symbol, side, ordId, clOrdId, state, type, sTime, eTime, from, limit, direct | Yes |
+| GET `/v3/trade/order/details` | Get Order Details | None | ordId, clOrdId | Yes |
+
+### Position
+| Endpoint | Description | Required | Optional | Authentication |
+|----------|-------------|----------|----------|----------------|
+| GET `/v3/trade/position/opens` | Get Current Position | None | symbol | Yes |
+| GET `/v3/trade/position/history` | Get Position History | None | symbol, mgnMode, posSide, sTime, eTime, from, limit, direct | Yes |
+| POST `/v3/trade/position/margin` | Adjust Margin (Isolated Mode) | symbol, amt, type | posSide | Yes |
+| GET `/v3/position/leverages` | Get Leverage List | symbol | mgnMode | Yes |
+| POST `/v3/position/leverage` | Set Leverage | symbol, mgnMode, posSide, lever | None | Yes |
+| GET `/v3/position/mode` | View Position Mode | None | None | Yes |
+| POST `/v3/position/mode` | Switch Position Mode | posMode | None | Yes |
+| GET `/v3/position/riskLimit` | Get User Position Risk Limit | symbol | mgnMode, posSide | Yes |
+
+### Market Data
+| Endpoint | Description | Required | Optional | Authentication |
+|----------|-------------|----------|----------|----------------|
+| GET `/v3/market/orderBook` | Get Order Book | symbol | scale, limit | No |
+| GET `/v3/market/candles` | Get K-line Data | symbol, interval | limit, sTime, eTime | No |
+| GET `/v3/market/trades` | Get Execution Info | symbol | limit | No |
+| GET `/v3/market/liquidationOrder` | Get Liquidation Orders | None | sTime, eTime, symbol, from, limit, direct | No |
+| GET `/v3/market/tickers` | Get Market Info (24h) | None | symbol | No |
+| GET `/v3/market/indexPrice` | Get Index Price | None | symbol | No |
+| GET `/v3/market/indexPriceComponents` | Get Index Price Components | symbol | None | No |
+| GET `/v3/market/indexPriceCandlesticks` | Get Index Price K-line Data | symbol, interval | sTime, eTime, limit | No |
+| GET `/v3/market/premiumIndexCandlesticks` | Get Premium Index K-line Data | symbol, interval | sTime, eTime, limit | No |
+| GET `/v3/market/markPrice` | Get Mark Price | None | symbol | No |
+| GET `/v3/market/markPriceCandlesticks` | Get Mark Price K-line Data | symbol, interval | sTime, eTime, limit | No |
+| GET `/v3/market/allInstruments` | Get All Contract Info | None | symbol | No |
+| GET `/v3/market/instruments` | Get Contract Info | symbol | None | No |
+| GET `/v3/market/fundingRate` | Get Current Funding Rate | symbol | None | No |
+| GET `/v3/market/fundingRate/history` | Get Historical Funding Rates | None | symbol, sT, eT, limit | No |
+| GET `/v3/market/openInterest` | Get Open Interest | symbol | None | No |
+| GET `/v3/market/insurance` | Get Insurance Fund Info | None | None | No |
+| GET `/v3/market/riskLimit` | Get Futures Risk Limit | symbol | mgnMode, tier | No |
+| GET `/v3/market/limitPrice` | Get Limit Price | symbol | None | No |
+
+---
+
+## Parameters
+
+### Common Parameters
+
+#### Contract & Symbol
+* **symbol**: Trading pair (e.g., BTCUSDTPERP, ETHUSDTPERP) — base currency + quote currency
+
+#### Account & Margin
+* **mgnMode**: Margin mode (CROSS, ISOLATED)
+* **posMode**: Position mode (HEDGE: LONG/SHORT two-way, ONE_WAY: BOTH)
+
+#### Order Parameters
+* **ordId**: Order ID
+* **clOrdId**: Client-assigned order ID
+* **side**: Order side (BUY, SELL)
+* **type**: Order type (MARKET, LIMIT, LIMIT_MAKER)
+* **sz**: Order size in Cont (contracts)
+* **px**: Price — required for LIMIT orders, omit for MARKET orders
+* **posSide**: Position side (LONG, SHORT, BOTH — use BOTH for one-way mode)
+* **reduceOnly**: Reduce only flag (Boolean)
+* **timeInForce**: Time in force (GTC default, FOK, IOC)
+* **stpMode**: Self-trade prevention (NONE default, EXPIRE_TAKER, EXPIRE_MAKER, EXPIRE_BOTH)
+
+#### Margin Adjustment Parameters
+* **amt**: Margin amount to add or reduce
+* **type**: Adjustment type (ADD, REDUCE)
+
+#### Leverage Parameters
+* **lever**: Leverage rate (1 to 75)
+
+#### Query & Pagination Parameters
+* **from**: Starting ID for cursor-based pagination (default 0)
+* **limit**: Page size (default 10, max 100; some endpoints max 500 or 1000)
+* **direct**: Search direction (NEXT: chronological default, PREV: reverse)
+* **sTime**: Start time (Unix timestamp in milliseconds)
+* **eTime**: End time (Unix timestamp in milliseconds)
+* **sT**: Start time (Unix timestamp in seconds — funding rate history)
+* **eT**: End time (Unix timestamp in seconds — funding rate history)
+* **state**: Order state filter (FILLED, PARTIALLY_CANCELED, CANCELED)
+
+#### Market Data Parameters
+* **interval**: K-line period (MINUTE_1, MINUTE_5, MINUTE_15, MINUTE_30, HOUR_1, HOUR_2, HOUR_4, HOUR_8, HOUR_12, DAY_1, DAY_3, WEEK_1)
+* **scale**: Market depth level
+* **tier**: Risk limit tier
+
+### Enums
+
+#### Order Side
+* **side**: BUY, SELL
+
+#### Order Type
+* **type**: MARKET, LIMIT, LIMIT_MAKER
+
+#### Time in Force
+* **timeInForce**: GTC (Good Till Cancel, default), FOK (Fill or Kill), IOC (Immediate or Cancel)
+
+#### Position Side
+* **posSide**: LONG, SHORT, BOTH (BOTH = one-way mode)
+
+#### Self-Trade Prevention
+* **stpMode**: NONE (default), EXPIRE_TAKER, EXPIRE_MAKER, EXPIRE_BOTH
+
+#### Margin Mode
+* **mgnMode**: CROSS, ISOLATED
+
+#### Position Mode
+* **posMode**: HEDGE (LONG/SHORT two-way), ONE_WAY (BOTH one-way)
+
+#### Order State
+* **state**: FILLED, PARTIALLY_CANCELED, CANCELED
+
+#### Pagination Direction
+* **direct**: NEXT (chronological, default), PREV (reverse chronological)
+
+---
+
+## Authentication
+
+For endpoints that require authentication, you will need to provide Poloniex API credentials.
+
+Required credentials:
+* **apiKey**: Your Poloniex API key
+* **secretKey**: Your Poloniex API secret (for signing)
+
+See `references/authentication.md` for detailed signing instructions.
+
+---
+
+## Security
+
+### Share Credentials
+
+Users can provide Poloniex API credentials by sending a file where the content is in the following format:
+
+```bash
+api_key_here
+secret_key_here
+```
+
+### Never Display Full Secrets
+
+When showing credentials to users:
+- **API Key:** Show first 5 + last 4 characters: `abcde...xyz1`
+- **Secret Key:** Always mask, show only last 5: `***...key12`
+
+Example response when asked for credentials:
+```
+Account: main
+API Key: abcde...xyz1
+Secret: ***...key12
+Environment: Production
+```
+
+### Listing Accounts
+
+When listing accounts, show names and environment only — never keys:
+```
+Poloniex Futures Accounts:
+* main (Production)
+* trading (Production)
+```
+
+### Transactions in Production
+
+When performing transactions in production, always confirm with the user before proceeding by asking them to write "CONFIRM" to proceed.
+
+---
+
+## Poloniex Futures Accounts
+
+### main
+- API Key: your_api_key
+- Secret: your_secret_key
+- Environment: https://api.poloniex.com
+- Description: Primary perpetual futures trading account
+
+
+### TOOLS.md Structure
+
+```bash
+## Poloniex Futures Accounts
+
+### main
+- API Key: abcde...xyz1
+- Secret: secret_abc...key
+- Environment: https://api.poloniex.com
+- Description: Primary perpetual futures trading account
+
+```
+
+## Agent Behavior
+
+1. **Credentials requested**: Mask secrets (show last 5 chars only)
+2. **Listing accounts**: Show names and environment, never keys
+3. **Account selection**: Ask if ambiguous, default to main
+4. **When doing a transaction in production**, confirm with user before by asking to write "CONFIRM" to proceed
+5. **New credentials**: Prompt for name, environment
+
+## Adding New Accounts
+
+When user provides new credentials:
+
+* Ask for account name
+* Ask: Which environment (Production)
+* Store in `TOOLS.md` with masked display confirmation
+
+## User Agent Header
+
+Include `User-Agent` header with the following string: `polo-futures/1.0.0 (Skill)`
+
+## Important Notes
+
+* All timestamps are in Unix milliseconds unless specified otherwise (funding rate history uses seconds)
+* Contract codes should use uppercase (e.g., BTCUSDTPERP, ETHUSDTPERP)
+* `sz` represents the number of contracts (Cont) for all order types
+* Rate limits apply — see Poloniex API documentation for details
+* Signature must be calculated for every authenticated request
+* Timestamp in signature must be within 5 minutes of server time
+* Both CROSS and ISOLATED margin modes are supported
+* Position modes: HEDGE (two-way LONG/SHORT) and ONE_WAY (BOTH); use `posSide=BOTH` for one-way mode
+* `px` (price) is required for LIMIT orders; omit for MARKET orders
+* Batch order endpoints support a maximum of 10 orders per request
+* Canceled orders (no fills) via API can only be queried for 5 hours; other order history: 90 days
+* Switch position mode only when there are no open positions or pending orders
+* Pagination uses cursor-based `from` + `limit` + `direct` parameters
+* For `Get Order Details`, either `ordId` or `clOrdId` must be provided; if both are passed, both are verified
+* All DELETE requests that do not require parameters must include a request body of `{}` (empty JSON object) — use `json={}` in the request
+* All request endpoints must match the endpoints specified in the documentation.
+
+

--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -50,6 +50,7 @@ import {
   type BanditCounter,
   type LeverageBucket,
 } from './thompsonBandit.js';
+import { monkeyKernel } from './monkey/loop.js';
 import {
   evaluatePreTradeVetoes,
   type KernelAccountState,
@@ -329,7 +330,7 @@ export class LiveSignalEngine extends EventEmitter {
   private async reconcileClosedTrades(): Promise<void> {
     try {
       const result = await pool.query(
-        `SELECT id, symbol, reason, pnl, exit_time, exit_price, entry_price, quantity, exit_reason, leverage
+        `SELECT id, symbol, reason, pnl, entry_time, exit_time, exit_price, entry_price, quantity, exit_reason, leverage, side, order_id
            FROM autonomous_trades
           WHERE status = 'closed'
             AND exit_time > $1
@@ -407,6 +408,23 @@ export class LiveSignalEngine extends EventEmitter {
             quantity: Number(row.quantity ?? 0),
             closedAt: closedAt.toISOString(),
           });
+          // Monkey witness (v0.2): attribute this real P&L to the
+          // perception basin Monkey held at entry — bootstraps her
+          // resonance bank from already-running trades without new
+          // capital risk. Fire-and-forget; her bank is best-effort.
+          const entryTimeRaw = row.entry_time;
+          const entryTime = entryTimeRaw ? new Date(entryTimeRaw as string | Date) : null;
+          if (entryTime && !Number.isNaN(entryTime.getTime())) {
+            const sideStr = String(row.side ?? '').toLowerCase();
+            const side: 'long' | 'short' = sideStr === 'sell' || sideStr === 'short' ? 'short' : 'long';
+            void monkeyKernel.witnessExit(
+              String(row.symbol),
+              entryTime,
+              pnl,
+              row.order_id ? String(row.order_id) : null,
+              side,
+            );
+          }
         } else if (isReconcilerClose) {
           logger.debug('[LiveSignal] skipping bandit update for reconciler-closed row', {
             symbol: row.symbol,

--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -89,49 +89,64 @@ export function currentEntryThreshold(s: BasinState): ExecutiveDecision<number> 
 }
 
 /**
- * currentPositionSize — f(sovereignty, Φ, dopamine, serotonin).
+ * currentPositionSize — f(sovereignty, Φ, dopamine, serotonin, maturity).
  *
- * Newborn Monkey (sovereignty ≈ 0) sizes tiny. Sovereign Monkey
- * sizes by confidence. Dopamine (reward history) amplifies size.
- * Low serotonin (high basin velocity = unstable) shrinks size.
+ * Newborn Monkey (bankSize ≈ 0) sizes by the exploration floor;
+ * mature Monkey sizes by confidence. Dopamine (reward history)
+ * amplifies; GABA dampens. Low serotonin (high basin velocity =
+ * unstable) shrinks size.
  *
- * Output is fraction of available equity to commit. BOUNDARY hints
- * (exchange min notional, available equity) are passed in and
- * respected — Monkey cannot place what the exchange won't accept.
+ * Output is MARGIN (USDT) to commit. The POSITION NOTIONAL is
+ * `margin × leverage`; the min-notional boundary is compared to
+ * that, not to margin (this was a v0.1 bug: on $19 equity at 1x the
+ * margin was always below ETH's $22.76 min, so sized always = 0).
+ *
+ * BOUNDARY hints (exchange min notional, available equity) passed
+ * in and respected — Monkey cannot place what the exchange won't
+ * accept.
  */
 export function currentPositionSize(
   s: BasinState,
   availableEquityUsdt: number,
   minNotionalUsdt: number,
+  leverage: number = 1,
+  bankSize: number = 0,
 ): ExecutiveDecision<number> {
   const nc = s.neurochemistry;
-  // Base fraction: Φ × sovereignty. Newborn or uncertain → tiny.
-  const baseFrac = s.phi * s.sovereignty;
+  // Lived-experience scaling. 0 at birth, 1 after ~20 witnessed trades.
+  // Drives both the organic size ramp and the exploration floor decay.
+  const maturity = Math.min(1, bankSize / 20);
+  // Base fraction: Φ × sovereignty × maturity. Immature → tiny even
+  // if sovereignty flipped to 1 after the first witnessed close.
+  const baseFrac = s.phi * s.sovereignty * maturity;
   // Reward modulation: dopamine amplifies, GABA dampens.
   const rewardMult = 1 + (nc.dopamine - nc.gaba) * 0.5;
   // Stability modulation: serotonin multiplies (stable → full size).
   const stabilityMult = 0.5 + nc.serotonin * 0.5;
 
-  // Newborn floor: even at sovereignty=0, some exploration must happen
-  // (Pillar 1 FLUCTUATIONS — exploration is substrate, not optional).
-  const explorationFloor = 0.05 * (1 - s.sovereignty);
+  // Exploration floor (Pillar 1 FLUCTUATIONS — substrate, not optional).
+  // Scales inversely with maturity, not sovereignty: a Monkey who just
+  // earned her first bubble has sovereignty=1 but 0.05 maturity, and
+  // she still needs the floor to place trade #2.
+  const explorationFloor = 0.10 * (1 - maturity);
 
   const rawFrac = Math.max(explorationFloor, baseFrac * rewardMult * stabilityMult);
   // Clamp to [0, 0.5] — at most half of available equity. This is a
   // BOUNDARY (survival) not a PARAMETER — exceeding it creates unrecoverable
   // states regardless of Φ.
   const frac = Math.min(0.5, Math.max(0, rawFrac));
-  const raw = frac * availableEquityUsdt;
-  // Must be at least min notional, else skip (0).
-  const sized = raw >= minNotionalUsdt ? raw : 0;
+  const margin = frac * availableEquityUsdt;
+  const notional = margin * Math.max(1, leverage);
+  // Compare the POSITION (notional) to the exchange min, not the margin.
+  const sized = notional >= minNotionalUsdt ? margin : 0;
 
   return {
     value: sized,
-    reason: `size = clip(Φ×S(${(s.phi * s.sovereignty).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)})) × equity(${availableEquityUsdt.toFixed(2)}) = ${sized.toFixed(2)}`,
+    reason: `size = floor(${explorationFloor.toFixed(3)}) or Φ×S×M(${(s.phi * s.sovereignty * maturity).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)}) × equity(${availableEquityUsdt.toFixed(2)}) @ ${leverage}x → margin ${margin.toFixed(2)}, notional ${notional.toFixed(2)} vs min ${minNotionalUsdt.toFixed(2)} = ${sized.toFixed(2)}`,
     derivation: {
-      phi: s.phi, sovereignty: s.sovereignty,
+      phi: s.phi, sovereignty: s.sovereignty, maturity, bankSize,
       dopamine: nc.dopamine, serotonin: nc.serotonin, gaba: nc.gaba,
-      rawFrac, frac, raw, sized,
+      explorationFloor, rawFrac, frac, margin, leverage, notional, minNotional: minNotionalUsdt, sized,
     },
   };
 }
@@ -153,8 +168,12 @@ export function currentLeverage(
   const regimeStability = s.regimeWeights.equilibrium + 0.5 * s.regimeWeights.efficient;
   const surpriseDiscount = 1 - 0.5 * s.neurochemistry.norepinephrine;
 
-  // Novice floor: newborn Monkey never uses high leverage until she has lived it.
-  const sovereignCap = 3 + 30 * s.sovereignty;  // 3x to 33x range by sovereignty
+  // Novice floor: newborn Monkey caps at 10x for exploration. The floor
+  // exists so her first witnessed-bootstrap trade can clear the exchange
+  // min notional on a sub-$20 account; without it a $0.95 margin × 3x =
+  // $2.85 notional never clears ETH's ~$22 min, observed for 6h at birth.
+  // Scales up to 33x once fully sovereign.
+  const sovereignCap = Math.max(10, 3 + 30 * s.sovereignty);
 
   const rawLev = sovereignCap * kappaProxim * regimeStability * surpriseDiscount;
   const lev = Math.max(1, Math.min(maxLeverageBoundary, Math.round(rawLev)));

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -277,7 +277,8 @@ export class MonkeyKernel extends EventEmitter {
     const precisions = await getPrecisions(symbol).catch(() => null);
     const lotSize = precisions?.lotSize ?? 0;
     const minNotional = lastPrice * Math.max(lotSize, 1e-9);
-    const size = currentPositionSize(basinState, availableEquity, minNotional);
+    const bankSize = await resonanceBank.bankSize();
+    const size = currentPositionSize(basinState, availableEquity, minNotional, leverage.value, bankSize);
     const autoFlatten = shouldAutoFlatten(basinState, state.fHealthHistory);
 
     // 6. DECIDE — propose action
@@ -402,6 +403,78 @@ export class MonkeyKernel extends EventEmitter {
     if (state.phiHistory.length > HISTORY_MAX) state.phiHistory.shift();
     state.fHealthHistory.push(fHealth);
     if (state.fHealthHistory.length > HISTORY_MAX) state.fHealthHistory.shift();
+  }
+
+  /**
+   * Bootstrap hook (v0.2): when liveSignalEngine closes a trade,
+   * attribute the outcome to the perception basin Monkey held at
+   * the moment of entry. This grows her resonance bank from the
+   * trading already happening — no new capital risk, sovereignty
+   * accrues, and the chicken-and-egg (size = Φ × sovereignty = 0)
+   * unsticks within hours instead of never.
+   *
+   * Restart-safe: reads the entry basin from monkey_trajectory, so
+   * a process restart between entry and exit is transparent.
+   *
+   * Called fire-and-forget from liveSignalEngine.reconcileClosedTrades.
+   */
+  async witnessExit(
+    symbol: string,
+    entryTime: Date,
+    realizedPnl: number,
+    orderId: string | null,
+    side: 'long' | 'short',
+  ): Promise<void> {
+    try {
+      const row = await pool.query(
+        `SELECT basin, phi
+           FROM monkey_trajectory
+          WHERE symbol = $1 AND at <= $2
+          ORDER BY at DESC LIMIT 1`,
+        [symbol, entryTime],
+      );
+      const rec = row.rows[0] as { basin: number[] | string; phi: number } | undefined;
+      if (!rec) {
+        logger.debug('[Monkey] witnessExit: no trajectory found for entry', {
+          symbol, entryTime: entryTime.toISOString(),
+        });
+        return;
+      }
+      const basinArr = typeof rec.basin === 'string' ? JSON.parse(rec.basin) : rec.basin;
+      const entryBasin: Basin = Float64Array.from(basinArr);
+      const phi = Number(rec.phi) || 0.5;
+
+      // Synthesize a bubble that looks like it was promoted from WM
+      // with the outcome attached. Bypass working memory — the bubble
+      // is already resolved.
+      const bubble: Bubble = {
+        id: `witness-${orderId ?? Date.now()}`,
+        center: entryBasin,
+        phi,
+        createdAt: entryTime.getTime(),
+        lifetimeMs: 0,
+        status: 'promoted',
+        metadata: { source: 'live_signal_witness', orderId },
+        payload: {
+          symbol,
+          signal: side === 'long' ? 'BUY' : 'SELL',
+          realizedPnl,
+          entryBasin,
+          orderId: orderId ?? undefined,
+        },
+      };
+      const written = await resonanceBank.writeBubble(bubble, getEngineVersion());
+      if (written) {
+        logger.info('[Monkey] witnessExit → bank', {
+          symbol, orderId, side, pnl: realizedPnl.toFixed(4),
+          entryTime: entryTime.toISOString(),
+        });
+      }
+    } catch (err) {
+      logger.debug('[Monkey] witnessExit failed (fail-soft)', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   private async fetchAccountContext(symbol: string): Promise<{


### PR DESCRIPTION
## Summary
Monkey v0.1 went 754 ticks over 6h in observe-only mode without ever reaching a tradeable size. Root cause: `size = Φ × sovereignty × equity = 0` because the bank starts empty and only grows from closed trades that never happen. This PR unsticks it three ways.

- **Witness hook** — `liveSignalEngine.reconcileClosedTrades` now fires `monkeyKernel.witnessExit(symbol, entryTime, pnl, orderId, side)` after a real-filled close. Monkey reads her perception basin at `entry_time` from `monkey_trajectory` (restart-safe), synthesizes a Bubble with the outcome attached, and writes it straight to the resonance bank. Sovereignty accrues from trades already happening. Zero new capital risk.
- **Leverage-aware sizing** — [executive.ts](apps/api/src/services/monkey/executive.ts) `currentPositionSize` now takes `leverage` and `bankSize`. The min-notional check compares `margin × leverage` to exchange min (previously compared margin alone, which on $19 equity never cleared ETH's ~$22 min).
- **Maturity-scaled exploration floor** — `explorationFloor = 0.10 × (1 - bankSize/20)` scales with lived experience instead of sovereignty. Newborn `sovereignCap` floor raised to 10x so her first witness-bootstrapped trade can clear ETH min.

Execution stays gated by `MONKEY_EXECUTE=true` (default false). This PR only unsticks the math and plumbs the witness; actual Monkey-placed orders are a follow-up once bank + sovereignty stabilize.

## Files
- [apps/api/src/services/monkey/executive.ts](apps/api/src/services/monkey/executive.ts) — sizing + leverage formula updates
- [apps/api/src/services/monkey/loop.ts](apps/api/src/services/monkey/loop.ts) — pass leverage/bankSize; new `witnessExit()` method
- [apps/api/src/services/liveSignalEngine.ts](apps/api/src/services/liveSignalEngine.ts) — wire witness hook in reconcileClosedTrades

## Test plan
- [x] `tsc --noEmit` clean
- [x] Existing vitest: 528 passed, 2 pre-existing riskKernel fails unrelated to this change (PR #510 1.5x→3x cap shift)
- [ ] After merge: first liveSignal close within minutes → `[Monkey] witnessExit → bank` log + `SELECT COUNT(*) FROM monkey_resonance_bank` goes from 0 → ≥1
- [ ] After ~10 witness bubbles: `proposed_action != 'hold'` starts appearing in `monkey_decisions`
- [ ] Flip `MONKEY_EXECUTE=true` only after we've confirmed the witness math produces sensible sizes across ≥20 outcomes

## Rollback
Revert the three files. Observe-only hold state returns; no position side-effects because nothing in this PR submits orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)