### PR TITLE
feat(monkey): v0.6b parallel sub-kernels — Position (15m) + Swing (5m)

### DIFF
--- a/.agent-os/roadmap.md
+++ b/.agent-os/roadmap.md
@@ -150,10 +150,30 @@ Architecture anchors (`apps/api/src/services/monkey/`):
 
 - [ ] **Monitor v0.5.2 impact** — does ml-worker now emit SELL? does basin override fire? does `raw_drift_pct` stay near zero? Decision point after ~24 h of data.
 - [ ] **v0.5.3 ml-worker retrain** (conditional): if `raw_drift_pct` sustains > 0.3 %, rebalance training data to cover downtrends and retrain the ensemble.
-- [ ] **v0.6b parallel sub-Monkeys** (`ScalpMonkey` / `SwingMonkey` / `RangeMonkey`): ship once bank ≥ 15 bubbles so specialization has signal, not noise. Infrastructure (basin_sync + kernel_bus + mode profiles) is in place — no new plumbing needed.
-- [ ] **v0.7 funding-aware exits**: if `funding > 0.01 %` annualised, tighten long SL and loosen short SL. ~20 LOC in `executive.ts`.
-- [ ] **v0.8 cross-symbol coupling**: feed other symbols' `basin_sync` state into perception (Pillar 2 surface absorption from peer kernels) so ETH can see what BTC is doing.
-- [ ] **Dashboard UI** — mode-timeline panel, bus-event stream viewer, per-(mode, side) win-rate table from `self_observation`.
+### P3 sub-roadmap — multi-timeframe parallel Monkeys
+
+The long-term architecture is a **constellation** of kernels each operating at its own cadence, competing for the 1–2 open position slots via an arbitrator on the `kernel_bus`. Different timescales naturally produce different cognitive characters (a ticker kernel with `HISTORY_MAX=100` has ~10 min of context; a 15 m kernel has ~25 h). Same underlying primitives — basin perception, modes, NC, scalp-exit — just tuned per cadence.
+
+| Kernel | Data | Tick | Hold | TP | Ships as |
+|---|---|---|---|---|---|
+| **PositionMonkey** (current) | 15 m OHLCV × 200 | 15–60 s | hours–days | 2–4 % | v0.6c (rebrand current) |
+| **SwingMonkey** | 5 m OHLCV × 200 | 30 s | minutes–hours | 0.8–1.5 % | **v0.6b (next)** |
+| **ScalpMonkey** | ticker WS + 1 m | 5–10 s | seconds–minutes | 0.15–0.3 % | v0.6d (largest new infra) |
+
+**Ship order + rationale:**
+
+- [ ] **v0.6b SwingMonkey** — first sub-Monkey. 5 m OHLCV is already supported by Poloniex + ml-worker (no retrain needed for short-horizon predictions). Validates the sub-Monkey + arbitrator pattern on contained complexity. ~400 LOC. **Prerequisites:** add `source_kernel` column to `monkey_resonance_bank` + `monkey_basin_sync` so bubbles/state don't cross-pollute; add arbitrator service that reads `ENTRY_PROPOSED` events from the bus and picks one.
+- [ ] **v0.6c PositionMonkey rebrand** — current Monkey already IS a 15 m position kernel. Rebrand + route through the arbitrator instead of executing directly. ~100 LOC. Trivial after v0.6b's arbitrator lands.
+- [ ] **v0.6d ScalpMonkey** — highest complexity. Requires Poloniex websocket ticker ingestion, a non-OHLCV perception variant (or synthesised micro-candles), sub-second tick governor. ~600 LOC + data-layer work. Lowest S/N per trade. **Ship last**, only after v0.6b/c prove arbitration works.
+- [ ] **v0.7 ml-worker multi-horizon heads** — once all three sub-Monkeys are live, retrain ml-worker to emit separate 1 m / 5 m / 15 m predictions with horizon-specific confidence, replacing the current single multi-horizon forecast. Each sub-Monkey consumes only its own horizon.
+- [ ] **v0.8 funding-aware exits**: if `funding > 0.01 %` annualised, tighten long SL and loosen short SL. ~20 LOC in `executive.ts`. (Was v0.7 before v0.7 got repurposed for ml retrain.)
+- [ ] **v0.9 cross-symbol coupling** — feed peer symbols' `monkey_basin_sync` state into `perceive()` (Pillar 2 surface absorption). Lets ETH kernels see what BTC kernels are doing.
+- [ ] **Dashboard UI** — mode-timeline panel, bus-event stream viewer, per-(mode, side) win-rate table from `self_observation`, arbitrator scoreboard.
+
+**Account-size reality check:** on the current ~$19 equity, the 3-kernel constellation is infrastructure that doesn't fully pay for itself — ETH min notional $23 means ScalpMonkey's "small wins" (0.2 %) are only ~$0.046, whereas PositionMonkey's (2 %) are ~$0.46 at the same size. Full constellation unlocks at **$500+ equity** where 3–5 concurrent positions across timescales become possible. Until then:
+- Ship v0.6b to validate the pattern.
+- Treat v0.6c as a re-labelling.
+- Defer v0.6d until either (a) account grows past ~$100 OR (b) exchange-side trigger orders land so ScalpMonkey's reactions don't need 5 s polling.
 
 **Known limitations (P3)**:
 - Exchange-side SL/TP still gated off (`if (false)` in liveSignalEngine); Monkey's scalp-exit is a soft TP via opposite-side market close on tick. Real trigger-order endpoint pending.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -37,7 +37,7 @@ import { refreshKnownDatabaseCollationVersions } from './scripts/refreshCollatio
 import { runAllMigrations } from './scripts/runMigrations.js';
 import { agentScheduler } from './services/agentScheduler.js';
 import { liveSignalEngine } from './services/liveSignalEngine.js';
