### PR TITLE
feat(monkey): v0.8.2 Python Poloniex v3 HMAC REST client

### DIFF
--- a/ml-worker/requirements.txt
+++ b/ml-worker/requirements.txt
@@ -19,3 +19,6 @@ qig-compute>=0.3.0
 # Postgres client for parameter registry (v0.8.1) + shared state with
 # apps/api (v0.8.3+). psycopg v3 with binary wheels (no compile step).
 psycopg[binary,pool]>=3.1.0
+# Async HTTP client for Poloniex v3 REST (v0.8.2). Matches the axios-
+# based TS client in apps/api/src/services/poloniexFuturesService.js.
+aiohttp>=3.9.0

--- a/ml-worker/src/exchange/__init__.py
+++ b/ml-worker/src/exchange/__init__.py
@@ -1,0 +1,24 @@
+"""
+exchange — Python port of TS exchange IO.
+
+v0.8.2 scope: Poloniex v3 Futures REST client. Async, HMAC-SHA256 auth,
+matching the TS signing scheme bit-for-bit. Port of
+apps/api/src/services/poloniexFuturesService.js.
+
+Future: poloniex_ws.py for WebSocket (deferred to v0.8.7 if REST polling
+is insufficient).
+"""
+
+from .poloniex_v3 import (
+    PoloniexV3Client,
+    PoloniexV3Credentials,
+    PoloniexV3Error,
+    generate_signature,
+)
+
+__all__ = [
+    "PoloniexV3Client",
+    "PoloniexV3Credentials",
+    "PoloniexV3Error",
+    "generate_signature",
+]

