### PR TITLE
fix(monkey): v0.6.4 adaptive sizeFraction — auto-widen on small accounts

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -465,9 +465,22 @@ export class MonkeyKernel extends EventEmitter {
     const lotSize = precisions?.lotSize ?? 0;
     const minNotional = lastPrice * Math.max(lotSize, 1e-9);
     const bankSize = await resonanceBank.bankSize();
-    // sizeFraction scales her share of the equity-based cap so parallel
-    // sub-kernels stay out of each other's way. (0.5 each = 1.0 combined.)
-    const cappedEquity = availableEquity * this.sizeFraction;
+    // sizeFraction scales her share of equity so parallel sub-kernels
+    // stay out of each other's way. (0.5 each = 1.0 combined.) On small
+    // accounts this would halve margin below exchange min notional for
+    // BOTH kernels — observed 2026-04-21: $19 × 0.5 × 0.09 × 12x = $10
+    // notional, below ETH's $23 min. So: effective sizeFraction bumps
+    // back to 1.0 when capped equity × explorationFloor × newborn-leverage
+    // can't reach min notional. On larger accounts this stays at the
+    // configured 0.5 and both kernels share cleanly; the risk-kernel 5×
+    // exposure cap still bounds combined concurrency.
+    const expFloorApprox = 0.10;               // modes.ts EXPLORATION/INVESTIGATION baseline
+    const maxNewbornLev = 20;                  // newborn sovereignCap floor
+    const minNeededForMinNotional = minNotional / (expFloorApprox * maxNewbornLev);
+    const effectiveSizeFraction = availableEquity * this.sizeFraction < minNeededForMinNotional
+      ? 1.0
+      : this.sizeFraction;
+    const cappedEquity = availableEquity * effectiveSizeFraction;
     const size = currentPositionSize(basinState, cappedEquity, minNotional, leverage.value, bankSize, mode);
     const autoFlatten = shouldAutoFlatten(basinState, state.fHealthHistory);
 


### PR DESCRIPTION
## Chain from today's work
- v0.6.3 fixed heldSide (Monkey was locked out by liveSignal)
- v0.6.3 exposed the next block: size = 0 below min notional
- v0.6.4 fixes that

## Math
At \$19 equity, sov=1.0, bank=2 (maturity 0.1):
  sizeFraction 0.5 → cappedEquity \$9.5
  explorationFloor 0.09 × \$9.5 = **\$0.86 margin**
  post-newborn leverage ~12x (regime-compressed) = **\$10 notional**
  ETH min \$23.08 → sized = 0

v0.6b's `sizeFraction=0.5` per-kernel was designed for accounts ≥ \$500 where splitting makes sense. At \$19 it deadlocks both kernels.

## Fix
Effective sizeFraction auto-bumps to 1.0 when the split amount can't fit min notional even at exploration-floor × newborn-leverage-cap. Each kernel competes at full equity; risk kernel's 5× per-symbol exposure cap still bounds combined concurrency (on \$19, 2 × \$23 = \$46 = 2.4× equity, well under \$95 cap).

Constants-based threshold (modes.ts EXPLORATION floor 0.10 + sovereignCap 20) — stable and cheap, no live-state dependency.

On larger accounts (\$500+), configured 0.5 stays and kernels share cleanly.

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest: **530 passed, 0 failed**
- [ ] Post-merge: expect `[Monkey] ORDER PLACED` within a few ticks (ML BUY 0.45, entry threshold ~0.12)
- [ ] Risk kernel may veto if combined notional exceeds 5× equity — correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Introduce an adaptive effective sizeFraction that temporarily bumps to full equity when split equity cannot satisfy the minimum notional given exploration-floor and leverage constraints, while preserving the configured split on larger accounts.