### PR TITLE
feat(v0.7.10): shadow-mode Python-parity call for autonomic tick

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -49,8 +49,10 @@ import {
   velocity,
   type Basin,
 } from './basin.js';
+import { callAutonomicTick } from './autonomic_client.js';
 import { BasinSync } from './basin_sync.js';
 import { BusEventType, getKernelBus, type KernelBus } from './kernel_bus.js';
+import { logParityDiff } from './kernel_client.js';
 import { detectMode, MODE_PROFILES, MonkeyMode } from './modes.js';
 import { computeNeurochemicals, summarizeNC, type NeurochemicalState } from './neurochemistry.js';
 import {
@@ -409,6 +411,33 @@ export class MonkeyKernel extends EventEmitter {
       rewardSerotoninDelta: rewardDeltas.serotonin,
       rewardEndorphinDelta: rewardDeltas.endorphin,
     });
+
+    // v0.7.10 shadow-mode: call the Python autonomic kernel in parallel
+    // and log parity diffs. TS path remains authoritative until
+    // MONKEY_KERNEL_PY=true flips the default. Fire-and-forget — shadow
+    // latency must not block the tick.
+    if (process.env.MONKEY_KERNEL_PY_SHADOW === 'true') {
+      void callAutonomicTick({
+        instanceId: this.instanceId,
+        phiDelta,
+        basinVelocity: bv,
+        surprise: Math.abs(phiDelta) * 2,
+        quantumWeight: regimeWeights.quantum,
+        kappa: state.kappa,
+        externalCoupling: couplingHealth,
+        currentMode: state.lastMode ?? 'investigation',
+        isFlat: !exchangeHeldSide,
+      }).then((pyResult) => {
+        logParityDiff('nc.dopamine', nc.dopamine, pyResult.nc.dopamine);
+        logParityDiff('nc.serotonin', nc.serotonin, pyResult.nc.serotonin);
+        logParityDiff('nc.endorphins', nc.endorphins, pyResult.nc.endorphins);
+        logParityDiff('nc.norepinephrine', nc.norepinephrine, pyResult.nc.norepinephrine);
+      }).catch((err) => {
+        logger.debug('[shadow] autonomic parity fetch failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
 
     const sovereignty = await resonanceBank.sovereignty();
 


### PR DESCRIPTION
First wiring of Python monkey_kernel into loop.ts. **Behaviour unchanged** — TS autonomic stays authoritative.

When `MONKEY_KERNEL_PY_SHADOW=true`:
- `callAutonomicTick` fires in parallel, fire-and-forget
- `logParityDiff()` compares each chemical to TS-computed value
- Warns on any numeric diff > 0.01

Shadow telemetry precedes the cut-over. One week of clean shadow logs → confidence to flip `MONKEY_KERNEL_PY=true` authoritative.

## Diffed
`nc.dopamine` / `nc.serotonin` / `nc.endorphins` / `nc.norepinephrine`. ACh and GABA are deterministic functions of single inputs, not diffed (noise reduction).

## Latency
Python call is fire-and-forget. Does NOT block the tick. Failed fetches dropped at debug level.

## Activation
```
export MONKEY_KERNEL_PY_SHADOW=true
# keep MONKEY_KERNEL_PY unset
```

## Test plan
- [x] tsc clean, vitest 530/530
- [ ] Post-merge: enable flag on Railway, check logs for `[kernel_client] parity diff` warnings. Expect 0 diffs > 0.01 (ideal) or small discrepancies to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)