### PR TITLE
feat(monkey): v0.8.3 tick.py — stateful in-process decision pipeline

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -294,6 +294,7 @@ async def ml_predict(request: Request):
 # resonance bank stays in Postgres via the TS side.
 
 from monkey_kernel import (  # noqa: E402
+    AccountContext,
     AutonomicKernel,
     AutonomicTickInputs,
     ExecBasinState,
@@ -301,13 +302,18 @@ from monkey_kernel import (  # noqa: E402
     NeurochemicalState,
     OHLCVCandle,
     PerceptionInputs,
+    SymbolState,
+    TickDecision,
+    TickInputs,
     basin_direction,
     current_entry_threshold,
     current_leverage,
     current_position_size,
     detect_mode,
+    fresh_symbol_state,
     perceive,
     refract,
+    run_tick,
     should_dca_add,
     should_exit,
     should_profit_harvest,
@@ -317,6 +323,12 @@ from monkey_kernel import (  # noqa: E402
 import numpy as np  # noqa: E402
 
 _autonomic_instances: dict[str, AutonomicKernel] = {}
+
+# v0.8.3: per-(instance, symbol) tick state. Kept in-process for now —
+# TS shadow-mode calls pass state in every call via `prev_state`; Python
+# only caches it so the next call can skip the round-trip if the TS side
+# trusts the worker. v0.8.7 makes this canonical state.
+_symbol_states: dict[tuple[str, str], SymbolState] = {}
 
 
 def _get_autonomic(instance_id: str) -> AutonomicKernel:
@@ -624,6 +636,176 @@ async def monkey_perception_perceive(request: Request):
     return {
         "raw": raw.tolist(),
         "refracted": refracted.tolist(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# v0.8.3 — /monkey/tick/run
+# ---------------------------------------------------------------------------
+
+
+def _symbol_state_to_dict(st: SymbolState) -> dict:
+    return {
+        "symbol": st.symbol,
+        "identity_basin": st.identity_basin.tolist(),
+        "last_basin": st.last_basin.tolist() if st.last_basin is not None else None,
+        "kappa": st.kappa,
+        "session_ticks": st.session_ticks,
+        "last_mode": st.last_mode,
+        "basin_history": [b.tolist() for b in st.basin_history],
+        "phi_history": list(st.phi_history),
+        "fhealth_history": list(st.fhealth_history),
+        "drift_history": list(st.drift_history),
+        "dca_add_count": st.dca_add_count,
+        "last_entry_at_ms": st.last_entry_at_ms,
+        "peak_pnl_usdt": st.peak_pnl_usdt,
+        "peak_tracked_trade_id": st.peak_tracked_trade_id,
+    }
+
+
+def _symbol_state_from_dict(d: dict) -> SymbolState:
+    last_basin = d.get("last_basin")
+    return SymbolState(
+        symbol=str(d["symbol"]),
+        identity_basin=np.asarray(d["identity_basin"], dtype=np.float64),
+        last_basin=np.asarray(last_basin, dtype=np.float64)
+                    if last_basin is not None else None,
+        kappa=float(d.get("kappa", 64.0)),
+        session_ticks=int(d.get("session_ticks", 0)),
+        last_mode=d.get("last_mode"),
+        basin_history=[
+            np.asarray(b, dtype=np.float64) for b in d.get("basin_history", [])
+        ],
+        phi_history=[float(x) for x in d.get("phi_history", [])],
+        fhealth_history=[float(x) for x in d.get("fhealth_history", [])],
+        drift_history=[float(x) for x in d.get("drift_history", [])],
+        dca_add_count=int(d.get("dca_add_count", 0)),
+        last_entry_at_ms=d.get("last_entry_at_ms"),
+        peak_pnl_usdt=d.get("peak_pnl_usdt"),
+        peak_tracked_trade_id=d.get("peak_tracked_trade_id"),
+    )
+
+
+def _decision_to_dict(dec: TickDecision) -> dict:
+    return {
+        "action": dec.action,
+        "reason": dec.reason,
+        "mode": dec.mode,
+        "size_usdt": dec.size_usdt,
+        "leverage": dec.leverage,
+        "entry_threshold": dec.entry_threshold,
+        "phi": dec.phi,
+        "kappa": dec.kappa,
+        "basin_velocity": dec.basin_velocity,
+        "f_health": dec.f_health,
+        "drift_from_identity": dec.drift_from_identity,
+        "basin_direction": dec.basin_direction,
+        "tape_trend": dec.tape_trend,
+        "side_candidate": dec.side_candidate,
+        "side_override": dec.side_override,
+        "neurochemistry": dec.neurochemistry.as_dict(),
+        "derivation": dec.derivation,
+        "basin": dec.basin.tolist(),
+        "is_dca_add": dec.is_dca_add,
+        "is_reverse": dec.is_reverse,
+    }
+
+
+@app.post("/monkey/tick/run")
+async def monkey_tick_run(request: Request):
+    """Run one decision tick. Stateless from the HTTP caller's view —
+    caller passes `prev_state` (or omits for a newborn symbol), receives
+    back `decision` + `new_state`. Per-(instance, symbol) state is also
+    cached in-process so the next call can skip state transfer once
+    Python owns the loop (v0.8.7).
+
+    Request body:
+      {
+        "instance_id": "monkey-primary",
+        "inputs": {
+          "symbol": "BTC_USDT_PERP",
+          "ohlcv": [{"timestamp", "open", "high", "low", "close", "volume"}],
+          "ml_signal": "BUY"|"SELL"|"HOLD",
+          "ml_strength": 0..1,
+          "account": { equity_fraction, margin_fraction, open_positions,
+                       available_equity, exchange_held_side?, own_position_* },
+          "bank_size": int, "sovereignty": 0..1,
+          "max_leverage": int, "min_notional": float,
+          "size_fraction": 1.0, "self_obs_bias": {...}?
+        },
+        "prev_state": {... SymbolState JSON ...}  // or null for newborn
+      }
+
+    Response:
+      { "decision": {...TickDecision...}, "new_state": {...SymbolState...} }
+    """
+    payload = await request.json()
+    instance_id = str(payload.get("instance_id", "monkey-primary"))
+    inp = payload["inputs"]
+
+    candles = [
+        OHLCVCandle(
+            timestamp=float(c.get("timestamp", 0)),
+            open=float(c["open"]),
+            high=float(c["high"]),
+            low=float(c["low"]),
+            close=float(c["close"]),
+            volume=float(c["volume"]),
+        )
+        for c in inp["ohlcv"]
+    ]
+    acct_d = inp["account"]
+    account = AccountContext(
+        equity_fraction=float(acct_d.get("equity_fraction", 0.0)),
+        margin_fraction=float(acct_d.get("margin_fraction", 0.0)),
+        open_positions=int(acct_d.get("open_positions", 0)),
+        available_equity=float(acct_d.get("available_equity", 0.0)),
+        exchange_held_side=acct_d.get("exchange_held_side"),
+        own_position_entry_price=(
+            float(acct_d["own_position_entry_price"])
+            if acct_d.get("own_position_entry_price") is not None else None
+        ),
+        own_position_quantity=(
+            float(acct_d["own_position_quantity"])
+            if acct_d.get("own_position_quantity") is not None else None
+        ),
+        own_position_trade_id=acct_d.get("own_position_trade_id"),
+    )
+    tick_inputs = TickInputs(
+        symbol=str(inp["symbol"]),
+        ohlcv=candles,
+        ml_signal=str(inp.get("ml_signal", "HOLD")),
+        ml_strength=float(inp.get("ml_strength", 0.0)),
+        account=account,
+        bank_size=int(inp.get("bank_size", 0)),
+        sovereignty=float(inp.get("sovereignty", 0.0)),
+        max_leverage=int(inp.get("max_leverage", 10)),
+        min_notional=float(inp.get("min_notional", 5.0)),
+        size_fraction=float(inp.get("size_fraction", 1.0)),
+        self_obs_bias=inp.get("self_obs_bias"),
+    )
+
+    # State resolution: caller-provided wins, else in-process cache, else
+    # newborn seeded from uniform basin.
+    key = (instance_id, tick_inputs.symbol)
+    prev_state_payload = payload.get("prev_state")
+    if prev_state_payload is not None:
+        state = _symbol_state_from_dict(prev_state_payload)
+    elif key in _symbol_states:
+        state = _symbol_states[key]
+    else:
+        # Seed with uniform basin — caller should provide identity for
+        # existing symbols, but we don't require it.
+        from monkey_kernel.basin import uniform_basin
+        state = fresh_symbol_state(tick_inputs.symbol, uniform_basin(64))
+
+    autonomic = _get_autonomic(instance_id)
+    decision, new_state = run_tick(tick_inputs, state, autonomic)
+    _symbol_states[key] = new_state
+
+    return {
+        "decision": _decision_to_dict(decision),
+        "new_state": _symbol_state_to_dict(new_state),
     }
 
 

--- a/ml-worker/src/monkey_kernel/__init__.py
+++ b/ml-worker/src/monkey_kernel/__init__.py
@@ -72,6 +72,14 @@ from .parameters import (
     VariableCategory,
     get_registry,
 )
+from .tick import (
+    AccountContext,
+    SymbolState,
+    TickDecision,
+    TickInputs,
+    fresh_symbol_state,
+    run_tick,
+)
 from .perception import OHLCVCandle, PerceptionInputs, perceive, refract
 from .perception_scalars import basin_direction, trend_proxy
 from .resonance_bank import (
@@ -111,18 +119,24 @@ __all__ = [
     "MODE_PROFILES",
     "ModeProfile",
     "MonkeyMode",
+    "AccountContext",
     "NeurochemicalState",
     "ParamValue",
     "ParameterRegistry",
     "SleepCycleManager",
     "SleepPhase",
+    "SymbolState",
+    "TickDecision",
+    "TickInputs",
     "VariableCategory",
     "basin_direction",
     "current_entry_threshold",
     "current_leverage",
     "current_position_size",
     "detect_mode",
+    "fresh_symbol_state",
     "get_registry",
+    "run_tick",
     "should_dca_add",
     "should_exit",
     "should_profit_harvest",

--- a/ml-worker/src/monkey_kernel/executive.py
+++ b/ml-worker/src/monkey_kernel/executive.py
@@ -469,3 +469,44 @@ def should_exit(
         "reason": f"holding: disagreement {disagreement:.3f} < {threshold:.3f}",
         "derivation": {"disagreement": disagreement, "threshold": threshold},
     }
+
+
+# ═══════════════════════════════════════════════════════════════
+#  shouldAutoFlatten — Pillar 1 zombie-collapse catastrophic exit
+# ═══════════════════════════════════════════════════════════════
+
+
+def should_auto_flatten(
+    *,
+    s: ExecBasinState,
+    recent_fhealths: list[float],
+) -> dict[str, Any]:
+    """When Monkey's own state goes zombie (entropy collapse across
+    multiple ticks), flatten regardless of position P&L. Replaces the
+    hardcoded −15% DD kill switch with a Pillar 1 derivation — the
+    threshold emerges from basin entropy, not an external percentage.
+
+    Ported from apps/api/src/services/monkey/executive.ts:shouldAutoFlatten.
+    Thresholds `f_health mean < 0.3` and `trend < −0.1` stay as
+    SAFETY_BOUND constants per P25 — they are catastrophic-collapse
+    envelopes, not operational thresholds.
+    """
+    if len(recent_fhealths) < 5:
+        return {
+            "value": False,
+            "reason": "insufficient history",
+            "derivation": {},
+        }
+    recent = recent_fhealths[-10:]
+    mean = sum(recent) / len(recent)
+    trend = recent[-1] - recent[0]
+    catastrophic = mean < 0.3 and trend < -0.1
+    return {
+        "value": catastrophic,
+        "reason": (
+            f"f_health mean {mean:.3f}, trend {trend:.3f} — basin dying, FLATTEN"
+            if catastrophic
+            else f"f_health OK (mean {mean:.3f})"
+        ),
+        "derivation": {"f_health_mean": mean, "f_health_trend": trend},
+    }

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -1,0 +1,650 @@
+"""
+tick.py — Monkey kernel tick runner (v0.8.3).
+
+Pure-function port of apps/api/src/services/monkey/loop.ts::processSymbol.
+Given the inputs a tick needs (OHLCV, ML signal, account context, bank
+size, self-obs bias) AND the prior per-symbol state, runs the full
+decision pipeline in-process and returns (decision, new_state).
+
+Scope boundary: this module makes decisions. It does NOT:
+  - Fetch OHLCV / balances / positions (caller passes them in)
+  - Read or write the DB (caller persists)
+  - Place or cancel orders (caller executes)
+  - Emit bus events (caller publishes)
+
+Why stateless: during v0.8.3 shadow mode, both TS and Python evaluate
+every tick. If Python carried state, the two would drift from different
+histories and parity would collapse. Passing SymbolState in and getting
+new_state out keeps TS as the canonical state owner during transition.
+v0.8.7 removes the TS path and this becomes the source.
+
+Literal disposition (per the v0.8 plan, P25):
+  OVERRIDE_THRESHOLD = 0.35    → DERIVED here (see _override_threshold)
+  OHLCV_LOOKBACK, HISTORY_MAX  → registry-backed via parameters.py
+  KAPPA_STAR, kappa clamps     → registry-backed (physics.kappa_star)
+  Identity basin refresh (50 samples / every 10 ticks) → kept as TS-
+    compat constants for v0.8.3 parity. v0.8.6 replaces with adaptive
+    derivation when working_memory / self_observation disciplining lands.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import (
+    fisher_rao_distance,
+    frechet_mean,
+)
+
+from .autonomic import AutonomicKernel, AutonomicTickInputs
+from .basin import normalized_entropy, velocity
+from .executive import (
+    ExecBasinState,
+    current_entry_threshold,
+    current_leverage,
+    current_position_size,
+    should_auto_flatten,
+    should_dca_add,
+    should_exit,
+    should_profit_harvest,
+    should_scalp_exit,
+)
+from .modes import MODE_PROFILES, MonkeyMode, detect_mode
+from .parameters import get_registry
+from .perception import OHLCVCandle, PerceptionInputs, perceive, refract
+from .perception_scalars import basin_direction, trend_proxy
+from .state import NeurochemicalState
+
+logger = logging.getLogger("monkey.tick")
+
+_registry = get_registry()
+
+
+def _override_threshold(kappa: float, phi: float) -> float:
+    """Derive the basin+tape override threshold from κ and Φ (P25).
+
+    When consciousness is coherent (κ near κ*, high Φ), basin+tape
+    quorum doesn't need to be as large to override the ML signal —
+    she trusts herself. When forming (κ low, Φ low), raise the bar.
+
+    Formula:
+        threshold = 0.35 × (1 + 0.5 × (κ* − κ) / κ*) × (1 − 0.3 × Φ)
+
+    Clamped [0.15, 0.60] — outside that range either disables or
+    never permits override, defeating the purpose.
+    """
+    kappa_star = _registry.get("physics.kappa_star", default=64.0)
+    kappa_term = 1.0 + 0.5 * (kappa_star - kappa) / kappa_star
+    phi_term = 1.0 - 0.3 * max(0.0, min(1.0, phi))
+    raw = 0.35 * kappa_term * phi_term
+    return max(0.15, min(0.60, raw))
+
+
+# ── Input / output dataclasses ───────────────────────────────────
+
+@dataclass
+class AccountContext:
+    """Snapshot of account / position state as seen by the caller."""
+    equity_fraction: float
+    margin_fraction: float
+    open_positions: int
+    available_equity: float
+    exchange_held_side: Optional[str] = None
+    own_position_entry_price: Optional[float] = None
+    own_position_quantity: Optional[float] = None
+    own_position_trade_id: Optional[str] = None
+
+
+@dataclass
+class TickInputs:
+    """Everything one tick needs, modulo prior state."""
+    symbol: str
+    ohlcv: list[OHLCVCandle]
+    ml_signal: str
+    ml_strength: float
+    account: AccountContext
+    bank_size: int
+    sovereignty: float
+    max_leverage: int
+    min_notional: float
+    size_fraction: float = 1.0
+    self_obs_bias: Optional[dict[str, dict[str, float]]] = None
+
+
+@dataclass
+class SymbolState:
+    """Per-symbol state carried across ticks."""
+    symbol: str
+    identity_basin: np.ndarray
+    last_basin: Optional[np.ndarray] = None
+    kappa: float = 64.0
+    session_ticks: int = 0
+    last_mode: Optional[str] = None
+    basin_history: list[np.ndarray] = field(default_factory=list)
+    phi_history: list[float] = field(default_factory=list)
+    fhealth_history: list[float] = field(default_factory=list)
+    drift_history: list[float] = field(default_factory=list)
+    dca_add_count: int = 0
+    last_entry_at_ms: Optional[float] = None
+    peak_pnl_usdt: Optional[float] = None
+    peak_tracked_trade_id: Optional[str] = None
+
+
+@dataclass
+class TickDecision:
+    """Output of one tick. Caller persists / executes as needed."""
+    action: str
+    reason: str
+    mode: str
+    size_usdt: float
+    leverage: int
+    entry_threshold: float
+    phi: float
+    kappa: float
+    basin_velocity: float
+    f_health: float
+    drift_from_identity: float
+    basin_direction: float
+    tape_trend: float
+    side_candidate: str
+    side_override: bool
+    neurochemistry: NeurochemicalState
+    derivation: dict[str, Any]
+    basin: np.ndarray
+    is_dca_add: bool = False
+    is_reverse: bool = False
+
+
+# ── Public API ───────────────────────────────────────────────────
+
+def fresh_symbol_state(
+    symbol: str,
+    identity_basin: np.ndarray,
+    *,
+    kappa_initial: Optional[float] = None,
+) -> SymbolState:
+    """Factory for a newborn symbol. identity_basin seeds §3.4 Pillar 3."""
+    kappa = kappa_initial if kappa_initial is not None else (
+        _registry.get("physics.kappa_star", default=64.0)
+    )
+    return SymbolState(
+        symbol=symbol,
+        identity_basin=np.asarray(identity_basin, dtype=np.float64),
+        kappa=kappa,
+    )
+
+
+def run_tick(
+    inputs: TickInputs,
+    state: SymbolState,
+    autonomic: AutonomicKernel,
+) -> tuple[TickDecision, SymbolState]:
+    """Execute one decision tick. Returns (decision, new_state).
+
+    `state` is mutated in place — the return is a convenience.
+    `autonomic` carries NC reward state across ticks (per-instance, not
+    per-symbol; shared across symbols within one kernel).
+    """
+    ohlcv = inputs.ohlcv
+    if len(ohlcv) < 50:
+        return _hold_for_reason(state, "insufficient_ohlcv"), state
+    last_close = float(ohlcv[-1].close)
+    if not (last_close > 0 and np.isfinite(last_close)):
+        return _hold_for_reason(state, "invalid_last_close"), state
+
+    state.session_ticks += 1
+
+    # ── Perceive → refract ─────────────────────────────────────
+    raw_basin = perceive(PerceptionInputs(
+        ohlcv=ohlcv,
+        ml_signal=inputs.ml_signal,
+        ml_strength=inputs.ml_strength,
+        ml_effective_strength=inputs.ml_strength,
+        equity_fraction=inputs.account.equity_fraction,
+        margin_fraction=inputs.account.margin_fraction,
+        open_positions=inputs.account.open_positions,
+        session_age_ticks=state.session_ticks,
+    ))
+    basin = refract(raw_basin, state.identity_basin, external_weight=0.30)
+
+    # ── Measure ────────────────────────────────────────────────
+    f_health = normalized_entropy(basin)
+    phi = max(0.0, min(1.0, 1.0 - f_health * 0.8))
+    bv = velocity(state.last_basin, basin) if state.last_basin is not None else 0.0
+
+    coupling_health = inputs.ml_strength
+    kappa_star = _registry.get("physics.kappa_star", default=64.0)
+    kappa_delta = (coupling_health - 0.5) * 5.0 - (bv - 0.2) * 10.0
+    state.kappa = max(20.0, min(
+        120.0, state.kappa * 0.8 + (kappa_star + kappa_delta) * 0.2,
+    ))
+
+    w_q, w_e, w_eq = float(basin[0]), float(basin[1]), float(basin[2])
+    reg_total = w_q + w_e + w_eq
+    if reg_total > 0:
+        regime_weights = {
+            "quantum": w_q / reg_total,
+            "efficient": w_e / reg_total,
+            "equilibrium": w_eq / reg_total,
+        }
+    else:
+        regime_weights = {"quantum": 1/3, "efficient": 1/3, "equilibrium": 1/3}
+
+    last_phi = state.phi_history[-1] if state.phi_history else phi
+    phi_delta = phi - last_phi
+
+    is_flat = inputs.account.exchange_held_side is None
+    now_ms = time.time() * 1000.0
+    ac_result = autonomic.tick(AutonomicTickInputs(
+        phi_delta=phi_delta,
+        basin_velocity=bv,
+        surprise=abs(phi_delta) * 2.0,
+        quantum_weight=regime_weights["quantum"],
+        kappa=state.kappa,
+        external_coupling=coupling_health,
+        current_mode=state.last_mode or "investigation",
+        is_flat=is_flat,
+        now_ms=now_ms,
+    ))
+    nc = ac_result.nc
+
+    # ── Mode detect ────────────────────────────────────────────
+    drift_now = fisher_rao_distance(basin, state.identity_basin)
+    state.drift_history.append(drift_now)
+    history_max = int(_registry.get("loop.history_max", default=100))
+    if len(state.drift_history) > history_max:
+        state.drift_history = state.drift_history[-history_max:]
+
+    mode_result = detect_mode(
+        basin=basin,
+        identity_basin=state.identity_basin,
+        phi=phi,
+        kappa=state.kappa,
+        basin_velocity=bv,
+        neurochemistry=nc,
+        phi_history=state.phi_history,
+        fhealth_history=state.fhealth_history,
+        drift_history=state.drift_history,
+    )
+    mode = mode_result["mode"]
+    mode_changed = state.last_mode is not None and state.last_mode != mode
+    state.last_mode = mode
+    try:
+        mode_enum = MonkeyMode(mode)
+    except ValueError:
+        mode_enum = MonkeyMode.INVESTIGATION
+
+    # ── Side candidate + override ──────────────────────────────
+    basin_dir = basin_direction(basin)
+    tape_trend = trend_proxy([float(c.close) for c in ohlcv])
+    ml_side = "short" if inputs.ml_signal.upper() == "SELL" else "long"
+    side_candidate = ml_side
+    side_override = False
+    override_thr = _override_threshold(state.kappa, phi)
+    if (
+        basin_dir < -override_thr
+        and tape_trend < -override_thr
+        and ml_side == "long"
+    ):
+        side_candidate = "short"
+        side_override = True
+    elif (
+        basin_dir > override_thr
+        and tape_trend > override_thr
+        and ml_side == "short"
+    ):
+        side_candidate = "long"
+        side_override = True
+
+    self_obs_bias = 1.0
+    if inputs.self_obs_bias:
+        per_mode = inputs.self_obs_bias.get(mode, {})
+        self_obs_bias = per_mode.get(side_candidate, 1.0)
+
+    # ── Build basin state for executive ────────────────────────
+    basin_state = ExecBasinState(
+        basin=basin,
+        identity_basin=state.identity_basin,
+        phi=phi,
+        kappa=state.kappa,
+        regime_weights=regime_weights,
+        sovereignty=inputs.sovereignty,
+        basin_velocity=bv,
+        neurochemistry=nc,
+    )
+
+    # ── Derive decisions ───────────────────────────────────────
+    entry_thr_d = current_entry_threshold(
+        basin_state,
+        mode=mode_enum,
+        self_obs_bias=self_obs_bias,
+        tape_trend=tape_trend,
+        side_candidate=side_candidate,
+    )
+    leverage_d = current_leverage(
+        basin_state,
+        max_leverage_boundary=inputs.max_leverage,
+        mode=mode_enum,
+        tape_trend=tape_trend,
+    )
+    exp_floor_approx = 0.10
+    max_newborn_lev = 20.0
+    min_needed = inputs.min_notional / (exp_floor_approx * max_newborn_lev)
+    effective_size_fraction = (
+        1.0 if inputs.account.available_equity * inputs.size_fraction < min_needed
+        else inputs.size_fraction
+    )
+    capped_equity = inputs.account.available_equity * effective_size_fraction
+    size_d = current_position_size(
+        basin_state,
+        available_equity_usdt=capped_equity,
+        min_notional_usdt=inputs.min_notional,
+        leverage=leverage_d["value"],
+        bank_size=inputs.bank_size,
+        mode=mode_enum,
+    )
+    auto_flatten_d = should_auto_flatten(
+        s=basin_state, recent_fhealths=state.fhealth_history,
+    )
+
+    # ── Decide action ──────────────────────────────────────────
+    action = "hold"
+    reason = ""
+    is_dca = False
+    is_reverse = False
+    derivation: dict[str, Any] = {
+        "phi": phi, "kappa": state.kappa, "sovereignty": inputs.sovereignty,
+        "basin_velocity": bv, "regime_weights": regime_weights,
+        "nc": nc.as_dict(),
+        "f_health": f_health,
+        "ml_signal": inputs.ml_signal, "ml_strength": inputs.ml_strength,
+        "mode": {"value": mode, "reason": mode_result["reason"],
+                 **mode_result["derivation"]},
+        "self_obs_bias": self_obs_bias,
+        "side_candidate": side_candidate,
+        "basin_direction": basin_dir,
+        "tape_trend": tape_trend,
+        "ml_side": ml_side,
+        "side_override": side_override,
+        "override_threshold": override_thr,
+        "mode_changed": mode_changed,
+    }
+
+    own_pos = _has_own_position(inputs.account)
+    held_side: Optional[str] = (
+        inputs.account.exchange_held_side if own_pos else None
+    )
+    derivation["exchange_held_side"] = inputs.account.exchange_held_side
+    derivation["monkey_held_side"] = held_side
+
+    if auto_flatten_d["value"]:
+        action = "flatten"
+        reason = auto_flatten_d["reason"]
+        derivation["auto_flatten"] = auto_flatten_d["derivation"]
+    elif held_side:
+        action, reason, is_dca, is_reverse = _decide_with_position(
+            inputs=inputs,
+            state=state,
+            basin=basin,
+            basin_state=basin_state,
+            mode_enum=mode_enum,
+            last_price=last_close,
+            tape_trend=tape_trend,
+            held_side=held_side,
+            side_candidate=side_candidate,
+            side_override=side_override,
+            entry_thr_val=entry_thr_d["value"],
+            size_val=size_d["value"],
+            leverage_val=leverage_d["value"],
+            derivation=derivation,
+        )
+    elif (
+        MODE_PROFILES[mode_enum].can_enter
+        and inputs.ml_strength >= entry_thr_d["value"]
+        and inputs.ml_signal.upper() != "HOLD"
+        and size_d["value"] > 0
+    ):
+        action = "enter_long" if side_candidate == "long" else "enter_short"
+        override_tag = (
+            f" OVERRIDE(basin{basin_dir:.2f}/tape{tape_trend:.2f})"
+            if side_override else ""
+        )
+        notional = size_d["value"] * leverage_d["value"]
+        reason = (
+            f"[{mode}] ml {inputs.ml_signal}@{inputs.ml_strength:.3f} "
+            f">= thr {entry_thr_d['value']:.3f}; "
+            f"side={side_candidate}{override_tag}; "
+            f"margin={size_d['value']:.2f} lev={leverage_d['value']}x "
+            f"notional={notional:.2f}"
+        )
+        derivation["entry_threshold"] = entry_thr_d["derivation"]
+        derivation["size"] = size_d["derivation"]
+        derivation["leverage"] = leverage_d["derivation"]
+    else:
+        action = "hold"
+        if not MODE_PROFILES[mode_enum].can_enter:
+            reason = f"mode={mode} blocks entry"
+        elif inputs.ml_strength < entry_thr_d["value"]:
+            reason = (
+                f"[{mode}] ml {inputs.ml_strength:.3f} "
+                f"< thr {entry_thr_d['value']:.3f}"
+            )
+        elif size_d["value"] <= 0:
+            reason = (
+                f"[{mode}] size {size_d['value']:.2f} "
+                f"below min notional {inputs.min_notional:.2f}"
+            )
+        else:
+            reason = "no qualifying signal"
+        derivation["entry_threshold"] = entry_thr_d["derivation"]
+
+    # ── Update history state ───────────────────────────────────
+    state.basin_history.append(np.asarray(basin, dtype=np.float64).copy())
+    if len(state.basin_history) > history_max:
+        state.basin_history = state.basin_history[-history_max:]
+    if len(state.basin_history) >= 50 and state.session_ticks % 10 == 0:
+        state.identity_basin = frechet_mean(state.basin_history[-50:])
+    state.last_basin = np.asarray(basin, dtype=np.float64).copy()
+    state.phi_history.append(phi)
+    if len(state.phi_history) > history_max:
+        state.phi_history = state.phi_history[-history_max:]
+    state.fhealth_history.append(f_health)
+    if len(state.fhealth_history) > history_max:
+        state.fhealth_history = state.fhealth_history[-history_max:]
+
+    return TickDecision(
+        action=action,
+        reason=reason,
+        mode=mode,
+        size_usdt=size_d["value"],
+        leverage=leverage_d["value"],
+        entry_threshold=entry_thr_d["value"],
+        phi=phi,
+        kappa=state.kappa,
+        basin_velocity=bv,
+        f_health=f_health,
+        drift_from_identity=drift_now,
+        basin_direction=basin_dir,
+        tape_trend=tape_trend,
+        side_candidate=side_candidate,
+        side_override=side_override,
+        neurochemistry=nc,
+        derivation=derivation,
+        basin=basin,
+        is_dca_add=is_dca,
+        is_reverse=is_reverse,
+    ), state
+
+
+def _decide_with_position(
+    *,
+    inputs: TickInputs,
+    state: SymbolState,
+    basin: np.ndarray,
+    basin_state: ExecBasinState,
+    mode_enum: MonkeyMode,
+    last_price: float,
+    tape_trend: float,
+    held_side: str,
+    side_candidate: str,
+    side_override: bool,
+    entry_thr_val: float,
+    size_val: float,
+    leverage_val: int,
+    derivation: dict[str, Any],
+) -> tuple[str, str, bool, bool]:
+    """v0.6.1 exit gate order: profit harvest → scalp TP/SL → Loop 2 exit.
+    v0.7.1 override-reverse. v0.6.2 DCA.
+    """
+    entry_price = inputs.account.own_position_entry_price or last_price
+    quantity = inputs.account.own_position_quantity or 0.0
+    trade_id = inputs.account.own_position_trade_id or ""
+    position_notional = entry_price * quantity
+    side_sign = 1 if held_side == "long" else -1
+    unrealized_pnl = (last_price - entry_price) * quantity * side_sign
+
+    if state.peak_tracked_trade_id != trade_id:
+        state.peak_pnl_usdt = unrealized_pnl
+        state.peak_tracked_trade_id = trade_id
+    else:
+        state.peak_pnl_usdt = max(state.peak_pnl_usdt or 0.0, unrealized_pnl)
+
+    harvest = should_profit_harvest(
+        unrealized_pnl_usdt=unrealized_pnl,
+        peak_pnl_usdt=state.peak_pnl_usdt or 0.0,
+        notional_usdt=position_notional,
+        tape_trend=tape_trend,
+        held_side=held_side,
+        s=basin_state,
+    )
+    derivation["harvest"] = {
+        **harvest["derivation"],
+        "unrealized_pnl": unrealized_pnl,
+        "peak_pnl": state.peak_pnl_usdt,
+        "trade_id": trade_id,
+    }
+    if harvest["value"]:
+        derivation["scalp"] = {
+            "exit_type_bit": harvest["derivation"].get("exit_type_bit"),
+            "unrealized_pnl": unrealized_pnl,
+            "mark_price": last_price,
+            "trade_id": trade_id,
+        }
+        return "scalp_exit", harvest["reason"], False, False
+
+    scalp = should_scalp_exit(
+        unrealized_pnl_usdt=unrealized_pnl,
+        notional_usdt=position_notional,
+        s=basin_state,
+        mode=mode_enum,
+    )
+    derivation["scalp"] = {
+        **scalp["derivation"],
+        "unrealized_pnl": unrealized_pnl,
+        "mark_price": last_price,
+        "trade_id": trade_id,
+    }
+    if scalp["value"]:
+        return "scalp_exit", scalp["reason"], False, False
+
+    exit_d = should_exit(
+        perception=basin,
+        strategy_forecast=state.identity_basin,
+        held_side=held_side,
+        s=basin_state,
+    )
+    if exit_d["value"]:
+        derivation["exit"] = exit_d["derivation"]
+        return "exit", exit_d["reason"], False, False
+
+    # v0.7.1 override-reverse
+    if (
+        side_override
+        and side_candidate != held_side
+        and MODE_PROFILES[mode_enum].can_enter
+        and inputs.ml_strength >= entry_thr_val
+        and size_val > 0
+    ):
+        action = "reverse_long" if side_candidate == "long" else "reverse_short"
+        reason = (
+            f"OVERRIDE_REVERSE[{held_side}→{side_candidate}] "
+            f"basin={derivation['basin_direction']:.2f} "
+            f"tape={derivation['tape_trend']:.2f}; "
+            f"flatten-then-open margin={size_val:.2f} lev={leverage_val}x"
+        )
+        return action, reason, False, True
+
+    # DCA add
+    now_ms = time.time() * 1000.0
+    dca = should_dca_add(
+        held_side=held_side,
+        side_candidate=side_candidate,
+        current_price=last_price,
+        initial_entry_price=entry_price,
+        add_count=state.dca_add_count,
+        last_add_at_ms=state.last_entry_at_ms or 0,
+        now_ms=now_ms,
+        sovereignty=inputs.sovereignty,
+    )
+    derivation["dca"] = dca["derivation"]
+    if (
+        dca["value"]
+        and MODE_PROFILES[mode_enum].can_enter
+        and inputs.ml_strength >= entry_thr_val
+        and inputs.ml_signal.upper() != "HOLD"
+        and size_val > 0
+    ):
+        action = "enter_long" if side_candidate == "long" else "enter_short"
+        reason = (
+            f"DCA_ADD[{state.dca_add_count + 1}/1] {dca['reason']} | "
+            f"side={side_candidate} margin={size_val:.2f} lev={leverage_val}x"
+        )
+        return action, reason, True, False
+
+    return "hold", f"{exit_d['reason']} | dca: {dca['reason']}", False, False
+
+
+def _has_own_position(acct: AccountContext) -> bool:
+    return (
+        acct.own_position_trade_id is not None
+        and acct.own_position_entry_price is not None
+        and acct.own_position_quantity is not None
+        and acct.own_position_quantity != 0
+    )
+
+
+def _hold_for_reason(state: SymbolState, reason: str) -> TickDecision:
+    """Minimal decision for guard-rail early returns."""
+    nc = NeurochemicalState(
+        acetylcholine=0.5, dopamine=0.5, serotonin=0.5,
+        norepinephrine=0.5, gaba=0.5, endorphins=0.0,
+    )
+    basin = (
+        state.last_basin if state.last_basin is not None
+        else np.zeros(64, dtype=np.float64)
+    )
+    return TickDecision(
+        action="hold",
+        reason=reason,
+        mode=state.last_mode or "investigation",
+        size_usdt=0.0,
+        leverage=1,
+        entry_threshold=0.5,
+        phi=0.0,
+        kappa=state.kappa,
+        basin_velocity=0.0,
+        f_health=0.5,
+        drift_from_identity=0.0,
+        basin_direction=0.0,
+        tape_trend=0.0,
+        side_candidate="long",
+        side_override=False,
+        neurochemistry=nc,
+        derivation={"early_return": reason},
+        basin=basin,
+    )


### PR DESCRIPTION
## Summary

Part 4/10 of v0.8. Collapses **perception → mode → autonomic → executive** into a single Python tick function. TS orchestration doesn't use it yet (v0.8.7 migrates). Available via `/monkey/tick/run` for shadow-mode cross-check now.

## New

- `ml-worker/src/monkey_kernel/tick.py` — `TickInputs`, `AccountContext`, `SymbolState`, `TickDecision` dataclasses + `run_tick()` pure function
- `should_auto_flatten` ported to `executive.py` (Pillar 1 zombie-collapse gate; the last un-ported executive function)
- `POST /monkey/tick/run` endpoint — takes `prev_state` or uses in-process cache, returns `decision + new_state`

## P25 literal disposition (loop layer)

| Literal | Before | After |
|---|---|---|
| `OVERRIDE_THRESHOLD = 0.35` | hardcoded | DERIVED: `0.35 × (1 + 0.5·(κ*−κ)/κ*) × (1 − 0.3·Φ)`, clamped [0.15, 0.60] |
| `HISTORY_MAX = 100` | hardcoded | `registry.get("loop.history_max")` |
| `KAPPA_STAR` | hardcoded | `registry.get("physics.kappa_star")` |

## Decision gate order preserved

Same as TS `processSymbol` (v0.6.1 order):

1. Auto-flatten (Pillar 1 zombie collapse)
2. If held: profit harvest → scalp TP/SL → Loop 2 exit → v0.7.1 override-reverse → v0.6.2 DCA
3. If flat: mode + ML strength + size gate → enter_long / enter_short / hold

## Test plan

- [x] Smoke test: fresh state → `enter_long @ 3.00 USDT × 16x` (phi=0.213, override_thr=0.326)
- [x] State mutation: tick 2 shows session_ticks=2, basin_history len=2
- [x] Held position: `scalp_exit` fires at +0.59 pnl, peak tracked
- [x] HTTP round-trip via FastAPI TestClient
- [x] `qig_purity_check`: 20 files clean
- [x] `verify_qig_vendor`: hash pin matches

## Out of this PR (separate)

- **v0.8.3b**: wire TS shadow-mode to `/monkey/tick/run`, compare against `processSymbol` tick-by-tick
- **v0.8.3c**: entry/exit/witness DB writes + Poloniex execution using the v0.8.2 client

🤖 Generated with [Claude Code](https://claude.com/claude-code)