### PR TITLE
feat(monkey): v0.6.1 trailing profit harvest

### DIFF
--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -207,6 +207,77 @@ export function currentLeverage(
 }
 
 /**
+ * shouldProfitHarvest — early-exit WHILE IN PROFIT (v0.6.1).
+ *
+ * Runs BEFORE shouldScalpExit. When a trade has been in profit, the peak
+ * unrealized P&L acts as a high-water mark. If the position gives back a
+ * chunk of that peak AND is still green, take what's there instead of
+ * waiting for the full TP threshold. Addresses the observed scenario
+ * where a position was up ~$0.65 on ETH at its peak, then retraced to
+ * −$0.67 while waiting for the 0.8–2 % TP — lost both directions.
+ *
+ * Two independent triggers (either fires):
+ *
+ *   TRAILING   peakFrac ≥ activation AND currentFrac < peakFrac × (1 − giveback)
+ *              → "profit retraced past my trailing stop"
+ *   TREND-FLIP currentFrac > 0 AND tapeTrend flipped against heldSide past threshold
+ *              → "tape turned on me, secure what I have"
+ *
+ * Both require currentFrac > 0 so we never exit at a loss from here; SL
+ * still handles loss exits. activation defaults to 0.2 % of notional so
+ * we don't flap on noise; giveback defaults to 0.4 (give back 40 % of peak).
+ */
+export function shouldProfitHarvest(
+  unrealizedPnlUsdt: number,
+  peakPnlUsdt: number,
+  notionalUsdt: number,
+  tapeTrend: number,
+  heldSide: 'long' | 'short',
+  s: BasinState,
+): ExecutiveDecision<boolean> {
+  if (notionalUsdt <= 0) {
+    return { value: false, reason: 'no position', derivation: {} };
+  }
+  const currentFrac = unrealizedPnlUsdt / notionalUsdt;
+  const peakFrac = Math.max(peakPnlUsdt, 0) / notionalUsdt;
+
+  // Activation floor — peak must have been meaningful before the trailing
+  // stop can fire. Scales with dopamine: recent wins → harvest earlier.
+  const activation = Math.max(0.002, 0.004 - 0.002 * s.neurochemistry.dopamine);
+  // Giveback fraction — how much of peak to surrender before exiting.
+  // Low serotonin (unstable) → tighter (0.30); high serotonin → looser (0.50).
+  const giveback = 0.30 + 0.20 * (1 - s.neurochemistry.serotonin);
+  const trailingFloor = peakFrac * (1 - giveback);
+
+  if (peakFrac >= activation && currentFrac < trailingFloor && currentFrac > 0) {
+    return {
+      value: true,
+      reason: `trailing_harvest: peak ${(peakFrac * 100).toFixed(3)}% → now ${(currentFrac * 100).toFixed(3)}% < ${(trailingFloor * 100).toFixed(3)}% floor`,
+      derivation: { currentFrac, peakFrac, trailingFloor, activation, giveback, exitTypeBit: 2 },
+    };
+  }
+
+  // TREND-FLIP trigger. Aligned entry means tapeTrend had the same sign
+  // as heldSide when she entered; if tape reverses against her while
+  // she's green, harvest now — the trend that justified entry is gone.
+  const alignmentNow = heldSide === 'long' ? tapeTrend : -tapeTrend;
+  const TREND_FLIP_THRESHOLD = -0.25;  // strongly against the position
+  if (currentFrac > 0 && alignmentNow <= TREND_FLIP_THRESHOLD && peakFrac >= activation) {
+    return {
+      value: true,
+      reason: `trend_flip_harvest: pnl +${(currentFrac * 100).toFixed(3)}%, tape flipped (align=${alignmentNow.toFixed(2)})`,
+      derivation: { currentFrac, peakFrac, alignment: alignmentNow, exitTypeBit: 3 },
+    };
+  }
+
+  return {
+    value: false,
+    reason: `profit_hold: current ${(currentFrac * 100).toFixed(3)}%, peak ${(peakFrac * 100).toFixed(3)}%, trail-floor ${(trailingFloor * 100).toFixed(3)}%`,
+    derivation: { currentFrac, peakFrac, trailingFloor, activation, giveback, alignment: alignmentNow },
+  };
+}
+
+/**
  * shouldScalpExit — P&L-driven take-profit / stop-loss gate (v0.4).
  *
  * Reward-harvesting exit per UCP v6.6 §29.4: when realized reward

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -69,6 +69,7 @@ import {
   currentPositionSize,
   shouldAutoFlatten,
   shouldExit,
+  shouldProfitHarvest,
   shouldScalpExit,
   type BasinState,
 } from './executive.js';
@@ -128,6 +129,13 @@ interface SymbolState {
   lastMode: MonkeyMode | null;
   /** Mode-specific tickMs last applied — used by adaptive-tick governor. */
   currentTickMs: number;
