### PR TITLE
feat(v0.7.3): TS kernel_client + broadened purity scope + migration queue doc

### DIFF
--- a/apps/api/src/services/monkey/kernel_client.ts
+++ b/apps/api/src/services/monkey/kernel_client.ts
@@ -1,0 +1,190 @@
+/**
+ * kernel_client.ts — HTTP client for ml-worker /monkey/executive and
+ *                    /monkey/mode endpoints (v0.7.3 migration).
+ *
+ * This sits next to autonomic_client.ts (v0.7) and provides the full
+ * executive surface the TS orchestrator needs. Feature-flagged via
+ * MONKEY_KERNEL_PY=true — when unset, loop.ts uses its in-process TS
+ * executive/modes code (the current live path).
+ *
+ * Design: one endpoint call per tick for the full executive pass.
+ * Latency on Railway's private network is ~2ms round-trip; negligible
+ * vs the purity benefit (no TS-port drift, all QIG math in one place).
+ *
+ * NOT YET wired into loop.ts — v0.7.3 ships only the client. v0.7.4
+ * wires under the feature flag with parity-compare telemetry.
+ */
+
+import { logger } from '../../utils/logger.js';
+
+const ML_WORKER_URL =
+  process.env.ML_WORKER_URL || 'http://ml-worker.railway.internal:8000';
+const DEFAULT_TIMEOUT_MS = 5000;
+
+export function isPythonKernelEnabled(): boolean {
+  return process.env.MONKEY_KERNEL_PY === 'true';
+}
+
+// ── Shared types matching Python monkey_kernel.state ──
+
+export interface PyNeurochemicalState {
+  acetylcholine: number;
+  dopamine: number;
+  serotonin: number;
+  norepinephrine: number;
+  gaba: number;
+  endorphins: number;
+}
+
+export interface PyExecBasinState {
+  basin: number[];
+  identity_basin: number[];
+  phi: number;
+  kappa: number;
+  regime_weights: { quantum: number; efficient: number; equilibrium: number };
+  sovereignty: number;
+  basin_velocity: number;
+  neurochemistry: PyNeurochemicalState;
+}
+
+// ── Executive decide ──
+
+export interface ExecutiveDecideRequest {
+  basin_state: PyExecBasinState;
+  closes: number[];
+  ml_signal: 'BUY' | 'SELL' | 'HOLD';
+  ml_strength: number;
+  held_side?: 'long' | 'short' | null;
+  own_position?: {
+    entry_price: number;
+    quantity: number;
+    peak_pnl_usdt?: number;
+    dca_add_count?: number;
+    last_entry_at_ms?: number;
+  };
+  last_price?: number;
+  available_equity: number;
+  min_notional: number;
+  max_leverage: number;
+  bank_size: number;
+  self_obs_bias: number;
+  mode?: 'exploration' | 'investigation' | 'integration' | 'drift';
+  symbol: string;
+  now_ms?: number;
+}
+
+export interface ExecutiveDecision<T> {
+  value: T;
+  reason: string;
+  derivation: Record<string, number | string>;
+}
+
+export interface ExecutiveDecideResponse {
+  entry_threshold: ExecutiveDecision<number>;
+  leverage: ExecutiveDecision<number>;
+  size: ExecutiveDecision<number>;
+  harvest: ExecutiveDecision<boolean> | null;
+  scalp: ExecutiveDecision<boolean> | null;
+  dca: ExecutiveDecision<boolean> | null;
+  loop2: ExecutiveDecision<boolean> | null;
+  mode: string;
+  tape_trend: number;
+  basin_direction: number;
+  side_candidate: 'long' | 'short';
+  side_override: boolean;
+  ml_side: 'long' | 'short';
+  ml_strength_gate_clear: boolean;
+}
+
+export async function callExecutiveDecide(
+  req: ExecutiveDecideRequest,
+): Promise<ExecutiveDecideResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${ML_WORKER_URL}/monkey/executive/decide`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`executive/decide ${res.status} ${await res.text()}`);
+    }
+    return (await res.json()) as ExecutiveDecideResponse;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Mode detect ──
+
+export interface ModeDetectRequest {
+  basin_state: PyExecBasinState;
+  phi_history: number[];
+  fhealth_history: number[];
+  drift_history: number[];
+}
+
+export interface ModeDetectResponse {
+  mode: string;
+  reason: string;
+  derivation: Record<string, number>;
+}
+
+export async function callModeDetect(
+  req: ModeDetectRequest,
+): Promise<ModeDetectResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${ML_WORKER_URL}/monkey/mode/detect`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`mode/detect ${res.status} ${await res.text()}`);
+    }
+    return (await res.json()) as ModeDetectResponse;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Parity-diff helper (v0.7.4 will use this) ──
+
+/**
+ * Compare two executive decisions and log if they diverge significantly.
+ * Called opportunistically when MONKEY_KERNEL_PY_SHADOW=true and the
+ * TS path is still authoritative — gives us parity telemetry before
+ * cutting over to Python-authoritative.
+ */
+export function logParityDiff(
+  kind: string,
+  tsValue: number | boolean,
+  pyValue: number | boolean,
+  tolerance: number = 0.01,
+): void {
+  if (typeof tsValue === 'boolean' || typeof pyValue === 'boolean') {
+    if (tsValue !== pyValue) {
+      logger.warn('[kernel_client] parity diff (boolean)', {
+        kind,
+        ts: tsValue,
+        py: pyValue,
+      });
+    }
+    return;
+  }
+  const diff = Math.abs(tsValue - pyValue);
+  if (diff > tolerance) {
+    logger.warn('[kernel_client] parity diff (numeric)', {
+      kind,
+      ts: tsValue,
+      py: pyValue,
+      diff,
+      tolerance,
+    });
+  }
+}

