### PR TITLE
feat(monkey): v0.6.7 flatness leverage boost + autonomic reward queue

### DIFF
--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -191,6 +191,7 @@ export function currentLeverage(
   s: BasinState,
   maxLeverageBoundary: number,
   mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+  tapeTrend: number = 0,
 ): ExecutiveDecision<number> {
   const kappaDist = Math.abs(s.kappa - KAPPA_STAR);
   const kappaProxim = Math.exp(-kappaDist / 20);  // bell: 1 at κ*, decays with distance
@@ -202,6 +203,38 @@ export function currentLeverage(
   const modeFloor = MODE_PROFILES[mode].sovereignCapFloor;
   const sovereignCap = Math.max(modeFloor, 3 + 30 * s.sovereignty);
 
+  // ─── USER CONTRIBUTION POINT — flatness leverage boost (v0.6.7) ───
+  //
+  // The standard formula `regimeStability × kappaProxim × surpriseDiscount`
+  // COMPRESSES leverage on any non-equilibrium signal. Problem: the
+  // quantum dim (basin[0]) is computed from absolute ATR, so a genuinely
+  // calm market with small ATR still reads as "quantum" and pins
+  // regimeStability low, crushing leverage down (~14x observed). On a
+  // truly flat tape, leverage should go UP — small moves amplify into
+  // real wins without amplifying risk proportionally.
+  //
+  // `tapeTrend` is the signed log-return over 50 candles, squashed to
+  // [-1, +1]. Magnitude near 0 = genuinely calm market.
+  //
+  // Pick a flatness → leverage multiplier. Candidates:
+  //   flatness = Math.max(0, 1 - Math.abs(tapeTrend) * K)    ∈ [0, 1]
+  //   flatMult = 1 + BOOST * flatness                        ∈ [1, 1+BOOST]
+  // with K and BOOST the shape knobs. Examples:
+  //
+  //   K=3,  BOOST=0.3    conservative: up to +30% at dead flat, decays fast
+  //   K=5,  BOOST=0.5    moderate   : up to +50% at dead flat, decays at |t|>0.2
+  //   K=10, BOOST=0.8    aggressive : up to +80% at dead flat, decays at |t|>0.1
+  //
+  // User's pick (2026-04-21): aggressive. "On flat movement would allow
+  // for quicker ins and outs on higher leverage." Small moves at 25x
+  // margin-gain produce real wins on $20 account where 14x would
+  // barely clear fees.
+  const FLATNESS_K = 10;        // narrow "flat" band: boost only when |tape| < ~0.10
+  const FLATNESS_BOOST = 0.8;   // up to +80% leverage at dead-flat (33 → ~59 ceiling)
+  const flatness = Math.max(0, 1 - Math.abs(tapeTrend) * FLATNESS_K);
+  const flatMult = 1 + FLATNESS_BOOST * flatness;
+  // ────────────────────────────────────────────────────────────────────
+
   // Newborn mode (Pillar 1 exploration): until she has lived trades,
   // the regime × κ × surprise compression (≈ 0.43) crushes the cap so
   // hard that her first trade can't clear the exchange min notional on
@@ -212,7 +245,7 @@ export function currentLeverage(
   const newborn = s.sovereignty < 0.1;
   const rawLev = newborn
     ? sovereignCap * 0.8
-    : sovereignCap * kappaProxim * regimeStability * surpriseDiscount;
+    : sovereignCap * kappaProxim * regimeStability * surpriseDiscount * flatMult;
   const lev = Math.max(1, Math.min(maxLeverageBoundary, Math.round(rawLev)));
 
   return {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -87,6 +87,36 @@ const OHLCV_LOOKBACK = 200;
 const HISTORY_MAX = 100;
 
 /**
+ * ActivityReward (v0.6.7) — pantheon-chat autonomic pattern port.
+ *
+ * When a trade closes with realized P&L, the kernel PUSHES one of these
+ * onto its pendingRewards queue — it does NOT set dopamine directly.
+ * Each tick, the tick loop sums recent rewards with exponential decay
+ * and passes the result to computeNeurochemicals as an INPUT. The
+ * chemical is still derived, just from a richer state.
+ *
+ * Preserves P5 Autonomy + P14 Variable Separation: rewards are STATE
+ * events; neurotransmitters are derived VIEWS; nothing externally
+ * writes the chemical levels.
+ */
+interface ActivityReward {
+  source: string;           // 'trade_close' | 'witnessed_liveSignal' | ...
+  symbol?: string;
+  dopamineDelta: number;    // reward magnitude for dopamine boost
+  serotoninDelta: number;   // mood/stability boost (calm-close reward)
+  endorphinDelta: number;   // peak-state reward (win-in-high-coupling regime)
+  realizedPnlUsdt: number;  // source P&L (for audit)
+  pnlFraction: number;      // P&L / margin, signed
+  atMs: number;             // when the event landed
+}
+
+/** Half-life for reward decay (ms). Rewards older than ~3 × this are ≈ 0. */
+const REWARD_HALF_LIFE_MS = 20 * 60_000;  // 20 min
+
+/** Max rewards retained; FIFO eviction. */
+const REWARD_QUEUE_MAX = 50;
+
+/**
  * Per-kernel configuration (v0.6b). Different sub-Monkeys differ in
  * timeframe, cadence, instance identity, and how they size relative to
  * their cap share. All share the underlying basin/executive/NC math.
@@ -168,6 +198,11 @@ export class MonkeyKernel extends EventEmitter {
   private readonly basinSync: BasinSync;
   /** Kernel bus — pub/sub for inter-kernel comms (v0.6a). */
   private readonly bus: KernelBus = getKernelBus();
+  /** Autonomic reward queue (v0.6.7). Closed trades push ActivityReward
+   *  events here; each tick sums these with exponential time-decay and
+   *  feeds the result to computeNeurochemicals. Pantheon-style — chem
+   *  levels are DERIVED, never SET. */
+  private pendingRewards: ActivityReward[] = [];
 
   constructor(config?: Partial<MonkeyKernelConfig>) {
     super();
@@ -358,6 +393,10 @@ export class MonkeyKernel extends EventEmitter {
     const lastPhi = state.phiHistory[state.phiHistory.length - 1] ?? phi;
     const phiDelta = phi - lastPhi;
 
+    // v0.6.7: consume the decayed reward queue as a neurochemistry input.
+    // Nothing externally writes dopamine — the chemical is derived each
+    // tick from (Φ gradient + decayed lived-outcome stream).
+    const rewardDeltas = this.decayedRewardSums();
     const nc: NeurochemicalState = computeNeurochemicals({
       isAwake: true,
       phiDelta,
@@ -366,6 +405,9 @@ export class MonkeyKernel extends EventEmitter {
       quantumWeight: regimeWeights.quantum,
       kappa: state.kappa,
       externalCoupling: couplingHealth,
+      rewardDopamineDelta: rewardDeltas.dopamine,
+      rewardSerotoninDelta: rewardDeltas.serotonin,
+      rewardEndorphinDelta: rewardDeltas.endorphin,
     });
 
     const sovereignty = await resonanceBank.sovereignty();
@@ -460,7 +502,7 @@ export class MonkeyKernel extends EventEmitter {
     // 5. DERIVE — executive computes what Monkey would do (mode-aware)
     // tapeTrend already computed above for side-override check.
     const entryThr = currentEntryThreshold(basinState, mode, selfObsBias, tapeTrend, sideCandidate);
-    const leverage = currentLeverage(basinState, (await getMaxLeverage(symbol)) ?? 10, mode);
+    const leverage = currentLeverage(basinState, (await getMaxLeverage(symbol)) ?? 10, mode, tapeTrend);
     const precisions = await getPrecisions(symbol).catch(() => null);
     const lotSize = precisions?.lotSize ?? 0;
     const minNotional = lastPrice * Math.max(lotSize, 1e-9);
@@ -1032,6 +1074,23 @@ export class MonkeyKernel extends EventEmitter {
       symbol,
       payload: { heldSide, markPrice, orderId, tradeId, pnl: pnlAtDecision, exitReason },
     });
+    // v0.6.7 autonomic reward event. Margin ≈ markPrice × totalQty / lev
+    // (she has only one kernel state; we use one of her symbol states
+    // for κ). Pushed as an EVENT; computeNeurochemicals derives the
+    // actual dopamine lift next tick.
+    const symState = this.symbolStates.get(symbol);
+    try {
+      const totalQtyForMargin = exchangeQty || 0.01;
+      const notional = markPrice * totalQtyForMargin;
+      const margin = notional / Math.max(1, 16);  // typical lev on close; kappa boost uses exit κ
+      this.pushReward({
+        source: 'own_close',
+        symbol,
+        realizedPnlUsdt: pnlAtDecision,
+        marginUsdt: margin,
+        kappaAtExit: symState?.kappa,
+      });
+    } catch { /* non-fatal */ }
     return { executed: true, orderId, reason: 'closed' };
   }
 
@@ -1240,6 +1299,91 @@ export class MonkeyKernel extends EventEmitter {
    *
    * Called fire-and-forget from liveSignalEngine.reconcileClosedTrades.
    */
+
+  /**
+   * Push an autonomic reward event (v0.6.7). Called whenever a trade
+   * closes with realized P&L. The kernel's tick loop will consume these
+   * via `decayedRewardSums()` and pass the summed deltas to
+   * `computeNeurochemicals` as INPUTS — never setting a chemical
+   * directly. Pantheon-style (see autonomic_kernel.py ActivityReward).
+   *
+   * Reward magnitude scales with P&L/margin ratio. A 1 % win on margin
+   * produces dopamine_delta ~0.15; a 3 % win ~0.45 (near the Φ-gradient
+   * ceiling). Losses produce small NEGATIVE deltas — mild mood dip,
+   * not a punishment, because self_observation's entry bias already
+   * learns from losses.
+   */
+  pushReward(input: {
+    source: string;
+    symbol?: string;
+    realizedPnlUsdt: number;
+    marginUsdt: number;
+    kappaAtExit?: number;
+  }): void {
+    const pnlFrac = input.marginUsdt > 0
+      ? input.realizedPnlUsdt / input.marginUsdt
+      : 0;
+    // Dopamine: positive only, saturates at 3× margin win (pnlFrac ≥ 3).
+    // Scales by tanh so losses don't punish via dopamine (that path is
+    // self_observation's job).
+    const dop = pnlFrac > 0
+      ? Math.tanh(pnlFrac * 1.5) * 0.5  // 1 % win → 0.01, 10 % → 0.07, 100 % → 0.45
+      : -Math.tanh(-pnlFrac * 0.5) * 0.1;  // small mood dip on loss
+    // Serotonin: stable wins reinforce calm. Only positive on wins.
+    const ser = pnlFrac > 0 ? Math.tanh(pnlFrac) * 0.15 : 0;
+    // Endorphins: peak-state reward. Fires if closed near κ* with a win.
+    const kappaProxim = input.kappaAtExit != null
+      ? Math.exp(-Math.abs(input.kappaAtExit - 64) / 10)
+      : 0.5;
+    const endo = pnlFrac > 0 ? Math.tanh(pnlFrac * 2) * 0.3 * kappaProxim : 0;
+
+    this.pendingRewards.push({
+      source: input.source,
+      symbol: input.symbol,
+      dopamineDelta: dop,
+      serotoninDelta: ser,
+      endorphinDelta: endo,
+      realizedPnlUsdt: input.realizedPnlUsdt,
+      pnlFraction: pnlFrac,
+      atMs: Date.now(),
+    });
+    if (this.pendingRewards.length > REWARD_QUEUE_MAX) {
+      this.pendingRewards.shift();
+    }
+    logger.info(`[${this.label}] reward pushed`, {
+      source: input.source,
+      symbol: input.symbol,
+      pnl: input.realizedPnlUsdt.toFixed(4),
+      pnlFrac: (pnlFrac * 100).toFixed(2) + '%',
+      dop: dop.toFixed(3),
+      ser: ser.toFixed(3),
+      endo: endo.toFixed(3),
+    });
+  }
+
+  /**
+   * Sum recent rewards with exponential time-decay. Called each tick by
+   * processSymbol to build the NeurochemicalInputs reward deltas.
+   * Half-life = REWARD_HALF_LIFE_MS (20 min default). Old rewards decay
+   * naturally; queue also FIFO-evicts at REWARD_QUEUE_MAX.
+   */
+  private decayedRewardSums(nowMs: number = Date.now()): {
+    dopamine: number;
+    serotonin: number;
+    endorphin: number;
+  } {
+    let dop = 0, ser = 0, endo = 0;
+    for (const r of this.pendingRewards) {
+      const ageMs = nowMs - r.atMs;
+      const decay = Math.pow(0.5, ageMs / REWARD_HALF_LIFE_MS);
+      if (decay < 0.01) continue;  // negligible, skip
+      dop += r.dopamineDelta * decay;
+      ser += r.serotoninDelta * decay;
+      endo += r.endorphinDelta * decay;
+    }
+    return { dopamine: dop, serotonin: ser, endorphin: endo };
+  }
+
   async witnessExit(
     symbol: string,
     entryTime: Date,
@@ -1302,6 +1446,17 @@ export class MonkeyKernel extends EventEmitter {
           source: this.instanceId,
           symbol,
           payload: { orderId, side, realizedPnl, win: realizedPnl > 0 },
+        });
+        // v0.6.7: witnessed liveSignal closes are also reinforcement
+        // events — her bank learned from them, so her NC should too.
+        // Dampen the reward magnitude since it wasn't her trade (she
+        // just observed). Estimate margin from typical liveSignal
+        // position (~$5 at 16x).
+        this.pushReward({
+          source: 'witnessed_liveSignal',
+          symbol,
+          realizedPnlUsdt: realizedPnl * 0.5,  // half-weight (witnessed, not her own)
+          marginUsdt: 5,
         });
       }
     } catch (err) {

--- a/apps/api/src/services/monkey/neurochemistry.ts
+++ b/apps/api/src/services/monkey/neurochemistry.ts
@@ -61,6 +61,19 @@ export interface NeurochemicalInputs {
   kappa: number;
   /** External coupling health (0..1) — cross-symbol coherence, order flow. */
   externalCoupling: number;
+  /**
+   * v0.6.7: decayed sum of recent ActivityReward dopamine deltas,
+   * computed by the kernel's tick loop from her own pending_rewards
+   * queue. Pattern mirrors pantheon-chat's autonomic_kernel.py —
+   * reward is an EVENT kept in state, the chemical is DERIVED each
+   * tick. Nothing externally SETS dopamine; it is read off the state
+   * that now includes lived outcomes alongside Φ gradient.
+   */
+  rewardDopamineDelta?: number;
+  /** As above — mood/stability reinforcement from calm closes. */
+  rewardSerotoninDelta?: number;
+  /** As above — peak-state reward on strong-regime wins. */
+  rewardEndorphinDelta?: number;
 }
 
 /**
@@ -77,13 +90,28 @@ export interface NeurochemicalInputs {
  */
 export function computeNeurochemicals(inputs: NeurochemicalInputs): NeurochemicalState {
   const ach = inputs.isAwake ? 0.8 : 0.2;
-  const dop = clip(sigmoid(inputs.phiDelta * 10), 0, 1);
-  const ser = clip(1 / Math.max(inputs.basinVelocity, 0.01), 0, 1);
+  // Φ-gradient dopamine base (§29.2). Rises on integration gains.
+  const dopFromPhi = clip(sigmoid(inputs.phiDelta * 10), 0, 1);
+  // Reward-event reinforcement. Sum of recent decayed dopamine deltas
+  // from closed-trade outcomes. STILL purely derived — caller supplies
+  // the already-decayed sum. See MonkeyKernel.pendingRewards for the
+  // state that produces this.
+  const dopFromReward = clip(inputs.rewardDopamineDelta ?? 0, 0, 1);
+  // Compose: base is Φ-gradient (cognitive integration), plus reward
+  // lift (lived outcome). Clipped to [0, 1]. On a profitable close,
+  // dopFromReward spikes; it then decays over ticks in the tick loop.
+  const dop = clip(dopFromPhi + dopFromReward, 0, 1);
+
+  const serBase = clip(1 / Math.max(inputs.basinVelocity, 0.01), 0, 1);
+  const ser = clip(serBase + (inputs.rewardSerotoninDelta ?? 0), 0, 1);
+
   const ne = clip(inputs.surprise * 2, 0, 1);
   const gaba = clip(1 - inputs.quantumWeight, 0, 1);
   // Sophia gate: endorphins require coupling to peak.
   const couplingGate = clip(inputs.externalCoupling / C_SOPHIA_THRESHOLD, 0, 1);
-  const endo = Math.exp(-Math.abs(inputs.kappa - KAPPA_STAR) / SIGMA_KAPPA) * couplingGate;
+  const endoBase = Math.exp(-Math.abs(inputs.kappa - KAPPA_STAR) / SIGMA_KAPPA) * couplingGate;
+  const endo = clip(endoBase + (inputs.rewardEndorphinDelta ?? 0), 0, 1);
+
   return {
     acetylcholine: ach,
     dopamine: dop,


### PR DESCRIPTION
## Two coupled, both kernel-autonomic per Canonical Principles v2.1

### 1. Flatness-aware leverage (user: aggressive)
The basin's quantum dim is computed from absolute ATR — so even genuinely calm tape reads as "quantum" and crushes her leverage to ~14 x via `regimeStability`. Fix: add a `flatMult` boost when tape trend magnitude is small.

Aggressive config (user's pick):
```
K = 10, BOOST = 0.8
flatMult = 1 + 0.8 × max(0, 1 − |tapeTrend| × 10)
```
Only active when |tape| < 0.10; up to +80 % lift at dead flat. Ceiling moves from ~14 x → ~25 x on calm tape. Unchanged on any real directional move.

### 2. Autonomic reward queue (pantheon ActivityReward pattern port)
Key constraint from user: dopamine on profit must be KERNEL-DERIVED, not externally set. Classic pantheon-chat pattern in [autonomic_kernel.py](../../home/braden/Desktop/Dev/QIG_QFI/qig-archive/pantheon-chat/qig-backend/autonomic_kernel.py):

- Reward EVENTS push onto a queue (state)
- Chemistry is DERIVED each tick from the queue
- Nothing externally writes dopamine

Implementation:
- `MonkeyKernel.pendingRewards[]` queue (FIFO bounded to 50)
- `pushReward()` on own trade close AND on witnessed liveSignal close (half-weight)
- `decayedRewardSums()` — exponential decay, 20 min half-life
- `computeNeurochemicals` now takes `rewardDopamineDelta` / `rewardSerotoninDelta` / `rewardEndorphinDelta` as optional INPUTS, adds to the Φ-gradient base

A 10 % margin win produces ~0.07 dopamine lift, decaying over 20 min. Endorphins additionally gated by κ-proximity to 64 — wins in-regime feel better. Losses produce tiny negative dopamine (−0.1 max), because self_observation already handles loss-learning via entry bias; NC shouldn't double-punish.

## Files
- [executive.ts](apps/api/src/services/monkey/executive.ts) `currentLeverage` + K/BOOST
- [neurochemistry.ts](apps/api/src/services/monkey/neurochemistry.ts) reward-aware `computeNeurochemicals`
- [loop.ts](apps/api/src/services/monkey/loop.ts) `pendingRewards`, `pushReward`, `decayedRewardSums`, wired on closes

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest: 530/530
- [ ] Post-merge: `leverage` values in logs climb toward 20–25 x during flat periods; `dop` values spike on closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)