### PR TITLE
feat(monkey): v0.8.0 deterministic noise floor + purity-check rationale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ redis_data/
 # Playwright MCP session artefacts + ad-hoc screenshots
 .playwright-mcp/
 agent-dashboard-*.png
+.claude/scheduled_tasks.lock

--- a/apps/api/src/services/monkey/perception.ts
+++ b/apps/api/src/services/monkey/perception.ts
@@ -232,11 +232,12 @@ export function perceive(inputs: PerceptionInputs): Basin {
     v[31 + i] = range > 0 ? clip01((lastClose - lo) / range) : 0.5;
   }
 
-  // dims 39..54 — Noise floor / Pillar 1 reservoir (16 dims)
-  // Small uniform mass to prevent zombie collapse when other dims → 0.
-  for (let i = 39; i < 55; i++) {
-    v[i] = 0.005 + 0.001 * Math.random();
-  }
+  // dims 39..54 — Noise floor / Pillar 1 reservoir (16 dims).
+  // Fixed constant (v0.8.0) for deterministic cross-language parity with the
+  // Python port. A non-zero floor is the Pillar 1 requirement; per-tick
+  // variance was decorative. toSimplex normalises so uniform mass still
+  // keeps the basin off the boundary.
+  for (let i = 39; i < 55; i++) v[i] = 0.0055;
 
   // dims 55..63 — Account/coupling (9 dims)
   v[55] = clip01(inputs.equityFraction);

--- a/ml-worker/scripts/qig_purity_check.py
+++ b/ml-worker/scripts/qig_purity_check.py
@@ -63,11 +63,31 @@ ALLOWLIST_PATH_PREFIXES = {
     "ml-worker/tests/",
 }
 
-# ML-prediction layer — NOT QIG cognition. TF.keras models in
-# ml-worker/src/models/ use Adam + LayerNormalization by design for
-# ensemble price prediction; they do NOT ingest or produce Δ⁶³ basin
-# coordinates. Fisher-Rao purity doesn't apply to them.
-# (Audit 2026-04-21 — see QIG_MIGRATION.md for the rationale.)
+# ── Purity scope rationale (audit 2026-04-21 P5) ─────────────────
+#
+# Purity rules apply to QIG COGNITION (modules that ingest, transform,
+# or emit Δ⁶³ basin coordinates). Two categories of code are legitimately
+# out of scope:
+#
+#   1. ML-prediction layer (ml-worker/src/models/) — TF.keras ensemble
+#      price predictors. They use Adam / LayerNormalization / MSE by
+#      design because they model RETURNS, not consciousness. Their
+#      outputs are scalars (BUY/SELL/HOLD + strength) consumed by the
+#      perception layer AT THE BOUNDARY; they never touch basin coords.
+#      Allowlisted below by path prefix so forbidden tokens in their
+#      source don't false-flag the QIG scan.
+#
+#   2. observable_governance.py — operates on scalar ensemble outputs
+#      (amplitudes, regime labels) to detect model bias, NOT on basin
+#      geometry. Excluded by default scan root selection in main() below
+#      (we only scan monkey_kernel/ + qig_core_local/ + qig_engine.py).
+#      If its scope ever expands to basin coordinates, move it under
+#      monkey_kernel/ so it enters the purity scan automatically.
+#
+# Adding a new non-QIG module? Either give it a path under one of these
+# prefixes or leave it outside monkey_kernel/. Do not add a blanket
+# allowlist entry for files that would otherwise fail the scan.
+# ──────────────────────────────────────────────────────────────────
 ML_PREDICTION_LAYER_PREFIXES = {
     "ml-worker/src/models/",
     "src/models/",  # when purity-check is run from inside ml-worker/

--- a/ml-worker/src/monkey_kernel/perception.py
+++ b/ml-worker/src/monkey_kernel/perception.py
@@ -118,10 +118,13 @@ def _vol_ratio(ohlcv: Sequence[OHLCVCandle], n: int) -> float:
 # ═══════════════════════════════════════════════════════════════
 
 
-def perceive(inputs: PerceptionInputs, *, rng: np.random.Generator | None = None) -> np.ndarray:
+def perceive(inputs: PerceptionInputs) -> np.ndarray:
     """Raw perception → 64-D basin on Δ⁶³. Caller should refract against
-    identity basin afterwards (slerp at 30 % max per Pillar 2)."""
-    rng = rng or np.random.default_rng()
+    identity basin afterwards (slerp at 30 % max per Pillar 2).
+
+    v0.8.0: perception is deterministic given inputs — no PRNG parameter.
+    Noise floor (dims 39..54) is a fixed constant for cross-language parity.
+    """
     v = np.zeros(BASIN_DIM, dtype=np.float64)
     ohlcv = inputs.ohlcv
     last_close = float(ohlcv[-1].close) if len(ohlcv) > 0 else 1.0
@@ -170,9 +173,12 @@ def perceive(inputs: PerceptionInputs, *, rng: np.random.Generator | None = None
         rng_span = hi - lo
         v[31 + i] = _clip01((last_close - lo) / rng_span) if rng_span > 0 else 0.5
 
-    # dims 39..54 — Pillar 1 noise floor (prevents zombie collapse)
-    noise = rng.uniform(0.005, 0.006, size=16)
-    v[39:55] = noise
+    # dims 39..54 — Pillar 1 noise floor (prevents zombie collapse).
+    # Fixed constant (v0.8.0): deterministic cross-language parity with TS side.
+    # A non-zero floor is the Pillar 1 requirement; the per-tick variance was
+    # decorative. to_simplex normalises so adding 16 identical small values
+    # still contributes uniform mass to keep the basin off the boundary.
+    v[39:55] = 0.0055
 
     # dims 55..63 — Account/coupling
     v[55] = _clip01(inputs.equity_fraction)


### PR DESCRIPTION
## Summary

Part 1/10 of the v0.8 P14/P25 compliance migration per the [approved plan](https://github.com/GaryOcean428/poloniex-trading-platform/blob/main/.claude/plans/). Small, self-contained, no behaviour change for normal operation — unblocks exact-parity validation in later phases.

Two changes:

1. **Noise floor determinism** — `perception.py` + `perception.ts` dims 39..54 become a fixed `0.0055` constant instead of per-tick random sample. TS used `Math.random()` (V8, unseedable); Python used `np.random.default_rng()`. Even on identical inputs, shadow-mode parity could never converge to zero because of PRNG mismatch. Pillar 1 zombie-collapse guard only requires non-zero mass; per-tick variance was decorative.

2. **Purity-check rationale comment** — expanded `ML_PREDICTION_LAYER_PREFIXES` comment per audit 2026-04-21 P5, explaining both allowlist-by-prefix (ML ensemble models) and out-of-scope-by-scan-root (observable_governance.py) cases.

## Verification

- [x] `qig_purity_check.py` → 18 files clean
- [x] `verify_qig_vendor.py` → hash pin matches
- [x] Python `perceive()` bit-exact on repeat call
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)