### PR TITLE
fix(risk-kernel): raise per-symbol exposure cap 3x→5x so BTC fits on sub-$30 accounts

### DIFF
--- a/apps/api/src/services/__tests__/riskKernel.test.ts
+++ b/apps/api/src/services/__tests__/riskKernel.test.ts
@@ -46,7 +46,8 @@ const autoContext: KernelContext = { isLive: false, mode: 'auto', symbolMaxLever
 const liveAutoContext: KernelContext = { isLive: true, mode: 'auto', symbolMaxLeverage: BTC_MAX_LEV };
 
 describe('checkPerSymbolExposure', () => {
-  it('allows an order when total notional stays under the 1.5× cap', () => {
+  it(`allows an order when total notional stays under the ${PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER}× cap`, () => {
+    // equity 100 × 5 = 500 cap; 100 + 10 = 110 ≪ 500 → allowed
     const state: KernelAccountState = {
       ...emptyAccount,
       equityUsdt: 100,
@@ -56,10 +57,11 @@ describe('checkPerSymbolExposure', () => {
   });
 
   it('blocks an order that would push same-symbol notional over the cap', () => {
+    // equity 100 × 5 = 500 cap; 495 + 10 = 505 > 500 → blocked
     const state: KernelAccountState = {
       ...emptyAccount,
       equityUsdt: 100,
-      openPositions: [{ symbol: 'BTC_USDT_PERP', side: 'long', notional: 145 }],
+      openPositions: [{ symbol: 'BTC_USDT_PERP', side: 'long', notional: 495 }],
     };
     const decision = checkPerSymbolExposure({ ...btcOrder, notional: 10 }, state);
     expect(decision.allowed).toBe(false);
@@ -70,12 +72,13 @@ describe('checkPerSymbolExposure', () => {
     // A short position still counts toward gross exposure; the kernel
     // doesn't net longs against shorts because a -2% candle moves both
     // against margin (via maintenance-margin stack).
+    // equity 100 × 5 = 500 cap; 300 + 200 + 20 = 520 > 500 → blocked
     const state: KernelAccountState = {
       ...emptyAccount,
       equityUsdt: 100,
       openPositions: [
-        { symbol: 'BTC_USDT_PERP', side: 'long', notional: 80 },
-        { symbol: 'BTC_USDT_PERP', side: 'short', notional: 60 },
+        { symbol: 'BTC_USDT_PERP', side: 'long', notional: 300 },
+        { symbol: 'BTC_USDT_PERP', side: 'short', notional: 200 },
       ],
     };
     expect(checkPerSymbolExposure({ ...btcOrder, notional: 20 }, state).allowed).toBe(false);

--- a/apps/api/src/services/riskKernel.ts
+++ b/apps/api/src/services/riskKernel.ts
@@ -83,16 +83,18 @@ export type ExecutionMode = 'auto' | 'paper_only' | 'pause';
 // ───────── Thresholds ─────────
 /**
  * Per-symbol gross notional cap as multiple of equity. Notional-based,
- * not margin-based — so at high leverage the effective margin commit
- * per unit of notional is small. At a $27 equity and Poloniex BTC
- * perp's 0.001 lot × $75k price = $75 minimum notional per order,
- * a 1.5× cap ($40.72) made it impossible to place the smallest
- * compliant order. 3.0× ($81) allows a single BTC lot while still
- * bounding stacked correlated positions; with 15× leverage that's
- * only ~18% of equity in margin commit. TODO: migrate to a
- * margin-based cap when the risk kernel gets its next iteration.
+ * not margin-based — at high leverage the effective margin commit per
+ * unit of notional is small. Poloniex BTC perp's structural min is
+ * 0.001 lot × spot-price-USDT per contract. At current prices (~$75k
+ * BTC), that's ~$75 per single lot. As equity shrinks, even a 3× cap
+ * fails: on $19 equity, 3× = $56.78, below the $75 floor. Raised to
+ * 5× ($94.65 here) so 1 BTC lot fits with headroom while still
+ * preventing stacked correlated positions. At 16× leverage a single
+ * $75 lot commits $4.70 margin (~25 % of equity) — within prudence.
+ * TODO: migrate to a margin-based cap when the risk kernel gets its
+ * next iteration.
  */
-export const PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER = 3.0;
+export const PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER = 5.0;
 export const UNREALIZED_DRAWDOWN_KILL_THRESHOLD = -0.15;         // −15% of equity
 
 function isLong(side: KernelOrder['side']): boolean {


### PR DESCRIPTION
## Summary
BTC perp has a structural min-notional of **~\$75** (0.001 lot × spot). On our current \$19 equity, the 3× cap computes to \$56.78 — below the floor, making BTC mathematically unreachable regardless of leverage. Leverage only controls margin commit, not notional.

Raising cap to **5×** (\$94.65 here) lets a single BTC lot through with headroom. 16× leverage on \$75 notional = \$4.70 margin commit (~25% of equity), still prudent. Stacking a second lot (\$150 > \$94.65) remains blocked → correlated-long-BTC stack still prevented.

Also repairs 2 tests stale since PR #510 (cap 1.5→3) that were left as known-failures — now aligned to 5x with explicit math in comments.

## Observed deadlock (pre-fix)
After v0.3 deploy, liveSignal tried BTC every tick and got vetoed:
```
[LiveSignal] kernel veto {
  code: 'per_symbol_exposure_cap',
  reason: 'Per-symbol exposure cap breached: 80.00 > 56.78 (3× equity)'
}
```
No BTC trades → liveSignal-to-Monkey witness bootstrap blocked on BTC. Monkey opened ETH herself at 10:31 UTC but her bank is still 0 until that position closes.

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest: **530 passed, 0 failed** (the 2 pre-existing pre-existing fails from PR #510 cap shift are now fixed)
- [ ] Post-merge: watch liveSignal BTC veto flip from `per_symbol_exposure_cap` to `kernel passes` on next tick with BUY strength ≥ 0.35

## Rollback
Revert the constant change. Tests stay aligned via the exported constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Increase the per-symbol exposure cap multiplier to keep BTC perp tradable on low-equity accounts and realign tests and documentation comments with the new risk limit.

Bug Fixes:
- Restore BTC perp tradability for low-equity accounts by raising the per-symbol notional exposure cap from 3× to 5× equity.

Enhancements:
- Clarify the per-symbol exposure cap documentation comment with updated numerical examples and rationale for the new multiplier.

Tests:
- Update per-symbol exposure unit tests to reference the shared cap constant and adjust scenarios to the new 5× limit, with explicit inline math for cap calculations.