--- a/ml-worker/src/exchange/poloniex_v3.py
+++ b/ml-worker/src/exchange/poloniex_v3.py
@@ -1,0 +1,488 @@
+"""
+poloniex_v3.py — Python port of Poloniex v3 Futures REST client.
+
+Source of truth: apps/api/src/services/poloniexFuturesService.js.
+The HMAC-SHA256 signing scheme is reproduced EXACTLY — identical inputs
+must produce identical signatures across the TS and Python clients (this
+is asserted in tests/test_poloniex_v3_signer.py with a known vector).
+
+Poloniex v3 API envelope: {code, data, msg}. A non-200 body code is an
+application error even when HTTP is 200 — most commonly seen on
+POST /v3/trade/order, where HTTP returns 200 but body is
+{code: <non-200>, msg: "<reason>"} with no data. Diagnosed 2026-04-19
+after phantom orders were being "placed" that never executed. This
+client raises PoloniexV3Error on application errors so callers don't
+silently swallow them.
+
+Purity: this module is NOT QIG cognition — it's BOUNDARY (per P14).
+Exchange IO is explicitly outside the purity-check scope. No Δ⁶³
+operations happen here.
+
+v0.8.2 — client only, no orchestration wiring. v0.8.7 will migrate
+call-sites from TS to this client as part of risk_kernel +
+live_signal + autonomous_trader ports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+from urllib.parse import quote
+
+logger = logging.getLogger("exchange.poloniex_v3")
+
+DEFAULT_BASE_URL = "https://api.poloniex.com"
+DEFAULT_TIMEOUT_S = 30.0
+
+# JavaScript encodeURIComponent leaves these characters unescaped:
+#   A-Z a-z 0-9 - _ . ! ~ * ' ( )
+# Python urllib.parse.quote's `safe` arg controls the same thing.
+# Match byte-for-byte so the signed paramString matches the TS output.
+_URI_COMPONENT_SAFE = "-_.!~*'()"
+
+
+@dataclass(frozen=True)
+class PoloniexV3Credentials:
+    """API credentials for authenticated endpoints.
+
+    Public endpoints (klines, contract info, trading info) do not require
+    credentials — pass None where credentials are optional.
+    """
+
+    api_key: str
+    api_secret: str
+
+
+class PoloniexV3Error(RuntimeError):
+    """Raised when Poloniex returns an application-level error.
+
+    Application errors arrive as HTTP 200 with a non-200 body code:
+      {code: 10001, msg: "Param error", data: null}
+    Attributes mirror the TS side (poloniexCode, poloniexMsg, endpoint)
+    so existing callers' error handling translates directly.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        code: Any,
+        msg: Optional[str],
+        http_status: int = 200,
+    ):
+        super().__init__(
+            f"Poloniex {endpoint} returned code={code}: {msg or 'no message'}"
+        )
+        self.endpoint = endpoint
+        self.poloniex_code = code
+        self.poloniex_msg = msg
+        self.http_status = http_status
+
+
+def normalize_symbol(symbol: str) -> str:
+    """Normalize a symbol to Poloniex v3 futures form (…_PERP).
+
+    BTC_USDT → BTC_USDT_PERP
+    BTC-USDT → BTC_USDT_PERP
+    BTC_USDT_PERP → BTC_USDT_PERP (unchanged)
+
+    Matches poloniexFuturesService.normalizeSymbol() exactly.
+    """
+    if not symbol:
+        return symbol
+    base = symbol.replace("-", "_")
+    if base.endswith("_PERP") or "PERP" in base:
+        return base
+    return f"{base}_PERP"
+
+
+def generate_signature(
+    method: str,
+    request_path: str,
+    params: Optional[dict[str, Any]],
+    body: Optional[dict[str, Any]],
+    timestamp: str,
+    api_secret: str,
+) -> str:
+    """Reproduce the TS HMAC-SHA256 signing scheme.
+
+    Three paramString shapes (matches poloniexFuturesService.js:65-102):
+
+      POST/PUT with body:
+        requestBody=<json>&signTimestamp=<ts>
+
+      GET/DELETE with params:
+        <key1>=<val1>&<key2>=<val2>&...&signTimestamp=<ts>
+        (keys sorted ASCII, values URL-encoded)
+
+      No params, no body:
+        signTimestamp=<ts>
+
+    Message: METHOD\\n<request_path>\\n<paramString>
+    Sign: HMAC-SHA256(api_secret, message) → base64
+    """
+    method_upper = method.upper()
+
+    if body is not None and method_upper in ("POST", "PUT"):
+        # JSON.stringify produces compact form in Node; json.dumps with
+        # separators=(",", ":") matches exactly.
+        body_json = json.dumps(body, separators=(",", ":"))
+        param_string = f"requestBody={body_json}&signTimestamp={timestamp}"
+    elif params:
+        # sort ASCII, url-encode values same way as encodeURIComponent
+        all_params = dict(params)
+        all_params["signTimestamp"] = timestamp
+        sorted_keys = sorted(all_params.keys())
+        encoded = [
+            f"{quote(str(k), safe=_URI_COMPONENT_SAFE)}="
+            f"{quote(str(all_params[k]), safe=_URI_COMPONENT_SAFE)}"
+            for k in sorted_keys
+        ]
+        param_string = "&".join(encoded)
+    else:
+        param_string = f"signTimestamp={timestamp}"
+
+    message = f"{method_upper}\n{request_path}\n{param_string}"
+    digest = hmac.new(
+        api_secret.encode("utf-8"),
+        message.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+class PoloniexV3Client:
+    """Async Poloniex v3 Futures REST client.
+
+    Usage:
+        async with PoloniexV3Client(credentials) as c:
+            bal = await c.get_account_balance()
+            positions = await c.get_positions()
+            await c.place_order({
+                "symbol": "BTC_USDT_PERP", "side": "BUY",
+                "mgnMode": "ISOLATED", "posSide": "LONG",
+                "type": "MARKET", "sz": "1",
+            })
+
+    Rate limiting: callers' responsibility — this client does not
+    throttle. In v0.8.7 the risk kernel's rate-limit budget mediates
+    all exchange calls (same pattern as the TS side).
+    """
+
+    def __init__(
+        self,
+        credentials: Optional[PoloniexV3Credentials] = None,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout_s: float = DEFAULT_TIMEOUT_S,
+    ):
+        self._creds = credentials
+        self._base_url = base_url.rstrip("/")
+        self._timeout_s = timeout_s
+        self._session = None  # aiohttp.ClientSession — lazy init
+
+    async def __aenter__(self):
+        await self._ensure_session()
+        return self
+
+    async def __aexit__(self, *_exc):
+        await self.close()
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def _ensure_session(self):
+        if self._session is None:
+            # Import here so module import doesn't require aiohttp
+            # installed until first actual use.
+            import aiohttp
+
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=self._timeout_s),
+            )
+
+    # ── Auth helpers ─────────────────────────────────────────────
+
+    def _auth_headers(
+        self,
+        method: str,
+        request_path: str,
+        params: Optional[dict[str, Any]],
+        body: Optional[dict[str, Any]],
+    ) -> dict[str, str]:
+        if self._creds is None:
+            raise RuntimeError(
+                "authenticated endpoint called without credentials"
+            )
+        timestamp = str(int(time.time() * 1000))
+        signature = generate_signature(
+            method, request_path, params, body, timestamp,
+            self._creds.api_secret,
+        )
+        return {
+            "Content-Type": "application/json",
+            "key": self._creds.api_key,
+            "signature": signature,
+            "signTimestamp": timestamp,
+            "signatureMethod": "hmacSHA256",
+            "signatureVersion": "2",
+        }
+
+    # ── Request engines ──────────────────────────────────────────
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        body: Optional[dict[str, Any]] = None,
+        authenticated: bool = True,
+    ) -> Any:
+        await self._ensure_session()
+        request_path = f"/v3{endpoint}"
+        url = f"{self._base_url}{request_path}"
+
+        # Symbol normalization mirrors TS client — authenticated only,
+        # both body and params.
+        if authenticated:
+            if body and "symbol" in body:
+                body = {**body, "symbol": normalize_symbol(body["symbol"])}
+            if params and "symbol" in params:
+                params = {**params, "symbol": normalize_symbol(params["symbol"])}
+
+        headers = (
+            self._auth_headers(method, request_path, params, body)
+            if authenticated
+            else {"Content-Type": "application/json"}
+        )
+
+        kwargs: dict[str, Any] = {"headers": headers}
+        if params and method.upper() == "GET":
+            kwargs["params"] = params
+        if body is not None and method.upper() in ("POST", "PUT", "DELETE"):
+            kwargs["data"] = json.dumps(body, separators=(",", ":"))
+
+        assert self._session is not None
+        async with self._session.request(method.upper(), url, **kwargs) as resp:
+            text = await resp.text()
+            http_status = resp.status
+            try:
+                payload = json.loads(text) if text else {}
+            except json.JSONDecodeError:
+                raise PoloniexV3Error(
+                    endpoint=request_path,
+                    code=None,
+                    msg=f"non-JSON response: {text[:200]}",
+                    http_status=http_status,
+                )
+
+        body_code = payload.get("code") if isinstance(payload, dict) else None
+        body_msg = payload.get("msg") if isinstance(payload, dict) else None
+
+        logger.debug(
+            "poloniex_v3 %s %s → http=%d code=%s msg=%s",
+            method.upper(), request_path, http_status, body_code, body_msg,
+        )
+
+        is_application_error = (
+            body_code is not None
+            and body_code != 200
+            and body_code != 0
+            and str(body_code).upper() != "SUCCESS"
+        )
+        if is_application_error:
+            raise PoloniexV3Error(
+                endpoint=request_path,
+                code=body_code,
+                msg=body_msg,
+                http_status=http_status,
+            )
+
+        if isinstance(payload, dict) and "data" in payload:
+            return payload["data"]
+        return payload
+
+    # ── Account ──────────────────────────────────────────────────
+
+    async def get_account_balance(self) -> Any:
+        """GET /v3/account/balance."""
+        return await self._request("GET", "/account/balance")
+
+    async def transfer_to_spot(self, amount: float) -> Any:
+        """POST /v3/account/transfer-out — USDT from futures to spot."""
+        return await self._request(
+            "POST", "/account/transfer-out",
+            body={"currency": "USDT", "amount": str(amount)},
+        )
+
+    async def get_account_bills(self, **params: Any) -> Any:
+        """GET /v3/account/bills."""
+        return await self._request("GET", "/account/bills", params=params or None)
+
+    # ── Positions ────────────────────────────────────────────────
+
+    async def get_positions(self, **params: Any) -> Any:
+        """GET /v3/trade/position/opens."""
+        return await self._request(
+            "GET", "/trade/position/opens", params=params or None,
+        )
+
+    async def get_position_history(self, **params: Any) -> Any:
+        """GET /v3/trade/position/history."""
+        return await self._request(
+            "GET", "/trade/position/history", params=params or None,
+        )
+
+    async def set_leverage(self, symbol: str, leverage: int, mgn_mode: str = "ISOLATED") -> Any:
+        """POST /v3/position/leverage."""
+        return await self._request(
+            "POST", "/position/leverage",
+            body={"symbol": symbol, "lever": str(leverage), "mgnMode": mgn_mode},
+        )
+
+    async def get_leverages(self, **params: Any) -> Any:
+        """GET /v3/position/leverages."""
+        return await self._request(
+            "GET", "/position/leverages", params=params or None,
+        )
+
+    async def get_position_mode(self) -> Any:
+        """GET /v3/position/mode — one-way vs hedge."""
+        return await self._request("GET", "/position/mode")
+
+    async def set_position_mode(self, mode: str) -> Any:
+        """POST /v3/position/mode. mode ∈ {'ONE_WAY', 'HEDGE'}."""
+        return await self._request(
+            "POST", "/position/mode", body={"posMode": mode},
+        )
+
+    # ── Orders ───────────────────────────────────────────────────
+
+    async def place_order(self, order: dict[str, Any]) -> Any:
+        """POST /v3/trade/order.
+
+        Caller must pass the v3 wire form (UPPER side/type, sz as string
+        in contracts, posSide, mgnMode). The TS placeOrder() wrapper does
+        extra ergonomic translation; v0.8.7 will move that translation
+        here when autonomous_trader.py lands.
+        """
+        return await self._request("POST", "/trade/order", body=order)
+
+    async def place_orders(self, orders: list[dict[str, Any]]) -> Any:
+        """POST /v3/trade/orders — batch."""
+        return await self._request("POST", "/trade/orders", body={"orders": orders})
+
+    async def cancel_order(self, order_id: str, symbol: str) -> Any:
+        """DELETE /v3/trade/order."""
+        return await self._request(
+            "DELETE", "/trade/order",
+            body={"symbol": symbol, "orderId": order_id},
+        )
+
+    async def cancel_all_orders(self, symbol: Optional[str] = None) -> Any:
+        """DELETE /v3/trade/allOrders."""
+        body = {"symbol": symbol} if symbol else {}
+        return await self._request("DELETE", "/trade/allOrders", body=body)
+
+    async def get_open_orders(self, **params: Any) -> Any:
+        """GET /v3/trade/order/opens."""
+        return await self._request(
+            "GET", "/trade/order/opens", params=params or None,
+        )
+
+    async def get_order_history(self, **params: Any) -> Any:
+        """GET /v3/trade/order/history."""
+        return await self._request(
+            "GET", "/trade/order/history", params=params or None,
+        )
+
+    async def get_execution_details(self, **params: Any) -> Any:
+        """GET /v3/trade/order/trades — fills."""
+        return await self._request(
+            "GET", "/trade/order/trades", params=params or None,
+        )
+
+    # ── Positions: close ─────────────────────────────────────────
+
+    async def close_position(
+        self, symbol: str, close_type: str = "close_long",
+    ) -> Any:
+        """POST /v3/trade/position. close_type ∈ {'close_long', 'close_short'}."""
+        return await self._request(
+            "POST", "/trade/position",
+            body={"symbol": symbol, "type": close_type},
+        )
+
+    async def close_all_positions(self) -> Any:
+        """POST /v3/trade/positionAll."""
+        return await self._request("POST", "/trade/positionAll", body={})
+
+    # ── Market data (public, no auth) ────────────────────────────
+
+    async def get_trading_info(self, symbol: Optional[str] = None) -> Any:
+        """GET /v3/market/get-trading-info."""
+        params = {"symbol": symbol} if symbol else None
+        return await self._request(
+            "GET", "/market/get-trading-info",
+            params=params, authenticated=False,
+        )
+
+    async def get_kline_data(
+        self,
+        symbol: str,
+        granularity: int | str,
+        *,
+        from_ts: Optional[int] = None,
+        to_ts: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Any:
+        """GET /v3/market/get-kline-data.
+
+        granularity in minutes: 1, 5, 15, 30, 60, 120, 240, 480, 720,
+        1440, 10080.
+        """
+        params: dict[str, Any] = {
+            "symbol": symbol,
+            "granularity": str(granularity),
+        }
+        if from_ts is not None:
+            params["from"] = from_ts
+        if to_ts is not None:
+            params["to"] = to_ts
+        if limit is not None:
+            params["limit"] = limit
+        return await self._request(
+            "GET", "/market/get-kline-data",
+            params=params, authenticated=False,
+        )
+
+    async def get_contract_info(self, symbol: Optional[str] = None) -> Any:
+        """GET /v3/market/get-contract-info."""
+        params = {"symbol": symbol} if symbol else None
+        return await self._request(
+            "GET", "/market/get-contract-info",
+            params=params, authenticated=False,
+        )
+
+
+# ── Convenience wrapper: sync one-shot calls ─────────────────────
+
+def run_sync(coro):
+    """Run an async call from sync code (tests / ad-hoc scripts).
+
+    Not for use in the main tick loop — that path is async throughout.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()

--- a/ml-worker/tests/exchange/test_poloniex_v3_signer.py
+++ b/ml-worker/tests/exchange/test_poloniex_v3_signer.py
@@ -1,0 +1,130 @@
+"""
+test_poloniex_v3_signer.py — parity tests for HMAC-SHA256 signing.
+
+The EXPECTED_* constants below were computed by running the TS reference
+signer in poloniexFuturesService.js with identical inputs (fixed secret
++ timestamp). They are committed as literal strings, NOT recomputed from
+a Python shadow implementation, because a test that re-derives its own
+expected values cannot detect drift between TS and Python in the
+algorithm itself — it only detects test-vs-prod divergence within
+Python, which is half the job.
+
+Re-pinning procedure (when the TS signer legitimately changes):
+  1. Update the Node snippet in commit message of v0.8.2 / run the block
+     in ml-worker/scripts/regenerate_poloniex_vectors.js (v0.8.7+)
+  2. Paste the updated sig strings below
+  3. Note the reason in the PR description
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make src/ importable without installing the package.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from exchange.poloniex_v3 import generate_signature, normalize_symbol
+
+
+# Fixed inputs — non-secret test data, identical across the TS Node run
+# and the Python signer.
+TEST_SECRET = "abcdef1234567890abcdef1234567890"
+TEST_TIMESTAMP = "1700000000000"
+
+
+# Pinned expected signatures from the TS reference implementation
+# (apps/api/src/services/poloniexFuturesService.js:generateSignature)
+# computed 2026-04-21 via Node v25.2.1.
+EXPECTED_GET_NO_PARAMS = "kD1x7m4deRUt8SIwDf4O7TdC5H3CQF0aI8CKhidLqjo="
+EXPECTED_GET_WITH_PARAMS = "j2mMdY8MeouuivQA9ET+jDNErpqUS9xnfeJ4T/OsNs4="
+EXPECTED_POST_WITH_BODY = "f+e+vwM08ejStcq2Hwukv/nx0t054g0t2jjyqZXzfZA="
+EXPECTED_DELETE_NO_BODY = "FWcWSzzT8711FUhkRUVA7ekkSv2zJo6x7929slboUdk="
+EXPECTED_UNSORTED_KEYS = "MFzbCriHP48/GUoEwMRUgSlsOAyCeOEs6utlLj6zGb4="
+
+
+def test_signature_get_no_params() -> None:
+    """GET/DELETE with no params → just signTimestamp in the message."""
+    sig = generate_signature(
+        "GET", "/v3/account/balance", None, None,
+        TEST_TIMESTAMP, TEST_SECRET,
+    )
+    assert sig == EXPECTED_GET_NO_PARAMS, f"got {sig!r}"
+
+
+def test_signature_get_with_params() -> None:
+    """GET with params → sorted keys + signTimestamp, URL-encoded."""
+    params = {"symbol": "BTC_USDT_PERP", "limit": "10"}
+    sig = generate_signature(
+        "GET", "/v3/trade/position/opens", params, None,
+        TEST_TIMESTAMP, TEST_SECRET,
+    )
+    assert sig == EXPECTED_GET_WITH_PARAMS, f"got {sig!r}"
+
+
+def test_signature_post_with_body() -> None:
+    """POST with JSON body → requestBody=<json>&signTimestamp=<ts>.
+
+    Key test: JSON must be compact (no spaces). TS JSON.stringify is
+    compact by default; Python json.dumps needs separators=(",", ":").
+    """
+    body = {
+        "symbol": "BTC_USDT_PERP",
+        "side": "BUY",
+        "mgnMode": "ISOLATED",
+        "posSide": "LONG",
+        "type": "MARKET",
+        "sz": "1",
+    }
+    sig = generate_signature(
+        "POST", "/v3/trade/order", None, body,
+        TEST_TIMESTAMP, TEST_SECRET,
+    )
+    assert sig == EXPECTED_POST_WITH_BODY, f"got {sig!r}"
+
+
+def test_signature_delete_with_body_hashes_timestamp_only() -> None:
+    """DELETE with body — TS code path: body only folds into the sig
+    on POST/PUT. DELETE-with-body falls through to the timestamp-only
+    branch. Mirror that exactly so auth doesn't silently fail.
+    """
+    sig = generate_signature(
+        "DELETE", "/v3/trade/order", None,
+        {"symbol": "BTC_USDT_PERP", "orderId": "abc"},
+        TEST_TIMESTAMP, TEST_SECRET,
+    )
+    assert sig == EXPECTED_DELETE_NO_BODY, f"got {sig!r}"
+
+
+def test_signature_params_sort_order() -> None:
+    """Keys must sort ASCII (not insertion) to match TS Object.keys().sort()."""
+    sig = generate_signature(
+        "GET", "/v3/foo",
+        {"zebra": "1", "alpha": "2", "mid": "3"},
+        None, TEST_TIMESTAMP, TEST_SECRET,
+    )
+    assert sig == EXPECTED_UNSORTED_KEYS, f"got {sig!r}"
+
+    # Reordering the dict keys must produce the identical signature.
+    sig_reordered = generate_signature(
+        "GET", "/v3/foo",
+        {"alpha": "2", "mid": "3", "zebra": "1"},
+        None, TEST_TIMESTAMP, TEST_SECRET,
+    )
+    assert sig_reordered == EXPECTED_UNSORTED_KEYS
+
+
+def test_normalize_symbol() -> None:
+    assert normalize_symbol("BTC_USDT") == "BTC_USDT_PERP"
+    assert normalize_symbol("BTC-USDT") == "BTC_USDT_PERP"
+    assert normalize_symbol("BTC_USDT_PERP") == "BTC_USDT_PERP"
+    assert normalize_symbol("") == ""
+    assert normalize_symbol("ETH_USDT_PERP") == "ETH_USDT_PERP"
+
+
+if __name__ == "__main__":
+    for name, fn in list(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"  ✓ {name}")
+    print("all signer parity tests passed")


### PR DESCRIPTION
## Summary

Part 3/10 of v0.8. Python async port of `poloniexFuturesService.js`. Sits unused on this PR — **no call-sites wired**. v0.8.7 migrates `risk_kernel` + `live_signal` + `autonomous_trader` onto this client as part of the orchestration port.

## What this is

- `ml-worker/src/exchange/poloniex_v3.py` — HMAC-SHA256 signer + async `PoloniexV3Client` covering the 10 REST endpoint families currently used in TS orchestration.
- `tests/exchange/test_poloniex_v3_signer.py` — six parity tests. **Expected signatures are hard-coded strings** computed by running the TS reference signer in Node v25.2.1. Tests do NOT re-derive them from a Python shadow impl (which would only catch Python-vs-Python drift, not real TS-vs-Py drift).

## Parity vectors

Computed once, committed as literals:

| Vector | Expected signature |
|---|---|
| GET no-params | `kD1x7m4deRUt8SIwDf4O7TdC5H3CQF0aI8CKhidLqjo=` |
| GET with params | `j2mMdY8MeouuivQA9ET+jDNErpqUS9xnfeJ4T/OsNs4=` |
| POST with body | `f+e+vwM08ejStcq2Hwukv/nx0t054g0t2jjyqZXzfZA=` |
| DELETE with body | `FWcWSzzT8711FUhkRUVA7ekkSv2zJo6x7929slboUdk=` |
| GET unsorted keys | `MFzbCriHP48/GUoEwMRUgSlsOAyCeOEs6utlLj6zGb4=` |

## Port mechanics verified

- JSON serialization: Python `separators=(",", ":")` matches V8 `JSON.stringify`
- URL encoding: `quote(safe="-_.!~*'()")` matches `encodeURIComponent`
- Sort order: Python `sorted()` on str keys matches `Object.keys().sort()`
- Application-error unwrap mirrors the 2026-04-19 phantom-order TS fix — raises `PoloniexV3Error` on `{code: <non-200>}` in HTTP 200 body

## Test plan

- [x] `python tests/exchange/test_poloniex_v3_signer.py` → 6/6 pass
- [x] `qig_purity_check.py` → 19 files clean (exchange/ is BOUNDARY, out of scope)
- [ ] v0.8.7 integration test — live signing against Poloniex sandbox

## Purity

`exchange/` is BOUNDARY per P14 (external data, sanitized on ingest). Excluded from the purity-check scan by default scan-root selection — same rationale as `observable_governance.py`. Documented in the `ML_PREDICTION_LAYER_PREFIXES` block (v0.8.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)