+  /** v0.6.1: high-water-mark unrealized PnL on the currently-held trade.
+   *  Reset to null on close. Survives kernel restarts? No — will re-peak
+   *  as ticks come in, which is safer than over-claiming. */
+  peakPnlUsdt: number | null;
+  /** Trade id of the position currently being peak-tracked. If the open
+   *  trade id changes (new position), peak resets. */
+  peakTrackedTradeId: string | null;
 }
 
 /**
@@ -226,6 +234,8 @@ export class MonkeyKernel extends EventEmitter {
       sessionTicks: 0,
       lastMode: null,
       currentTickMs: this.tickMs,
+      peakPnlUsdt: null,
+      peakTrackedTradeId: null,
     };
   }
 
@@ -463,23 +473,63 @@ export class MonkeyKernel extends EventEmitter {
       reason = autoFlatten.reason;
       derivation.autoFlatten = autoFlatten.derivation;
     } else if (heldSide) {
-      // v0.4+v0.5: Scalp TP/SL gate runs FIRST with mode-specific thresholds.
-      let scalpFired = false;
+      // Exit-gate order (v0.6.1):
+      //   1. profit harvest (trailing + trend-flip, only while green)
+      //   2. scalp TP/SL
+      //   3. Loop 2 regime-shift (shouldExit)
+      let exitFired = false;
       const openRow = await this.findOpenMonkeyTrade(symbol);
       if (openRow) {
         const positionNotional = Number(openRow.entry_price) * Number(openRow.quantity);
         const sidesign = heldSide === 'long' ? 1 : -1;
         const unrealizedPnl = (lastPrice - Number(openRow.entry_price)) * Number(openRow.quantity) * sidesign;
-        const scalp = shouldScalpExit(unrealizedPnl, positionNotional, basinState, mode);
-        derivation.scalp = { ...scalp.derivation, unrealizedPnl, markPrice: lastPrice, tradeId: String(openRow.id) };
-        if (scalp.value) {
-          action = 'scalp_exit';
-          reason = scalp.reason;
-          scalpFired = true;
+        const tradeId = String(openRow.id);
+
+        // Reset peak tracking when we detect a NEW trade vs what we
+        // were peak-tracking. (Covers reconciler-replaced rows.)
+        if (state.peakTrackedTradeId !== tradeId) {
+          state.peakPnlUsdt = unrealizedPnl;
+          state.peakTrackedTradeId = tradeId;
+        } else {
+          state.peakPnlUsdt = Math.max(state.peakPnlUsdt ?? 0, unrealizedPnl);
+        }
+
+        // 1. Profit harvest — trailing stop + trend-flip, only while green
+        const harvest = shouldProfitHarvest(
+          unrealizedPnl,
+          state.peakPnlUsdt ?? 0,
+          positionNotional,
+          tapeTrend,
+          heldSide,
+          basinState,
+        );
+        derivation.harvest = { ...harvest.derivation, unrealizedPnl, peakPnl: state.peakPnlUsdt, tradeId };
+        if (harvest.value) {
+          action = 'scalp_exit';  // executes via same close path
+          reason = harvest.reason;
+          exitFired = true;
+          // Tag the exit type so closeHeldPosition stores the right exit_reason
+          derivation.scalp = {
+            exitTypeBit: harvest.derivation.exitTypeBit,
+            unrealizedPnl,
+            markPrice: lastPrice,
+            tradeId,
+          };
+        }
+
+        // 2. Scalp TP/SL (only if harvest didn't fire)
+        if (!exitFired) {
+          const scalp = shouldScalpExit(unrealizedPnl, positionNotional, basinState, mode);
+          derivation.scalp = { ...scalp.derivation, unrealizedPnl, markPrice: lastPrice, tradeId };
+          if (scalp.value) {
+            action = 'scalp_exit';
+            reason = scalp.reason;
+            exitFired = true;
+          }
         }
       }
-      if (!scalpFired) {
-        // Loop 2 debate — perception vs identity
+      if (!exitFired) {
+        // 3. Loop 2 debate — perception vs identity
         const exit = shouldExit(basin, state.identityBasin, heldSide, basinState);
         if (exit.value) {
           action = 'exit';
@@ -542,7 +592,12 @@ export class MonkeyKernel extends EventEmitter {
         const scalpDeriv = derivation.scalp as Record<string, unknown> | undefined;
         const tradeId = scalpDeriv?.tradeId ? String(scalpDeriv.tradeId) : null;
         const exitTypeBit = Number(scalpDeriv?.exitTypeBit ?? 0);
-        const exitType = exitTypeBit === 1 ? 'take_profit' : exitTypeBit === -1 ? 'stop_loss' : 'scalp_exit';
+        const exitType =
+          exitTypeBit === 1 ? 'take_profit' :
+          exitTypeBit === -1 ? 'stop_loss' :
+          exitTypeBit === 2 ? 'trailing_harvest' :
+          exitTypeBit === 3 ? 'trend_flip_harvest' :
+          'scalp_exit';
         const pnlAtDecision = Number(scalpDeriv?.unrealizedPnl ?? 0);
         if (tradeId) {
           const closeResult = await this.closeHeldPosition({
@@ -555,6 +610,11 @@ export class MonkeyKernel extends EventEmitter {
           });
           executed = closeResult.executed;
           monkeyOrderId = closeResult.orderId;
+          if (executed) {
+            // Clear peak tracking now the trade is closed.
+            state.peakPnlUsdt = null;
+            state.peakTrackedTradeId = null;
+          }
           if (!executed) {
             reason += ` | close: ${closeResult.reason}`;
           } else {


### PR DESCRIPTION
## Symptom (observed 2026-04-21)
Monkey ETH long opened 01:30 @ \$2322.84. ETH rallied to ~\$2345 (peak ≈ **+\$0.66 unrealized**), retraced all the way back through entry, now sitting at **−\$0.67**. Her 2 % TP in INTEGRATION mode would only fire at ~+\$1.40 — she waited for a win that was already in her hand.

## Fix
New `shouldProfitHarvest` gate runs BEFORE scalp TP/SL. Fires only while green. Two triggers:

| Trigger | Condition |
|---|---|
| **TRAILING** | peak ≥ activation AND current retraced > giveback from peak |
| **TREND-FLIP** | currentFrac > 0 AND tapeTrend flipped strongly against heldSide (< −0.25) |

**Activation** floor: 0.2–0.4 % of notional. Scales inward with dopamine (recent wins → harvest earlier).
**Giveback**: 30 % default, tightens to 50 % when serotonin low (high basin velocity → lock fast).

Peak tracked in-memory per-(kernel × symbol). Resets when trade id changes or on successful close. Restart resets peak to current, which is safer than over-claiming. New `exit_reason` values `trailing_harvest` and `trend_flip_harvest`.

## Inherited by both sub-Monkeys
Position (15 m) and Swing (5 m) share the same executive.ts. On 5 m Swing, the 0.2 % activation is roughly typical intra-candle move on ETH — should trigger cleanly on session-level pulls.

## NOT in this PR
**DCA / add-to-position** (the user's second ask — "buy lower if it thinks it'll recover"). Classic averaging-into-losers failure mode. Queued as v0.6.2 pending its own risk-kernel interaction design.

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest: **530 passed, 0 failed**
- [ ] Post-merge: watch for `trailing_harvest` or `trend_flip_harvest` log lines on the next ETH/BTC round trip where price pumps then fades
- [ ] Exit_reason column shows the new values in closed `monkey|%` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)