### PR TITLE
fix(agent): dashboard + reconciler + kill-switch must include monkey|% rows

### DIFF
--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -558,8 +558,8 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
     const executionMode = modeRecord?.mode ?? 'auto';
 
     // P&L buckets from autonomous_trades. Closed + pnl IS NOT NULL.
-    // Only rows with reason LIKE 'live_signal|%' to stay aligned with
-    // the live signal engine; legacy/paper rows skew the headline.
+    // Both live_signal|% AND monkey|% rows count — the dashboard is the
+    // whole bot, not just one engine. Legacy/paper rows stay excluded.
     const pnlResult = await pool.query(
       `SELECT
          COALESCE(SUM(pnl) FILTER (WHERE exit_time > NOW() - INTERVAL '24 hours'), 0) AS pnl_24h,
@@ -571,16 +571,19 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
          COALESCE(SUM(pnl), 0) AS pnl_all,
          COUNT(*)               AS trades_all
        FROM autonomous_trades
-       WHERE status = 'closed' AND pnl IS NOT NULL AND reason LIKE 'live_signal|%'
+       WHERE status = 'closed' AND pnl IS NOT NULL
+         AND (reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%')
          AND user_id = $1`,
       [userId],
     );
     const pnl = pnlResult.rows[0] as Record<string, string>;
 
-    // Win rate over last 20 closed trades.
+    // Win rate over last 20 closed trades (both engines).
     const lastTradesResult = await pool.query(
       `SELECT pnl FROM autonomous_trades
-        WHERE status = 'closed' AND pnl IS NOT NULL AND reason LIKE 'live_signal|%' AND user_id = $1
+        WHERE status = 'closed' AND pnl IS NOT NULL
+          AND (reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%')
+          AND user_id = $1
         ORDER BY exit_time DESC LIMIT 20`,
       [userId],
     );
@@ -592,9 +595,16 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
 
     // Open-trade counts: exchange-authoritative vs DB-authoritative.
     // Divergence = phantom state — should alarm.
+    // Count BOTH live_signal AND monkey trades — otherwise the divergence
+    // alert false-triggers as soon as Monkey opens a position (2026-04-20
+    // 10:31 UTC was the first, and state-of-bot immediately flagged as
+    // out-of-sync because Monkey's row wasn't in the count).
     const dbOpenResult = await pool.query(
       `SELECT COUNT(*) AS n FROM autonomous_trades
-        WHERE status = 'open' AND reason LIKE 'live_signal|%' AND user_id = $1`,
+        WHERE status = 'open'
+          AND (reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%')
+          AND user_id = $1
+          AND deleted_at IS NULL`,
       [userId],
     );
     const dbOpenPositions = parseInt((dbOpenResult.rows[0] as { n: string }).n, 10) || 0;
@@ -640,9 +650,10 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
     const stale = lastTickAgeMs !== null && lastTickAgeMs > 5 * 60_000;
 
     // Trades placed in the last tick interval (~60s). If > 0, phase = trading.
+    // Both engines count.
     const recentOpenResult = await pool.query(
       `SELECT COUNT(*) AS n FROM autonomous_trades
-        WHERE reason LIKE 'live_signal|%' AND user_id = $1
+        WHERE (reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%') AND user_id = $1
           AND (entry_time > NOW() - INTERVAL '90 seconds' OR created_at > NOW() - INTERVAL '90 seconds')`,
       [userId],
     );
@@ -663,7 +674,7 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
       phaseReason = `${recentlyOpened} order${recentlyOpened === 1 ? '' : 's'} placed in last 90s`;
     } else if (dbOpenPositions > 0) {
       phase = 'skipping';
-      phaseReason = `${dbOpenPositions} open live-signal position${dbOpenPositions === 1 ? '' : 's'} — stacking guard blocks new entries until they close`;
+      phaseReason = `${dbOpenPositions} open position${dbOpenPositions === 1 ? '' : 's'} (live-signal + monkey) — stacking guard blocks new entries until they close`;
     } else {
       phase = 'evaluating';
       phaseReason = 'No qualifying signal this tick — watching';

--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -289,15 +289,18 @@ export class LiveSignalEngine extends EventEmitter {
             err: closeErr instanceof Error ? closeErr.message : String(closeErr),
           });
         }
-        // Close any open live_signal DB rows too, so stacking guard + reconciler
-        // see the correct state on next tick.
+        // Close any open live_signal OR monkey DB rows too, so stacking guard
+        // + reconciler see the correct state on next tick. Kill-switch flattens
+        // the exchange net position unconditionally; the DB rows for BOTH
+        // engines have to close to match.
         try {
           await pool.query(
             `UPDATE autonomous_trades
                 SET status = 'closed', exit_time = NOW(),
                     exit_reason = 'kill_switch_auto_flatten',
                     pnl = COALESCE(pnl, 0)
-              WHERE user_id = $1 AND status = 'open' AND reason LIKE 'live_signal|%'`,
+              WHERE user_id = $1 AND status = 'open'
+                AND (reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%')`,
             [userId],
           );
         } catch { /* non-fatal */ }

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -302,20 +302,26 @@ class StateReconciliationService {
         });
       }
 
