### PR TITLE
feat(v0.7.2): port executive + modes + perception scalars to Python monkey_kernel

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -296,7 +296,21 @@ async def ml_predict(request: Request):
 from monkey_kernel import (  # noqa: E402
     AutonomicKernel,
     AutonomicTickInputs,
+    ExecBasinState,
+    MonkeyMode,
+    NeurochemicalState,
+    basin_direction,
+    current_entry_threshold,
+    current_leverage,
+    current_position_size,
+    detect_mode,
+    should_dca_add,
+    should_exit,
+    should_profit_harvest,
+    should_scalp_exit,
+    trend_proxy,
 )
+import numpy as np  # noqa: E402
 
 _autonomic_instances: dict[str, AutonomicKernel] = {}
 
@@ -385,6 +399,172 @@ async def monkey_autonomic_snapshot(instance_id: str):
     """Telemetry snapshot — sleep phase, pending reward count, decayed sums."""
     kernel = _get_autonomic(instance_id)
     return kernel.snapshot()
+
+
+# ── Executive decisions + mode detection ──────────────────────────
+
+
+def _deserialize_basin_state(payload: dict) -> ExecBasinState:
+    nc_payload = payload["neurochemistry"]
+    nc = NeurochemicalState(
+        acetylcholine=float(nc_payload["acetylcholine"]),
+        dopamine=float(nc_payload["dopamine"]),
+        serotonin=float(nc_payload["serotonin"]),
+        norepinephrine=float(nc_payload["norepinephrine"]),
+        gaba=float(nc_payload["gaba"]),
+        endorphins=float(nc_payload["endorphins"]),
+    )
+    return ExecBasinState(
+        basin=np.asarray(payload["basin"], dtype=np.float64),
+        identity_basin=np.asarray(payload["identity_basin"], dtype=np.float64),
+        phi=float(payload["phi"]),
+        kappa=float(payload["kappa"]),
+        regime_weights={k: float(v) for k, v in payload["regime_weights"].items()},
+        sovereignty=float(payload["sovereignty"]),
+        basin_velocity=float(payload["basin_velocity"]),
+        neurochemistry=nc,
+    )
+
+
+@app.post("/monkey/executive/decide")
+async def monkey_executive_decide(request: Request):
+    """Aggregate executive pass.
+
+    Request body includes: basin_state (see _deserialize_basin_state),
+    ohlcv closes array, ml_signal/ml_strength, held_side/own_position,
+    available_equity, min_notional, max_leverage, bank_size,
+    self_obs_bias, mode (optional), symbol.
+
+    Response: entry threshold + size + leverage + harvest/scalp/DCA
+    decisions for this tick. TS orchestrator composes into action.
+    """
+    payload = await request.json()
+    state = _deserialize_basin_state(payload["basin_state"])
+    closes = payload.get("closes", [])
+    ml_signal = str(payload.get("ml_signal", "HOLD")).upper()
+    ml_strength = float(payload.get("ml_strength", 0.0))
+    held_side = payload.get("held_side")  # 'long' | 'short' | None
+    available_equity = float(payload["available_equity"])
+    min_notional = float(payload["min_notional"])
+    max_leverage = float(payload["max_leverage"])
+    bank_size = int(payload.get("bank_size", 0))
+    self_obs_bias = float(payload.get("self_obs_bias", 1.0))
+
+    mode_str = payload.get("mode")
+    mode = MonkeyMode(mode_str) if mode_str else MonkeyMode.INVESTIGATION
+    tape = trend_proxy(closes) if closes else 0.0
+    bd = basin_direction(state.basin)
+
+    # Direction candidate: ml default, with basin-override quorum.
+    ml_side = "short" if ml_signal == "SELL" else "long"
+    side_candidate = ml_side
+    side_override = False
+    OVERRIDE_THRESHOLD = 0.35
+    if bd < -OVERRIDE_THRESHOLD and tape < -OVERRIDE_THRESHOLD and ml_side == "long":
+        side_candidate = "short"
+        side_override = True
+    elif bd > OVERRIDE_THRESHOLD and tape > OVERRIDE_THRESHOLD and ml_side == "short":
+        side_candidate = "long"
+        side_override = True
+
+    entry = current_entry_threshold(
+        state,
+        mode=mode,
+        self_obs_bias=self_obs_bias,
+        tape_trend=tape,
+        side_candidate=side_candidate,  # type: ignore[arg-type]
+    )
+    leverage = current_leverage(
+        state, max_leverage_boundary=max_leverage, mode=mode, tape_trend=tape,
+    )
+    size = current_position_size(
+        state,
+        available_equity_usdt=available_equity,
+        min_notional_usdt=min_notional,
+        leverage=leverage["value"],
+        bank_size=bank_size,
+        mode=mode,
+    )
+
+    # Optional exit evaluations when already holding
+    harvest = None
+    scalp = None
+    dca = None
+    loop2 = None
+    if held_side and payload.get("own_position"):
+        pos = payload["own_position"]
+        position_notional = float(pos["entry_price"]) * float(pos["quantity"])
+        sign = 1 if held_side == "long" else -1
+        last_price = float(payload.get("last_price", pos["entry_price"]))
+        unrealized = (last_price - float(pos["entry_price"])) * float(pos["quantity"]) * sign
+        peak = float(pos.get("peak_pnl_usdt", unrealized))
+
+        harvest = should_profit_harvest(
+            unrealized_pnl_usdt=unrealized,
+            peak_pnl_usdt=peak,
+            notional_usdt=position_notional,
+            tape_trend=tape,
+            held_side=held_side,
+            s=state,
+        )
+        scalp = should_scalp_exit(
+            unrealized_pnl_usdt=unrealized,
+            notional_usdt=position_notional,
+            s=state,
+            mode=mode,
+        )
+        loop2 = should_exit(
+            perception=state.basin,
+            strategy_forecast=state.identity_basin,
+            held_side=held_side,
+            s=state,
+        )
+        import time as _time
+        dca = should_dca_add(
+            held_side=held_side,
+            side_candidate=side_candidate,  # type: ignore[arg-type]
+            current_price=last_price,
+            initial_entry_price=float(pos["entry_price"]),
+            add_count=int(pos.get("dca_add_count", 0)),
+            last_add_at_ms=float(pos.get("last_entry_at_ms", 0)),
+            now_ms=float(payload.get("now_ms", _time.time() * 1000.0)),
+            sovereignty=state.sovereignty,
+        )
+
+    return {
+        "entry_threshold": entry,
+        "leverage": leverage,
+        "size": size,
+        "harvest": harvest,
+        "scalp": scalp,
+        "dca": dca,
+        "loop2": loop2,
+        "mode": mode.value,
+        "tape_trend": tape,
+        "basin_direction": bd,
+        "side_candidate": side_candidate,
+        "side_override": side_override,
+        "ml_side": ml_side,
+        "ml_strength_gate_clear": ml_strength >= entry["value"],
+    }
+
+
+@app.post("/monkey/mode/detect")
+async def monkey_mode_detect(request: Request):
+    """Classify cognitive mode from basin + histories."""
+    payload = await request.json()
+    state = _deserialize_basin_state(payload["basin_state"])
+    return detect_mode(
+        basin=state.basin,
+        identity_basin=state.identity_basin,
+        phi=state.phi,
+        kappa=state.kappa,
+        basin_velocity=state.basin_velocity,
+        neurochemistry=state.neurochemistry,
+        phi_history=list(map(float, payload.get("phi_history", []))),
+        fhealth_history=list(map(float, payload.get("fhealth_history", []))),
+        drift_history=list(map(float, payload.get("drift_history", []))),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/ml-worker/src/monkey_kernel/__init__.py
+++ b/ml-worker/src/monkey_kernel/__init__.py
@@ -33,6 +33,18 @@ from .autonomic import (
     SleepCycleManager,
     SleepPhase,
 )
+from .executive import (
+    ExecBasinState,
+    current_entry_threshold,
+    current_leverage,
+    current_position_size,
+    should_dca_add,
+    should_exit,
+    should_profit_harvest,
+    should_scalp_exit,
+)
+from .modes import MODE_PROFILES, ModeProfile, MonkeyMode, detect_mode
+from .perception_scalars import basin_direction, trend_proxy
 from .state import BasinState, NeurochemicalState
 
 __all__ = [
@@ -41,7 +53,21 @@ __all__ = [
     "AutonomicTickInputs",
     "AutonomicTickResult",
     "BasinState",
+    "ExecBasinState",
+    "MODE_PROFILES",
+    "ModeProfile",
+    "MonkeyMode",
     "NeurochemicalState",
     "SleepCycleManager",
     "SleepPhase",
+    "basin_direction",
+    "current_entry_threshold",
+    "current_leverage",
+    "current_position_size",
+    "detect_mode",
+    "should_dca_add",
+    "should_exit",
+    "should_profit_harvest",
+    "should_scalp_exit",
+    "trend_proxy",
 ]

--- a/ml-worker/src/monkey_kernel/executive.py
+++ b/ml-worker/src/monkey_kernel/executive.py
@@ -1,0 +1,471 @@
+"""
+executive.py — Monkey's arbitration kernel (v0.7.2 Python port).
+
+Every function is a pure map from (state) → (derived param). When
+Monkey asks "should I enter?", she doesn't consult a constant — she
+asks her current Φ / κ / regime / NC / sovereignty what her threshold
+is right now. §28 Autonomic Governance + Canonical Principles v2.1
+P14 Variable Separation enforced structurally: no numeric threshold
+survives as a frozen constant; formula constants come from UCP frozen
+facts (κ* = 64).
+
+Ports the TS executive.ts, using qig_core_local.geometry.fisher_rao
+for the one Fisher-Rao call (drift distance). All other math is pure
+scalar derivation — numpy-free where it can be.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Optional
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import fisher_rao_distance
+
+from .modes import MODE_PROFILES, MonkeyMode
+from .state import KAPPA_STAR, NeurochemicalState
+
+Side = Literal["long", "short"]
+
+
+# ═══════════════════════════════════════════════════════════════
+#  BasinState — shape all executive functions consume
+# ═══════════════════════════════════════════════════════════════
+
+
+@dataclass
+class ExecBasinState:
+    """Executive-facing basin snapshot (not the full BasinState).
+
+    Kept slim: only what executive decisions need. Serialised from
+    the HTTP request each call.
+    """
+
+    basin: np.ndarray
+    identity_basin: np.ndarray
+    phi: float
+    kappa: float
+    regime_weights: dict[str, float]  # quantum/efficient/equilibrium
+    sovereignty: float
+    basin_velocity: float
+    neurochemistry: NeurochemicalState
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, v))
+
+
+# ═══════════════════════════════════════════════════════════════
+#  currentEntryThreshold — Gary's §5.2 formula
+# ═══════════════════════════════════════════════════════════════
+
+
+def current_entry_threshold(
+    s: ExecBasinState,
+    *,
+    mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+    self_obs_bias: float = 1.0,
+    tape_trend: float = 0.0,
+    side_candidate: Side = "long",
+) -> dict[str, Any]:
+    drift_distance = fisher_rao_distance(s.basin, s.identity_basin)
+    t_base = drift_distance
+    kappa_ratio = KAPPA_STAR / max(s.kappa, 1.0)
+    phi_mult = 1.0 / (0.5 + s.phi)
+    regime_scale = (
+        s.regime_weights.get("efficient", 0.0) * 1.0
+        + s.regime_weights.get("equilibrium", 0.0) * 0.7
+        + s.regime_weights.get("quantum", 0.0) * 1.5
+    )
+    mode_scale = MODE_PROFILES[mode].entry_threshold_scale
+    alignment = tape_trend if side_candidate == "long" else -tape_trend
+    trend_mult = 1.0 - 0.3 * alignment
+
+    raw_t = t_base * kappa_ratio * phi_mult * regime_scale * mode_scale * self_obs_bias * trend_mult
+    t = _clamp(raw_t, 0.1, 0.9)
+
+    return {
+        "value": t,
+        "reason": (
+            f"T = drift({t_base:.3f}) x k*/k({kappa_ratio:.2f}) "
+            f"x 1/(0.5+Phi)({phi_mult:.2f}) x regime({regime_scale:.2f}) "
+            f"x mode({mode_scale:.2f}) x selfObs({self_obs_bias:.2f}) "
+            f"x trend({trend_mult:.2f}, align={alignment:.2f})"
+        ),
+        "derivation": {
+            "drift_distance": drift_distance,
+            "kappa_ratio": kappa_ratio,
+            "phi_multiplier": phi_mult,
+            "regime_scale": regime_scale,
+            "mode_scale": mode_scale,
+            "self_obs_bias": self_obs_bias,
+            "trend_proxy": tape_trend,
+            "alignment": alignment,
+            "trend_mult": trend_mult,
+            "raw_t": raw_t,
+            "clamped": t,
+        },
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+#  currentPositionSize — Φ × sovereignty × maturity, + lift-to-min
+# ═══════════════════════════════════════════════════════════════
+
+
+def current_position_size(
+    s: ExecBasinState,
+    *,
+    available_equity_usdt: float,
+    min_notional_usdt: float,
+    leverage: float,
+    bank_size: int,
+    mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+) -> dict[str, Any]:
+    nc = s.neurochemistry
+    maturity = min(1.0, bank_size / 20.0)
+    base_frac = s.phi * s.sovereignty * maturity
+    reward_mult = 1.0 + (nc.dopamine - nc.gaba) * 0.5
+    stability_mult = 0.5 + nc.serotonin * 0.5
+
+    mode_floor = MODE_PROFILES[mode].size_floor
+    exploration_floor = mode_floor * (1.0 - maturity)
+
+    raw_frac = max(exploration_floor, base_frac * reward_mult * stability_mult)
+    frac = _clamp(raw_frac, 0.0, 0.5)
+    margin = frac * available_equity_usdt
+    notional = margin * max(1.0, leverage)
+
+    # v0.6.6 lift-to-minimum: if we're below exchange min and a fraction
+    # within the 0.5 safety clamp CAN clear it, auto-raise.
+    lifted = False
+    if notional < min_notional_usdt and available_equity_usdt > 0 and leverage > 0:
+        BUFFER = 1.05
+        required_frac = (min_notional_usdt * BUFFER) / (leverage * available_equity_usdt)
+        if required_frac <= 0.5:
+            frac = max(frac, required_frac)
+            margin = frac * available_equity_usdt
+            notional = margin * leverage
+            lifted = True
+
+    sized = margin if notional >= min_notional_usdt else 0.0
+
+    return {
+        "value": sized,
+        "reason": (
+            f"size = {'lifted-to-min ' if lifted else ''}"
+            f"floor({exploration_floor:.3f}) or PhixSxM({base_frac:.3f}) "
+            f"x reward({reward_mult:.2f}) x stab({stability_mult:.2f}) "
+            f"x equity({available_equity_usdt:.2f}) @ {leverage:.0f}x "
+            f"-> margin {margin:.2f}, notional {notional:.2f} vs min {min_notional_usdt:.2f} "
+            f"= {sized:.2f}"
+        ),
+        "derivation": {
+            "phi": s.phi,
+            "sovereignty": s.sovereignty,
+            "maturity": maturity,
+            "bank_size": bank_size,
+            "exploration_floor": exploration_floor,
+            "raw_frac": raw_frac,
+            "frac": frac,
+            "margin": margin,
+            "leverage": leverage,
+            "notional": notional,
+            "min_notional": min_notional_usdt,
+            "sized": sized,
+            "lifted_to_min": 1 if lifted else 0,
+        },
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+#  currentLeverage — κ-prox × regimeStab × surpDisc × flatMult
+# ═══════════════════════════════════════════════════════════════
+
+
+def current_leverage(
+    s: ExecBasinState,
+    *,
+    max_leverage_boundary: float,
+    mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+    tape_trend: float = 0.0,
+) -> dict[str, Any]:
+    kappa_dist = abs(s.kappa - KAPPA_STAR)
+    kappa_proxim = float(np.exp(-kappa_dist / 20.0))
+    regime_stability = (
+        s.regime_weights.get("equilibrium", 0.0)
+        + 0.5 * s.regime_weights.get("efficient", 0.0)
+    )
+    surprise_discount = 1.0 - 0.5 * s.neurochemistry.norepinephrine
+
+    mode_floor = MODE_PROFILES[mode].sovereign_cap_floor
+    sovereign_cap = max(mode_floor, 3.0 + 30.0 * s.sovereignty)
+
+    # v0.6.7 aggressive flatness boost (K=10, BOOST=0.8)
+    FLATNESS_K = 10.0
+    FLATNESS_BOOST = 0.8
+    flatness = max(0.0, 1.0 - abs(tape_trend) * FLATNESS_K)
+    flat_mult = 1.0 + FLATNESS_BOOST * flatness
+
+    newborn = s.sovereignty < 0.1
+    if newborn:
+        raw_lev = sovereign_cap * 0.8
+    else:
+        raw_lev = sovereign_cap * kappa_proxim * regime_stability * surprise_discount * flat_mult
+
+    lev = max(1, min(int(max_leverage_boundary), round(raw_lev)))
+
+    return {
+        "value": lev,
+        "reason": (
+            f"lev = sovcap({sovereign_cap:.1f}) x k-prox({kappa_proxim:.3f}) "
+            f"x regstab({regime_stability:.2f}) x surp({surprise_discount:.2f}) "
+            f"x flat({flat_mult:.2f}) -> {lev}x"
+        ),
+        "derivation": {
+            "kappa": s.kappa,
+            "kappa_dist": kappa_dist,
+            "kappa_proxim": kappa_proxim,
+            "regime_stability": regime_stability,
+            "surprise_discount": surprise_discount,
+            "sovereign_cap": sovereign_cap,
+            "flat_mult": flat_mult,
+            "raw_lev": raw_lev,
+            "lev": lev,
+        },
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+#  shouldProfitHarvest — trailing + trend-flip (v0.6.1)
+# ═══════════════════════════════════════════════════════════════
+
+
+def should_profit_harvest(
+    *,
+    unrealized_pnl_usdt: float,
+    peak_pnl_usdt: float,
+    notional_usdt: float,
+    tape_trend: float,
+    held_side: Side,
+    s: ExecBasinState,
+) -> dict[str, Any]:
+    if notional_usdt <= 0:
+        return {"value": False, "reason": "no position", "derivation": {}}
+
+    current_frac = unrealized_pnl_usdt / notional_usdt
+    peak_frac = max(peak_pnl_usdt, 0.0) / notional_usdt
+
+    activation = max(0.002, 0.004 - 0.002 * s.neurochemistry.dopamine)
+    giveback = 0.30 + 0.20 * (1 - s.neurochemistry.serotonin)
+    trailing_floor = peak_frac * (1.0 - giveback)
+
+    alignment_now = tape_trend if held_side == "long" else -tape_trend
+
+    if peak_frac >= activation and current_frac < trailing_floor and current_frac > 0:
+        return {
+            "value": True,
+            "reason": (
+                f"trailing_harvest: peak {peak_frac*100:.3f}% -> "
+                f"now {current_frac*100:.3f}% < {trailing_floor*100:.3f}% floor"
+            ),
+            "derivation": {
+                "current_frac": current_frac,
+                "peak_frac": peak_frac,
+                "trailing_floor": trailing_floor,
+                "activation": activation,
+                "giveback": giveback,
+                "exit_type_bit": 2,
+            },
+        }
+
+    TREND_FLIP_THRESHOLD = -0.25
+    if current_frac > 0 and alignment_now <= TREND_FLIP_THRESHOLD and peak_frac >= activation:
+        return {
+            "value": True,
+            "reason": (
+                f"trend_flip_harvest: pnl +{current_frac*100:.3f}%, "
+                f"tape flipped (align={alignment_now:.2f})"
+            ),
+            "derivation": {
+                "current_frac": current_frac,
+                "peak_frac": peak_frac,
+                "alignment": alignment_now,
+                "exit_type_bit": 3,
+            },
+        }
+
+    return {
+        "value": False,
+        "reason": (
+            f"profit_hold: current {current_frac*100:.3f}%, peak {peak_frac*100:.3f}%, "
+            f"trail-floor {trailing_floor*100:.3f}%"
+        ),
+        "derivation": {
+            "current_frac": current_frac,
+            "peak_frac": peak_frac,
+            "trailing_floor": trailing_floor,
+            "activation": activation,
+            "giveback": giveback,
+            "alignment": alignment_now,
+        },
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+#  shouldScalpExit — Φ-derived TP / SL (v0.4)
+# ═══════════════════════════════════════════════════════════════
+
+
+def should_scalp_exit(
+    *,
+    unrealized_pnl_usdt: float,
+    notional_usdt: float,
+    s: ExecBasinState,
+    mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+) -> dict[str, Any]:
+    if notional_usdt <= 0:
+        return {"value": False, "reason": "no position notional", "derivation": {}}
+
+    pnl_frac = unrealized_pnl_usdt / notional_usdt
+    nc = s.neurochemistry
+    profile = MODE_PROFILES[mode]
+    tp_thr = max(0.003, profile.tp_base_frac - 0.003 * nc.dopamine + 0.005 * s.phi)
+    sl_thr = tp_thr * profile.sl_ratio
+
+    if pnl_frac >= tp_thr:
+        return {
+            "value": True,
+            "reason": f"take_profit: {pnl_frac*100:.3f}% >= {tp_thr*100:.3f}%",
+            "derivation": {
+                "pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr,
+                "exit_type_bit": 1,
+            },
+        }
+    if pnl_frac <= -sl_thr:
+        return {
+            "value": True,
+            "reason": f"stop_loss: {pnl_frac*100:.3f}% <= -{sl_thr*100:.3f}%",
+            "derivation": {
+                "pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr,
+                "exit_type_bit": -1,
+            },
+        }
+    return {
+        "value": False,
+        "reason": (
+            f"scalp hold: pnl {pnl_frac*100:.3f}% in "
+            f"[-{sl_thr*100:.3f}%, {tp_thr*100:.3f}%]"
+        ),
+        "derivation": {"pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr},
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+#  shouldDCAAdd — five guard rails (v0.6.2)
+# ═══════════════════════════════════════════════════════════════
+
+
+DCA_MAX_ADDS_PER_POSITION = 1
+DCA_COOLDOWN_MS = 15 * 60 * 1000
+DCA_BETTER_PRICE_FRAC = 0.01
+DCA_MIN_SOVEREIGNTY = 0.1
+
+
+def should_dca_add(
+    *,
+    held_side: Side,
+    side_candidate: Side,
+    current_price: float,
+    initial_entry_price: float,
+    add_count: int,
+    last_add_at_ms: float,
+    now_ms: float,
+    sovereignty: float,
+) -> dict[str, Any]:
+    if held_side != side_candidate:
+        return {
+            "value": False,
+            "reason": f"side mismatch ({side_candidate} vs held {held_side})",
+            "derivation": {"rule": 1},
+        }
+    if add_count >= DCA_MAX_ADDS_PER_POSITION:
+        return {
+            "value": False,
+            "reason": f"add cap reached ({add_count}/{DCA_MAX_ADDS_PER_POSITION})",
+            "derivation": {"rule": 4, "add_count": add_count},
+        }
+    if now_ms - last_add_at_ms < DCA_COOLDOWN_MS:
+        sec_remain = round((DCA_COOLDOWN_MS - (now_ms - last_add_at_ms)) / 1000)
+        return {
+            "value": False,
+            "reason": f"cooldown ({sec_remain}s remaining)",
+            "derivation": {"rule": 3, "sec_remain": sec_remain},
+        }
+    if sovereignty < DCA_MIN_SOVEREIGNTY:
+        return {
+            "value": False,
+            "reason": f"sovereignty too low ({sovereignty:.3f} < {DCA_MIN_SOVEREIGNTY})",
+            "derivation": {"rule": 5, "sovereignty": sovereignty},
+        }
+    price_delta = (current_price - initial_entry_price) / initial_entry_price
+    price_is_better = (
+        price_delta < -DCA_BETTER_PRICE_FRAC
+        if held_side == "long"
+        else price_delta > DCA_BETTER_PRICE_FRAC
+    )
+    if not price_is_better:
+        return {
+            "value": False,
+            "reason": (
+                f"price not better ({price_delta*100:.3f}% from entry vs "
+                f"±{DCA_BETTER_PRICE_FRAC*100:.1f}% required)"
+            ),
+            "derivation": {"rule": 2, "price_delta": price_delta},
+        }
+    return {
+        "value": True,
+        "reason": (
+            f"DCA_OK: {price_delta*100:.2f}% from entry, "
+            f"addCount={add_count}, sov={sovereignty:.2f}"
+        ),
+        "derivation": {
+            "rule": 0,
+            "price_delta": price_delta,
+            "add_count": add_count,
+            "sovereignty": sovereignty,
+        },
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+#  shouldExit — Loop 2: perception vs identity basin
+# ═══════════════════════════════════════════════════════════════
+
+
+def should_exit(
+    *,
+    perception: np.ndarray,
+    strategy_forecast: np.ndarray,
+    held_side: Optional[Side],
+    s: ExecBasinState,
+) -> dict[str, Any]:
+    if held_side is None:
+        return {"value": False, "reason": "no open position", "derivation": {}}
+
+    disagreement = fisher_rao_distance(perception, strategy_forecast)
+    threshold = 0.55 * (1.0 + 0.5 * s.neurochemistry.norepinephrine)
+    if disagreement > threshold:
+        return {
+            "value": True,
+            "reason": (
+                f"kernel disagreement {disagreement:.3f} > {threshold:.3f} - exit"
+            ),
+            "derivation": {"disagreement": disagreement, "threshold": threshold},
+        }
+    return {
+        "value": False,
+        "reason": f"holding: disagreement {disagreement:.3f} < {threshold:.3f}",
+        "derivation": {"disagreement": disagreement, "threshold": threshold},
+    }

--- a/ml-worker/src/monkey_kernel/modes.py
+++ b/ml-worker/src/monkey_kernel/modes.py
@@ -1,0 +1,215 @@
+"""
+modes.py — Cognitive mode detector (v0.7.2 Python port).
+
+Ports /home/braden/Desktop/Dev/QIG_QFI/qig-verification/src/qigv/analysis/
+cognitive_modes_refined.py into Monkey's Python kernel. Four modes
+with geometric signatures — each has a trading-behaviour profile
+(TP / SL / entry bias / size floor / leverage floor / tick cadence).
+
+Basin-proximity is primary; motivators resolve ties. Canonical
+Principles v2.1 P14 Variable Separation — modes are DERIVED VIEWS of
+Φ / κ / regime / NC state, not free parameters.
+
+Reference: pre-existing TS modes.ts port, now superseded by this
+file once the TS adapter cuts over under MONKEY_KERNEL_PY.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import fisher_rao_distance
+
+from .perception_scalars import basin_direction
+from .state import NeurochemicalState
+
+
+class MonkeyMode(StrEnum):
+    EXPLORATION = "exploration"
+    INVESTIGATION = "investigation"
+    INTEGRATION = "integration"
+    DRIFT = "drift"
+
+
+@dataclass(frozen=True)
+class ModeProfile:
+    tp_base_frac: float       # TP threshold as fraction of notional
+    sl_ratio: float           # SL as fraction of TP (asymmetric R:R)
+    entry_threshold_scale: float  # multiplier on currentEntryThreshold
+    size_floor: float         # exploration floor (fraction of equity)
+    sovereign_cap_floor: float  # newborn sovereignCap floor for leverage
+    tick_ms: int
+    can_enter: bool
+    description: str
+
+
+MODE_PROFILES: dict[MonkeyMode, ModeProfile] = {
+    MonkeyMode.EXPLORATION: ModeProfile(
+        tp_base_frac=0.004,
+        sl_ratio=0.6,
+        entry_threshold_scale=0.9,
+        size_floor=0.08,
+        sovereign_cap_floor=15,
+        tick_ms=15_000,
+        can_enter=True,
+        description="volatile / hunting — tight TP, fast cadence",
+    ),
+    MonkeyMode.INVESTIGATION: ModeProfile(
+        tp_base_frac=0.008,
+        sl_ratio=0.5,
+        entry_threshold_scale=1.0,
+        size_floor=0.10,
+        sovereign_cap_floor=20,
+        tick_ms=30_000,
+        can_enter=True,
+        description="trend forming — medium TP, full size",
+    ),
+    MonkeyMode.INTEGRATION: ModeProfile(
+        tp_base_frac=0.020,
+        sl_ratio=0.3,
+        entry_threshold_scale=1.1,
+        size_floor=0.12,
+        sovereign_cap_floor=25,
+        tick_ms=60_000,
+        can_enter=True,
+        description="trend confirmed — wide TP, let winners run",
+    ),
+    MonkeyMode.DRIFT: ModeProfile(
+        tp_base_frac=0.005,
+        sl_ratio=0.6,
+        entry_threshold_scale=99.0,
+        size_floor=0.0,
+        sovereign_cap_floor=1,
+        tick_ms=60_000,
+        can_enter=False,
+        description="sideways noise — observe only",
+    ),
+}
+
+
+@dataclass
+class Motivators:
+    """Five scalar fields per Refined Cognitive Modes §."""
+
+    surprise: float       # norepinephrine (unexpectedness)
+    curiosity: float      # ΔΦ (volume expansion)
+    investigation: float  # −Δdrift (attractor pursuit)
+    integration: float    # 1 − CV(f_health over window)
+    frustration: float    # persistent drift without investigation
+
+
+def compute_motivators(
+    *,
+    phi_history: list[float],
+    drift_history: list[float],
+    fhealth_history: list[float],
+    neurochemistry: NeurochemicalState,
+) -> Motivators:
+    curiosity = (
+        phi_history[-1] - phi_history[-2] if len(phi_history) >= 2 else 0.0
+    )
+    investigation = (
+        drift_history[-2] - drift_history[-1] if len(drift_history) >= 2 else 0.0
+    )
+
+    integration = 0.0
+    recent = fhealth_history[-10:]
+    if len(recent) >= 3:
+        arr = np.asarray(recent, dtype=np.float64)
+        mean = float(arr.mean())
+        if mean > 0:
+            cv = float(arr.std() / mean)
+            integration = max(0.0, 1.0 - cv * 10.0)
+
+    surprise = neurochemistry.norepinephrine
+    drift_mag = abs(drift_history[-1]) if drift_history else 0.0
+    frustration = drift_mag if investigation <= 0 else 0.0
+
+    return Motivators(
+        surprise=surprise,
+        curiosity=curiosity,
+        investigation=investigation,
+        integration=integration,
+        frustration=frustration,
+    )
+
+
+def detect_mode(
+    *,
+    basin: np.ndarray,
+    identity_basin: np.ndarray,
+    phi: float,  # kept for signature parity with TS; unused here
+    kappa: float,  # kept for signature parity with TS; unused here
+    basin_velocity: float,
+    neurochemistry: NeurochemicalState,
+    phi_history: list[float],
+    fhealth_history: list[float],
+    drift_history: list[float],
+) -> dict[str, Any]:
+    """Classify current cognitive mode from derived state.
+
+    Returns:
+      {
+        "mode": MonkeyMode,
+        "reason": str,
+        "derivation": { driftNow, fHealthNow, basinVelocity, motivators... }
+      }
+    """
+    drift_now = fisher_rao_distance(basin, identity_basin)
+    fh_now = fhealth_history[-1] if fhealth_history else 0.5
+    mot = compute_motivators(
+        phi_history=phi_history,
+        drift_history=drift_history,
+        fhealth_history=fhealth_history,
+        neurochemistry=neurochemistry,
+    )
+
+    # v0.6.5 gate — basinDirection blocks DRIFT. A clear directional
+    # reading means she is NOT in an ambiguous state, regardless of
+    # fHealth (which is structurally pinned ≥ 0.97 by noise-floor dims).
+    bd = basin_direction(basin)
+    has_direction = abs(bd) > 0.30
+
+    if (
+        fh_now > 0.97
+        and abs(mot.curiosity) < 0.005
+        and basin_velocity < 0.015
+        and not has_direction
+    ):
+        mode = MonkeyMode.DRIFT
+        reason = (
+            f"fh={fh_now:.3f} diffuse, curiosity={mot.curiosity:.4f} flat, "
+            f"bv={basin_velocity:.3f}, basinDir={bd:.2f} flat"
+        )
+    elif drift_now > 0.30 and mot.curiosity > 0.002:
+        mode = MonkeyMode.EXPLORATION
+        reason = f"drift={drift_now:.3f}>0.3, curiosity={mot.curiosity:.4f}>0"
+    elif drift_now < 0.15 and basin_velocity < 0.02 and mot.integration > 0.3:
+        mode = MonkeyMode.INTEGRATION
+        reason = (
+            f"drift={drift_now:.3f}<0.15, bv={basin_velocity:.3f}<0.02, "
+            f"integ={mot.integration:.3f}"
+        )
+    else:
+        mode = MonkeyMode.INVESTIGATION
+        reason = f"drift={drift_now:.3f}, invest={mot.investigation:.4f}"
+
+    return {
+        "mode": mode.value,
+        "reason": reason,
+        "derivation": {
+            "drift_now": drift_now,
+            "f_health_now": fh_now,
+            "basin_velocity": basin_velocity,
+            "basin_direction": bd,
+            "curiosity": mot.curiosity,
+            "investigation": mot.investigation,
+            "integration": mot.integration,
+            "surprise": mot.surprise,
+            "frustration": mot.frustration,
+        },
+    }

--- a/ml-worker/src/monkey_kernel/perception_scalars.py
+++ b/ml-worker/src/monkey_kernel/perception_scalars.py
@@ -1,0 +1,50 @@
+"""
+perception_scalars.py — signed scalars read from basin + tape (v0.7.2).
+
+These are NOT perception kernel internals — just the two scalar signals
+the executive needs to gate direction: basinDirection (from the basin's
+momentum spectrum dims 7..14) and trendProxy (log-return over last N
+candles, tanh-squashed to [-1, 1]).
+
+Both are computed server-side so the TS orchestrator doesn't have to
+ship an OHLCV window AND basin for every tick — the Python side
+receives the basin (required for QIG primitives) plus the most-recent
+OHLCV window and derives both locally.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+def basin_direction(basin: np.ndarray) -> float:
+    """Signed directional reading from the momentum-spectrum dims 7..14.
+
+    Returns a scalar in [-1, 1]. Positive = recent uptrend seen in basin;
+    negative = downtrend; magnitude = conviction. Computed by centering
+    the 8 momentum-spectrum dims at 0.5 (their sigmoid-normalised
+    neutral) and tanh-squashing the sum. Independent of ml-worker's
+    opinion — Monkey's own directional reading.
+    """
+    # Sum of (dim - 0.5) across dims 7..14 (inclusive, 8 dims).
+    centred_sum = float(np.sum(basin[7:15]) - 0.5 * 8)
+    return float(np.tanh(centred_sum * 2.0))
+
+
+def trend_proxy(closes: Sequence[float], lookback: int = 50) -> float:
+    """Log-return over lookback candles, tanh-squashed to [-1, 1].
+
+    With 15-minute candles and lookback=50 this sees ~12.5 hours of
+    tape — long enough to filter scalp noise, short enough to pivot on
+    real reversals. At K×log-return>>1, saturates near ±1.
+    """
+    if len(closes) < lookback + 1:
+        return 0.0
+    last = float(closes[-1])
+    base = float(closes[-1 - lookback])
+    if base <= 0 or last <= 0:
+        return 0.0
+    r = float(np.log(last / base))
+    return float(np.tanh(r * 50.0))


### PR DESCRIPTION
## Continues v0.7 migration

Ships Monkey's full decision layer + mode classifier in Python, using `qig_core_local` primitives directly. No behaviour change — TS orchestrator still uses its in-process path. Next PR wires the adapter under `MONKEY_KERNEL_PY`.

## New files (`ml-worker/src/monkey_kernel/`)
- **`perception_scalars.py`** — `basin_direction()` (momentum dims 7..14) and `trend_proxy()` (log-return tanh-squashed)
- **`modes.py`** — MonkeyMode enum, MODE_PROFILES table, compute_motivators, detect_mode with v0.6.5 basinDirection gate blocking DRIFT
- **`executive.py`** — six pure decision functions:
  - `current_entry_threshold` (§5.2 formula)
  - `current_position_size` (v0.6.6 lift-to-min adaptation)
  - `current_leverage` (v0.6.7 flatness boost K=10 BOOST=0.8)
  - `should_scalp_exit` (TP/SL)
  - `should_profit_harvest` (trailing + trend-flip)
  - `should_dca_add` (five guard rails)
  - `should_exit` (Loop 2 FR distance)

## FastAPI endpoints (`main.py`)
- `POST /monkey/executive/decide` — aggregate pass: entry threshold + leverage + size + harvest + scalp + DCA + loop2 + mode + side override
- `POST /monkey/mode/detect` — standalone mode classifier

## Purity / correctness
- Purity check: **6 files clean** ✓
- Smoke test end-to-end: entry T clamps to min, leverage=21 with flatness boost, sized=$1.16 with lift-to-minimum clearing \$23.17 ETH min on tight \$5.20 equity

## No behaviour change
The TS Monkey continues to run as-is. This PR only adds the Python surface. Next: v0.7.3 wires TS `executive_client.ts` + `mode_client.ts` to call these endpoints under `MONKEY_KERNEL_PY=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)