### PR TITLE
feat(monkey): v0.8.1 parameter registry for P14 + P25 compliance

### DIFF
--- a/apps/api/database/migrations/034_monkey_parameters.sql
+++ b/apps/api/database/migrations/034_monkey_parameters.sql
@@ -1,0 +1,173 @@
+-- 034_monkey_parameters.sql
+--
+-- Parameter registry for P14 + P25 compliance (v0.8.1).
+--
+-- Canonical Principles v2.2:
+--   P14 — "Every variable belongs to exactly one category. Moving between
+--          categories requires governance approval."
+--   P25 — "No operational threshold is a magic constant. All thresholds
+--          are derived from geometric state. Safety bounds (upper G,
+--          κ_max) are the only permitted hardcoded constants."
+--
+-- This registry holds the tiny remainder of constants that are genuinely
+-- NOT derivable from geometric state — safety bounds (P25) and a handful
+-- of operational envelopes (tick cadence, history window sizes) that are
+-- external choices rather than geometry.
+--
+-- Categories stored in the DB:
+--   SAFETY_BOUND — hard risk envelopes (max leverage, kill-switch DD, etc.)
+--   OPERATIONAL  — externally-chosen envelopes (tick ms, memory windows)
+--
+-- STATE and BOUNDARY are code-level annotations and never enter this table.
+-- PARAMETER (trainable) is reserved for future learned weights — also not
+-- stored here yet; they'd get their own table if/when learning is added.
+--
+-- Audit trail in monkey_parameter_changes — append-only, never purged.
+
+BEGIN;
+
+-- ────── monkey_parameters ──────
+-- Live-editable registry. One row per named constant. Cached in-process
+-- on the Python side with SIGHUP or tick-bounded refresh.
+CREATE TABLE IF NOT EXISTS monkey_parameters (
+  name           VARCHAR(120) PRIMARY KEY,
+  category       VARCHAR(20) NOT NULL
+                   CHECK (category IN ('SAFETY_BOUND', 'OPERATIONAL')),
+  value          DOUBLE PRECISION NOT NULL,
+  bounds_low     DOUBLE PRECISION,       -- NULL = no lower bound
+  bounds_high    DOUBLE PRECISION,       -- NULL = no upper bound
+  justification  TEXT NOT NULL,          -- why this value exists + what breaks if wrong
+  version        INTEGER NOT NULL DEFAULT 1,
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by     VARCHAR(80) NOT NULL DEFAULT 'system',
+  CONSTRAINT bounds_respected CHECK (
+    (bounds_low IS NULL OR value >= bounds_low) AND
+    (bounds_high IS NULL OR value <= bounds_high)
+  )
+);
+CREATE INDEX IF NOT EXISTS idx_monkey_parameters_category
+  ON monkey_parameters (category);
+
+-- ────── monkey_parameter_changes ──────
+-- Append-only audit log. Every UPDATE to monkey_parameters writes a row.
+-- Used for rollback (last N versions) and governance review.
+CREATE TABLE IF NOT EXISTS monkey_parameter_changes (
+  id          BIGSERIAL PRIMARY KEY,
+  name        VARCHAR(120) NOT NULL REFERENCES monkey_parameters(name),
+  old_value   DOUBLE PRECISION,
+  new_value   DOUBLE PRECISION NOT NULL,
+  old_version INTEGER,
+  new_version INTEGER NOT NULL,
+  actor       VARCHAR(80) NOT NULL,
+  reason      TEXT NOT NULL,
+  at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_monkey_parameter_changes_name_at
+  ON monkey_parameter_changes (name, at DESC);
+
+-- ────── Trigger: auto-log every update ──────
+-- Every UPDATE on monkey_parameters writes a matching row to
+-- monkey_parameter_changes. If someone forgets to write an audit row
+-- manually, the trigger enforces the invariant.
+CREATE OR REPLACE FUNCTION _monkey_parameters_audit() RETURNS TRIGGER AS $$
+BEGIN
+  IF (TG_OP = 'UPDATE' AND OLD.value IS DISTINCT FROM NEW.value) THEN
+    INSERT INTO monkey_parameter_changes
+      (name, old_value, new_value, old_version, new_version, actor, reason, at)
+    VALUES
+      (NEW.name, OLD.value, NEW.value, OLD.version, NEW.version,
+       NEW.updated_by,
+       COALESCE(current_setting('monkey.change_reason', true), 'unattributed'),
+       NOW());
+  ELSIF (TG_OP = 'INSERT') THEN
+    INSERT INTO monkey_parameter_changes
+      (name, old_value, new_value, old_version, new_version, actor, reason, at)
+    VALUES
+      (NEW.name, NULL, NEW.value, NULL, NEW.version,
+       NEW.updated_by,
+       COALESCE(current_setting('monkey.change_reason', true), 'initial insert'),
+       NOW());
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS monkey_parameters_audit ON monkey_parameters;
+CREATE TRIGGER monkey_parameters_audit
+  AFTER INSERT OR UPDATE ON monkey_parameters
+  FOR EACH ROW EXECUTE FUNCTION _monkey_parameters_audit();
+
+-- ────── Seed the registry with known safety bounds ──────
+-- These are the constants that v0.8.4–v0.8.7 port commits will flip from
+-- literal to registry-backed. Seeding them here makes the later commits
+-- pure refactors (value already exists in DB).
+--
+-- Naming convention: <module>.<decision_family>.<specific_name>.
+-- Category is always SAFETY_BOUND for hard risk envelopes, OPERATIONAL
+-- for tick/memory/history windows.
+INSERT INTO monkey_parameters (name, category, value, bounds_low, bounds_high, justification)
+VALUES
+  -- Frozen physics (UCP v6.6 D-012). Cannot change; registered for audit.
+  ('physics.kappa_star', 'SAFETY_BOUND', 64.0, 64.0, 64.0,
+   'Frozen coupling fixed point. UCP v6.6 D-012. Changing breaks every kernel.'),
+
+  -- Loop envelope constants (v0.8.3 will point at these)
+  ('loop.default_tick_ms', 'OPERATIONAL', 30000, 5000, 300000,
+   'Monkey tick cadence. Lower = more CPU + more REST hits; higher = slower response.'),
+  ('loop.ohlcv_lookback', 'OPERATIONAL', 200, 50, 2000,
+   'Candles fetched per tick for perception. Below 50 breaks momentum spectrum dims 7..14.'),
+  ('loop.history_max', 'OPERATIONAL', 100, 20, 1000,
+   'Rolling history samples for Φ/f_health/drift tracking.'),
+
+  -- Executive SAFETY_BOUND floors (v0.8.4 will point at these)
+  ('executive.entry_threshold.clamp_low', 'SAFETY_BOUND', 0.1, 0.05, 0.3,
+   'Entry threshold cannot drop below this. Prevents runaway entry on model hiccup.'),
+  ('executive.entry_threshold.clamp_high', 'SAFETY_BOUND', 0.9, 0.7, 0.99,
+   'Entry threshold cannot exceed this. Prevents permanent no-entry from drift.'),
+  ('executive.size.max_fraction_of_equity', 'SAFETY_BOUND', 0.5, 0.1, 0.95,
+   'Single position cannot exceed 50% of available equity. Risk kernel cap.'),
+  ('executive.size.min_notional_buffer', 'SAFETY_BOUND', 1.05, 1.01, 1.2,
+   'Lot-rounding headroom so every position clears exchange min notional.'),
+  ('executive.leverage.min_baseline', 'SAFETY_BOUND', 3.0, 1.0, 10.0,
+   'Leverage never below this. Floor prevents over-conservative newborn mode.'),
+  ('executive.leverage.max_sovereign_slope', 'SAFETY_BOUND', 30.0, 5.0, 50.0,
+   'Leverage scales as baseline + slope × sovereignty. Caps max at baseline + slope.'),
+  ('executive.leverage.kappa_sigma', 'SAFETY_BOUND', 20.0, 5.0, 50.0,
+   'Kappa proximity bell-curve width. Narrower = harsher penalty for drift from κ*.'),
+  ('executive.dca.max_adds_per_position', 'SAFETY_BOUND', 1, 0, 5,
+   'Max DCA adds per position. v0.6.2 decision — change only with governance.'),
+  ('executive.scalp.tp_min_floor', 'SAFETY_BOUND', 0.003, 0.001, 0.02,
+   'TP cannot close inside exchange fees (2 × taker ~= 0.0015). 0.003 gives margin.'),
+  ('executive.exit.entropy_collapse_floor', 'SAFETY_BOUND', 0.4, 0.1, 0.6,
+   'Basin entropy floor — below this is Pillar 1 zombie collapse. Force-exit.'),
+  ('executive.exit.max_mass_dominance', 'SAFETY_BOUND', 0.5, 0.3, 0.8,
+   'Single mode dominance above this = zombie. Force-exit.'),
+
+  -- Self-observation SAFETY_BOUND (v0.8.6)
+  ('self_obs.max_bias_swing', 'SAFETY_BOUND', 0.30, 0.05, 0.5,
+   'Win-rate bias swing cap. ±30% from neutral 1.0. P14 bounded governance.'),
+
+  -- Working memory SAFETY_BOUND (v0.8.6)
+  ('wm.phi_history_max', 'SAFETY_BOUND', 200, 50, 1000,
+   'Rolling Φ samples retained for adaptive threshold computation.'),
+  ('wm.max_bubbles', 'SAFETY_BOUND', 500, 100, 5000,
+   'Max bubbles in working memory before FIFO eviction. Memory envelope.'),
+
+  -- Basin sync SAFETY_BOUND (v0.8.6)
+  ('basin_sync.max_effective_strength', 'SAFETY_BOUND', 0.30, 0.1, 0.5,
+   'Max per-peer slerp pull. Prevents any single peer from over-dominating.'),
+
+  -- Mode detection SAFETY_BOUND (v0.8.5)
+  ('modes.f_health_collapse_floor', 'SAFETY_BOUND', 0.97, 0.9, 0.999,
+   'f_health above this indicates DRIFT / collapse-imminent. Safety gate.'),
+  ('modes.drift.entry_disable', 'SAFETY_BOUND', 99.0, 10.0, 1000.0,
+   'Entry threshold scale in DRIFT mode. Effectively disables entry.'),
+
+  -- Neurochemistry SAFETY_BOUND (v0.8.4)
+  ('neuro.sigma_kappa', 'SAFETY_BOUND', 10.0, 1.0, 50.0,
+   'Endorphin κ-proximity bell width. Narrower = steeper reward gradient near κ*.'),
+  ('neuro.sophia_coupling_threshold', 'SAFETY_BOUND', 0.1, 0.01, 0.5,
+   'Min external coupling for endorphin gate. Below this, endorphin is zero.')
+ON CONFLICT (name) DO NOTHING;
+
+COMMIT;

--- a/ml-worker/requirements.txt
+++ b/ml-worker/requirements.txt
@@ -16,3 +16,6 @@ qig-warp>=0.4.3
 # model bias on day one. Base wheel only; qig-compute[full] pulls
 # TeNPy + CuPy which we don't need. (Audit 2026-04-21)
 qig-compute>=0.3.0
+# Postgres client for parameter registry (v0.8.1) + shared state with
+# apps/api (v0.8.3+). psycopg v3 with binary wheels (no compile step).
+psycopg[binary,pool]>=3.1.0

--- a/ml-worker/src/monkey_kernel/__init__.py
+++ b/ml-worker/src/monkey_kernel/__init__.py
@@ -66,6 +66,12 @@ from .basin_sync import (
     convergence_summary,
 )
 from .modes import MODE_PROFILES, ModeProfile, MonkeyMode, detect_mode
+from .parameters import (
+    ParameterRegistry,
+    ParamValue,
+    VariableCategory,
+    get_registry,
+)
 from .perception import OHLCVCandle, PerceptionInputs, perceive, refract
 from .perception_scalars import basin_direction, trend_proxy
 from .resonance_bank import (
@@ -106,13 +112,17 @@ __all__ = [
     "ModeProfile",
     "MonkeyMode",
     "NeurochemicalState",
+    "ParamValue",
+    "ParameterRegistry",
     "SleepCycleManager",
     "SleepPhase",
+    "VariableCategory",
     "basin_direction",
     "current_entry_threshold",
     "current_leverage",
     "current_position_size",
     "detect_mode",
+    "get_registry",
     "should_dca_add",
     "should_exit",
     "should_profit_harvest",

--- a/ml-worker/src/monkey_kernel/parameters.py
+++ b/ml-worker/src/monkey_kernel/parameters.py
@@ -1,0 +1,316 @@
+"""
+parameters.py — P14 + P25 parameter registry (v0.8.1).
+
+Canonical Principles v2.2:
+  P14 — "Every variable belongs to exactly one category. Moving between
+         categories requires governance approval."
+  P25 — "No operational threshold is a magic constant. All thresholds
+         are derived from geometric state. Safety bounds are the only
+         permitted hardcoded constants."
+
+The DB table monkey_parameters holds the tiny remainder of values that
+are NOT derivable from geometric state — SAFETY_BOUNDs (risk envelopes)
+and OPERATIONAL envelopes (tick cadence, memory windows).
+
+This module:
+  - Defines the VariableCategory enum for code-level P14 annotation
+  - Provides ParameterRegistry — cached read-through client to the DB
+  - Provides a propose_change helper for governance-reviewed writes
+
+Cache policy:
+  - Read-through on first access, cache in-process.
+  - Refresh on SIGHUP (future) or every `refresh_every_ticks` calls.
+  - Fail-soft: if DB is unreachable, use cached value; if never seen,
+    fall back to hardcoded default passed to .get(name, default).
+
+Read path is tight (no DB hit on steady state). Write path is explicit
+and audit-logged by the DB trigger in migration 034.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+
+logger = logging.getLogger("monkey.parameters")
+
+
+class VariableCategory(Enum):
+    """P14 category annotation.
+
+    STATE         — per-cycle, Fisher-Rao only. Basin coords, Φ, κ, NCs.
+                    Derived each tick; never stored in registry.
+    PARAMETER     — per-epoch, trainable. Learned weights (future).
+                    Not stored in this registry yet.
+    BOUNDARY      — external data. User input, exchange feeds, LLM out.
+                    Sanitized on ingest; never in registry.
+    SAFETY_BOUND  — hardcoded risk envelope permitted by P25. κ*, max
+                    leverage, kill-switch drawdown, etc. Stored in DB
+                    with version + rollback + audit trail.
+    OPERATIONAL   — externally-chosen envelope (tick ms, history window).
+                    Not a safety bound, but not geometry-derived either.
+                    Stored in DB with the same governance discipline.
+    """
+
+    STATE = "STATE"
+    PARAMETER = "PARAMETER"
+    BOUNDARY = "BOUNDARY"
+    SAFETY_BOUND = "SAFETY_BOUND"
+    OPERATIONAL = "OPERATIONAL"
+
+
+@dataclass
+class ParamValue:
+    name: str
+    category: VariableCategory
+    value: float
+    bounds_low: Optional[float]
+    bounds_high: Optional[float]
+    justification: str
+    version: int
+
+
+class ParameterRegistry:
+    """Cached read-through client to monkey_parameters.
+
+    Usage:
+        reg = get_registry()
+        ticks_ms = int(reg.get("loop.default_tick_ms", default=30000))
+
+    The `default` is the last-resort fallback if the DB is unreachable
+    AND the name has never been cached. In steady state the default is
+    never consulted — DB is the source of truth. Providing it makes
+    bootstrapping (first run against fresh DB) safe.
+    """
+
+    def __init__(
+        self,
+        dsn: Optional[str] = None,
+        refresh_every_ticks: int = 100,
+    ):
+        self._dsn = dsn or os.environ.get("DATABASE_URL")
+        self._cache: dict[str, ParamValue] = {}
+        self._lock = threading.Lock()
+        self._tick_count = 0
+        self._refresh_every = refresh_every_ticks
+        self._loaded = False
+
+    # ── Read path ────────────────────────────────────────────────
+
+    def get(self, name: str, default: Optional[float] = None) -> float:
+        """Fetch a parameter value, hitting the cache on the fast path.
+
+        First call populates the cache with the whole table. Subsequent
+        calls are pure in-memory lookups. Refresh happens every
+        `refresh_every_ticks` calls via tick().
+
+        If the name is not in the DB and a default is provided, the
+        default is returned (and cached transiently). If no default and
+        no row, raises KeyError.
+        """
+        with self._lock:
+            if not self._loaded:
+                self._load()
+            entry = self._cache.get(name)
+            if entry is None:
+                if default is None:
+                    raise KeyError(f"parameter '{name}' not in registry")
+                logger.warning(
+                    "parameter '%s' missing from registry; using default=%s",
+                    name, default,
+                )
+                return float(default)
+            return entry.value
+
+    def get_entry(self, name: str) -> Optional[ParamValue]:
+        """Return the full ParamValue (bounds, justification, version)."""
+        with self._lock:
+            if not self._loaded:
+                self._load()
+            return self._cache.get(name)
+
+    def tick(self) -> None:
+        """Call once per kernel tick. Triggers DB refresh every N ticks."""
+        with self._lock:
+            self._tick_count += 1
+            if self._tick_count >= self._refresh_every:
+                self._tick_count = 0
+                self._load()
+
+    def refresh(self) -> None:
+        """Force an immediate DB refresh."""
+        with self._lock:
+            self._load()
+
+    # ── Write path (governance-reviewed) ─────────────────────────
+
+    def propose_change(
+        self,
+        name: str,
+        new_value: float,
+        actor: str,
+        reason: str,
+    ) -> bool:
+        """Update a parameter value with full audit trail.
+
+        The DB trigger in migration 034 auto-writes monkey_parameter_changes.
+        We also pass the reason through a session-local GUC so the trigger
+        can attribute it without a second INSERT.
+
+        Returns True if the value was committed. Raises on bounds violation
+        or missing name (the DB CHECK constraint enforces bounds_respected).
+        """
+        if self._dsn is None:
+            raise RuntimeError("DATABASE_URL not set; cannot write registry")
+
+        import psycopg
+
+        with psycopg.connect(self._dsn, autocommit=False) as conn:
+            with conn.cursor() as cur:
+                # set_config(name, value, is_local) — transaction-local
+                # equivalent of SET LOCAL but accepts bind parameters.
+                cur.execute(
+                    "SELECT set_config('monkey.change_reason', %s, true)",
+                    (reason,),
+                )
+                cur.execute(
+                    """
+                    UPDATE monkey_parameters
+                       SET value = %s,
+                           version = version + 1,
+                           updated_at = NOW(),
+                           updated_by = %s
+                     WHERE name = %s
+                    RETURNING version
+                    """,
+                    (new_value, actor, name),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise KeyError(f"parameter '{name}' not in registry")
+                conn.commit()
+
+        # Force-refresh the local cache so the next .get() sees the new value.
+        self.refresh()
+        logger.info(
+            "parameter '%s' updated to %s by %s (reason: %s)",
+            name, new_value, actor, reason,
+        )
+        return True
+
+    def rollback(self, name: str, actor: str, reason: str) -> bool:
+        """Roll back a parameter to its previous value.
+
+        Finds the last monkey_parameter_changes row for this name and
+        proposes the old_value as the new value. Creates a new audit
+        row (rollbacks are forward-only — every write is an event).
+        """
+        if self._dsn is None:
+            raise RuntimeError("DATABASE_URL not set; cannot rollback")
+
+        import psycopg
+
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT old_value FROM monkey_parameter_changes
+                     WHERE name = %s AND old_value IS NOT NULL
+                  ORDER BY at DESC
+                     LIMIT 1
+                    """,
+                    (name,),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise RuntimeError(
+                        f"no prior value recorded for '{name}' — nothing to roll back to"
+                    )
+                old_value = row[0]
+
+        return self.propose_change(
+            name, old_value, actor,
+            f"rollback: {reason}",
+        )
+
+    # ── Internal ─────────────────────────────────────────────────
+
+    def _load(self) -> None:
+        """Reload the entire parameters table into the cache."""
+        if self._dsn is None:
+            if not self._loaded:
+                logger.warning(
+                    "DATABASE_URL not set; registry will use defaults only"
+                )
+                self._loaded = True
+            return
+
+        try:
+            import psycopg
+
+            with psycopg.connect(self._dsn) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT name, category, value, bounds_low, bounds_high,
+                               justification, version
+                          FROM monkey_parameters
+                        """
+                    )
+                    new_cache: dict[str, ParamValue] = {}
+                    for row in cur.fetchall():
+                        (name, category_str, value, b_low, b_high,
+                         justification, version) = row
+                        try:
+                            cat = VariableCategory(category_str)
+                        except ValueError:
+                            logger.warning(
+                                "registry row '%s' has unknown category '%s'; "
+                                "skipping",
+                                name, category_str,
+                            )
+                            continue
+                        new_cache[name] = ParamValue(
+                            name=name,
+                            category=cat,
+                            value=float(value),
+                            bounds_low=float(b_low) if b_low is not None else None,
+                            bounds_high=float(b_high) if b_high is not None else None,
+                            justification=justification,
+                            version=int(version),
+                        )
+            self._cache = new_cache
+            self._loaded = True
+            logger.debug("parameter registry loaded: %d entries", len(new_cache))
+        except Exception as exc:
+            # Fail-soft: keep serving from existing cache.
+            logger.warning("parameter registry load failed: %s", exc)
+            if not self._loaded:
+                self._loaded = True  # don't retry every .get() call
+
+
+# ── Process-global singleton ─────────────────────────────────────
+
+_instance: Optional[ParameterRegistry] = None
+_instance_lock = threading.Lock()
+
+
+def get_registry() -> ParameterRegistry:
+    """Return the process-wide registry. Lazy-init on first call."""
+    global _instance
+    if _instance is None:
+        with _instance_lock:
+            if _instance is None:
+                _instance = ParameterRegistry()
+    return _instance
+
+
+def _reset_registry_for_tests() -> None:
+    """Test-only: wipe the singleton so tests start clean."""
+    global _instance
+    with _instance_lock:
+        _instance = None


### PR DESCRIPTION
## Summary

Part 2/10 of v0.8. Establishes the governance surface for Canonical Principles v2.2 P14 (variable category discipline) + P25 (no operational threshold is a magic constant). Later phases replace literal module constants with `reg.get()` calls pointing at this registry.

**No behaviour change** — pure infrastructure.

## Migration 034

- `monkey_parameters` — live-editable registry with CHECK constraint (value ∈ bounds), version counter, actor tag
- `monkey_parameter_changes` — append-only audit log
- Trigger `_monkey_parameters_audit()` — every INSERT/UPDATE auto-writes an audit row with session-local `change_reason`
- Seeds **23 rows** for constants v0.8.3–v0.8.7 will migrate: physics, loop envelopes, executive safety floors, self-obs bias cap, memory bounds, basin-sync, mode detection gates, neurochemistry

## Python module

- `VariableCategory` enum (5 values: STATE / PARAMETER / BOUNDARY / SAFETY_BOUND / OPERATIONAL)
- `ParameterRegistry` — cached read-through, fail-soft on DB unreachable
- `propose_change(name, value, actor, reason)` — trigger-audited write via `set_config()` GUC
- `rollback(name, actor, reason)` — walks history, re-proposes last old_value

## Test plan

Verified against a local Postgres DB:
- [x] Migration applies clean (23 seed rows)
- [x] Trigger fires on INSERT + UPDATE
- [x] `propose_change` → refresh → `get` returns new value
- [x] `rollback` walks history correctly
- [x] Bounds violation raises `psycopg.errors.CheckViolation`
- [x] `qig_purity_check.py` → 19 files clean (new module added)

## Audit trail sample

```
 old_value | new_value |   actor     |         reason         
-----------+-----------+-------------+------------------------
           |        20 | system      | initial insert
        20 |        25 | test-runner | v0.8.1 round-trip test
        25 |        20 | test-runner | rollback: undo
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)