### PR TITLE
fix(monkey): v0.6.6 lift position fraction to clear exchange min notional

### DIFF
--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -143,19 +143,38 @@ export function currentPositionSize(
   // Clamp to [0, 0.5] — at most half of available equity. This is a
   // BOUNDARY (survival) not a PARAMETER — exceeding it creates unrecoverable
   // states regardless of Φ.
-  const frac = Math.min(0.5, Math.max(0, rawFrac));
-  const margin = frac * availableEquityUsdt;
-  const notional = margin * Math.max(1, leverage);
-  // Compare the POSITION (notional) to the exchange min, not the margin.
+  let frac = Math.min(0.5, Math.max(0, rawFrac));
+  let margin = frac * availableEquityUsdt;
+  let notional = margin * Math.max(1, leverage);
+
+  // v0.6.6 "lift to minimum" — if we're below exchange min notional but
+  // a fraction within the 0.5 safety clamp CAN clear it, auto-raise to
+  // just enough. Observed 2026-04-21: when liveSignal's committed margin
+  // shrank availableEquity to $5.20, the 9% exploration floor produced
+  // $0.47 margin × 14x = $6.54 notional — below the $23 ETH min even
+  // though $1.70 margin (33%) would clear it cleanly.
+  let liftedToMin = false;
+  if (notional < minNotionalUsdt && availableEquityUsdt > 0 && leverage > 0) {
+    const BUFFER = 1.05;  // 5% headroom so lot-rounding doesn't put us just under
+    const requiredFrac = (minNotionalUsdt * BUFFER) / (leverage * availableEquityUsdt);
+    if (requiredFrac <= 0.5) {
+      frac = Math.max(frac, requiredFrac);
+      margin = frac * availableEquityUsdt;
+      notional = margin * leverage;
+      liftedToMin = true;
+    }
+  }
+
   const sized = notional >= minNotionalUsdt ? margin : 0;
 
   return {
     value: sized,
-    reason: `size = floor(${explorationFloor.toFixed(3)}) or Φ×S×M(${(s.phi * s.sovereignty * maturity).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)}) × equity(${availableEquityUsdt.toFixed(2)}) @ ${leverage}x → margin ${margin.toFixed(2)}, notional ${notional.toFixed(2)} vs min ${minNotionalUsdt.toFixed(2)} = ${sized.toFixed(2)}`,
+    reason: `size = ${liftedToMin ? 'lifted-to-min ' : ''}floor(${explorationFloor.toFixed(3)}) or Φ×S×M(${(s.phi * s.sovereignty * maturity).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)}) × equity(${availableEquityUsdt.toFixed(2)}) @ ${leverage}x → margin ${margin.toFixed(2)}, notional ${notional.toFixed(2)} vs min ${minNotionalUsdt.toFixed(2)} = ${sized.toFixed(2)}`,
     derivation: {
       phi: s.phi, sovereignty: s.sovereignty, maturity, bankSize,
       dopamine: nc.dopamine, serotonin: nc.serotonin, gaba: nc.gaba,
-      explorationFloor, rawFrac, frac, margin, leverage, notional, minNotional: minNotionalUsdt, sized,
+      explorationFloor, rawFrac, frac, margin, leverage, notional,
+      minNotional: minNotionalUsdt, sized, liftedToMin: liftedToMin ? 1 : 0,
     },
   };
 }


### PR DESCRIPTION
## Running onion-peel of Monkey entry blockers
```
v0.6.3 #533  heldSide        (SHIPPED)
v0.6.4 #534  sizeFraction    (SHIPPED)
v0.6.5 #535  DRIFT gate      (SHIPPED)
v0.6.6 this  lift-to-minimum
```

## This one
After v0.6.5, Monkey reached INVESTIGATION mode successfully. But **still size=0** because liveSignal's 3 open positions tied up ~\$13.80 of her \$19 total balance → `availableEquity ≈ \$5.20`:

```
explorationFloor 0.09 × \$5.20 = \$0.47 margin
leverage 14x (post-newborn regime compressed)
notional = \$0.47 × 14 = \$6.54  ← below \$23 ETH min → sized = 0
```

But the 0.5 max-fraction safety cap leaves headroom — 33% of \$5.20 = \$1.72 × 14x = \$24 notional would clear with 5% buffer. The sizing formula just wasn't trying to reach the minimum.

## Fix
When `frac × equity × leverage < minNotional`, compute the minimum frac that would clear (with 5% buffer for lot rounding), clamped to the 0.5 cap. If it fits, raise frac; if even 0.5 can't fit, skip correctly.

New `liftedToMin` flag in derivation so we can see how often this fires.

Three regimes:
- Abundant equity → rawFrac already clears, no lift
- Tight equity + feasible → lift to min (today's case)
- Too-tight → frac maxes at 0.5, below min → skip correctly

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest 530/530
- [ ] Post-merge: `[Monkey] ORDER PLACED` should fire on next few ticks; `liftedToMin=1` in derivation should appear when equity is tight

🤖 Generated with [Claude Code](https://claude.com/claude-code)