### PR TITLE
feat(v0.7.8/9): port resonance_bank + working_memory to monkey_kernel

### DIFF
--- a/ml-worker/src/monkey_kernel/__init__.py
+++ b/ml-worker/src/monkey_kernel/__init__.py
@@ -68,11 +68,30 @@ from .basin_sync import (
 from .modes import MODE_PROFILES, ModeProfile, MonkeyMode, detect_mode
 from .perception import OHLCVCandle, PerceptionInputs, perceive, refract
 from .perception_scalars import basin_direction, trend_proxy
+from .resonance_bank import (
+    BankEntry,
+    DepthAudit,
+    NearestNeighbor,
+    TradeOutcome,
+    audit_depth,
+    classify_outcome,
+    compute_initial_depth,
+    score_nearest,
+    sovereignty,
+    top_by_depth,
+)
 from .self_observation import (
     ClosedTradeRow,
     SelfObservation,
     aggregate_and_bias,
     self_observation_to_dict,
+)
+from .working_memory import (
+    Bubble,
+    BubblePayload,
+    BubbleStatus,
+    WorkingMemory,
+    WorkingMemoryStats,
 )
 from .state import BasinState, NeurochemicalState
 

--- a/ml-worker/src/monkey_kernel/resonance_bank.py
+++ b/ml-worker/src/monkey_kernel/resonance_bank.py
@@ -1,0 +1,155 @@
+"""
+resonance_bank.py — Geometric side of Monkey's long-term memory (v0.7.8).
+
+Port of resonance_bank.ts. The TS adapter keeps Postgres IO; this
+module does the QIG math on rows the adapter hands in:
+
+  - Fisher-Rao nearest-neighbour scoring over stored basins
+  - Hebbian depth updates (win→deepen, loss→shallow)
+  - Sovereignty computation (lived / total)
+
+No Euclidean anywhere. All distance via qig_core_local.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Literal, Optional
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import Basin, fisher_rao_distance
+
+TradeOutcome = Literal["win", "loss", "breakeven", "exited_early"]
+
+
+@dataclass
+class BankEntry:
+    id: str
+    symbol: str
+    entry_basin: Basin
+    realized_pnl: Optional[float]
+    trade_duration_ms: Optional[int]
+    trade_outcome: Optional[TradeOutcome]
+    order_id: Optional[str]
+    basin_depth: float
+    access_count: int
+    phi_at_creation: Optional[float]
+    source: Literal["lived", "harvested"]
+
+
+@dataclass
+class NearestNeighbor:
+    entry: BankEntry
+    distance: float  # Fisher-Rao
+
+
+def score_nearest(
+    query_basin: Basin,
+    entries: Iterable[BankEntry],
+    *,
+    top_k: int = 5,
+) -> list[NearestNeighbor]:
+    """Fisher-Rao nearest-neighbour search.
+
+    Linear scan — bank is small enough that an ANN index is overkill.
+    Caller prefilters by symbol if it wants "same-symbol nearest."
+    """
+    scored: list[NearestNeighbor] = []
+    for e in entries:
+        d = fisher_rao_distance(query_basin, e.entry_basin)
+        scored.append(NearestNeighbor(entry=e, distance=d))
+    scored.sort(key=lambda n: n.distance)
+    return scored[:top_k]
+
+
+def compute_initial_depth(
+    *,
+    phi: float,
+    realized_pnl: float,
+    pnl_normalizer_usdt: float = 1.0,
+) -> float:
+    """Hebbian initial depth: win deepens, loss shallows. Magnitude
+    proportional to |pnl|, capped at ±30 % swing."""
+    outcome_magnitude = min(1.0, abs(realized_pnl) / max(pnl_normalizer_usdt, 1e-6))
+    if realized_pnl > 0:
+        initial = phi * (1.0 + 0.3 * outcome_magnitude)
+    elif realized_pnl < 0:
+        initial = phi * (1.0 - 0.3 * outcome_magnitude)
+    else:
+        initial = phi
+    return max(0.05, min(0.95, initial))
+
+
+def classify_outcome(realized_pnl: float) -> TradeOutcome:
+    if realized_pnl > 0:
+        return "win"
+    if realized_pnl < 0:
+        return "loss"
+    return "breakeven"
+
+
+def sovereignty(entries: Iterable[BankEntry]) -> float:
+    """Lived / total. 1.0 for newborn Monkey (no bootstrap)."""
+    lived = 0
+    total = 0
+    for e in entries:
+        total += 1
+        if e.source == "lived":
+            lived += 1
+    return 0.0 if total == 0 else lived / total
+
+
+# ── Bank-audit helpers (v0.6.8 sleep-consolidation companion) ──
+
+
+@dataclass
+class DepthAudit:
+    """What the sleep-consolidation pass wants to change in one batch.
+
+    Returned as delta lists; the TS adapter applies them to Postgres.
+    Keeps this module pure (no side effects).
+    """
+    to_boost: list[tuple[str, float]]  # (id, new_depth) — recently accessed
+    to_decay: list[tuple[str, float]]  # (id, new_depth) — untouched
+    to_prune: list[str]                # ids with depth collapsed below floor
+
+
+def audit_depth(
+    entries: Iterable[BankEntry],
+    *,
+    now_ms: float,
+    last_accessed_ms_by_id: dict[str, float],
+    boost_window_hours: float = 2.0,
+    decay_window_hours: float = 24.0,
+    prune_window_hours: float = 72.0,
+    boost_step: float = 0.05,
+    decay_step: float = 0.02,
+    prune_floor: float = 0.10,
+) -> DepthAudit:
+    """Return depth deltas for the sleep-consolidation pass. Pure
+    function — caller applies to DB.
+    """
+    boost: list[tuple[str, float]] = []
+    decay: list[tuple[str, float]] = []
+    prune: list[str] = []
+    boost_cutoff = now_ms - boost_window_hours * 3600_000
+    decay_cutoff = now_ms - decay_window_hours * 3600_000
+    prune_cutoff = now_ms - prune_window_hours * 3600_000
+    for e in entries:
+        last = last_accessed_ms_by_id.get(e.id)
+        if last is not None and last > boost_cutoff:
+            boost.append((e.id, min(0.95, e.basin_depth + boost_step)))
+        elif last is None or last < decay_cutoff:
+            decayed = max(0.05, e.basin_depth - decay_step)
+            decay.append((e.id, decayed))
+            if decayed < prune_floor and (last is None or last < prune_cutoff):
+                prune.append(e.id)
+    return DepthAudit(to_boost=boost, to_decay=decay, to_prune=prune)
+
+
+def top_by_depth(entries: Iterable[BankEntry], n: int = 5) -> list[BankEntry]:
+    """Top-N bank entries by basin_depth. Used by identity
+    recrystallization (caller then Fréchet-means their basins)."""
+    sorted_entries = sorted(entries, key=lambda e: e.basin_depth, reverse=True)
+    return sorted_entries[:n]

--- a/ml-worker/src/monkey_kernel/working_memory.py
+++ b/ml-worker/src/monkey_kernel/working_memory.py
@@ -1,0 +1,258 @@
+"""
+working_memory.py — qig-cache bubble lifecycle (v0.7.9).
+
+Pure Fisher-Rao working memory. Port of working_memory.ts. Per P25
+Canonical Principles v2.1, pop/merge/promote thresholds are DERIVED
+from running Φ / FR-distance distributions each tick — not set as
+constants.
+
+Bubble structure:
+  id, center (64-D basin), phi, createdAt, lifetimeMs, payload,
+  status (alive | merged | popped | promoted), metadata
+
+Each tick:
+  1. Pop expired (Φ-based pop threshold OR age)
+  2. Merge pairwise-close bubbles (FR distance < adaptive merge threshold)
+  3. Promote Φ-strong bubbles (above adaptive promote threshold)
+  4. Compact (bound total count)
+
+Purity: all merge decisions via qig_core_local.fisher_rao_distance.
+No Euclidean. Merge centers via Fréchet mean — Karcher mean on Δ⁶³.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import (
+    Basin,
+    fisher_rao_distance,
+    frechet_mean,
+)
+
+BubbleStatus = Literal["alive", "merged", "popped", "promoted"]
+
+
+@dataclass
+class BubblePayload:
+    symbol: Optional[str] = None
+    signal: Optional[str] = None
+    realized_pnl: Optional[float] = None
+    entry_basin: Optional[Basin] = None
+    order_id: Optional[str] = None
+
+
+@dataclass
+class Bubble:
+    id: str
+    center: Basin
+    phi: float
+    created_at_ms: float
+    lifetime_ms: float
+    payload: Optional[BubblePayload] = None
+    status: BubbleStatus = "alive"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class WorkingMemoryStats:
+    alive: int
+    popped: int
+    merged: int
+    promoted: int
+    phi_mean: float
+    phi_max: float
+    age_mean_ms: float
+    pop_threshold: float
+    promote_threshold: float
+    merge_threshold: float
+
+
+class WorkingMemory:
+    """FOAM-phase working memory. One instance per perception kernel.
+
+    Adaptive thresholds (P25):
+      pop threshold    = 25th percentile of recent Φ
+      promote threshold = 75th percentile of recent Φ
+      merge threshold  = median pairwise FR distance of alive bubbles
+    Bootstrap defaults (permissive) until we have ≥ 10 samples.
+    """
+
+    PHI_HISTORY_MAX: int = 200
+
+    def __init__(
+        self,
+        *,
+        default_lifetime_ms: float = 15 * 60 * 1000.0,
+        max_bubbles: int = 500,
+    ) -> None:
+        self.bubbles: list[Bubble] = []
+        self.default_lifetime_ms = default_lifetime_ms
+        self.max_bubbles = max_bubbles
+        self._phi_history: list[float] = []
+
+    # ─── adaptive thresholds (P25) ───
+
+    def _adaptive_thresholds(self) -> dict[str, float]:
+        if len(self._phi_history) < 10:
+            return {"pop": 0.15, "promote": 0.70, "merge": 0.15}
+
+        sorted_phi = sorted(self._phi_history)
+
+        def q(p: float) -> float:
+            i = min(len(sorted_phi) - 1, int(len(sorted_phi) * p))
+            return sorted_phi[i]
+
+        # Merge threshold: 25th percentile of alive pairwise FR distances.
+        alive = [b for b in self.bubbles if b.status == "alive"]
+        merge_thr = 0.15
+        if len(alive) >= 2:
+            distances: list[float] = []
+            for i in range(len(alive)):
+                for j in range(i + 1, len(alive)):
+                    distances.append(
+                        fisher_rao_distance(alive[i].center, alive[j].center)
+                    )
+            if distances:
+                distances.sort()
+                merge_thr = distances[min(len(distances) - 1, int(len(distances) * 0.25))]
+
+        return {"pop": q(0.25), "promote": q(0.75), "merge": merge_thr}
+
+    # ─── public API ───
+
+    def add(
+        self,
+        center: Basin,
+        phi: float,
+        *,
+        now_ms: float,
+        metadata: Optional[dict[str, Any]] = None,
+        lifetime_ms: Optional[float] = None,
+    ) -> Bubble:
+        b = Bubble(
+            id=f"b-{int(now_ms)}-{uuid.uuid4().hex[:6]}",
+            center=center,
+            phi=phi,
+            created_at_ms=now_ms,
+            lifetime_ms=lifetime_ms or self.default_lifetime_ms,
+            status="alive",
+            metadata=metadata or {},
+        )
+        self.bubbles.append(b)
+        self._phi_history.append(phi)
+        if len(self._phi_history) > self.PHI_HISTORY_MAX:
+            self._phi_history.pop(0)
+        return b
+
+    def reinforce(self, bubble_id: str, delta: float) -> None:
+        for b in self.bubbles:
+            if b.id == bubble_id and b.status == "alive":
+                b.phi = max(0.0, min(1.0, b.phi + delta))
+                return
+
+    def tick(self, *, now_ms: float) -> WorkingMemoryStats:
+        """Advance one cycle: pop → merge → promote → compact.
+        Returns stats + adaptive thresholds used this cycle.
+
+        Promotion callbacks: this module is pure — the TS / FastAPI
+        adapter calls promote hooks AFTER reading the returned list of
+        promoted bubble ids.
+        """
+        th = self._adaptive_thresholds()
+        popped = merged = promoted = 0
+
+        # 1. Pop expired / weak
+        for b in self.bubbles:
+            if b.status != "alive":
+                continue
+            if now_ms - b.created_at_ms > b.lifetime_ms or b.phi < th["pop"]:
+                b.status = "popped"
+                popped += 1
+
+        # 2. Merge similar (greedy pairwise)
+        alive = [b for b in self.bubbles if b.status == "alive"]
+        merged_indices: set[int] = set()
+        new_merges: list[Bubble] = []
+        for i in range(len(alive)):
+            if i in merged_indices:
+                continue
+            group: list[Bubble] = [alive[i]]
+            for j in range(i + 1, len(alive)):
+                if j in merged_indices:
+                    continue
+                d = fisher_rao_distance(alive[i].center, alive[j].center)
+                if d <= th["merge"]:
+                    group.append(alive[j])
+                    merged_indices.add(j)
+            if len(group) >= 2:
+                # Fréchet mean as new center (Karcher on Δ⁶³ — NOT Euclidean)
+                new_center = frechet_mean([g.center for g in group])
+                new_phi = max(g.phi for g in group)
+                oldest = min(g.created_at_ms for g in group)
+                for g in group:
+                    g.status = "merged"
+                merged += len(group) - 1
+                new_merges.append(
+                    Bubble(
+                        id=f"b-{int(now_ms)}-{uuid.uuid4().hex[:6]}",
+                        center=new_center,
+                        phi=new_phi,
+                        created_at_ms=oldest,
+                        lifetime_ms=self.default_lifetime_ms,
+                        status="alive",
+                        metadata={"merged_from": [g.id for g in group]},
+                    )
+                )
+        self.bubbles.extend(new_merges)
+
+        # 3. Promote strong
+        for b in self.bubbles:
+            if b.status != "alive":
+                continue
+            if b.phi >= th["promote"]:
+                b.status = "promoted"
+                promoted += 1
+
+        # 4. Compact (FIFO-evict non-alive beyond max)
+        if len(self.bubbles) > self.max_bubbles:
+            kept_alive = [b for b in self.bubbles if b.status == "alive"]
+            kept_dead = [b for b in self.bubbles if b.status != "alive"]
+            self.bubbles = kept_alive + kept_dead[-max(1, self.max_bubbles // 4):]
+
+        return self._stats_with_counts(
+            popped=popped, merged=merged, promoted=promoted, thresholds=th,
+            now_ms=now_ms,
+        )
+
+    def _stats_with_counts(
+        self,
+        *,
+        popped: int, merged: int, promoted: int,
+        thresholds: dict[str, float], now_ms: float,
+    ) -> WorkingMemoryStats:
+        alive = [b for b in self.bubbles if b.status == "alive"]
+        phis = [b.phi for b in alive]
+        ages = [now_ms - b.created_at_ms for b in alive]
+        return WorkingMemoryStats(
+            alive=len(alive),
+            popped=popped,
+            merged=merged,
+            promoted=promoted,
+            phi_mean=(sum(phis) / len(phis)) if phis else 0.0,
+            phi_max=max(phis) if phis else 0.0,
+            age_mean_ms=(sum(ages) / len(ages)) if ages else 0.0,
+            pop_threshold=thresholds["pop"],
+            promote_threshold=thresholds["promote"],
+            merge_threshold=thresholds["merge"],
+        )
+
+    def alive_bubbles(self) -> list[Bubble]:
+        return [b for b in self.bubbles if b.status == "alive"]
+
+    def promoted_bubbles(self) -> list[Bubble]:
+        return [b for b in self.bubbles if b.status == "promoted"]


### PR DESCRIPTION
Two final data-memory modules. All simplex-only. **18 files purity-clean** (up from 16).

## resonance_bank.py
Pure math on BankEntry rows. Postgres IO stays in TS adapter.
- `score_nearest` — FR linear scan NN
- `compute_initial_depth` — Hebbian ±30%
- `sovereignty`, `classify_outcome`, `top_by_depth`
- `audit_depth` — sleep-consolidation batch deltas

## working_memory.py
qig-cache bubbles with **adaptive** pop/merge/promote thresholds per P25:
- pop = 25th-pct Φ, promote = 75th, merge = 25th-pct pairwise FR distance
- Merge centers via `frechet_mean` (Karcher on Δ⁶³, NOT Euclidean avg)
- All distance via `qig_core_local.fisher_rao_distance`

## Smoke
- WM tick: 5 random bubbles → 3 alive, 2 promoted, thresholds adapt
- Bank NN: 3 sorted by distance
- sovereignty=1.0, initial_depth math checks out
- audit_depth: 1 boost, 4 decay, 0 prune

## Migration
v0.7.10 wires `loop.ts` under `MONKEY_KERNEL_PY` with shadow-mode parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)