### PR TITLE
docs(roadmap): sync canonical roadmap with v0.2→v0.5.2 Monkey work

### DIFF
--- a/.agent-os/roadmap.md
+++ b/.agent-os/roadmap.md
@@ -1,12 +1,18 @@
 ---
 owner: Agent OS
-updated: 2025-08-11T19:56:15+08:00
+updated: 2026-04-21T08:30:00+00:00
 status: active
 ---
 
 # Polytrade Autonomous Poloniex Futures Platform — Roadmap
 
 This roadmap operationalizes the specs and canonical market catalog into a deliverable plan. It is organized by phases with clear acceptance criteria, owners (to assign), and links to tasks and scripts.
+
+## Recent activity summary (2026-04-19 → 2026-04-21)
+
+**P0–P2 baseline completed; Phase P3 (Cognitive Kernel "Monkey") started and shipped through v0.5.2.**
+
+Live trading unblocked 2026-04-19 after an 11-PR serial unmasking of bugs (lot rounding, v3 placeOrder schema, setLeverage schema, exposure cap tier, error-swallow). Monkey-kernel architecture (perception → basin → mode → executive → execute) shipped 2026-04-20 and has placed real trades under `MONKEY_EXECUTE=true`. See Phase P3 below for the full version ladder.
 
 ## Canonical Sources
 
@@ -58,37 +64,102 @@ Goal: End-to-end functionality in paper mode with catalog-driven parameters, rob
 Goal: Establish profitable, risk-controlled strategies and promotion gates from research to paper to canary.
 
 - Strategies
-  - [ ] Baselines: trend-follow, mean-reversion, breakout, funding bias.
-  - [ ] Feature pipeline and indicators library.
-  - Acceptance: unit-tested strategies with deterministic signals.
+  - [x] Baselines via ml-worker ensemble (ARIMA/Prophet/GBM/LSTM/Transformer) behind `liveSignalEngine`, 60 s tick on BTC+ETH perps.
+  - [x] QIG regime classifier routing (`ensemble_predictor.py` regime-aware weights).
+  - [x] Feature pipeline: 64 D perception basin in `apps/api/src/services/monkey/perception.ts` (momentum + vol + volume + price-structure + account context).
+  - Acceptance: ensemble + regime weights deterministic given seed; unit-tested via vitest.
 
 - Optimization & Robustness
-  - [ ] Grid/random/Bayesian search; walk-forward and OOS validation.
-  - [ ] Monte Carlo equity perturbations and PBO/reality-check reporting.
-  - Acceptance: top-k configs with statistically defensible edge.
+  - [x] `strategyLearningEngine` random-search + elitism with Thompson-sampled leverage bandit (`apps/api/src/services/thompsonBandit.ts`).
+  - [x] OOS walk-forward in `backtestingEngine.js`; censored-window detection per PR #516 and earlier.
+  - [ ] Monte Carlo equity perturbations, PBO/reality-check.
+  - Acceptance: leverage bandit convergence visible in `monkey_bus_events` OUTCOME stream; PBO pending.
 
 - Promotion Gates