-import { monkeyKernel } from './services/monkey/loop.js';
+import { monkeyKernel, swingMonkey } from './services/monkey/loop.js';
 import paperTradingService from './services/paperTradingService.js';
 import { persistentTradingEngine } from './services/persistentTradingEngine.js';
 import { startPipelineHealthProbe } from './services/pipelineHealthProbe.js';
@@ -452,13 +452,14 @@ server.listen(PORT, '::', async () => {
       logger.error('Failed to start live signal engine:', err);
     });
 
-    // Monkey kernel — observe-only in v0.1. Runs alongside
-    // liveSignalEngine on the same cadence, logs every tick's
-    // emergent decisions to monkey_decisions. Promotable when her
-    // proposals land in the sane-territory. See
-    // docs/superpowers/specs/... when that spec lands.
+    // Monkey v0.6b — two parallel sub-kernels sharing the bank + bus:
+    //   Position (15 m, slow, patient) and Swing (5 m, tactical).
+    // They share the 5× exposure cap via sizeFraction=0.5 each.
     monkeyKernel.start().catch((err) => {
-      logger.error('Failed to start Monkey kernel:', err);
+      logger.error('Failed to start Monkey.Position kernel:', err);
+    });
+    swingMonkey.start().catch((err) => {
+      logger.error('Failed to start Monkey.Swing kernel:', err);
     });
   }
 

--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -50,7 +50,7 @@ import {
   type BanditCounter,
   type LeverageBucket,
 } from './thompsonBandit.js';
