### PR TITLE
fix(monkey): v0.6.3 scope heldSide per-kernel so Monkey isn't locked out by liveSignal

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -301,8 +301,19 @@ export class MonkeyKernel extends EventEmitter {
     const mlStrength = Number(raw?.strength) || 0;
 
     // Account context (also shared with liveSignalEngine).
-    const { equityFraction, marginFraction, openPositions, heldSide, availableEquity } =
-      await this.fetchAccountContext(symbol);
+    // NOTE: exchangeHeldSide is the SHARED exchange position state —
+    // includes positions held by liveSignalEngine and any other engine.
+    // Do NOT use it to gate Monkey's entry logic (2026-04-21 bug: she
+    // was locked out any time liveSignal held a position). Use it only
+    // for perception inputs; her own held-side is derived per-kernel
+    // from findOpenMonkeyTrade below.
+    const {
+      equityFraction,
+      marginFraction,
+      openPositions,
+      heldSide: exchangeHeldSide,
+      availableEquity,
+    } = await this.fetchAccountContext(symbol);
 
     // 2. PERCEIVE — raw basin then refract through identity.
     const rawBasin = perceive({
@@ -476,6 +487,17 @@ export class MonkeyKernel extends EventEmitter {
       sideOverride,
     };
 
+    // v0.6.3: Monkey's "held side" is scoped to HER OWN open rows only.
+    // If only liveSignal holds a position on this symbol, Monkey treats
+    // herself as flat and her entry logic can still fire (risk kernel's
+    // exposure cap is the only thing bounding combined concurrency).
+    const ownOpenRow = await this.findOpenMonkeyTrade(symbol);
+    const heldSide: 'long' | 'short' | null = ownOpenRow
+      ? (exchangeHeldSide ?? 'long')  // exchange must agree or fetchAccountContext was stale
+      : null;
+    derivation.exchangeHeldSide = exchangeHeldSide;
+    derivation.monkeyHeldSide = heldSide;
+
     if (autoFlatten.value) {
       action = 'flatten';
       reason = autoFlatten.reason;
@@ -486,7 +508,7 @@ export class MonkeyKernel extends EventEmitter {
       //   2. scalp TP/SL
       //   3. Loop 2 regime-shift (shouldExit)
       let exitFired = false;
-      const openRow = await this.findOpenMonkeyTrade(symbol);
+      const openRow = ownOpenRow;  // reuse the lookup from above
       if (openRow) {
         const positionNotional = Number(openRow.entry_price) * Number(openRow.quantity);
         const sidesign = heldSide === 'long' ? 1 : -1;


### PR DESCRIPTION
## Bug discovered during 14:00 UTC check-in
Monkey hasn't traded in 2 h despite 612 ticks, all BUY, mode detector cycling, and all derivatives working. Reason: `fetchAccountContext` reads the shared exchange net-position, which includes liveSignal's longs on both BTC and ETH. Monkey sees `heldSide=long` → routes into exit branch → `findOpenMonkeyTrade` returns null (she has no rows) → all exit gates skip → she hits `hold`. **She can never enter a position while any other engine holds anything on her watch symbols.**

This worked when Monkey was the only engine; broken since v0.3 made her co-tenant with liveSignal.

## Fix
Compute `heldSide` from Monkey's OWN rows (`findOpenMonkeyTrade`) before the decide block. If her row doesn't exist, she's flat — even if the exchange shows a position from another engine. Risk kernel's 5× per-symbol exposure cap is the correct guard for combined-exposure safety; `heldSide` should gate only HER exit logic.

Cached `ownOpenRow` reused in the exit branch (no double query).

Both sub-kernels inherit the fix — each scopes heldSide to its own instanceId via the existing `findOpenMonkeyTrade` filter.

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest: **530 passed, 0 failed**
- [ ] Post-merge: expect `[Monkey] ORDER PLACED` log line within a few ticks (ML already BUY at 0.45 strength, entry threshold ~0.12)
- [ ] Monkey sub-kernel rows appear in autonomous_trades alongside the existing liveSignal rows
- [ ] Risk-kernel veto might fire if combined exposure > 5× equity — that's correct behavior

## Rollback
Revert. No state changes, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Scope Monkey kernel position state to its own open trades so it can enter positions independently of other engines sharing the account context.

Bug Fixes:
- Prevent Monkey from being blocked from opening trades when other engines hold positions on the same symbols by deriving heldSide from its own open rows.

Enhancements:
- Expose both shared exchange-held side and Monkey-specific held side in the derivation state and reuse the open-row lookup to avoid duplicate queries.