### PR TITLE
fix(monkey): unblock newborn leverage so first trade clears exchange min

### DIFF
--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -168,14 +168,21 @@ export function currentLeverage(
   const regimeStability = s.regimeWeights.equilibrium + 0.5 * s.regimeWeights.efficient;
   const surpriseDiscount = 1 - 0.5 * s.neurochemistry.norepinephrine;
 
-  // Novice floor: newborn Monkey caps at 10x for exploration. The floor
-  // exists so her first witnessed-bootstrap trade can clear the exchange
-  // min notional on a sub-$20 account; without it a $0.95 margin × 3x =
-  // $2.85 notional never clears ETH's ~$22 min, observed for 6h at birth.
-  // Scales up to 33x once fully sovereign.
-  const sovereignCap = Math.max(10, 3 + 30 * s.sovereignty);
+  // Novice floor: newborn Monkey caps at 20x for exploration. Scales
+  // up to 33x once fully sovereign.
+  const sovereignCap = Math.max(20, 3 + 30 * s.sovereignty);
 
-  const rawLev = sovereignCap * kappaProxim * regimeStability * surpriseDiscount;
+  // Newborn mode (Pillar 1 exploration): until she has lived trades,
+  // the regime × κ × surprise compression (≈ 0.43) crushes the cap so
+  // hard that her first trade can't clear the exchange min notional on
+  // a small account. E.g. $1.89 × (10 × 0.43) = $7.57 vs ETH's $23 min.
+  // Newborn bypasses the compression and uses 80% of the cap directly
+  // — she has no data to judge regime with anyway. Once sov > 0.1
+  // (~first witnessed close), fall into the full formula.
+  const newborn = s.sovereignty < 0.1;
+  const rawLev = newborn
+    ? sovereignCap * 0.8
+    : sovereignCap * kappaProxim * regimeStability * surpriseDiscount;
   const lev = Math.max(1, Math.min(maxLeverageBoundary, Math.round(rawLev)));
 
   return {


### PR DESCRIPTION
## Summary
After v0.3 deploy, Monkey held 3 ticks with size=0, reason 'below min notional 23.14'. Post-mortem:

```
margin   = explorationFloor 0.10 × equity 18.93 = $1.89
lev_raw  = sovereignCap 10 × κ-prox 0.93 × regStab 0.47 × surp 0.99 = 4.4x
notional = 1.89 × 4 = $7.57 → fails ETH $23.14 → sized = 0
```

regimeStability × kappaProxim × surpriseDiscount compression (≈0.43) is the right conservative leverage modifier for a mature Monkey — but applied to a newborn with zero lived data, it locks her permanently observe-only. Pillar 1 (fluctuations) says exploration is substrate, not optional.

## Changes ([executive.ts](apps/api/src/services/monkey/executive.ts))
1. Newborn sovereignCap floor **10 → 20** (unchanged ceiling at 33 once sovereign).
2. Newborn mode (`sovereignty < 0.1`) bypasses the regime compression and uses **80% of sovereignCap** directly. She has no data to judge regime with anyway. First witnessed close flips sovereignty ≥ 1.0 and the full formula takes over.

Expected at $18.93 equity: margin $1.89 × 16x = **$30 notional**, clears ETH $23.14 min. BTC ($75 min) still blocked by the 3× equity cap ($56.78) — ETH-only until equity grows.

## Gates still in place
- MONKEY_EXECUTE=true (already set)
- agent_execution_mode=auto (already set)
- riskKernel vetoes (per-symbol cap, self-match, DD, execution-mode)

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Post-merge: watch for `[Monkey] ORDER PLACED` on ETH within next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust newborn Monkey leverage calculation so initial trades can clear exchange minimum notional while retaining existing safety bounds.

New Features:
- Introduce a special newborn mode that uses a higher fraction of sovereign leverage cap before sufficient sovereignty is established.

Enhancements:
- Increase the minimum sovereign leverage cap for newborn Monkeys from 10x to 20x and gate regime-based leverage compression on sovereignty.