-      // Source 2: users with an open live-signal trade. This is the
-      // liveSignalEngine's footprint — if phantom rows accumulate here,
-      // the stacking guard freezes all future entries until reconciler
-      // catches them. Covering this surface is the whole point of P2.
+      // Source 2: users with an open auto-trader row. This is the
+      // liveSignalEngine's + Monkey's footprint — if phantom rows
+      // accumulate on either, the stacking guard freezes all future
+      // entries until reconciler catches them. Covering this surface is
+      // the whole point of P2. Post-v0.3 Monkey is also a producer of
+      // open rows (reason LIKE 'monkey|%'); omitting her hides any
+      // phantoms she leaves behind (observed 2026-04-20 — state-of-bot
+      // read 1 DB open vs 2 exchange open because this query excluded
+      // Monkey's ETH row).
       try {
-        const liveSignalUsers = await pool.query(
+        const traderUsers = await pool.query(
           `SELECT DISTINCT user_id FROM autonomous_trades
-            WHERE status = 'open' AND reason LIKE 'live_signal|%'`,
+            WHERE status = 'open'
+              AND (reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%')`,
         );
-        for (const row of liveSignalUsers.rows as Array<{ user_id: string }>) {
+        for (const row of traderUsers.rows as Array<{ user_id: string }>) {
           userIds.add(String(row.user_id));
         }
       } catch (err) {
-        logger.warn('[RECONCILE] live-signal-users lookup failed', {
+        logger.warn('[RECONCILE] auto-trader users lookup failed', {
           err: err instanceof Error ? err.message : String(err),
         });
       }


### PR DESCRIPTION
## Symptom
Dashboard showed **\`Exchange: 2 open · DB: 1 open · DIVERGENCE — phantom state likely\`** at 12:55 UTC. Real state:

```
autonomous_trades where status='open':
  25994b8d ETH_USDT_PERP monkey|phi=0.215|kappa=63.81|sov=0.000|src=v0.3  ← Monkey
  88dbd4aa BTC_USDT_PERP live_signal|key=ml_breakout|...                  ← liveSignal
Exchange: both open ✓
DB open count: 1 (only counting live_signal|%)
```

Not phantom state — a counter bug. Four surfaces were still filtering only \`live_signal|%\` and silently excluded Monkey after v0.3 made her an autonomous_trades row producer.

## Fixes
1. **[agent.ts `state-of-bot`](apps/api/src/routes/agent.ts)** — dbOpenPositions, pnl buckets, winRateLast20, recentlyOpened all now \`reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%'\`.
2. **[stateReconciliationService.ts](apps/api/src/services/stateReconciliationService.ts)** — user-list seed for reconciler now includes Monkey. Without this, phantom rows she leaves wouldn't get reconciled until a live_signal user happened to exist.
3. **[liveSignalEngine.ts kill-switch](apps/api/src/services/liveSignalEngine.ts)** — auto-flatten DB close now covers both prefixes. The kill-switch flattens the EXCHANGE net unconditionally; leaving Monkey rows as 'open' against a flat exchange = guaranteed phantom.

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest: **530 passed, 0 failed**
- [ ] Post-merge: refresh State-of-the-Bot card → "in sync" instead of DIVERGENCE
- [ ] P&L/trades count for Monkey's ETH starts showing in 24h bucket when her trade closes

## Rollback
Revert. Each change reverts independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)