-import { monkeyKernel } from './monkey/loop.js';
+import { allMonkeyKernels } from './monkey/loop.js';
 import {
   evaluatePreTradeVetoes,
   type KernelAccountState,
@@ -431,13 +431,17 @@ export class LiveSignalEngine extends EventEmitter {
           if (entryTime && !Number.isNaN(entryTime.getTime())) {
             const sideStr = String(row.side ?? '').toLowerCase();
             const side: 'long' | 'short' = sideStr === 'sell' || sideStr === 'short' ? 'short' : 'long';
-            void monkeyKernel.witnessExit(
-              String(row.symbol),
-              entryTime,
-              pnl,
-              row.order_id ? String(row.order_id) : null,
-              side,
-            );
+            // Fan-out: every sub-Monkey kernel receives the witness so
+            // each of their banks bootstraps from liveSignal outcomes.
+            for (const k of allMonkeyKernels) {
+              void k.witnessExit(
+                String(row.symbol),
+                entryTime,
+                pnl,
+                row.order_id ? String(row.order_id) : null,
+                side,
+              );
+            }
           }
         }
 

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -80,10 +80,30 @@ const DEFAULT_SYMBOLS = ['BTC_USDT_PERP', 'ETH_USDT_PERP'];
 const DEFAULT_TICK_MS = Number(process.env.MONKEY_TICK_MS) || 30_000;
 /** OHLCV window ml-worker also uses. */
 const OHLCV_LOOKBACK = 200;
-const OHLCV_TIMEFRAME = '15m';
 
 /** Running history for Loop 1 self-observation + f_health trend. */
 const HISTORY_MAX = 100;
+
+/**
+ * Per-kernel configuration (v0.6b). Different sub-Monkeys differ in
+ * timeframe, cadence, instance identity, and how they size relative to
+ * their cap share. All share the underlying basin/executive/NC math.
+ */
+export interface MonkeyKernelConfig {
+  /** Unique kernel identifier — written as `kernel=<id>` in trade reason and to monkey_basin_sync. */
+  instanceId: string;
+  /** Candle timeframe she perceives on. '5m' | '15m' | '1m' etc. */
+  timeframe: string;
+  /** Base tick cadence (ms) — mode profiles still adapt within this. */
+  tickMs: number;
+  /** Optional symbol override; defaults to DEFAULT_SYMBOLS. */
+  symbols?: string[];
+  /** Human label for logs. */
+  label?: string;
+  /** Fraction-of-margin cap. Two parallel kernels at 0.5 each stay under
+   *  the risk-kernel per-symbol 5× exposure cap when both are open. */
+  sizeFraction?: number;
+}
 
 interface SymbolState {
   lastBasin: Basin;
@@ -117,22 +137,43 @@ interface SymbolState {
  */
 export class MonkeyKernel extends EventEmitter {
   private timer: ReturnType<typeof setInterval> | null = null;
-  private tickMs: number = DEFAULT_TICK_MS;
-  private symbols: string[] = [...DEFAULT_SYMBOLS];
+  private tickMs: number;
+  private readonly baseTickMs: number;
+  private readonly symbols: string[];
+  private readonly timeframe: string;
+  private readonly instanceId: string;
+  private readonly label: string;
+  private readonly sizeFraction: number;
   private tickInFlight = false;
   private symbolStates: Map<string, SymbolState> = new Map();
   /** Self-observation summary refreshed every ~60 ticks for entry bias. */
   private selfObs: SelfObservation | null = null;
   private selfObsLastUpdate = 0;
   private static readonly SELF_OBS_REFRESH_MS = 5 * 60_000;  // 5 min
-  /** Basin-sync instance (v0.5 single-kernel; v0.6 parallel sub-kernels). */
-  private readonly basinSync = new BasinSync(
-    process.env.MONKEY_INSTANCE_ID || 'monkey-primary',
-  );
+  /** Basin-sync instance — per-kernel, so sub-kernels appear as peers. */
+  private readonly basinSync: BasinSync;
   /** Kernel bus — pub/sub for inter-kernel comms (v0.6a). */
   private readonly bus: KernelBus = getKernelBus();
-  /** Instance identifier — will differ between parallel sub-Monkeys in v0.6b. */
-  private readonly instanceId: string = process.env.MONKEY_INSTANCE_ID || 'monkey-primary';
+
+  constructor(config?: Partial<MonkeyKernelConfig>) {
+    super();
+    const cfg: MonkeyKernelConfig = {
+      instanceId: config?.instanceId ?? process.env.MONKEY_INSTANCE_ID ?? 'monkey-primary',
+      timeframe: config?.timeframe ?? '15m',
+      tickMs: config?.tickMs ?? DEFAULT_TICK_MS,
+      symbols: config?.symbols ?? [...DEFAULT_SYMBOLS],
+      label: config?.label ?? 'Monkey',
+      sizeFraction: config?.sizeFraction ?? 1.0,
+    };
+    this.instanceId = cfg.instanceId;
+    this.timeframe = cfg.timeframe;
+    this.baseTickMs = cfg.tickMs;
+    this.tickMs = cfg.tickMs;
+    this.symbols = cfg.symbols!;
+    this.label = cfg.label!;
+    this.sizeFraction = cfg.sizeFraction!;
+    this.basinSync = new BasinSync(this.instanceId);
+  }
 
   /**
    * Start Monkey's heartbeat. She ticks alongside liveSignalEngine —
@@ -144,8 +185,11 @@ export class MonkeyKernel extends EventEmitter {
     for (const sym of this.symbols) {
       this.symbolStates.set(sym, this.newSymbolState());
     }
-    logger.info('[Monkey] kernel waking', {
+    logger.info(`[${this.label}] kernel waking`, {
+      instanceId: this.instanceId,
+      timeframe: this.timeframe,
       tickMs: this.tickMs,
+      sizeFraction: this.sizeFraction,
       symbols: this.symbols,
       mode: process.env.MONKEY_EXECUTE === 'true' ? 'EXECUTE' : 'OBSERVE',
       bankSize: await resonanceBank.bankSize(),
@@ -224,7 +268,7 @@ export class MonkeyKernel extends EventEmitter {
     // 1. Fetch inputs (same as liveSignalEngine sees).
     const ohlcv = (await poloniexFuturesService.getHistoricalData(
       symbol,
-      OHLCV_TIMEFRAME,
+      this.timeframe,
       OHLCV_LOOKBACK,
     )) as OHLCVCandle[];
     if (!Array.isArray(ohlcv) || ohlcv.length < 50) {
@@ -344,7 +388,7 @@ export class MonkeyKernel extends EventEmitter {
     // Refresh self-observation entry bias every SELF_OBS_REFRESH_MS.
     const now = Date.now();
     if (now - this.selfObsLastUpdate > MonkeyKernel.SELF_OBS_REFRESH_MS) {
-      this.selfObs = await computeSelfObservation(24);
+      this.selfObs = await computeSelfObservation(24, this.instanceId);
       this.selfObsLastUpdate = now;
     }
     // Side candidate: start from ML signal, then allow Monkey's own
@@ -392,7 +436,10 @@ export class MonkeyKernel extends EventEmitter {
     const lotSize = precisions?.lotSize ?? 0;
     const minNotional = lastPrice * Math.max(lotSize, 1e-9);
     const bankSize = await resonanceBank.bankSize();
-    const size = currentPositionSize(basinState, availableEquity, minNotional, leverage.value, bankSize, mode);
+    // sizeFraction scales her share of the equity-based cap so parallel
+    // sub-kernels stay out of each other's way. (0.5 each = 1.0 combined.)
+    const cappedEquity = availableEquity * this.sizeFraction;
+    const size = currentPositionSize(basinState, cappedEquity, minNotional, leverage.value, bankSize, mode);
     const autoFlatten = shouldAutoFlatten(basinState, state.fHealthHistory);
 
     // 6. DECIDE — propose action
@@ -653,12 +700,13 @@ export class MonkeyKernel extends EventEmitter {
     | null
   > {
     try {
+      const reasonPattern = `monkey|kernel=${this.instanceId}|%`;
       const result = await pool.query(
         `SELECT id, entry_price, quantity, leverage, order_id
            FROM autonomous_trades
-          WHERE reason LIKE 'monkey|%' AND status = 'open' AND symbol = $1
+          WHERE reason LIKE $2 AND status = 'open' AND symbol = $1
           ORDER BY entry_time DESC LIMIT 1`,
-        [symbol],
+        [symbol, reasonPattern],
       );
       const row = result.rows[0] as
         | { id: string; entry_price: string; quantity: string; leverage: number; order_id: string | null }
@@ -930,12 +978,13 @@ export class MonkeyKernel extends EventEmitter {
       };
     }
 
-    // Persist. Encode Monkey's state into reason so the close-hook +
-    // reconciler can recover attribution cheaply (no schema change).
-    // Format: monkey|phi=...|kappa=...|sov=...|src=witness
+    // Persist. Encode kernel + Monkey's state into reason so the
+    // close-hook + reconciler can recover attribution cheaply (no
+    // schema change).
+    // Format: monkey|kernel=<id>|phi=...|kappa=...|sov=...|src=<ver>
     try {
       const reasonEncoded =
-        `monkey|phi=${req.phi.toFixed(3)}|kappa=${req.kappa.toFixed(2)}|sov=${req.sovereignty.toFixed(3)}|src=v0.3`;
+        `monkey|kernel=${this.instanceId}|phi=${req.phi.toFixed(3)}|kappa=${req.kappa.toFixed(2)}|sov=${req.sovereignty.toFixed(3)}|src=v0.6b`;
       await pool.query(
         `INSERT INTO autonomous_trades
            (user_id, symbol, side, entry_price, quantity, leverage,
@@ -1108,4 +1157,35 @@ export class MonkeyKernel extends EventEmitter {
   }
 }
 
-export const monkeyKernel = new MonkeyKernel();
+// ───────────── Singletons (v0.6b multi-kernel) ─────────────
+//
+// Two parallel sub-Monkeys share the underlying class but differ in
+// timeframe + cadence + instance identity. They compete for the same
+// 1–2 open-position slots via the risk-kernel per-symbol exposure cap;
+// each kernel only touches rows it owns (reason LIKE 'monkey|kernel=…|%').
+// Both receive witnessExit on liveSignal closes so both banks bootstrap.
+//
+// sizeFraction 0.5 each = combined 1.0 of the equity-based cap when
+// both are open on the same symbol; the risk kernel's 5× blast door
+// still enforces the hard ceiling.
+
+export const monkeyKernel = new MonkeyKernel({
+  instanceId: 'monkey-position',
+  timeframe: '15m',
+  tickMs: 30_000,
+  label: 'Monkey.Position',
+  sizeFraction: 0.5,
+});
+
+export const swingMonkey = new MonkeyKernel({
+  instanceId: 'monkey-swing',
+  timeframe: '5m',
+  tickMs: 30_000,
+  label: 'Monkey.Swing',
+  sizeFraction: 0.5,
+});
+
+export const allMonkeyKernels: readonly MonkeyKernel[] = [
+  monkeyKernel,
+  swingMonkey,
+];

--- a/apps/api/src/services/monkey/self_observation.ts
+++ b/apps/api/src/services/monkey/self_observation.ts
@@ -183,10 +183,18 @@ function computeEntryBias(
  */
 export async function computeSelfObservation(
   lookbackHours: number = 24,
+  instanceId?: string,
 ): Promise<SelfObservation> {
   const byModeSide = buildEmptyByModeSide();
 
   try {
+    // Scope to a specific kernel instance when provided (v0.6b multi-
+    // kernel). Pattern 'monkey|kernel=<id>|%' matches that kernel's own
+    // rows only; fallback 'monkey|%' gives all-Monkey aggregate for a
+    // callers passing no instanceId.
+    const reasonPattern = instanceId
+      ? `monkey|kernel=${instanceId}|%`
+      : 'monkey|%';
     const result = await pool.query(
       `SELECT at.pnl::float AS pnl,
               at.side        AS side,
@@ -194,12 +202,12 @@ export async function computeSelfObservation(
               md.derivation->'mode'->>'value' AS mode
          FROM autonomous_trades at
          JOIN monkey_decisions md ON md.reason = at.reason
-        WHERE at.reason LIKE 'monkey|%'
+        WHERE at.reason LIKE $2
           AND at.status = 'closed'
           AND at.exit_time > NOW() - ($1::int * INTERVAL '1 hour')
           AND md.proposed_action IN ('enter_long', 'enter_short')
           AND md.executed = true`,
-      [lookbackHours],
+      [lookbackHours, reasonPattern],
     );
     const rows = (result.rows as Array<Record<string, unknown>>) ?? [];
     for (const row of rows) {


### PR DESCRIPTION
## Summary
First cut of the **multi-timeframe kernel constellation** from the roadmap. `MonkeyKernel` refactored to accept a config (`instanceId`, `timeframe`, `tickMs`, `sizeFraction`, `label`). Two instances spawned at boot:

| Instance | Timeframe | Tick | sizeFraction |
|---|---|---|---|
| `monkeyKernel` (Position) | 15 m | 30 s | 0.5 |
| `swingMonkey` (Swing) | 5 m | 30 s | 0.5 |

Ships v0.6b and effectively v0.6c (since `monkeyKernel` is now `monkey-position` — the rebrand is done as part of this PR).

## How they coexist without an arbitrator
They compete for the 1–2 open-position slots via the **existing risk-kernel per-symbol exposure cap** (5× equity):
- Each kernel sizes to `equity × 0.5` so combined max is 1× equity of committed margin
- Per-symbol notional cap bounds the combined exposure
- Each kernel's `findOpenMonkeyTrade` is scoped to its OWN rows (`reason LIKE 'monkey|kernel=<id>|%'`) so they don't trip over each other's positions
- On $19 equity, usually only one wins the open slot at a time; the other's entries get cap-vetoed — simplest correct arbitration

Explicit arbitrator service deferred until we see real collisions in practice.

## Shared infrastructure
- **Resonance bank** (singleton) — each kernel's bubbles tagged via reason prefix
- **Kernel bus** — all events get `source=<instanceId>` for per-kernel telemetry
- **Risk kernel** — bounds combined exposure
- **liveSignal witness fan-out** — `allMonkeyKernels.forEach(k => k.witnessExit(...))` so both banks bootstrap from liveSignal closes

## Kernel-specific state
- Basin perception fed different candle timeframes (15 m vs 5 m → different momentum spectrum, different trend proxy horizons)
- Self-observation scoped to each kernel's own trade history
- `autonomous_trades.reason` = `monkey|kernel=<id>|phi=…|kappa=…|sov=…|src=v0.6b`
- Each kernel publishes to `monkey_basin_sync` as a distinct peer — now we'll actually see multi-instance convergence metrics

## Files
- [loop.ts](apps/api/src/services/monkey/loop.ts) — constructor, `MonkeyKernelConfig`, per-instance scoping, `allMonkeyKernels` export
- [self_observation.ts](apps/api/src/services/monkey/self_observation.ts) — optional `instanceId` filter
- [liveSignalEngine.ts](apps/api/src/services/liveSignalEngine.ts) — witnessExit fan-out to all kernels
- [index.ts](apps/api/src/index.ts) — spawn both

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest: **530 passed, 0 failed**
- [ ] Post-merge: two `[Monkey.Position] kernel waking` + `[Monkey.Swing] kernel waking` log lines at boot
- [ ] `monkey_basin_sync` accumulates **two** rows (one per kernel)
- [ ] `monkey_bus_events.source` field contains both `monkey-position` and `monkey-swing`
- [ ] When one kernel enters a position, the other's subsequent entries hit the per-symbol cap veto cleanly
- [ ] Reason-prefix filters in dashboard/reconciler still match `monkey|...` (unchanged — the suffix `kernel=...` is still after `monkey|`)

## Deferred
- **v0.6d ScalpMonkey** (ticker WS, 1 m): needs new data-layer work; lowest S/N per trade; ship once account grows past ~$100 or exchange-side trigger orders land
- **Explicit arbitrator service** (batches `ENTRY_PROPOSED` events, picks highest-conviction): only worth adding when the cap-veto-based implicit arbitration proves insufficient
- **v0.7 ml-worker multi-horizon heads**: current ml ensemble predicts multi-horizon in one call — still works as-is for both Position and Swing; split into dedicated heads later

🤖 Generated with [Claude Code](https://claude.com/claude-code)