-  - [ ] Define promotion policy (paper -> canary -> full), capital limits.
-  - [ ] Shadow mode (paper parallel to live decisions) and drift monitoring.
-  - Acceptance: gated, auditable promotions with rollback plan.
+  - [x] `generated → backtest (IS+OOS) → paper → live` pipeline with `agent_execution_mode` gate (`auto | paper_only | pause`).
+  - [x] Risk kernel blast door (`apps/api/src/services/riskKernel.ts`): per-symbol exposure cap 5× equity (raised from 3× in PR #521 so BTC $75-min fits on sub-$30 accounts), self-match prevention, unrealized-DD kill-switch at −15 %, symbol max-leverage, execution-mode guard.
+  - [x] Shadow mode: `LIVE_SIGNAL_EXECUTE=false` and `MONKEY_EXECUTE=false` toggles ship each engine in observe-only without code change.
+  - Acceptance: ✅ auditable promotions with rollback (revert branch + unset env var instantly reverts).
 
 ## Phase P2 — Live Autonomy and Scale
 
 Goal: 24/7 live operation with resilience, portfolio constraints, and compliance.
 
 - Live OMS & Reconciliation
-  - [ ] Idempotent order submission, amend/cancel, partial fill handling, rate-limit safe.
-  - [ ] State reconciliation on restart; safe resume.
-  - Acceptance: no orphaned positions; SLA on execution and cancel latencies.
+  - [x] v3-schema order submission (`poloniexFuturesService.placeOrder`) with lot-size rounding post PR #511; liveSignal first real fill 2026-04-19 09:22 UTC.
+  - [x] `stateReconciliationService` 5-min reconciler — orphan + ghost detection across `live_signal|%` AND `monkey|%` rows (PR #526).
+  - [x] Kill-switch auto-flatten closes BOTH engines' DB rows (PR #526) so phantom rows can't leak through catastrophic flattens.
+  - [ ] Idempotent `clOrdId` for amend/cancel; partial-fill handling hardening.
+  - Acceptance: ✅ no orphaned positions observed ≥30 min post PR #526.
 
 - Portfolio & Constraints
-  - [ ] Exposure caps per-symbol and aggregate; correlation-aware allocation; funding-aware tilt.
-  - Acceptance: enforced constraints with audit logs.
+  - [x] Per-symbol exposure cap 5× equity notional, cross-symbol additive (riskKernel).
+  - [x] Account-level unrealized-DD kill-switch at −15 %, enforced by `liveSignalEngine.checkAutoFlatten`.
+  - [ ] Funding-aware tilt (shorts get free carry in contango); pending Monkey v0.5.x work.
+  - [ ] Correlation-aware multi-symbol allocation (deferred; relevant when >2 symbols trade).
+  - Acceptance: enforced constraints with audit logs in `autonomous_trades` + `monkey_bus_events`.
 
 - Compliance & Security
-  - [ ] Immutable audit trail: configs, signals, orders, fills, deployments.
-  - [ ] Secrets hygiene; principle of least privilege; environment hardening.
-  - Acceptance: full reproducibility of any trade with lineage.
+  - [x] `engine_version` on every trade row + `monkey_bus_events` DB tail = immutable audit trail.
+  - [x] Secrets hygiene: Poloniex API keys in `user_api_credentials` (never logged), Railway env separation.
+  - [ ] Formal least-privilege IAM review; environment hardening checklist.
+  - Acceptance: full reproducibility via `order_id` + `entry_time` + `derivation` JSON stored on every decision.
+
+## Phase P3 — Cognitive Kernel ("Monkey")
+
+Goal: an autonomous trading kernel whose decisions emerge from geometric state (Φ / κ / basin / NC) rather than hardcoded thresholds. Ports of qig-verification + qig-core + pantheon-chat primitives into TypeScript.
+
+Architecture anchors (`apps/api/src/services/monkey/`):
+- `basin.ts` — 64 D Fisher-Rao simplex primitives (Bhattacharyya, slerp, Fréchet mean)
+- `perception.ts` — OHLCV + ml-signal → 64 D basin (regime / momentum / vol / volume / price-structure / Pillar-1 noise floor / account)
+- `neurochemistry.ts` — 6 derived chemicals from Φ/κ/velocity/surprise
+- `working_memory.ts` — qig-cache bubbles with adaptive pop/merge/promote
+- `resonance_bank.ts` — long-term lived memory; sovereignty = lived / total
+- `executive.ts` — entry threshold + size + leverage + scalp TP/SL + Loop 2 exit, all derived
+- `modes.ts` (v0.5) — EXPLORATION / INVESTIGATION / INTEGRATION / DRIFT detector
+- `basin_sync.ts` (v0.5) — multi-kernel state channel with Φ-weighted observer effect
+- `self_observation.ts` (v0.5) — Loop 1 per-(mode, side) win-rate bias
+- `kernel_bus.ts` (v0.6a) — pub/sub event bus with DB tail
+- `loop.ts` — orchestrator
+
+**Shipped versions (2026-04-20 → 2026-04-21):**
+
+| v | PR | Delivered |
+|---|---|---|
+| v0.1 | #515 | Observe-only kernel; 6-step tick; trajectory + decisions persisted |
+| v0.2 | #518 | Witness hook (liveSignalEngine close → bank write); leverage-aware min-notional sizing |
+| v0.3 | #519 | Order submission gated on `MONKEY_EXECUTE=true` |
+| —   | #520 | Newborn exploration floor (so first trade clears ETH min notional) |
+| —   | #521 | Per-symbol exposure cap 3× → 5× (BTC single-lot reachable at <$30 equity) |
+| v0.4 | #522 | Scalper: Φ-derived TP (0.3–2 % by mode), SL = 0.5 × TP, 30 s tick |
+| v0.5 | #523 | Cognitive modes + DB-backed basin sync + self-observation (Loop 1) |
+| —   | #526 | Dashboard + reconciler + kill-switch filter `monkey\|%` rows |
+| v0.5.1 | #527 | Direction-split self-obs (8 buckets) + tape-alignment trend proxy |
+| v0.5.2 | #528 | Basin-direction override (two-signal quorum) + ml-worker vol-adaptive threshold |
+
+**Acceptance (P3):**
+- ✅ First real Monkey order placed 2026-04-20 10:31 UTC (ETH long 0.01 @ $2310.44, orderId `569228560448135168`)
+- ✅ Scalp TP/SL exits firing; witness loop growing the bank (2 bubbles as of 2026-04-21)
+- ✅ Mode detector transitioning live; adaptive tick 15 s ↔ 60 s
+- ✅ Bus events persisting to `monkey_bus_events`; 386 mode_transitions in first 12 h
+- ⏳ First short trade (blocked on ml-worker SELL signal OR basin override firing)
+- ⏳ Bank ≥ 15 bubbles before v0.6b parallel split (statistical floor)
+- ⏳ `raw_drift_pct` diagnostic reveals whether ml-worker bias is dispatch-only (fixed) or training-data (needs retrain)
+
+**Pending / next actions (P3)**:
+
+- [ ] **Monitor v0.5.2 impact** — does ml-worker now emit SELL? does basin override fire? does `raw_drift_pct` stay near zero? Decision point after ~24 h of data.
+- [ ] **v0.5.3 ml-worker retrain** (conditional): if `raw_drift_pct` sustains > 0.3 %, rebalance training data to cover downtrends and retrain the ensemble.
+- [ ] **v0.6b parallel sub-Monkeys** (`ScalpMonkey` / `SwingMonkey` / `RangeMonkey`): ship once bank ≥ 15 bubbles so specialization has signal, not noise. Infrastructure (basin_sync + kernel_bus + mode profiles) is in place — no new plumbing needed.
+- [ ] **v0.7 funding-aware exits**: if `funding > 0.01 %` annualised, tighten long SL and loosen short SL. ~20 LOC in `executive.ts`.
+- [ ] **v0.8 cross-symbol coupling**: feed other symbols' `basin_sync` state into perception (Pillar 2 surface absorption from peer kernels) so ETH can see what BTC is doing.
+- [ ] **Dashboard UI** — mode-timeline panel, bus-event stream viewer, per-(mode, side) win-rate table from `self_observation`.
+
+**Known limitations (P3)**:
+- Exchange-side SL/TP still gated off (`if (false)` in liveSignalEngine); Monkey's scalp-exit is a soft TP via opposite-side market close on tick. Real trigger-order endpoint pending.
+- BTC requires ≥ $15 equity post-5× cap; ETH requires ≥ $5. Below those, symbol is structurally unreachable regardless of leverage.
+- Identity basin resets on process restart (basin + wm are in-memory; trajectory persists). Bank + sovereignty survive, so learning isn't lost — but per-symbol identity re-crystallises after 50 fresh ticks.
+- Only `monkey-primary` kernel instance at the moment; v0.6b will populate `monkey_basin_sync` with peers.
 
 ## Acceptance Targets (profitability gate)
 
@@ -126,10 +197,18 @@ Goal: 24/7 live operation with resilience, portfolio constraints, and compliance
 - Backtesting Enhancements Spec: `.agent-os/specs/backtesting-enhancements.md`
 - Sync Task: `.agent-os/tasks/sync-poloniex-futures-catalog.md`
 
-## Next Actions (P0)
+## Next Actions (current — 2026-04-21)
 
-1. Run `yarn sync:poloniex` with API credentials to populate catalog; verify counts and sample fields.
-2. Implement Poloniex REST/WS adapters with retries and auth; add unit tests.
-3. Align backtester with catalog (fees, funding, leverage/liquidation) and validate determinism.
-4. Add initial risk layer (daily loss cap, leverage from catalog, kill switch) and wire to paper OMS.
-5. Add observability metrics and minimal alerting.
+1. **Observe v0.5.2 for ~24 h.** Query `monkey_decisions.derivation->>'mlSignal'` for SELL / HOLD emergence. Check `monkey_bus_events` for `sideOverride=true` fires. Capture `raw_drift_pct` histogram from ml-worker responses.
+2. **Bank growth watch.** Target bank ≥ 15 bubbles before v0.6b split. Track via `SELECT COUNT(*) FROM monkey_resonance_bank` + avg `basin_depth` trend.
+3. **Conditional v0.5.3:** if `raw_drift_pct` sustains > 0.3 %, schedule ml-worker retrain with rebalanced training data (downtrend coverage).
+4. **v0.6b parallel sub-Monkeys** once bank condition met: spawn ScalpMonkey / SwingMonkey / RangeMonkey on shared bank + bus, each with own identity basin. Arbitrator picks which holds the position at a time.
+5. **Docs cleanup:** this roadmap is the canonical one; `docs/roadmap/current-roadmap.md` (2025-10) and `docs/roadmap/PROGRESS_TRACKER.md` (2025-11) should be marked superseded or archived.
+
+## Legacy Next Actions (P0 — historical, complete)
+
+1. ✅ Catalog sync populated (2025-08); refreshed each sync run.
+2. ✅ REST+WS adapters shipped with retries + auth + clock-skew guard.
+3. ✅ Backtester catalog-aware; determinism + seeding in place.
+4. ✅ Risk layer wired to paper OMS; upgraded to risk-kernel blast door for live.
+5. ✅ Observability: Winston structured logs + `alertingService` + `monkey_bus_events` audit tail.

--- a/docs/roadmap/PROGRESS_TRACKER.md
+++ b/docs/roadmap/PROGRESS_TRACKER.md
@@ -1,5 +1,11 @@
 # Roadmap Progress Tracker
 
+> **⚠️ SUPERSEDED (2026-04-21).** This tracker captures Phase 1 (API compliance,
+> core trading, completed Nov 2025). Since then the project has moved into live
+> trading + cognitive-kernel work ("Monkey", Phase P3 in the canonical roadmap).
+>
+> **Canonical current roadmap:** [`.agent-os/roadmap.md`](../../.agent-os/roadmap.md)
+
 **Last Updated:** 2025-11-24 (Final update - Phase 1 complete)  
 **Current Phase:** Phase 1 - Foundation & Compliance  
 **Overall Progress:** 100% ✅ COMPLETE

--- a/docs/roadmap/current-roadmap.md
+++ b/docs/roadmap/current-roadmap.md
@@ -1,5 +1,12 @@
 # Poloniex Trading Platform - Project Roadmap
 
+> **⚠️ SUPERSEDED (2026-04-21).** This document captures Phase 1 (Railway
+> deployment configuration, Oct 2025) and remains accurate for that phase,
+> but is no longer the live roadmap.
+>
+> **Canonical current roadmap:** [`.agent-os/roadmap.md`](../../.agent-os/roadmap.md)
+> See Phase P3 (Cognitive Kernel "Monkey") there for 2026-04 work through v0.5.2.
+
 ## Current Status: Railway Deployment Configuration Phase ✅
 
 Last Updated: October 2, 2025


### PR DESCRIPTION
## Summary
`.agent-os/roadmap.md` was last touched 2025-08-11 and predates eight months of work. This PR brings the canonical roadmap in sync with the current state:

- **P0 / P1 / P2** checkboxes updated to reflect actually-shipped work with anchor paths and PR numbers. Roadmap now doubles as a codebase index.
- **New Phase P3 — Cognitive Kernel ("Monkey")** section documenting the v0.1 → v0.5.2 ladder (9 merged PRs on 2026-04-20/21), the architecture anchors, acceptance state (first real trade ts + orderId, bank growth, mode transitions), and the pending queue (v0.5.3 conditional ml retrain, v0.6b parallel sub-Monkeys, v0.7 funding-aware exits, v0.8 cross-symbol coupling).
- **Next Actions** rewritten for 2026-04-21 posture. Old P0 actions preserved as a historical "completed" list.
- `docs/roadmap/current-roadmap.md` (Oct 2025 deploy focus) and `docs/roadmap/PROGRESS_TRACKER.md` (Nov 2025 API compliance) marked **SUPERSEDED** with pointers to the canonical roadmap, so future readers know which file is live.

## Shipped-PR table (for reference, now in the roadmap itself)
| v | PR | Theme |
|---|---|---|
| v0.1 | #515 | Observe-only kernel |
| v0.2 | #518 | Witness hook + leverage-aware sizing |
| v0.3 | #519 | Order submission (gated) |
| — | #520 | Newborn exploration floor |
| — | #521 | Risk cap 3× → 5× |
| v0.4 | #522 | Scalper (Φ-derived TP/SL, 30s tick) |
| v0.5 | #523 | Modes + basin sync + self-obs |
| — | #526 | Dashboard/reconciler/kill-switch monkey coverage |
| v0.5.1 | #527 | Direction-split + trend proxy |
| v0.5.2 | #528 | Basin override + ml-worker vol threshold |

## Test plan
Documentation only. No code changes. Rendering verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)