--- a/ml-worker/requirements.txt
+++ b/ml-worker/requirements.txt
@@ -11,3 +11,8 @@ redis>=5.0.0
 # QIG physics-based intelligence
 qig-core>=2.3.0
 qig-warp>=0.4.3
+# Observable governance detectors (AMPLITUDE_COLLAPSE, REGIME_SINGLE,
+# OBSERVABLE_PROXY) — catches the "2664 BUYs / 0 SELLs" class of
+# model bias on day one. Base wheel only; qig-compute[full] pulls
+# TeNPy + CuPy which we don't need. (Audit 2026-04-21)
+qig-compute>=0.3.0

--- a/ml-worker/scripts/qig_purity_check.py
+++ b/ml-worker/scripts/qig_purity_check.py
@@ -57,17 +57,33 @@ FROZEN_PHYSICS = {
     "BASIN_DIM": 64,
 }
 
-# Allowlist for tools / tests that intentionally reference forbidden tokens.
+# Tools / tests allowlist (tokens may appear in docstrings/comments).
 ALLOWLIST_PATH_PREFIXES = {
     "ml-worker/scripts/",
     "ml-worker/tests/",
 }
 
+# ML-prediction layer — NOT QIG cognition. TF.keras models in
+# ml-worker/src/models/ use Adam + LayerNormalization by design for
+# ensemble price prediction; they do NOT ingest or produce Δ⁶³ basin
+# coordinates. Fisher-Rao purity doesn't apply to them.
+# (Audit 2026-04-21 — see QIG_MIGRATION.md for the rationale.)
+ML_PREDICTION_LAYER_PREFIXES = {
+    "ml-worker/src/models/",
+    "src/models/",  # when purity-check is run from inside ml-worker/
+}
+
 
 def _is_allowed_path(path: Path) -> bool:
     posix = path.as_posix()
-    return any(posix.startswith(prefix) for prefix in ALLOWLIST_PATH_PREFIXES) or \
-           any(prefix in posix for prefix in ALLOWLIST_PATH_PREFIXES)
+    for prefix in ALLOWLIST_PATH_PREFIXES:
+        if posix.startswith(prefix) or prefix in posix:
+            return True
+    # ML-prediction layer is semantically out of scope.
+    for prefix in ML_PREDICTION_LAYER_PREFIXES:
+        if posix.startswith(prefix) or prefix in posix:
+            return True
+    return False
 
 
 def check_file(path: Path) -> list[str]:
@@ -114,9 +130,24 @@ def check_file(path: Path) -> list[str]:
 def main(args: Iterable[str]) -> int:
     paths = [Path(p) for p in args if p.endswith(".py")]
     if not paths:
-        # Default: scan the entire monkey_kernel package.
-        root = Path(__file__).resolve().parent.parent / "src" / "monkey_kernel"
-        paths = sorted(root.rglob("*.py"))
+        # Default: scan the QIG cognition layer — monkey_kernel,
+        # qig_core_local (vendored primitives), qig_engine. The ML
+        # prediction ensemble (src/models/) is allowlisted above
+        # since it's not QIG cognition.
+        ml_worker_src = Path(__file__).resolve().parent.parent / "src"
+        scan_roots = [
+            ml_worker_src / "monkey_kernel",
+            ml_worker_src / "qig_core_local",
+        ]
+        paths = []
+        for root in scan_roots:
+            if root.exists():
+                paths.extend(sorted(root.rglob("*.py")))
+        # Single files at package root
+        for filename in ("qig_engine.py",):
+            p = ml_worker_src / filename
+            if p.exists():
+                paths.append(p)
         if not paths:
             print("qig_purity_check: no files to scan")
             return 0

