### PR TITLE
fix(monkey): v0.7.1 flatten-then-reverse for basin override against held side

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -620,6 +620,28 @@ export class MonkeyKernel extends EventEmitter {
           action = 'exit';
           reason = exit.reason;
           derivation.exit = exit.derivation;
+        } else if (
+          // 3b. v0.7.1 — OVERRIDE REVERSAL. When basin + tape quorum
+          // flipped sideCandidate AGAINST the currently-held side, she
+          // wants to reverse, not add. Poloniex v3 one-way position
+          // mode NETS a reverse-direction order against the existing
+          // position — so naive "submit SHORT while LONG" just cancels
+          // the long and leaves the exchange flat. Fix: flatten-first,
+          // then submit new direction. Observed 2026-04-21 09:29 UTC
+          // when she attempted a basin-override short while ETH long
+          // was open; short vanished via netting.
+          sideOverride &&
+          sideCandidate !== heldSide &&
+          MODE_PROFILES[mode].canEnter &&
+          mlStrength >= entryThr.value &&
+          size.value > 0
+        ) {
+          action = sideCandidate === 'long' ? 'reverse_long' : 'reverse_short';
+          reason = `OVERRIDE_REVERSE[${heldSide}→${sideCandidate}] basin=${basinDir.toFixed(2)} tape=${tapeTrend.toFixed(2)}; flatten-then-open margin=${size.value.toFixed(2)} lev=${leverage.value}x`;
+          derivation.entryThreshold = entryThr.derivation;
+          derivation.size = size.derivation;
+          derivation.leverage = leverage.derivation;
+          derivation.isReverse = true;
         } else {
           // 4. v0.6.2 — DCA add eligibility. Can she add to the position
           //    at a better price while the ML signal still supports the
@@ -752,6 +774,63 @@ export class MonkeyKernel extends EventEmitter {
             reason += ` | close: ${closeResult.reason}`;
           } else {
             reason += ` | closed@${lastPrice.toFixed(2)} pnl=${pnlAtDecision.toFixed(4)}`;
+          }
+        }
+      } else if ((action === 'reverse_long' || action === 'reverse_short') && heldSide) {
+        // v0.7.1 — flatten-then-reverse. Two-phase:
+        //   1. reduce-only close the existing opposite-side position
+        //   2. brief settle delay so the exchange nets cleanly
+        //   3. fresh executeEntry in the new direction
+        const newSide: 'long' | 'short' = action === 'reverse_long' ? 'long' : 'short';
+        const existingRowId = ownOpenRow ? String(ownOpenRow.id) : null;
+        // Use current unrealized as pnl estimate for the close row update.
+        let pnlAtDecision = 0;
+        if (ownOpenRow) {
+          const entryP = Number(ownOpenRow.entry_price);
+          const qty = Number(ownOpenRow.quantity);
+          const sidesign = heldSide === 'long' ? 1 : -1;
+          pnlAtDecision = (lastPrice - entryP) * qty * sidesign;
+        }
+        if (existingRowId) {
+          const closeResult = await this.closeHeldPosition({
+            symbol,
+            tradeId: existingRowId,
+            heldSide,
+            markPrice: lastPrice,
+            exitReason: 'override_reverse',
+            pnlAtDecision,
+          });
+          if (closeResult.executed) {
+            state.peakPnlUsdt = null;
+            state.peakTrackedTradeId = null;
+            state.dcaAddCount = 0;
+            state.lastEntryAtMs = null;
+            // Settle delay — give the exchange ~500ms to flatten net.
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            const execResult = await this.executeEntry({
+              symbol,
+              side: newSide,
+              marginUsdt: size.value,
+              leverage: leverage.value,
+              entryPrice: lastPrice,
+              minNotional,
+              phi,
+              kappa: state.kappa,
+              sovereignty,
+              trajectoryId: null,
+              isDCAAdd: false,
+              dcaAddIndex: 0,
+            });
+            executed = execResult.executed;
+            monkeyOrderId = execResult.orderId;
+            if (executed) {
+              state.lastEntryAtMs = Date.now();
+              reason += ` | closed@${lastPrice.toFixed(2)} pnl=${pnlAtDecision.toFixed(4)} | new ${newSide} orderId=${monkeyOrderId}`;
+            } else {
+              reason += ` | flattened ok, new-entry failed: ${execResult.reason}`;
+            }
+          } else {
+            reason += ` | flatten failed: ${closeResult.reason}; reverse aborted`;
           }
         }
       }


### PR DESCRIPTION
## Observed bug (2026-04-21 09:29:55 UTC)
v0.5.2's basin-override fired for the first time — `basinDir=-1.000` + `tape=-0.399` both past ±0.35 quorum, flipped ML `BUY` → `SELL`. But the short order was reconciler-closed 60 seconds later (`reconciled_not_on_exchange`).

Root cause: Poloniex v3 runs in **one-way position mode**. Submitting a SHORT on a symbol where she holds LONG NETS against the existing position rather than opening a separate short. Net effect: both long and short cancelled, exchange flat, DB rows dangle as orphans until the 5-min reconciler cleans them up.

## Fix
New action `reverse_long` / `reverse_short` in the held-side branch. Execute block two-phase:

1. **reduce-only close** the existing opposite-side position
2. **500 ms settle delay** for the exchange to net cleanly
3. **fresh executeEntry** in the new direction

Gated by `sideOverride && sideCandidate != heldSide && mode.canEnter && mlStrength >= entryThr && size > 0`. Takes precedence over DCA (reversal > add).

Existing trade closes with `exit_reason='override_reverse'` and pnl from current mark; new entry persists as a fresh row (not DCA). Dashboard + self_observation + witness hook all see a normal close + open.

## Not affected
- Schema: unchanged
- Python boundary: unchanged (orchestration/exchange IO stays TS per v0.7 migration plan)
- Live TS Monkey: unchanged behaviour on non-override ticks

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest **530 / 530**
- [ ] Post-merge: next time `override=true` fires against held side, expect:
  - `[Monkey] POSITION CLOSED exitReason: override_reverse`
  - 500 ms later `[Monkey] ORDER PLACED side=short` (or long)
  - No `reconciled_not_on_exchange` follow-up
- [ ] Reconciler stops emitting `reconciled_not_on_exchange` on Monkey rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)