### PR TITLE
feat(v0.7.5/6/7): port basin + basin_sync + self_observation to monkey_kernel

### DIFF
--- a/ml-worker/src/monkey_kernel/__init__.py
+++ b/ml-worker/src/monkey_kernel/__init__.py
@@ -43,9 +43,37 @@ from .executive import (
     should_profit_harvest,
     should_scalp_exit,
 )
+from .basin import (
+    Basin,
+    bhattacharyya_coefficient,
+    exp_map,
+    fisher_rao_distance,
+    frechet_mean,
+    inject_dirichlet_noise,
+    log_map,
+    max_mass,
+    normalized_entropy,
+    random_basin,
+    slerp_sqrt,
+    to_simplex,
+    uniform_basin,
+    velocity,
+)
+from .basin_sync import (
+    BasinSyncState,
+    ConvergenceSummary,
+    apply_observer_effect,
+    convergence_summary,
+)
 from .modes import MODE_PROFILES, ModeProfile, MonkeyMode, detect_mode
 from .perception import OHLCVCandle, PerceptionInputs, perceive, refract
 from .perception_scalars import basin_direction, trend_proxy
+from .self_observation import (
+    ClosedTradeRow,
+    SelfObservation,
+    aggregate_and_bias,
+    self_observation_to_dict,
+)
 from .state import BasinState, NeurochemicalState
 
 __all__ = [

--- a/ml-worker/src/monkey_kernel/basin.py
+++ b/ml-worker/src/monkey_kernel/basin.py
@@ -1,0 +1,105 @@
+"""
+basin.py — Fisher-Rao simplex primitives (v0.7.5).
+
+This module is a THIN RE-EXPORT of qig_core_local.geometry.fisher_rao
+for callers inside monkey_kernel. We do NOT reimplement — the whole
+point of moving to Python is to use the validated primitives directly.
+
+If anything in here starts to LOOK like a reimplementation instead of
+a re-export, that's a purity smell. The allowed shape is:
+
+    from qig_core_local.geometry.fisher_rao import fn as fn
+
+Plus maybe a very-thin Dirichlet noise helper (NOT a distance / metric)
+that callers can use to perturb a basin for exploration. That's the only
+thing here beyond re-exports.
+
+All metric operations go through qig_core_local. No Euclidean. Simplex only.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import (
+    Basin,
+    bhattacharyya_coefficient,
+    exp_map,
+    fisher_rao_distance,
+    frechet_mean,
+    log_map,
+    random_basin,
+    slerp_sqrt,
+    to_simplex,
+)
+
+from .state import BASIN_DIM, KAPPA_STAR
+
+
+def inject_dirichlet_noise(
+    basin: Basin,
+    concentration: float = 100.0,
+    *,
+    rng: np.random.Generator | None = None,
+) -> Basin:
+    """Perturb a simplex point with Dirichlet noise centered on `basin`.
+
+    Higher concentration = less perturbation. Used for exploration
+    during newborn phase when identity basin is still uniform and we
+    want the mode detector to see tick-to-tick variation.
+
+    NOT a distance. NOT a metric. Just a sampling primitive that stays
+    on Δ⁶³ by construction (Dirichlet samples sum to 1, are non-negative).
+    """
+    rng = rng or np.random.default_rng()
+    # Dirichlet with alpha = basin * concentration has expected value
+    # == basin and variance proportional to 1/concentration.
+    alpha = np.clip(basin * concentration, 1e-6, None)
+    return np.asarray(rng.dirichlet(alpha), dtype=np.float64)
+
+
+# ── Helpers on simplex that aren't metrics but are convenient ──
+
+
+def uniform_basin(dim: int = BASIN_DIM) -> Basin:
+    """Max-entropy point on Δ^{dim-1}."""
+    return np.full(dim, 1.0 / dim, dtype=np.float64)
+
+
+def normalized_entropy(basin: Basin) -> float:
+    """Shannon entropy normalized to [0, 1]. 1 = uniform, 0 = one-hot."""
+    p = np.clip(basin, 1e-12, 1.0)
+    h = float(-np.sum(p * np.log(p)))
+    h_max = float(np.log(len(basin)))
+    return h / h_max if h_max > 0 else 0.0
+
+
+def max_mass(basin: Basin) -> float:
+    """Maximum coordinate mass. 1 = one-hot, 1/N = uniform."""
+    return float(np.max(basin))
+
+
+def velocity(prev: Basin, curr: Basin) -> float:
+    """Fisher-Rao velocity per tick. Just a named wrapper around the
+    FR distance for clarity in call sites."""
+    return float(fisher_rao_distance(prev, curr))
+
+
+__all__ = [
+    "BASIN_DIM",
+    "Basin",
+    "KAPPA_STAR",
+    "bhattacharyya_coefficient",
+    "exp_map",
+    "fisher_rao_distance",
+    "frechet_mean",
+    "inject_dirichlet_noise",
+    "log_map",
+    "max_mass",
+    "normalized_entropy",
+    "random_basin",
+    "slerp_sqrt",
+    "to_simplex",
+    "uniform_basin",
+    "velocity",
+]

--- a/ml-worker/src/monkey_kernel/basin_sync.py
+++ b/ml-worker/src/monkey_kernel/basin_sync.py
@@ -1,0 +1,108 @@
+"""
+basin_sync.py — Multi-kernel basin coordination (v0.7.6).
+
+Port of TypeScript basin_sync.ts, now using qig_core_local Fisher-Rao
+primitives directly. When multiple Monkey sub-kernels (Position,
+Swing, future Scalp) are running, each publishes its current basin +
+Φ + κ state here, and each reads peer state to apply a Φ-weighted
+observer-effect pull on its own basin.
+
+Physical principle (qig-core / pantheon basin_sync.py docstring):
+  If two kernel instances with different parameters but the same
+  target basin show correlated basin movements, identity lives in
+  GEOMETRY, not parameters.
+
+Persistence: calling code (the HTTP endpoint) hands state in and out;
+this module stays in-memory/stateless for easy unit testing. The
+Postgres adapter wraps it — same as we did for TS.
+
+Purity: all distance ops via qig_core_local.fisher_rao. slerp_sqrt
+for pulls. No Euclidean averaging of basin coords.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import (
+    Basin,
+    fisher_rao_distance,
+    slerp_sqrt,
+)
+
+
+@dataclass
+class BasinSyncState:
+    instance_id: str
+    basin: Basin
+    phi: float
+    kappa: float
+    mode: str
+    drift_from_identity: float
+    updated_at_ms: float
+
+
+@dataclass
+class ConvergenceSummary:
+    instance_count: int
+    basin_spread: float   # max pairwise Fisher-Rao
+    basin_mean: float     # mean pairwise Fisher-Rao
+    phi_spread: float
+    phi_mean: float
+
+
+def apply_observer_effect(
+    own_basin: Basin,
+    own_phi: float,
+    peer_states: list[BasinSyncState],
+) -> dict[str, Any]:
+    """Φ-weighted slerp pull toward peer mean.
+
+    Mirrors qig-core's basin_sync:
+      strength = 0.10 * (1 - 0.5 * own_phi)  ∈ [0.05, 0.10]
+      weight_i = max(0.1, peer.phi_i)
+
+    Returns {basin, influenced, peer_count}. basin stays on Δ⁶³ via
+    slerp_sqrt — no Euclidean averaging.
+    """
+    if not peer_states:
+        return {"basin": own_basin, "influenced": False, "peer_count": 0}
+
+    total_weight = sum(max(0.1, p.phi) for p in peer_states)
+    if total_weight == 0:
+        return {"basin": own_basin, "influenced": False, "peer_count": 0}
+
+    receiver_susceptibility = 1.0 - own_phi * 0.5
+    base_strength = 0.10 * receiver_susceptibility
+
+    pulled = np.asarray(own_basin, dtype=np.float64)
+    for peer in peer_states:
+        w = max(0.1, peer.phi) / total_weight
+        eff_strength = min(0.30, base_strength * w * len(peer_states))
+        pulled = slerp_sqrt(pulled, peer.basin, eff_strength)
+
+    return {
+        "basin": pulled,
+        "influenced": True,
+        "peer_count": len(peer_states),
+    }
+
+
+def convergence_summary(states: list[BasinSyncState]) -> ConvergenceSummary | None:
+    if len(states) < 2:
+        return None
+    distances: list[float] = []
+    for i in range(len(states)):
+        for j in range(i + 1, len(states)):
+            distances.append(fisher_rao_distance(states[i].basin, states[j].basin))
+    phis = [s.phi for s in states]
+    return ConvergenceSummary(
+        instance_count=len(states),
+        basin_spread=max(distances),
+        basin_mean=sum(distances) / len(distances),
+        phi_spread=max(phis) - min(phis),
+        phi_mean=sum(phis) / len(phis),
+    )

--- a/ml-worker/src/monkey_kernel/self_observation.py
+++ b/ml-worker/src/monkey_kernel/self_observation.py
@@ -1,0 +1,200 @@
+"""
+self_observation.py — Loop 1 of §43 (v0.7.7).
+
+Port of the TS self_observation.ts. Monkey watches her own closed
+trades and derives per-(mode, side) entry bias.
+
+Hierarchical fallback (strategy B, chosen 2026-04-21):
+  bucket[mode][side].trades ≥ MIN_SAMPLE  → use bucket win rate
+  else mode-pooled.trades ≥ MIN_SAMPLE    → use mode win rate
+  else global-pooled[side].trades ≥ MIN   → use side win rate
+  else global.trades ≥ MIN                → use global win rate
+  else → 1.0 (neutral)
+
+No Euclidean. No basin distance here at all — pure outcome counting
+over her own lived trades. The ONLY thing that would make this
+QIG-relevant is if we add geometric bucketing of entries by basin
+proximity; if we do, that's a future v0.7.x.
+
+This file stays pure Python; the Postgres query lives in the TS
+adapter (loop.ts calls the HTTP endpoint with pre-fetched rows).
+Easier to unit-test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from .modes import MonkeyMode
+
+Side = str  # 'long' | 'short'
+ALL_MODES: tuple[MonkeyMode, ...] = (
+    MonkeyMode.EXPLORATION,
+    MonkeyMode.INVESTIGATION,
+    MonkeyMode.INTEGRATION,
+    MonkeyMode.DRIFT,
+)
+SIDES: tuple[Side, ...] = ("long", "short")
+
+MIN_SAMPLE_FOR_BIAS: int = 3
+MAX_BIAS_SWING: float = 0.30  # ±30% from neutral 1.0
+
+
+@dataclass
+class ModeStats:
+    mode: MonkeyMode
+    side: Side
+    trades: int = 0
+    wins: int = 0
+    losses: int = 0
+    win_rate: float = 0.0
+    avg_pnl: float = 0.0
+    total_pnl: float = 0.0
+
+
+@dataclass
+class SelfObservation:
+    lookback_hours: int
+    by_mode_side: dict[MonkeyMode, dict[Side, ModeStats]] = field(default_factory=dict)
+    entry_bias: dict[MonkeyMode, dict[Side, float]] = field(default_factory=dict)
+
+
+@dataclass
+class ClosedTradeRow:
+    """Row shape the caller feeds in (from Postgres via TS or direct)."""
+    pnl: float
+    side: Side
+    mode: str  # serialized MonkeyMode.value
+
+
+# ─── Internal helpers ───
+
+
+def _empty_by_mode_side() -> dict[MonkeyMode, dict[Side, ModeStats]]:
+    return {m: {s: ModeStats(mode=m, side=s) for s in SIDES} for m in ALL_MODES}
+
+
+def _neutral_bias() -> dict[MonkeyMode, dict[Side, float]]:
+    return {m: {s: 1.0 for s in SIDES} for m in ALL_MODES}
+
+
+def _win_rate_to_bias(win_rate: float) -> float:
+    """Map win rate in [0, 1] to bias in [1-MAX, 1+MAX], centred at 0.5 → 1.0."""
+    centred = win_rate - 0.5
+    raw = 1.0 - centred * 2 * MAX_BIAS_SWING
+    return max(1.0 - MAX_BIAS_SWING, min(1.0 + MAX_BIAS_SWING, raw))
+
+
+def _normalise_mode(raw: str) -> MonkeyMode:
+    try:
+        return MonkeyMode(raw)
+    except ValueError:
+        return MonkeyMode.INVESTIGATION
+
+
+def _normalise_side(raw: str) -> Side:
+    r = (raw or "").lower()
+    return "short" if r in ("sell", "short") else "long"
+
+
+# ─── Public API ───
+
+
+def aggregate_and_bias(
+    rows: Iterable[ClosedTradeRow],
+    *,
+    lookback_hours: int = 24,
+) -> SelfObservation:
+    """Aggregate closed-trade rows by (mode, side) and compute entry bias.
+
+    Strategy B (hierarchical fallback) — reviewed 2026-04-21. See
+    self_observation.ts for history.
+    """
+    by_ms = _empty_by_mode_side()
+
+    for row in rows:
+        mode = _normalise_mode(row.mode)
+        side = _normalise_side(row.side)
+        stats = by_ms[mode][side]
+        stats.trades += 1
+        stats.total_pnl += row.pnl
+        if row.pnl > 0:
+            stats.wins += 1
+        elif row.pnl < 0:
+            stats.losses += 1
+
+    for mode in ALL_MODES:
+        for side in SIDES:
+            s = by_ms[mode][side]
+            s.win_rate = s.wins / s.trades if s.trades > 0 else 0.0
+            s.avg_pnl = s.total_pnl / s.trades if s.trades > 0 else 0.0
+
+    # Pool per-mode and per-side for hierarchical fallback.
+    mode_pooled: dict[MonkeyMode, dict[str, float]] = {}
+    for mode in ALL_MODES:
+        t = by_ms[mode]["long"].trades + by_ms[mode]["short"].trades
+        w = by_ms[mode]["long"].wins + by_ms[mode]["short"].wins
+        mode_pooled[mode] = {
+            "trades": t,
+            "wins": w,
+            "win_rate": w / t if t > 0 else 0.0,
+        }
+
+    side_pooled: dict[Side, dict[str, float]] = {
+        "long": {"trades": 0, "wins": 0, "win_rate": 0.0},
+        "short": {"trades": 0, "wins": 0, "win_rate": 0.0},
+    }
+    for side in SIDES:
+        for mode in ALL_MODES:
+            side_pooled[side]["trades"] += by_ms[mode][side].trades
+            side_pooled[side]["wins"] += by_ms[mode][side].wins
+        t = side_pooled[side]["trades"]
+        side_pooled[side]["win_rate"] = side_pooled[side]["wins"] / t if t > 0 else 0.0
+
+    all_t = side_pooled["long"]["trades"] + side_pooled["short"]["trades"]
+    all_w = side_pooled["long"]["wins"] + side_pooled["short"]["wins"]
+    global_win_rate = all_w / all_t if all_t > 0 else 0.0
+
+    bias = _neutral_bias()
+    for mode in ALL_MODES:
+        for side in SIDES:
+            bucket = by_ms[mode][side]
+            if bucket.trades >= MIN_SAMPLE_FOR_BIAS:
+                bias[mode][side] = _win_rate_to_bias(bucket.win_rate)
+            elif mode_pooled[mode]["trades"] >= MIN_SAMPLE_FOR_BIAS:
+                bias[mode][side] = _win_rate_to_bias(mode_pooled[mode]["win_rate"])
+            elif side_pooled[side]["trades"] >= MIN_SAMPLE_FOR_BIAS:
+                bias[mode][side] = _win_rate_to_bias(side_pooled[side]["win_rate"])
+            elif all_t >= MIN_SAMPLE_FOR_BIAS:
+                bias[mode][side] = _win_rate_to_bias(global_win_rate)
+
+    return SelfObservation(
+        lookback_hours=lookback_hours,
+        by_mode_side=by_ms,
+        entry_bias=bias,
+    )
+
+
+def self_observation_to_dict(so: SelfObservation) -> dict:
+    """Serialise for JSON response."""
+    return {
+        "lookback_hours": so.lookback_hours,
+        "by_mode_side": {
+            m.value: {
+                s: {
+                    "mode": st.mode.value,
+                    "side": st.side,
+                    "trades": st.trades,
+                    "wins": st.wins,
+                    "losses": st.losses,
+                    "win_rate": st.win_rate,
+                    "avg_pnl": st.avg_pnl,
+                    "total_pnl": st.total_pnl,
+                }
+                for s, st in stats_by_side.items()
+            }
+            for m, stats_by_side in so.by_mode_side.items()
+        },
+        "entry_bias": {m.value: dict(bs) for m, bs in so.entry_bias.items()},
+    }


### PR DESCRIPTION
Three small modules in one PR. All simplex-only per user directive.

## v0.7.5 — `basin.py` — thin re-export of `qig_core_local`
No reimplementation. Re-exports `fisher_rao_distance`, `slerp_sqrt`, `frechet_mean`, `bhattacharyya_coefficient`, `exp_map`, `log_map`, `to_simplex`, `random_basin`. Plus four NON-METRIC helpers: `inject_dirichlet_noise`, `uniform_basin`, `normalized_entropy`, `max_mass`, `velocity` (named wrapper over FR distance).

## v0.7.6 — `basin_sync.py` — multi-kernel coordination
Φ-weighted observer-effect slerp pull. Convergence summary via pairwise FR distance. Stateless — persistence lives in TS adapter.

## v0.7.7 — `self_observation.py` — Loop 1
Per-(mode, side) bucket aggregation with hierarchical fallback (strategy B):
`bucket → mode-pooled → side-pooled → global → neutral`. MIN_SAMPLE_FOR_BIAS=3, MAX_BIAS_SWING=±30 %.

## Verified
- Purity: **16 files clean** (up from 13)
- Smoke: `uniform_basin.sum() = 1.0`, perturbed sum = 1.0, observer-pulled sum = 1.0, bias computed correctly

## Not changed
TS modules still live. v0.7.10 wires the cut-over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)