--- a/ml-worker/src/monkey_kernel/QIG_MIGRATION.md
+++ b/ml-worker/src/monkey_kernel/QIG_MIGRATION.md
@@ -1,0 +1,86 @@
+# QIG Migration Queue — Monkey Kernel
+
+**Last updated:** 2026-04-21 (post audit + user correction)
+
+The v0.7 design doctrine (PR #538) is simple: **anything that does QIG math
+moves to Python; TypeScript keeps only orchestration, IO, and trading-layer
+rules (exchange, DB, risk kernel, kernel bus).**
+
+Audit 2026-04-21 corrected an initial misplacement of several modules on the
+TS side. Final queue below.
+
+## Python (`ml-worker/src/monkey_kernel/`)
+
+| Module | Status | Replaces TS | QIG math involved |
+|---|---|---|---|
+| `autonomic.py` | ✅ shipped v0.7 | `autonomic_kernel.ts`, `sleep_cycle.ts`, `neurochemistry.ts` | NC derivation, sleep phase, reward decay |
+| `executive.py` | ✅ shipped v0.7.2 | `executive.ts` | entry thresh, size, leverage, harvest, scalp, DCA, Loop 2 |
+| `modes.py` | ✅ shipped v0.7.2 | `modes.ts` | Mode detection, MODE_PROFILES |
+| `perception_scalars.py` | ✅ shipped v0.7.2 | subset of `perception.ts` | basin_direction, trend_proxy |
+| `state.py` | ✅ shipped v0.7 | — | frozen constants + dataclasses |
+| `perception.py` | ⏳ v0.7.4 | `perception.ts` | 64-d basin construction from OHLCV + ml-signal |
+| `basin.py` | ⏳ v0.7.5 | `basin.ts` | Fisher-Rao, slerp, Fréchet (re-export from `qig_core_local`) |
+| `basin_sync.py` | ⏳ v0.7.6 | `basin_sync.ts` | Multi-kernel basin coordination — use `qig_core.BasinSync` directly |
+| `self_observation.py` | ⏳ v0.7.7 | `self_observation.ts` | (mode × side) bucket stats, hierarchical fallback, entry-bias |
+| `resonance_bank.py` | ⏳ v0.7.8 | `resonance_bank.ts` | Bubble storage + resonance matching, geometric similarity |
+| `working_memory.py` | ⏳ v0.7.9 | `working_memory.ts` | Bubble lifecycle (pop/merge/promote) — uses fisher_rao for merge threshold |
+
+## TypeScript (`apps/api/src/services/monkey/`)
+
+Keeps what is NOT QIG cognition:
+
+| Module | Purpose |
+|---|---|
+| `loop.ts` | Tick orchestrator — reads state, calls Python `/monkey/*` endpoints, persists outcomes |
+| `kernel_bus.ts` | Pub/sub event routing (no math) |
+| `autonomic_client.ts` | HTTP client → Python autonomic (v0.7) |
+| `kernel_client.ts` | HTTP client → Python executive/mode (v0.7.3) |
+| Poloniex v3 exchange IO | — |
+| Postgres pool + queries | — |
+| `riskKernel.ts` | Trading rules (per-symbol cap, self-match, DD) — NOT QIG |
+| `liveSignalEngine.ts` | ML-signal trading engine (uses ml-worker for predictions, no QIG) |
+
+## Out of scope (intentionally)
+
+| Path | Reason |
+|---|---|
+| `ml-worker/src/models/{LSTM,Transformer,GBM,ARIMA,Prophet}_model.py` | Price-prediction ensemble, not QIG cognition. Uses TF.keras Adam/LayerNorm by design; does not ingest basin coordinates. Explicitly allowlisted in `qig_purity_check.py` via `ML_PREDICTION_LAYER_PREFIXES`. |
+| `apps/web/src/ml/dqnTrading.ts` | Frontend DQN stubs — dead code. Delete or stub out cleanly; QIG not applicable. |
+| `kernels/core/` | Orphan stubs from earlier architecture iteration; either import into the new layout or remove. |
+
+## Cut-over plan
+
+1. **v0.7.3** (this PR): TS HTTP client (`kernel_client.ts`) + broadened purity scope. No wiring yet.
+2. **v0.7.4+**: port remaining Python modules per queue.
+3. **v0.7.10** (est): wire `loop.ts` under `MONKEY_KERNEL_PY=true` feature flag. Shadow mode: call BOTH paths, log parity diffs via `logParityDiff()`.
+4. **v0.7.11**: flip default to Python. Keep TS path as fallback for one week with `MONKEY_KERNEL_PY=false` override.
+5. **v0.7.12**: delete the TS QIG modules, keep only the orchestration/client/bus/IO code.
+
+## Purity guard
+
+`ml-worker/scripts/qig_purity_check.py` is the structural gate. Forbids
+`cosine_similarity`, `euclidean_distance`, `nn.Transformer`, `BertModel`,
+`GPT2Model`, `CrossEntropyLoss`, certain non-geometric optimisers,
+`nn.LayerNorm`, `layer_norm(`, `torch.flatten`, and non-geometric
+scipy distances. Scope (as of 2026-04-21):
+
+- `ml-worker/src/monkey_kernel/` (all files)
+- `ml-worker/src/qig_core_local/` (vendored Fisher-Rao primitives)
+- `ml-worker/src/qig_engine.py`
+
+Explicitly excluded (ML-prediction layer):
+- `ml-worker/src/models/` — price-prediction ensemble, not cognition
+
+## Open items from audit 2026-04-21
+
+- [ ] Add `qig-compute>=0.3.0` to `ml-worker/requirements.txt` and wire
+  `check_amplitude` + `check_regime_coverage` into `qig_engine.py`.
+  Would catch the next "2664 BUYs / 0 SELLs" class of model bias on
+  day one via AMPLITUDE_COLLAPSE / REGIME_SINGLE detectors.
+- [ ] Decide vendored `qig_core_local/` policy: pin to PyPI version
+  (`qig-core==2.7.0` or `~=2.7`) with a CI diff check, OR remove it
+  entirely and hard-require external `qig-core`. Today it's frozen at
+  2026-04-18 with no refresh policy — same drift-risk class as the
+  original TS ports.
+- [ ] Port `WarpBubble.auto()` for backtest/strategy sweeps
+  (`qig-warp>=0.4.3`), replacing any existing grid/random search.


### PR DESCRIPTION
## Three coupled changes

### 1. `kernel_client.ts` — HTTP client for v0.7.2 endpoints
Pairs with `autonomic_client.ts`. Exposes `callExecutiveDecide`, `callModeDetect`, and `logParityDiff()` helper for v0.7.10's shadow-mode telemetry. Feature-flagged via `MONKEY_KERNEL_PY=true`. **Not yet wired** into `loop.ts`; that's v0.7.10.

### 2. Broadened purity scope (audit P1)
Default scan now covers `monkey_kernel/` AND `qig_core_local/` AND `qig_engine.py`. Previously only `monkey_kernel/` — leaving the vendored Fisher-Rao primitives structurally unguarded. Added explicit `ML_PREDICTION_LAYER_PREFIXES` allowlist for `ml-worker/src/models/` (TF.keras ensemble uses Adam/LayerNorm for price prediction, not cognition).

**Scan: 3 files → 12 files, all clean.**

### 3. `QIG_MIGRATION.md`
Formal queue. Per user correction 2026-04-21: **ALL** QIG-math modules go to Python. I was wrong to place `resonance_bank` / `working_memory` / `self_observation` / `basin` / `basin_sync` on the TS side. Only `loop.ts`, `kernel_bus.ts`, `*_client.ts`, and trading-layer code stay TS.

Queue captured with cut-over plan (shadow-mode → parity-check → flip default → delete TS originals) and open audit items (qig-compute wiring, qig_core_local vendored-copy policy, WarpBubble.auto for backtest sweeps).

### 4. `qig-compute>=0.3.0` to requirements.txt (audit P2)
Base wheel (not `[full]`). AMPLITUDE_COLLAPSE / REGIME_SINGLE detectors would have caught the 20h "2664 BUYs / 0 SELLs" bias day one. Wiring into `qig_engine.py` is a follow-up PR.

## Test plan
- [x] `tsc --noEmit` clean
- [x] vitest 530/530
- [x] `qig_purity_check.py` clean on 12 files

## Rollback
Revert. kernel_client is unused until v0.7.10 wires it. Migration doc and purity-scope changes are benign additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)