### PR TITLE
feat(monkey): v0.6a kernel bus — inter-kernel pub/sub with DB audit

### DIFF
--- a/apps/api/database/migrations/033_monkey_bus_events.sql
+++ b/apps/api/database/migrations/033_monkey_bus_events.sql
@@ -1,0 +1,20 @@
+-- 033_monkey_bus_events.sql
+--
+-- Append-only audit log for kernel_bus events (v0.6a).
+-- 7-day retention via a cron-or-app cleanup task (not included in migration).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS monkey_bus_events (
+  id        BIGSERIAL PRIMARY KEY,
+  at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  type      VARCHAR(40) NOT NULL,
+  source    VARCHAR(80) NOT NULL,
+  symbol    VARCHAR(50),
+  payload   JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS idx_monkey_bus_events_at ON monkey_bus_events (at DESC);
+CREATE INDEX IF NOT EXISTS idx_monkey_bus_events_type_at ON monkey_bus_events (type, at DESC);
+CREATE INDEX IF NOT EXISTS idx_monkey_bus_events_symbol_at ON monkey_bus_events (symbol, at DESC);
+
+COMMIT;

--- a/apps/api/src/services/monkey/kernel_bus.ts
+++ b/apps/api/src/services/monkey/kernel_bus.ts
@@ -1,0 +1,202 @@
+/**
+ * kernel_bus.ts — Inter-kernel pub/sub (v0.6a)
+ *
+ * Faster-than-DB inter-kernel communication. Ported in spirit from
+ * /home/braden/Desktop/Dev/archived-repos-docs/pantheon-projects/Dev/SSC/
+ * SearchSpaceCollapse/server/strategy-knowledge-bus.ts — an in-memory
+ * event bus that lets kernels publish insights and subscribe to patterns,
+ * with a DB tail for persistence + audit.
+ *
+ * v0.6a goal: the infrastructure is in place BEFORE parallel sub-Monkeys
+ * (v0.6b) spawn, so adding ScalpMonkey / SwingMonkey / RangeMonkey only
+ * needs `new SubKernel(bus)` — zero bus wiring at that point.
+ *
+ * Event types are a closed enum so subscribers can pattern-filter without
+ * parsing free-text. Payloads are typed per event.
+ *
+ * Persistence: every event lands in monkey_bus_events (append-only) with
+ * a 7-day retention TTL. Useful for post-hoc debugging (why did Monkey
+ * flip to DRIFT at 03:14?) and for replay during integration tests.
+ */
+
+import { EventEmitter } from 'events';
+
+import { pool } from '../../db/connection.js';
+import { logger } from '../../utils/logger.js';
+
+export enum BusEventType {
+  /** Monkey entered a new cognitive mode (transition). */
+  MODE_TRANSITION = 'mode_transition',
+  /** Entry proposed by a decision kernel (not yet executed). */
+  ENTRY_PROPOSED = 'entry_proposed',
+  /** Entry executed — order placed at exchange. */
+  ENTRY_EXECUTED = 'entry_executed',
+  /** Exit triggered — scalp TP/SL, Loop 2, or autoflatten. */
+  EXIT_TRIGGERED = 'exit_triggered',
+  /** Risk kernel vetoed an order. */
+  KERNEL_VETO = 'kernel_veto',
+  /** Trade closed at exchange; realized P&L attached. */
+  OUTCOME = 'outcome',
+  /** Anomaly detected by self-observation — downstream kernels may act. */
+  ANOMALY = 'anomaly',
+  /** Cross-kernel insight: a sub-kernel found a pattern worth sharing. */
+  INSIGHT = 'insight',
+  /** Witness bubble landed in the resonance bank. */
+  BANK_WRITE = 'bank_write',
+}
+
+export interface BusEvent {
+  type: BusEventType;
+  source: string;        // which kernel emitted (e.g. 'monkey-primary', 'risk-kernel', 'scalp-monkey')
+  symbol?: string;
+  payload: Record<string, unknown>;
+  at: number;            // ms since epoch
+}
+
+type BusSubscriber = {
+  id: string;
+  types: Set<BusEventType> | null;   // null = all
+  symbols: Set<string> | null;        // null = all
+  handler: (event: BusEvent) => void | Promise<void>;
+};
+
+class _KernelBus extends EventEmitter {
+  private subscribers: BusSubscriber[] = [];
+  private static readonly MAX_LISTENERS = 50;
+
+  constructor() {
+    super();
+    this.setMaxListeners(_KernelBus.MAX_LISTENERS);
+  }
+
+  /**
+   * Publish an event. Sync fan-out to subscribers (fire-and-forget —
+   * subscriber exceptions don't propagate). Async DB write in background.
+   */
+  publish(event: Omit<BusEvent, 'at'>): void {
+    const full: BusEvent = { ...event, at: Date.now() };
+    // Sync fan-out first so subscribers see it immediately.
+    for (const sub of this.subscribers) {
+      if (sub.types && !sub.types.has(full.type)) continue;
+      if (sub.symbols && full.symbol && !sub.symbols.has(full.symbol)) continue;
+      try {
+        const out = sub.handler(full);
+        if (out && typeof (out as Promise<void>).catch === 'function') {
+          (out as Promise<void>).catch((err) => {
+            logger.debug('[KernelBus] subscriber async error', {
+              sub: sub.id, err: err instanceof Error ? err.message : String(err),
+            });
+          });
+        }
+      } catch (err) {
+        logger.debug('[KernelBus] subscriber sync error', {
+          sub: sub.id, err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    // DB tail — non-blocking.
+    void this.persist(full);
+    // Classic EventEmitter broadcast for anyone wanting raw on().
+    this.emit(full.type, full);
+    this.emit('*', full);
+  }
+
+  /**
+   * Subscribe to events. Returns unsubscribe function.
+   */
+  subscribe(opts: {
+    id: string;
+    types?: BusEventType[];
+    symbols?: string[];
+    handler: (event: BusEvent) => void | Promise<void>;
+  }): () => void {
+    const sub: BusSubscriber = {
+      id: opts.id,
+      types: opts.types ? new Set(opts.types) : null,
+      symbols: opts.symbols ? new Set(opts.symbols) : null,
+      handler: opts.handler,
+    };
+    this.subscribers.push(sub);
+    return () => {
+      const idx = this.subscribers.findIndex((s) => s === sub);
+      if (idx >= 0) this.subscribers.splice(idx, 1);
+    };
+  }
+
+  /** Number of active subscribers — surfaced for dashboard. */
+  subscriberCount(): number {
+    return this.subscribers.length;
+  }
+
+  private async persist(event: BusEvent): Promise<void> {
+    try {
+      await pool.query(
+        `INSERT INTO monkey_bus_events (at, type, source, symbol, payload)
+         VALUES (to_timestamp($1::double precision / 1000), $2, $3, $4, $5::jsonb)`,
+        [event.at, event.type, event.source, event.symbol ?? null, JSON.stringify(event.payload)],
+      );
+    } catch (err) {
+      logger.debug('[KernelBus] persist failed (fail-soft)', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Query recent events by filter. Used by the UI timeline and by
+   * self-observation for pattern discovery.
+   */
+  async queryRecent(opts: {
+    types?: BusEventType[];
+    symbol?: string;
+    sinceMs?: number;
+    limit?: number;
+  } = {}): Promise<BusEvent[]> {
+    const { types, symbol, sinceMs, limit = 100 } = opts;
+    const conds: string[] = [];
+    const params: unknown[] = [];
+    if (types && types.length > 0) {
+      params.push(types);
+      conds.push(`type = ANY($${params.length}::text[])`);
+    }
+    if (symbol) {
+      params.push(symbol);
+      conds.push(`symbol = $${params.length}`);
+    }
+    if (sinceMs) {
+      params.push(new Date(sinceMs).toISOString());
+      conds.push(`at > $${params.length}`);
+    }
+    const where = conds.length > 0 ? `WHERE ${conds.join(' AND ')}` : '';
+    params.push(limit);
+    try {
+      const result = await pool.query(
+        `SELECT at, type, source, symbol, payload FROM monkey_bus_events
+         ${where}
+         ORDER BY at DESC LIMIT $${params.length}`,
+        params,
+      );
+      return (result.rows as Array<Record<string, unknown>>).map((r) => ({
+        type: r.type as BusEventType,
+        source: String(r.source),
+        symbol: r.symbol ? String(r.symbol) : undefined,
+        payload: typeof r.payload === 'string' ? JSON.parse(r.payload) : (r.payload as Record<string, unknown>),
+        at: new Date(r.at as string).getTime(),
+      }));
+    } catch (err) {
+      logger.debug('[KernelBus] queryRecent failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+  }
+}
+
+export type KernelBus = _KernelBus;
+
+// Singleton — one bus per process. Sub-kernels grab it with getKernelBus().
+let _instance: _KernelBus | null = null;
+export function getKernelBus(): _KernelBus {
+  if (!_instance) _instance = new _KernelBus();
+  return _instance;
+}

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -50,6 +50,7 @@ import {
   type Basin,
 } from './basin.js';
 import { BasinSync } from './basin_sync.js';
+import { BusEventType, getKernelBus, type KernelBus } from './kernel_bus.js';
 import { detectMode, MODE_PROFILES, MonkeyMode } from './modes.js';
 import { computeNeurochemicals, summarizeNC, type NeurochemicalState } from './neurochemistry.js';
 import { perceive, refract, type OHLCVCandle } from './perception.js';
@@ -122,6 +123,10 @@ export class MonkeyKernel extends EventEmitter {
   private readonly basinSync = new BasinSync(
     process.env.MONKEY_INSTANCE_ID || 'monkey-primary',
   );
+  /** Kernel bus — pub/sub for inter-kernel comms (v0.6a). */
+  private readonly bus: KernelBus = getKernelBus();
+  /** Instance identifier — will differ between parallel sub-Monkeys in v0.6b. */
+  private readonly instanceId: string = process.env.MONKEY_INSTANCE_ID || 'monkey-primary';
 
   /**
    * Start Monkey's heartbeat. She ticks alongside liveSignalEngine —
@@ -320,6 +325,12 @@ export class MonkeyKernel extends EventEmitter {
         from: state.lastMode,
         to: mode,
         reason: modeDecision.reason,
+      });
+      this.bus.publish({
+        type: BusEventType.MODE_TRANSITION,
+        source: this.instanceId,
+        symbol,
+        payload: { from: state.lastMode, to: mode, reason: modeDecision.reason, phi, kappa: state.kappa },
       });
     }
     state.lastMode = mode;
@@ -732,6 +743,12 @@ export class MonkeyKernel extends EventEmitter {
       symbol, heldSide, markPrice, orderId, tradeId,
       pnl: pnlAtDecision.toFixed(4), exitReason,
     });
+    this.bus.publish({
+      type: BusEventType.EXIT_TRIGGERED,
+      source: this.instanceId,
+      symbol,
+      payload: { heldSide, markPrice, orderId, tradeId, pnl: pnlAtDecision, exitReason },
+    });
     return { executed: true, orderId, reason: 'closed' };
   }
 
@@ -808,6 +825,12 @@ export class MonkeyKernel extends EventEmitter {
       logger.info('[Monkey] kernel veto', {
         symbol, side, notional: notionalUsdt, leverage,
         code: decision.code, reason: decision.reason,
+      });
+      this.bus.publish({
+        type: BusEventType.KERNEL_VETO,
+        source: this.instanceId,
+        symbol,
+        payload: { side, notional: notionalUsdt, leverage, code: decision.code, reason: decision.reason },
       });
       return { executed: false, orderId: null, reason: `veto:${decision.code}:${decision.reason}` };
     }
@@ -900,6 +923,16 @@ export class MonkeyKernel extends EventEmitter {
       sov: req.sovereignty.toFixed(3),
     });
 
+    this.bus.publish({
+      type: BusEventType.ENTRY_EXECUTED,
+      source: this.instanceId,
+      symbol,
+      payload: {
+        side, orderId, margin: marginUsdt, notional: notionalUsdt, leverage,
+        entryPrice, phi: req.phi, kappa: req.kappa, sovereignty: req.sovereignty,
+      },
+    });
+
     return { executed: true, orderId, reason: 'placed' };
   }
 
@@ -966,6 +999,18 @@ export class MonkeyKernel extends EventEmitter {
         logger.info('[Monkey] witnessExit → bank', {
           symbol, orderId, side, pnl: realizedPnl.toFixed(4),
           entryTime: entryTime.toISOString(),
+        });
+        this.bus.publish({
+          type: BusEventType.BANK_WRITE,
+          source: this.instanceId,
+          symbol,
+          payload: { orderId, side, realizedPnl, entryTime: entryTime.toISOString() },
+        });
+        this.bus.publish({
+          type: BusEventType.OUTCOME,
+          source: this.instanceId,
+          symbol,
+          payload: { orderId, side, realizedPnl, win: realizedPnl > 0 },
         });
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
Port the strategy-knowledge-bus pattern from archived pantheon-projects (SSC/server/strategy-knowledge-bus.ts) into Monkey. **In-process EventEmitter + append-only monkey_bus_events DB tail**. Closed-enum event types → subscribers pattern-filter cleanly.

## Why this ships before v0.6b (parallel sub-Monkeys)
Per user: pantheon-chat used a bus for faster-than-DB inter-kernel comms. Spawning ScalpMonkey / SwingMonkey / RangeMonkey without the bus would mean re-wiring them later. This PR is pure infrastructure — v0.6b is then purely sub-kernel code.

## Event types (closed enum)
Publishers live in loop.ts:
- `MODE_TRANSITION` — every mode change
- `ENTRY_EXECUTED` — after placeOrder success
- `EXIT_TRIGGERED` — after reduce-only close success
- `KERNEL_VETO` — risk kernel blocked an order
- `BANK_WRITE` — witness bubble written
- `OUTCOME` — realized P&L attached

Reserved for v0.6b: `ENTRY_PROPOSED`, `ANOMALY`, `INSIGHT`.

## Files
- [kernel_bus.ts](apps/api/src/services/monkey/kernel_bus.ts) (new, 180 LOC) — singleton bus with `publish`/`subscribe`/`queryRecent`
- [loop.ts](apps/api/src/services/monkey/loop.ts) — 6 `.publish()` call sites alongside existing log lines
- [033_monkey_bus_events.sql](apps/api/database/migrations/033_monkey_bus_events.sql) — audit table + indexes

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest: **530 passed, 0 failed**
- [ ] Post-merge: watch `monkey_bus_events` rows accumulate with MODE_TRANSITION / ENTRY_EXECUTED / EXIT_TRIGGERED / BANK_WRITE / OUTCOME types
- [ ] Query for UI timeline: `SELECT at, type, source, symbol, payload FROM monkey_bus_events ORDER BY at DESC LIMIT 50;`

## Rollback
Revert the branch. Publishers are no-op additions — no existing logic relies on the bus. The new table stays; can be dropped separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)