### PR TITLE
feat(ml-worker): v0.8.3.5a additive merge — lift kernels/core into ml-worker

### DIFF
--- a/ml-worker/ingest_markets.py
+++ b/ml-worker/ingest_markets.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""
+Poloniex Futures Markets Ingestion (Python service)
+
+Goal:
+- Fetch Poloniex Futures v3 markets (product info + risk limits)
+- Normalize to project catalog schema: docs/markets/poloniex-futures-v3.json
+- Use official SDK if available; otherwise fallback to signed REST
+- No secrets committed. Reads env vars:
+    - POLO_API_KEY / POLO_API_SECRET (preferred for Python SDK)
+    - POLONIEX_API_KEY / POLONIEX_API_SECRET (fallback names)
+
+Requirements:
+- Python 3.8+
+- requests (if SDK not used)
+- Optional: polo-sdk-python (git+https://github.com/poloniex/polo-sdk-python)
+
+Run:
+  export POLO_API_KEY="..."
+  export POLO_API_SECRET="..."
+  python3 python-services/poloniex/ingest_markets.py
+
+or using Poloniex env names:
+  export POLONIEX_API_KEY="..."
+  export POLONIEX_API_SECRET="..."
+  python3 python-services/poloniex/ingest_markets.py
+"""
+import base64
+import hashlib
+import hmac
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# Try to import SDK (if installed)
+SDK_AVAILABLE = False
+try:
+    # The SDK structure/documentation is sparse; keep import optional.
+    # If a Futures client exists under polosdk, import it here.
+    # Fallback to REST if import fails.
+    import polosdk  # type: ignore
+    SDK_AVAILABLE = True
+except Exception:
+    SDK_AVAILABLE = False
+
+import requests
+
+
+# Hosts and prefixes (updated for proper v3 API)
+PRIMARY_HOST = "https://api.poloniex.com"
+PRIMARY_PREFIX = "/v3"  # correct v3 API prefix
+FALLBACK_HOST = "https://api.poloniex.com" 
+FALLBACK_PREFIX = "/v3"  # consistent v3 prefix
+
+# Correct v3 API endpoints
+PATH_ALL_PRODUCT_INFO = "/market/allInstruments"
+PATH_MARKET_INFO = "/market/tickers"
+PATH_FUTURES_RISK_LIMIT = "/market/riskLimit"
+
+
+def env_str(*names: str) -> str:
+    for n in names:
+        v = os.environ.get(n)
+        if v:
+            return v
+    return ""
+
+
+API_KEY = env_str("POLO_API_KEY", "POLONIEX_API_KEY")
+API_SECRET = env_str("POLO_API_SECRET", "POLONIEX_API_SECRET")
+
+
+def sign_message(secret: str, msg: str) -> str:
+    mac = hmac.new(secret.encode("utf-8"), msg.encode("utf-8"), hashlib.sha256)
+    return base64.b64encode(mac.digest()).decode("utf-8")
+
+
+def build_headers(method: str, request_path: str, body: str = "") -> Dict[str, str]:
+    """
+    Build Poloniex v3 API authentication headers.
+    Signature format: METHOD\n + REQUEST_PATH\n + BODY + timestamp
+    """
+    timestamp = str(int(time.time() * 1000))  # v3 API expects milliseconds
+    
+    # Build signature string per v3 spec
+    message = f"{method.upper()}\n{request_path}\n{body}{timestamp}"
+    sig = sign_message(API_SECRET, message)
+    
+    return {
+        "Accept": "application/json", 
+        "Content-Type": "application/json",
+        "key": API_KEY,
+        "signature": sig,
+        "signTimestamp": timestamp,
+        "signatureMethod": "HmacSHA256",
+        "signatureVersion": "2"
+    }
+
+
+def fetch_json(url: str, headers: Optional[Dict[str, str]] = None, method: str = "GET", body: Optional[str] = None) -> Any:
+    if method == "GET":
+        resp = requests.get(url, headers=headers, timeout=20)
+    else:
+        resp = requests.request(method, url, headers=headers, data=body or "", timeout=20)
+    ctype = resp.headers.get("content-type", "")
+    if not resp.ok:
+        preview = ""
+        try:
+            preview = resp.text[:400]
+        except Exception:
+            preview = ""
+        raise RuntimeError(f"HTTP {resp.status_code} for {url} :: {preview}")
+    if "application/json" not in ctype:
+        text = ""
+        try:
+            text = resp.text[:400]
+        except Exception:
+            text = ""
+        raise RuntimeError(f"Non-JSON from {url}: {text}")
+    return resp.json()
+
+
+def try_candidates(relative_path: str, signed: bool = True) -> Any:
+    """
+    Try (host, prefix) combinations with optional signed headers.
+    """
+    errors: List[str] = []
+    for host, prefix in ((PRIMARY_HOST, PRIMARY_PREFIX), (FALLBACK_HOST, FALLBACK_PREFIX)):
+        request_path = prefix + relative_path
+        url = host + request_path
+        try:
+            headers = build_headers("GET", request_path, "") if signed else {"Accept": "application/json"}
+            data = fetch_json(url, headers=headers)
+            return data
+        except Exception as e:
+            errors.append(f"{url} :: {e}")
+            continue
+    raise RuntimeError("All candidates failed for " + relative_path + " :: " + " | ".join(errors))
+
+
+def safe_number(v: Any, fallback: Optional[float] = None) -> Optional[float]:
+    try:
+        n = float(v)
+        if n == float("inf") or n == float("-inf"):
+            return fallback
+        return n
+    except Exception:
+        return fallback
+
+
+def infer_precisions_from_tick_lot(tick: Optional[float], lot: Optional[float]) -> Tuple[Optional[int], Optional[int]]:
+    def decimals(x: Optional[float]) -> Optional[int]:
+        if x is None:
+            return None
+        s = f"{x}"
+        if "." in s:
+            return len(s.split(".")[1])
+        return 0
+    return decimals(tick), decimals(lot)
+
+
+def extract_products_common(src_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for p in src_list:
+        symbol = str(p.get("symbol") or p.get("contract") or p.get("instId") or p.get("name") or "").replace("-", "").upper()
+        if not symbol:
+            continue
+        base = str(p.get("baseCurrency") or p.get("base") or "").upper()
+        quote = str(p.get("quoteCurrency") or p.get("quote") or "").upper()
+
+        tick_size = safe_number(p.get("tickSize")) or safe_number(p.get("priceTick")) or safe_number(p.get("priceTickSize"))
+        lot_size = safe_number(p.get("lotSize")) or safe_number(p.get("qtyStep")) or safe_number(p.get("quantityStep"))
+        min_notional = safe_number(p.get("minNotional")) or safe_number(p.get("minValue")) or safe_number(p.get("minTradeValue"))
+        max_leverage = safe_number(p.get("maxLeverage")) or safe_number(p.get("lever") or p.get("leverage"))
+        status_raw = str(p.get("status") or p.get("state") or "").lower()
+        if "trade" in status_raw or status_raw in ("online", "open"):
+            status = "trading"
+        elif "pause" in status_raw:
+            status = "paused"
+        elif "delist" in status_raw:
+            status = "delisted"
+        else:
+            status = "trading"
+
+        price_precision = None
+        qty_precision = None
+        if isinstance(p.get("pricePrecision"), (int, float)):
+            price_precision = int(p.get("pricePrecision"))
+        if isinstance(p.get("quantityPrecision") or p.get("qtyPrecision"), (int, float)):
+            qty_precision = int(p.get("quantityPrecision") or p.get("qtyPrecision"))
+
+        if price_precision is None or qty_precision is None:
+            inf_pp, inf_qp = infer_precisions_from_tick_lot(tick_size, lot_size)
+            if price_precision is None:
+                price_precision = inf_pp
+            if qty_precision is None:
+                qty_precision = inf_qp
+
+        contract_type = str(p.get("contractType") or p.get("type") or "perpetual").lower()
+
+        out.append({
+            "symbol": symbol,
+            "base": base,
+            "quote": quote,
+            "contractType": contract_type,
+            "status": status,
+            "pricePrecision": price_precision,
+            "quantityPrecision": qty_precision,
+            "tickSize": tick_size,
+            "lotSize": lot_size,
+            "minNotional": min_notional,
+            "maxLeverage": max_leverage,
+        })
+    return out
+
+
+def extract_from_all_product_info(json_obj: Any) -> List[Dict[str, Any]]:
+    data = []
+    if isinstance(json_obj, dict):
+        if isinstance(json_obj.get("data"), list):
+            data = json_obj["data"]
+        elif isinstance(json_obj.get("products"), list):
+            data = json_obj["products"]
+    elif isinstance(json_obj, list):
+        data = json_obj
+    return extract_products_common(data)
+
+
+def extract_from_market_info(json_obj: Any) -> List[Dict[str, Any]]:
+    candidates = []
+    if isinstance(json_obj, dict):
+        for key in ("data", "symbols"):
+            val = json_obj.get(key)
+            if isinstance(val, list):
+                candidates = val
+                break
+        if not candidates and isinstance(json_obj.get("data"), dict):
+            if isinstance(json_obj["data"].get("symbols"), list):
+                candidates = json_obj["data"]["symbols"]
+    elif isinstance(json_obj, list):
+        candidates = json_obj
+    return extract_products_common(candidates)
+
+
+def build_risk_map(risk_json: Any) -> Dict[str, List[Dict[str, Any]]]:
+    out: Dict[str, List[Dict[str, Any]]] = {}
+    lst = []
+    if isinstance(risk_json, dict):
+        if isinstance(risk_json.get("data"), list):
+            lst = risk_json["data"]
+        elif isinstance(risk_json.get("riskLimits"), list):
+            lst = risk_json["riskLimits"]
+    elif isinstance(risk_json, list):
+        lst = risk_json
+    for item in lst:
+        # Accept shape: { symbol, tiers: [...] } or a list of tiers
+        symbol = str(item.get("symbol") or item.get("contract") or item.get("instId") or "").replace("-", "").upper()
+        tiers: List[Dict[str, Any]] = []
+        if isinstance(item.get("tiers"), list):
+            src = item["tiers"]
+        elif isinstance(item, list):
+            src = item
+        else:
+            src = [item]
+        for t in src:
+            tiers.append({
+                "tier": int(t.get("tier") or 0),
+                "maxPosition": safe_number(t.get("maxPosition")),
+                "initialMarginRate": safe_number(t.get("initialMarginRate")),
+                "maintenanceMarginRate": safe_number(t.get("maintenanceMarginRate")),
+            })
+        if symbol:
+            out[symbol] = tiers
+    return out
+
+
+def merge_products_with_risk(products: List[Dict[str, Any]], risk_map: Dict[str, List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    merged: List[Dict[str, Any]] = []
+    for prod in products:
+        sym = prod["symbol"]
+        tiers = risk_map.get(sym, [])
+        maintenance_table = []
+        for t in tiers:
+            mmr = t.get("maintenanceMarginRate")
+            if mmr is not None:
+                maintenance_table.append({
+                    "notionalFloor": t.get("maxPosition") or 0,
+                    "maintenanceMarginRate": mmr,
+                })
+        merged.append({
+            **prod,
+            "maintenanceMarginTable": maintenance_table,
+            "riskLimits": tiers,
+            "feesBps": {"maker": None, "taker": None},
+            "funding": {"intervalHours": 8, "rateCap": None},
+        })
+    return merged
+
+
+def load_catalog(catalog_path: Path) -> Dict[str, Any]:
+    if not catalog_path.exists():
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "_note": "Generated markets catalog. Policy: include all markets; use exchange max leverage and exchange fees.",
+            "version": 1,
+            "source": "../railway-poloniex-docs.md",
+            "lastSynced": "",
+            "markets": []
+        }
+    try:
+        return json.loads(catalog_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "_note": "Generated markets catalog. Policy: include all markets; use exchange max leverage and exchange fees.",
+            "version": 1,
+            "source": "../railway-poloniex-docs.md",
+            "lastSynced": "",
+            "markets": []
+        }
+
+
+def save_catalog(catalog_path: Path, data: Dict[str, Any]) -> None:
+    catalog_path.parent.mkdir(parents=True, exist_ok=True)
+    catalog_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def main() -> int:
+    print("[PY-INGEST] Starting Poloniex Futures markets ingestion (Python).", flush=True)
+
+    # Locate project root and catalog path
+    service_dir = Path(__file__).resolve().parent
+    project_root = service_dir.parents[1]  # python-services/poloniex -> python-services -> project root
+    catalog_path = (project_root / "docs" / "markets" / "poloniex-futures-v3.json").resolve()
+
+    use_signed = bool(API_KEY and API_SECRET)
+    if not use_signed:
+        print("[PY-INGEST] Warning: API key/secret not set (POLO_API_KEY/POLO_API_SECRET or POLONIEX_API_*). "
+              "Unsigned requests will likely return 400 or 503.", flush=True)
+
+    products: List[Dict[str, Any]] = []
+    # Try signed get-all-product-info
+    try:
+        data = try_candidates(PATH_ALL_PRODUCT_INFO, signed=use_signed)
+        products = extract_from_all_product_info(data)
+        if products:
+            print(f"[PY-INGEST] Extracted {len(products)} products from get-all-product-info", flush=True)
+    except Exception as e:
+        print(f"[PY-INGEST] get-all-product-info failed: {e}", flush=True)
+
+    # Fallback to get-market-info if needed
+    if not products:
+        try:
+            data2 = try_candidates(PATH_MARKET_INFO, signed=use_signed)
+            products = extract_from_market_info(data2)
+            if products:
+                print(f"[PY-INGEST] Extracted {len(products)} products from get-market-info", flush=True)
+        except Exception as e:
+            print(f"[PY-INGEST] get-market-info failed: {e}", flush=True)
+
+    # Risk limits
+    risk_map: Dict[str, List[Dict[str, Any]]] = {}
+    try:
+        risk_json = try_candidates(PATH_FUTURES_RISK_LIMIT, signed=use_signed)
+        risk_map = build_risk_map(risk_json)
+        print(f"[PY-INGEST] Risk map entries: {len(risk_map)}", flush=True)
+    except Exception as e:
+        print(f"[PY-INGEST] get-futures-risk-limit failed: {e}", flush=True)
+
+    if not products:
+        print("[PY-INGEST] No products extracted. Catalog will not be updated with markets.", flush=True)
+        # We still update lastSynced to reflect attempt, but keep empty markets
+        catalog = load_catalog(catalog_path)
+        updated = {
+            **catalog,
+            "lastSynced": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "markets": catalog.get("markets", []),
+        }
+        save_catalog(catalog_path, updated)
+        print(f"[PY-INGEST] Catalog written (no markets) at {catalog_path}", flush=True)
+        return 0
+
+    merged = merge_products_with_risk(products, risk_map)
+    catalog = load_catalog(catalog_path)
+    prev_count = len(catalog.get("markets", [])) if isinstance(catalog.get("markets"), list) else 0
+    next_count = len(merged)
+    version = catalog.get("version")
+    try:
+        version_num = int(version)
+    except Exception:
+        version_num = 1
+
+    updated = {
+        **catalog,
+        "version": version_num + (1 if next_count != prev_count else 0),
+        "lastSynced": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "markets": merged,
+    }
+    save_catalog(catalog_path, updated)
+    print(f"[PY-INGEST] Catalog updated at {catalog_path} with {next_count} markets.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1,23 +1,47 @@
 """
 ML Worker FastAPI Server
 Serves ML predictions via HTTP and listens on Redis pub/sub.
+
+v0.8.3.5a — unified deploy surface (previously split between
+/kernels/core/health.py and /ml-worker/main.py). /ml/predict now has
+two backends coexisting behind the ROUTE_VERSION env flag:
+
+  ROUTE_VERSION=v0.8    → StrategyLoop + RegimeDetector (deterministic,
+                          matches kernels/core/health.py live behavior)
+  anything else / unset → EnsemblePredictor (LSTM + Transformer + GBM
+                          + ARIMA + Prophet; requires trained weights
+                          at ./saved_models/)
+
+Stage 2 Railway cut-over sets ROUTE_VERSION=v0.8 so live behavior
+is preserved at deploy-flip time. The opposite backend runs in
+shadow mode when ML_PREDICT_SHADOW=true, logging parity diffs to
+/governance/ml-predict-parity for later promotion evidence.
 """
 
+import asyncio
 import json
 import logging
 import os
+import subprocess
 import sys
 import threading
+import time
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
 
 import pandas as pd
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
-# Ensure src/ is on the path so models can be imported
+# Ensure src/ is on the path so models + proprietary_core can be imported
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
 from ensemble_predictor import EnsemblePredictor
+from proprietary_core.regime import RegimeDetector  # noqa: F401  (re-exported via StrategyLoop)
+from proprietary_core.strategy_loop import MarketRegime, StrategyLoop  # noqa: F401  (MarketRegime re-exported for ops)
 
 logger = logging.getLogger("ml-worker")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -164,10 +188,224 @@ def _start_trade_outcome_listener():
 
 
 # ---------------------------------------------------------------------------
-# Shared prediction logic
+# StrategyLoop prediction backend (v0.8.3.5a — ported from
+# /kernels/core/health.py::_run_prediction)
+# ---------------------------------------------------------------------------
+
+def _strategy_to_signal(strategy_value: str, regime: str) -> dict[str, Any]:
+    """Translate StrategyLoop output into the signal format expected by polytrade-be.
+
+    Identical to kernels/core/health.py:_strategy_to_signal. Output shape
+    must stay byte-for-byte compatible — polytrade-be's mlPredictionService
+    is calibrated against this mapping.
+    """
+    strategy = strategy_value.lower()
+    regime_l = regime.lower() if regime else "unknown"
+
+    action_map = {
+        "momentum": "BUY",
+        "breakout": "BUY",
+        "trend_follow": "BUY",
+        "mean_revert": "SELL",
+        "cash": "HOLD",
+    }
+    strength_map = {
+        "momentum": 0.75,
+        "breakout": 0.65,
+        "trend_follow": 0.70,
+        "mean_revert": 0.60,
+        "cash": 0.30,
+    }
+
+    action = action_map.get(strategy, "HOLD")
+    strength = strength_map.get(strategy, 0.30)
+    return {
+        "signal": action,
+        "strength": strength,
+        "reason": f"regime={regime_l} strategy={strategy}",
+    }
+
+
+def _regime_to_direction(regime: str, trend_strength: float) -> str:
+    """Map (regime, trend_strength) → BULLISH / BEARISH / NEUTRAL.
+
+    Identical to kernels/core/health.py:_regime_to_direction.
+    """
+    regime_l = (regime or "").lower()
+    if regime_l == "creator" and trend_strength > 0.1:
+        return "BULLISH"
+    if regime_l == "preserver" and trend_strength > 0.15:
+        return "BULLISH"
+    if regime_l in ("dissolver",):
+        return "NEUTRAL"
+    if trend_strength < -0.05:
+        return "BEARISH"
+    return "NEUTRAL"
+
+
+def _handle_predict_strategyloop(payload: dict) -> dict:
+    """Deterministic regime-based predictor.
+
+    Ported 1:1 from kernels/core/health.py:_run_prediction. Produces the
+    exact signal distribution polytrade-be's risk engine is calibrated
+    against. Default path once ROUTE_VERSION=v0.8 is set.
+    """
+    action = payload.get("action", "multi_horizon")
+    symbol = payload.get("symbol", "UNKNOWN")
+    data = payload.get("data", [])
+    current_price = float(payload.get("current_price", 0.0))
+
+    if action == "health":
+        return {"status": "healthy", "service": "ml-worker", "models": ["regime", "strategy_loop"]}
+
+    if not data:
+        raise ValueError("No OHLCV data provided")
+
+    prices: list[float] = []
+    for candle in data:
+        if isinstance(candle, dict):
+            close = candle.get("close") or candle.get("c")
+        else:
+            close = candle
+        if close is not None:
+            prices.append(float(close))
+
+    if not prices:
+        raise ValueError("Could not extract close prices from data")
+
+    if not current_price and prices:
+        current_price = prices[-1]
+
+    loop = StrategyLoop(symbol=symbol)
+    decision = None
+    for p in prices:
+        decision = loop.tick(price=p)
+
+    if decision is None or decision.regime is None:
+        neutral_pred = {"price": current_price, "confidence": 40, "direction": "NEUTRAL"}
+        if action == "signal":
+            return {"signal": "HOLD", "strength": 0.3, "reason": "Insufficient data for regime detection"}
+        return {"1h": neutral_pred, "4h": neutral_pred, "24h": neutral_pred}
+
+    regime_val = decision.regime.regime.value if decision.regime else "dissolver"
+    confidence_raw = decision.regime.confidence if decision.regime else 0.4
+    trend_strength = decision.regime.trend_strength if decision.regime else 0.0
+    direction = _regime_to_direction(regime_val, trend_strength)
+    confidence_pct = int(min(max(confidence_raw * 100, 10), 95))
+
+    if action == "signal":
+        sig = _strategy_to_signal(decision.selected_strategy.value, regime_val)
+        sig["strength"] = round(confidence_raw, 4)
+        return sig
+
+    horizon_decay = {"1h": 1.0, "4h": 0.85, "24h": 0.70}
+    result: dict[str, Any] = {}
+    for h, decay in horizon_decay.items():
+        h_conf = int(min(confidence_pct * decay, 95))
+        h_dir = direction if h_conf >= 45 else "NEUTRAL"
+        horizon_hours = {"1h": 1, "4h": 4, "24h": 24}[h]
+        price_change = trend_strength * 0.01 * horizon_hours * (1.0 if h_dir != "BEARISH" else -1.0)
+        predicted_price = round(current_price * (1.0 + price_change), 8)
+        result[h] = {"price": predicted_price, "confidence": h_conf, "direction": h_dir}
+
+    if action == "predict":
+        horizon = payload.get("horizon", "1h")
+        return result.get(horizon, result["1h"])
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Shadow-diff ring buffer + parity telemetry (v0.8.3.5a per advisor)
+# ---------------------------------------------------------------------------
+#
+# Every /ml/predict call can optionally fire the OTHER backend in the
+# background (fire-and-forget) and record a parity-diff row. Exposed at
+# /governance/ml-predict-parity on the same pattern as /governance/status
+# from v0.7.11. This is the evidence stream that lets us promote
+# EnsemblePredictor later — or detect it was broken before the swap.
+
+_PARITY_LOG: list[dict[str, Any]] = []
+_PARITY_LOG_MAX = 2_000
+_PARITY_LOG_LOCK = threading.Lock()
+
+
+def _record_parity(row: dict[str, Any]) -> None:
+    with _PARITY_LOG_LOCK:
+        _PARITY_LOG.append(row)
+        if len(_PARITY_LOG) > _PARITY_LOG_MAX:
+            del _PARITY_LOG[: _PARITY_LOG_MAX // 10]
+
+
+def _shadow_compare(payload: dict, live_result: dict, live_backend: str) -> None:
+    """Run the non-live backend in a thread, log the diff. Never raises.
+
+    Called from the /ml/predict path as fire-and-forget. Latency is
+    borne by the worker pool, not the caller.
+    """
+    shadow_backend = "ensemble" if live_backend == "strategyloop" else "strategyloop"
+    started = time.monotonic()
+    shadow_result: dict[str, Any] | None = None
+    err: str | None = None
+    try:
+        if shadow_backend == "ensemble":
+            shadow_result = _handle_predict_ensemble(payload)
+        else:
+            shadow_result = _handle_predict_strategyloop(payload)
+    except Exception as exc:
+        err = f"{type(exc).__name__}: {exc}"
+
+    # For the "signal" action we can diff signal+strength cleanly. For
+    # multi_horizon the shapes differ between backends — just record
+    # both payloads and let downstream tooling compare fields.
+    row = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "action": payload.get("action"),
+        "symbol": payload.get("symbol"),
+        "live_backend": live_backend,
+        "shadow_backend": shadow_backend,
+        "live_signal": live_result.get("signal"),
+        "shadow_signal": (shadow_result or {}).get("signal"),
+        "live_strength": live_result.get("strength"),
+        "shadow_strength": (shadow_result or {}).get("strength"),
+        "shadow_error": err,
+        "shadow_latency_ms": round((time.monotonic() - started) * 1000, 2),
+    }
+    _record_parity(row)
+
+
+# ---------------------------------------------------------------------------
+# Shared prediction logic (dispatcher)
 # ---------------------------------------------------------------------------
 
 def _handle_predict(payload: dict) -> dict:
+    """Route /ml/predict to the selected backend.
+
+    ROUTE_VERSION=v0.8  → StrategyLoop (live-equivalent to
+                          kernels/core). Ensure this is set on
+                          Railway at Stage 2 cut-over time.
+    unset / anything else → EnsemblePredictor (ml-worker's
+                            historical default).
+
+    If ML_PREDICT_SHADOW=true, also fires the OTHER backend in a
+    background thread for parity-diff evidence.
+    """
+    backend = "strategyloop" if os.environ.get("ROUTE_VERSION") == "v0.8" else "ensemble"
+    live_result = (
+        _handle_predict_strategyloop(payload) if backend == "strategyloop"
+        else _handle_predict_ensemble(payload)
+    )
+    if os.environ.get("ML_PREDICT_SHADOW") == "true":
+        t = threading.Thread(
+            target=_shadow_compare,
+            args=(payload, live_result, backend),
+            daemon=True, name="ml-predict-shadow",
+        )
+        t.start()
+    return live_result
+
+
+def _handle_predict_ensemble(payload: dict) -> dict:
     """Route a prediction request to the ensemble predictor."""
     action = payload.get("action", "predict")
     symbol = payload.get("symbol", "UNKNOWN")
@@ -269,17 +507,227 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="ML Worker", lifespan=lifespan)
 
 
+# ---------------------------------------------------------------------------
+# /ml/predict request shape (matches kernels/core/health.py byte-for-byte)
+# ---------------------------------------------------------------------------
+
+class PredictRequest(BaseModel):
+    """Mirrors kernels/core/health.py::PredictRequest.
+
+    Keep field names + defaults identical so Pydantic validation rejects
+    the same malformed inputs on both sides. Stage 1b byte-diff testing
+    depends on identical request parsing.
+    """
+
+    action: str = "multi_horizon"
+    symbol: str = "UNKNOWN"
+    data: list[Any] = []
+    horizon: str = "1h"
+    current_price: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
 @app.get("/health")
 async def health():
-    return {"status": "ok"}
+    """Liveness probe. Returns ok + basic service identity.
+
+    Matches the shape of kernels/core/health.py::health for deploy-cut
+    compatibility — Railway health-check + polytrade-be liveness code
+    both rely on {"status": "ok"} being present.
+    """
+    return {
+        "status": "ok",
+        "service": "ml-worker",
+        "version": "0.8.3.5a",
+        "route_version": os.environ.get("ROUTE_VERSION") or "default-ensemble",
+    }
+
+
+@app.get("/healthz")
+async def healthz():
+    """Kubernetes-style readiness alias. Plain 'ok' string body —
+    Railway's health-check sometimes probes /healthz instead of /health.
+    """
+    return JSONResponse(content={"ok": True}, status_code=200)
+
+
+@app.get("/")
+async def root():
+    """Root handler — surfaces endpoint map for ops / curl introspection.
+    Parity with kernels/core/health.py::root so flipping rootDirectory
+    doesn't make this 404.
+    """
+    return {
+        "service": "ml-worker",
+        "version": "0.8.3.5a",
+        "route_version": os.environ.get("ROUTE_VERSION") or "default-ensemble",
+        "endpoints": {
+            "health": "/health (GET)",
+            "healthz": "/healthz (GET)",
+            "status": "/api/status (GET)",
+            "predict": "/ml/predict (POST)",
+            "ingest": "/run/ingest (POST)",
+            "governance_status": "/governance/status (GET)",
+            "governance_ml_parity": "/governance/ml-predict-parity (GET)",
+            "monkey_tick": "/monkey/tick/run (POST)",
+            "monkey_autonomic_tick": "/monkey/autonomic/tick (POST)",
+            "monkey_executive_decide": "/monkey/executive/decide (POST)",
+            "monkey_perception_perceive": "/monkey/perception/perceive (POST)",
+            "monkey_mode_detect": "/monkey/mode/detect (POST)",
+        },
+    }
 
 
 @app.post("/ml/predict")
-async def ml_predict(request: Request):
-    payload = await request.json()
-    result = _handle_predict(payload)
-    status_code = 200 if result.get("status") != "error" else 422
-    return JSONResponse(content=result, status_code=status_code)
+async def ml_predict(request: PredictRequest):
+    """Dispatch to the selected backend via _handle_predict.
+
+    Error handling mirrors kernels/core/health.py::ml_predict:
+      - ValueError  → HTTP 400 (caller sent bad data)
+      - other       → HTTP 500 (backend blew up)
+      - success     → {"status": "success", ...result}
+    """
+    try:
+        result = _handle_predict(request.model_dump())
+        # EnsemblePredictor path may return {"status": "error", ...} rather
+        # than raising — honour that shape with 422.
+        if isinstance(result, dict) and result.get("status") == "error":
+            return JSONResponse(content=result, status_code=422)
+        return {"status": "success", **result}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"/ml/predict crashed: {exc}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+MAX_OUTPUT_LENGTH = 4000  # subprocess tail length for /run/ingest responses
+
+
+@app.post("/run/ingest")
+async def run_ingest():
+    """Trigger the markets-ingestion subprocess on demand.
+
+    Ported from kernels/core/health.py::run_ingest. The ingest script
+    lives at the repo root of ml-worker after the v0.8.3.5a merge.
+    Requires POLONIEX_API_KEY + POLONIEX_API_SECRET env vars.
+    """
+    script = Path(__file__).resolve().parent / "ingest_markets.py"
+
+    if not script.exists():
+        raise HTTPException(
+            status_code=500,
+            detail=f"ingest_markets.py not found at {script}",
+        )
+
+    if not os.getenv("POLONIEX_API_KEY") or not os.getenv("POLONIEX_API_SECRET"):
+        raise HTTPException(
+            status_code=500,
+            detail="POLONIEX_API_KEY and POLONIEX_API_SECRET must be set",
+        )
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=str(script.parent),
+            env=os.environ.copy(),
+            timeout=60 * 10,
+            text=True,
+            check=True,
+        )
+        return JSONResponse(
+            status_code=200,
+            content={
+                "ok": True,
+                "code": 0,
+                "message": "Ingestion completed successfully",
+                "output": proc.stdout[-MAX_OUTPUT_LENGTH:],
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    except subprocess.TimeoutExpired as exc:
+        return JSONResponse(
+            status_code=504,
+            content={
+                "ok": False,
+                "error": "timeout",
+                "message": "Ingestion timed out after 10 minutes",
+                "output": (exc.stdout or "")[-MAX_OUTPUT_LENGTH:] if hasattr(exc, "stdout") else "",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    except subprocess.CalledProcessError as exc:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "ok": False,
+                "code": exc.returncode,
+                "error": "process_failed",
+                "message": f"Ingestion failed with code {exc.returncode}",
+                "output": (exc.stdout or "")[-MAX_OUTPUT_LENGTH:],
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    except Exception as exc:
+        logger.error(f"/run/ingest error: {exc}", exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={
+                "ok": False,
+                "error": "unknown",
+                "message": str(exc),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+
+@app.get("/api/status")
+async def api_status():
+    """Operational status snapshot. Ops-only; no TS callers today."""
+    return {
+        "service": "ml-worker",
+        "version": "0.8.3.5a",
+        "route_version": os.environ.get("ROUTE_VERSION") or "default-ensemble",
+        "shadow_enabled": os.environ.get("ML_PREDICT_SHADOW") == "true",
+        "redis_configured": bool(REDIS_URL),
+        "trade_outcomes_buffered": len(get_recent_trade_outcomes(limit=_TRADE_OUTCOMES_MAX)),
+        "parity_log_size": len(_PARITY_LOG),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@app.get("/governance/ml-predict-parity")
+async def governance_ml_predict_parity(limit: int = 200):
+    """Parity-diff ring buffer for /ml/predict backends.
+
+    Evidence stream for later promotion of EnsemblePredictor. Populated
+    only while ML_PREDICT_SHADOW=true. Same telemetry pattern as
+    /governance/status (v0.7.11).
+    """
+    with _PARITY_LOG_LOCK:
+        rows = list(_PARITY_LOG[-max(1, min(limit, _PARITY_LOG_MAX)):])
+    # Compute a fast summary so ops can eyeball drift without downloading rows.
+    diffs = 0
+    for r in rows:
+        if r.get("shadow_error"):
+            continue
+        if r.get("live_signal") != r.get("shadow_signal"):
+            diffs += 1
+    return {
+        "available": True,
+        "shadow_enabled": os.environ.get("ML_PREDICT_SHADOW") == "true",
+        "sample_count": len(rows),
+        "signal_disagreements": diffs,
+        "disagreement_ratio": (diffs / len(rows)) if rows else 0.0,
+        "rows": rows,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/ml-worker/requirements.txt
+++ b/ml-worker/requirements.txt
@@ -22,3 +22,7 @@ psycopg[binary,pool]>=3.1.0
 # Async HTTP client for Poloniex v3 REST (v0.8.2). Matches the axios-
 # based TS client in apps/api/src/services/poloniexFuturesService.js.
 aiohttp>=3.9.0
+# Sync HTTP client for ingest_markets.py (ported from kernels/core
+# in v0.8.3.5a). Different from aiohttp (async) — ingest runs as a
+# subprocess from /run/ingest and uses blocking calls.
+requests>=2.31.0

--- a/ml-worker/src/proprietary_core/__init__.py
+++ b/ml-worker/src/proprietary_core/__init__.py
@@ -1,0 +1,22 @@
+"""Proprietary Core — ML and intelligence layer for Poloniex Trading Platform.
+
+Modules:
+    regime   — Market regime detector (Creator/Preserver/Dissolver)
+    coupling — Strategy coupling estimator (κ, R²)
+    sizing   — Adaptive position sizing based on regime + coupling
+    models   — Pydantic models for API validation
+"""
+
+from .regime import MarketRegime, RegimeDetector, RegimeState
+from .coupling import CouplingEstimator, CouplingState
+from .sizing import AdaptiveSizer, SizeDecision
+
+__all__ = [
+    "MarketRegime",
+    "RegimeDetector",
+    "RegimeState",
+    "CouplingEstimator",
+    "CouplingState",
+    "AdaptiveSizer",
+    "SizeDecision",
+]

--- a/ml-worker/src/proprietary_core/api.py
+++ b/ml-worker/src/proprietary_core/api.py
@@ -1,0 +1,213 @@
+"""FastAPI endpoints for the intelligence layer.
+
+Exposes regime detection, coupling estimation, basin detection,
+and the full strategy loop via REST API.
+
+Mounts under the existing FastAPI app in main.py.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from .basins import BasinDetector
+from .coupling import CouplingEstimator
+from .regime import RegimeDetector
+from .strategy_loop import StrategyLoop
+
+router = APIRouter(prefix="/intelligence", tags=["Intelligence Layer"])
+
+# Per-symbol state stores (Pillar 3: each symbol gets its own instances)
+_regime_detectors: dict[str, RegimeDetector] = {}
+_coupling_estimators: dict[str, CouplingEstimator] = {}
+_basin_detectors: dict[str, BasinDetector] = {}
+_strategy_loops: dict[str, StrategyLoop] = {}
+
+
+# --- Request/Response models ---
+
+class PriceTick(BaseModel):
+    symbol: str = Field(..., description="Trading pair symbol")
+    price: float = Field(..., gt=0, description="Current price")
+
+
+class PriceBatch(BaseModel):
+    symbol: str
+    prices: list[float] = Field(..., min_length=1)
+
+
+class CouplingTick(BaseModel):
+    symbol: str
+    signal_value: float
+    pnl_value: float
+
+
+class LoopTick(BaseModel):
+    symbol: str
+    price: float = Field(..., gt=0)
+    signal_value: float | None = None
+    pnl_value: float | None = None
+    account_equity: float = 100_000.0
+    current_exposure_pct: float = 0.0
+
+
+# --- Endpoints ---
+
+@router.post("/regime/tick")
+def regime_tick(data: PriceTick):
+    """Feed a single price tick and get regime classification."""
+    if data.symbol not in _regime_detectors:
+        _regime_detectors[data.symbol] = RegimeDetector()
+    det = _regime_detectors[data.symbol]
+    state = det.update(data.price)
+    if state is None:
+        return {"status": "accumulating", "symbol": data.symbol}
+    return {
+        "symbol": data.symbol,
+        "regime": state.regime.value,
+        "entropy": round(state.entropy, 4),
+        "fisher_info": round(state.fisher_info, 6),
+        "trend_strength": round(state.trend_strength, 4),
+        "volatility": round(state.volatility, 8),
+        "confidence": round(state.confidence, 4),
+        "is_transition": state.is_transition,
+        "pillar1_gate": state.pillar1_gate,
+    }
+
+
+@router.post("/regime/batch")
+def regime_batch(data: PriceBatch):
+    """Feed a batch of prices and get current regime."""
+    if data.symbol not in _regime_detectors:
+        _regime_detectors[data.symbol] = RegimeDetector()
+    det = _regime_detectors[data.symbol]
+    state = det.update_batch(data.prices)
+    if state is None:
+        return {"status": "accumulating", "symbol": data.symbol, "n_prices": len(data.prices)}
+    return {
+        "symbol": data.symbol,
+        "regime": state.regime.value,
+        "entropy": round(state.entropy, 4),
+        "fisher_info": round(state.fisher_info, 6),
+        "trend_strength": round(state.trend_strength, 4),
+        "volatility": round(state.volatility, 8),
+        "confidence": round(state.confidence, 4),
+        "is_transition": state.is_transition,
+        "pillar1_gate": state.pillar1_gate,
+    }
+
+
+@router.post("/coupling/tick")
+def coupling_tick(data: CouplingTick):
+    """Feed a signal/P&L pair and get coupling state."""
+    if data.symbol not in _coupling_estimators:
+        _coupling_estimators[data.symbol] = CouplingEstimator()
+    est = _coupling_estimators[data.symbol]
+    state = est.update(data.signal_value, data.pnl_value)
+    if state is None:
+        return {"status": "accumulating", "symbol": data.symbol}
+    return {
+        "symbol": data.symbol,
+        "kappa": round(state.kappa, 6),
+        "r_squared": round(state.r_squared, 4),
+        "n_samples": state.n_samples,
+        "is_coupled": state.is_coupled,
+        "is_inverted": state.is_inverted,
+        "stud_crossing": state.stud_crossing,
+    }
+
+
+@router.post("/basins/detect")
+def basins_detect(data: PriceBatch):
+    """Feed price history and detect support/resistance basins."""
+    if data.symbol not in _basin_detectors:
+        _basin_detectors[data.symbol] = BasinDetector()
+    det = _basin_detectors[data.symbol]
+    det.update_batch(data.prices)
+    basin_map = det.detect()
+    if basin_map is None:
+        return {"status": "insufficient_data", "symbol": data.symbol}
+    return {
+        "symbol": data.symbol,
+        "current_price": basin_map.current_price,
+        "n_basins": len(basin_map.basins),
+        "basins": [
+            {
+                "level": round(b.level, 8),
+                "density": round(b.density, 6),
+                "depth": round(b.depth, 6),
+                "dwell_fraction": round(b.dwell_fraction, 4),
+                "is_support": b.is_support,
+                "is_resistance": b.is_resistance,
+            }
+            for b in basin_map.basins
+        ],
+        "nearest_support": round(basin_map.nearest_support.level, 8) if basin_map.nearest_support else None,
+        "nearest_resistance": round(basin_map.nearest_resistance.level, 8) if basin_map.nearest_resistance else None,
+        "n_prices": basin_map.n_prices,
+    }
+
+
+@router.post("/loop/tick")
+def loop_tick(data: LoopTick):
+    """Full strategy loop: one tick through scan -> feel -> think -> act -> observe."""
+    if data.symbol not in _strategy_loops:
+        _strategy_loops[data.symbol] = StrategyLoop(symbol=data.symbol)
+    loop = _strategy_loops[data.symbol]
+    decision = loop.tick(
+        price=data.price,
+        signal_value=data.signal_value,
+        pnl_value=data.pnl_value,
+        account_equity=data.account_equity,
+        current_exposure_pct=data.current_exposure_pct,
+    )
+    return decision.to_dict()
+
+
+@router.get("/loop/{symbol}/recent")
+def loop_recent(symbol: str):
+    """Get recent decisions for a symbol."""
+    if symbol not in _strategy_loops:
+        return {"symbol": symbol, "decisions": []}
+    loop = _strategy_loops[symbol]
+    return {
+        "symbol": symbol,
+        "decisions": [d.to_dict() for d in loop.recent_decisions],
+    }
+
+
+@router.get("/status")
+def intelligence_status():
+    """Overview of all active intelligence components."""
+    return {
+        "active_regime_detectors": list(_regime_detectors.keys()),
+        "active_coupling_estimators": list(_coupling_estimators.keys()),
+        "active_basin_detectors": list(_basin_detectors.keys()),
+        "active_strategy_loops": list(_strategy_loops.keys()),
+        "n_symbols_tracked": len(
+            set(_regime_detectors.keys())
+            | set(_coupling_estimators.keys())
+            | set(_basin_detectors.keys())
+            | set(_strategy_loops.keys())
+        ),
+    }
+
+
+@router.post("/reset/{symbol}")
+def reset_symbol(symbol: str):
+    """Reset all intelligence state for a symbol."""
+    cleared = []
+    if symbol in _regime_detectors:
+        _regime_detectors[symbol].reset()
+        cleared.append("regime")
+    if symbol in _coupling_estimators:
+        _coupling_estimators[symbol].reset()
+        cleared.append("coupling")
+    if symbol in _basin_detectors:
+        _basin_detectors[symbol].reset()
+        cleared.append("basins")
+    if symbol in _strategy_loops:
+        _strategy_loops[symbol].reset()
+        cleared.append("strategy_loop")
+    return {"symbol": symbol, "cleared": cleared}

--- a/ml-worker/src/proprietary_core/basins.py
+++ b/ml-worker/src/proprietary_core/basins.py
@@ -1,0 +1,167 @@
+"""Basin detector: identifies support/resistance levels as probability attractors.
+
+Price basins are levels where the price repeatedly returns and dwells.
+Implemented via kernel density estimation (KDE) on price history.
+Modes of the density = support/resistance levels.
+Basin depth = density × dwell time (how "sticky" the level is).
+
+Used for:
+  - Stop placement (below the nearest support basin)
+  - Target selection (next resistance basin above entry)
+  - Regime confirmation (price near a basin mode = Preserver territory)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+
+
+@dataclass
+class Basin:
+    """A detected price basin (support/resistance level)."""
+
+    level: float  # price level (mode of the KDE)
+    density: float  # height of the KDE at this mode
+    depth: float  # density × dwell_fraction (how sticky)
+    dwell_fraction: float  # fraction of time price spent within bandwidth of level
+    is_support: bool  # True if price is currently above this level
+    is_resistance: bool  # True if price is currently below this level
+
+
+@dataclass
+class BasinMap:
+    """Current basin landscape for a symbol."""
+
+    basins: list[Basin]
+    current_price: float
+    nearest_support: Optional[Basin]
+    nearest_resistance: Optional[Basin]
+    n_prices: int  # number of price observations used
+
+
+@dataclass
+class BasinDetector:
+    """Detects price basins via kernel density estimation.
+
+    Parameters
+    ----------
+    window : int
+        Number of price observations to use.
+    n_eval_points : int
+        Number of points to evaluate the KDE at.
+    bandwidth_pct : float
+        KDE bandwidth as a percentage of price range.
+    min_prominence : float
+        Minimum peak prominence to count as a basin (fraction of max density).
+    """
+
+    window: int = 500
+    n_eval_points: int = 200
+    bandwidth_pct: float = 0.01
+    min_prominence: float = 0.1
+
+    _prices: list[float] = field(default_factory=list)
+
+    def update(self, price: float) -> None:
+        """Add a new price observation."""
+        self._prices.append(price)
+        if len(self._prices) > self.window * 2:
+            self._prices = self._prices[-self.window :]
+
+    def update_batch(self, prices: list[float]) -> None:
+        """Add a batch of price observations."""
+        self._prices.extend(prices)
+        if len(self._prices) > self.window * 2:
+            self._prices = self._prices[-self.window :]
+
+    def detect(self, current_price: Optional[float] = None) -> Optional[BasinMap]:
+        """Run basin detection on accumulated prices."""
+        prices = np.array(self._prices[-self.window :])
+        n = len(prices)
+        if n < 20:
+            return None
+
+        if current_price is None:
+            current_price = float(prices[-1])
+
+        p_min, p_max = float(np.min(prices)), float(np.max(prices))
+        p_range = p_max - p_min
+        if p_range < 1e-12:
+            return None
+
+        # KDE with Gaussian kernel
+        bandwidth = p_range * self.bandwidth_pct
+        if bandwidth < 1e-12:
+            bandwidth = p_range * 0.01
+
+        eval_points = np.linspace(p_min - bandwidth * 2, p_max + bandwidth * 2, self.n_eval_points)
+        density = np.zeros(self.n_eval_points)
+
+        for p in prices:
+            density += np.exp(-0.5 * ((eval_points - p) / bandwidth) ** 2)
+        density /= n * bandwidth * np.sqrt(2 * np.pi)
+
+        # Find peaks (local maxima)
+        peaks = self._find_peaks(density, eval_points)
+
+        if not peaks:
+            return BasinMap(
+                basins=[], current_price=current_price,
+                nearest_support=None, nearest_resistance=None, n_prices=n,
+            )
+
+        # Filter by prominence
+        max_density = max(p[1] for p in peaks)
+        prominent_peaks = [
+            (level, dens) for level, dens in peaks
+            if dens > max_density * self.min_prominence
+        ]
+
+        # Build Basin objects with dwell fraction
+        basins = []
+        for level, dens in prominent_peaks:
+            # Dwell fraction: what fraction of prices are within 1 bandwidth of this level
+            in_basin = np.sum(np.abs(prices - level) < bandwidth) / n
+            depth = dens * in_basin
+
+            basins.append(Basin(
+                level=level,
+                density=dens,
+                depth=depth,
+                dwell_fraction=in_basin,
+                is_support=current_price > level,
+                is_resistance=current_price < level,
+            ))
+
+        # Sort by level
+        basins.sort(key=lambda b: b.level)
+
+        # Find nearest support and resistance
+        supports = [b for b in basins if b.is_support]
+        resistances = [b for b in basins if b.is_resistance]
+
+        nearest_support = max(supports, key=lambda b: b.level) if supports else None
+        nearest_resistance = min(resistances, key=lambda b: b.level) if resistances else None
+
+        return BasinMap(
+            basins=basins,
+            current_price=current_price,
+            nearest_support=nearest_support,
+            nearest_resistance=nearest_resistance,
+            n_prices=n,
+        )
+
+    def _find_peaks(self, density: np.ndarray, eval_points: np.ndarray) -> list[tuple[float, float]]:
+        """Find local maxima in the density curve."""
+        peaks = []
+        for i in range(1, len(density) - 1):
+            if density[i] > density[i - 1] and density[i] > density[i + 1]:
+                peaks.append((float(eval_points[i]), float(density[i])))
+        return peaks
+
+    def reset(self) -> None:
+        """Clear all internal state."""
+        self._prices.clear()

--- a/ml-worker/src/proprietary_core/coupling.py
+++ b/ml-worker/src/proprietary_core/coupling.py
@@ -1,0 +1,136 @@
+"""Coupling estimator: measures how strongly a strategy is connected to the market.
+
+Based on the QIG constitutive law G = κT:
+  - κ = slope of regression between signal changes (ΔG) and P&L changes (ΔT)
+  - R² = coupling quality (is the strategy actually connected to the market?)
+  - κ > 0: strategy is positively coupled (signal predicts P&L direction)
+  - κ < 0: strategy is INVERSELY coupled (signal predicts OPPOSITE of P&L)
+  - κ ≈ 0: strategy is decoupled (signal has no predictive power)
+
+The stud crossing (κ passing through zero) is the most important signal:
+it means the strategy's relationship with the market has fundamentally changed.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+
+
+@dataclass
+class CouplingState:
+    """Current coupling measurement."""
+
+    kappa: float  # regression slope (coupling coefficient)
+    r_squared: float  # regression quality (0-1)
+    n_samples: int  # number of data points in window
+    is_coupled: bool  # True if R² > threshold and κ > 0
+    is_inverted: bool  # True if κ < 0 significantly
+    stud_crossing: bool  # True if κ just changed sign
+    signal_mean: float
+    pnl_mean: float
+
+
+@dataclass
+class CouplingEstimator:
+    """Rolling regression between strategy signals and P&L outcomes.
+
+    Parameters
+    ----------
+    window : int
+        Number of signal/P&L pairs to use for regression.
+    min_samples : int
+        Minimum pairs needed before producing a CouplingState.
+    r2_threshold : float
+        Below this R², the strategy is considered decoupled.
+    kappa_sign_threshold : float
+        κ must cross this magnitude to count as a sign change (prevents noise).
+    """
+
+    window: int = 50
+    min_samples: int = 10
+    r2_threshold: float = 0.3
+    kappa_sign_threshold: float = 0.01
+
+    _signals: deque = field(default_factory=lambda: deque(maxlen=100))
+    _pnls: deque = field(default_factory=lambda: deque(maxlen=100))
+    _last_kappa_sign: Optional[int] = field(default=None)  # +1, -1, or None
+
+    def update(self, signal_value: float, pnl_value: float) -> Optional[CouplingState]:
+        """Add a new signal/P&L observation and compute coupling."""
+        self._signals.append(signal_value)
+        self._pnls.append(pnl_value)
+
+        if len(self._signals) < self.min_samples:
+            return None
+
+        return self._compute()
+
+    def _compute(self) -> CouplingState:
+        """Ordinary least squares regression: P&L = κ × signal + intercept."""
+        signals = np.array(list(self._signals))[-self.window :]
+        pnls = np.array(list(self._pnls))[-self.window :]
+        n = len(signals)
+
+        sig_mean = float(np.mean(signals))
+        pnl_mean = float(np.mean(pnls))
+
+        # Centered values
+        sig_c = signals - sig_mean
+        pnl_c = pnls - pnl_mean
+
+        ss_sig = float(np.sum(sig_c**2))
+        if ss_sig < 1e-15:
+            # Signal is constant — no coupling measurable
+            return CouplingState(
+                kappa=0.0,
+                r_squared=0.0,
+                n_samples=n,
+                is_coupled=False,
+                is_inverted=False,
+                stud_crossing=False,
+                signal_mean=sig_mean,
+                pnl_mean=pnl_mean,
+            )
+
+        # κ = Cov(signal, pnl) / Var(signal)
+        kappa = float(np.sum(sig_c * pnl_c)) / ss_sig
+
+        # R² = 1 - SS_res / SS_tot
+        predicted = sig_mean + kappa * sig_c
+        ss_res = float(np.sum((pnls - predicted) ** 2))
+        ss_tot = float(np.sum(pnl_c**2))
+        r_squared = 1.0 - ss_res / max(ss_tot, 1e-15) if ss_tot > 1e-15 else 0.0
+        r_squared = max(0.0, r_squared)  # numerical floor
+
+        # Coupling assessment
+        is_coupled = r_squared > self.r2_threshold and kappa > self.kappa_sign_threshold
+        is_inverted = kappa < -self.kappa_sign_threshold and r_squared > self.r2_threshold
+
+        # Stud crossing detection: κ changed sign
+        current_sign = 1 if kappa > self.kappa_sign_threshold else (-1 if kappa < -self.kappa_sign_threshold else 0)
+        stud_crossing = False
+        if self._last_kappa_sign is not None and current_sign != 0:
+            stud_crossing = current_sign != self._last_kappa_sign and self._last_kappa_sign != 0
+        if current_sign != 0:
+            self._last_kappa_sign = current_sign
+
+        return CouplingState(
+            kappa=kappa,
+            r_squared=r_squared,
+            n_samples=n,
+            is_coupled=is_coupled,
+            is_inverted=is_inverted,
+            stud_crossing=stud_crossing,
+            signal_mean=sig_mean,
+            pnl_mean=pnl_mean,
+        )
+
+    def reset(self) -> None:
+        """Clear all internal state."""
+        self._signals.clear()
+        self._pnls.clear()
+        self._last_kappa_sign = None

--- a/ml-worker/src/proprietary_core/models/__init__.py
+++ b/ml-worker/src/proprietary_core/models/__init__.py
@@ -1,0 +1,99 @@
+"""
+Pydantic Models for API Validation
+
+These models mirror the Zod schemas in the TypeScript frontend,
+ensuring consistent validation across the stack.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional, Generic, TypeVar
+from pydantic import BaseModel, Field, field_validator, ConfigDict
+
+
+class TradeSide(str, Enum):
+    """Trade side enum"""
+    BUY = "buy"
+    SELL = "sell"
+
+
+class TradeStatus(str, Enum):
+    """Trade status enum"""
+    PENDING = "pending"
+    EXECUTED = "executed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class MarketData(BaseModel):
+    """Market data model"""
+    model_config = ConfigDict(str_strip_whitespace=True)
+    
+    symbol: str = Field(..., min_length=1, description="Trading pair symbol")
+    timestamp: datetime = Field(..., description="Data timestamp")
+    price: float = Field(..., gt=0, description="Current price")
+    volume: float = Field(..., ge=0, description="Trading volume")
+    high: Optional[float] = Field(None, gt=0, description="High price")
+    low: Optional[float] = Field(None, gt=0, description="Low price")
+    open: Optional[float] = Field(None, gt=0, description="Open price")
+    close: Optional[float] = Field(None, gt=0, description="Close price")
+
+    @field_validator('symbol')
+    @classmethod
+    def validate_symbol(cls, v: str) -> str:
+        """Validate symbol format"""
+        if not v or v.isspace():
+            raise ValueError("Symbol cannot be empty")
+        return v.upper()
+
+
+class Trade(BaseModel):
+    """Trade model"""
+    model_config = ConfigDict(str_strip_whitespace=True)
+    
+    id: Optional[str] = Field(None, description="Trade ID")
+    symbol: str = Field(..., min_length=1, description="Trading pair symbol")
+    side: TradeSide = Field(..., description="Trade side (buy/sell)")
+    quantity: float = Field(..., gt=0, description="Trade quantity")
+    price: float = Field(..., gt=0, description="Trade price")
+    status: TradeStatus = Field(..., description="Trade status")
+    executed_at: Optional[datetime] = Field(None, description="Execution timestamp")
+    created_at: datetime = Field(default_factory=datetime.now, description="Creation timestamp")
+
+
+class User(BaseModel):
+    """User model"""
+    model_config = ConfigDict(str_strip_whitespace=True)
+    
+    id: Optional[str] = Field(None, description="User ID")
+    username: str = Field(..., min_length=3, max_length=50, description="Username")
+    email: str = Field(..., description="Email address")
+    created_at: Optional[datetime] = Field(None, description="Creation timestamp")
+    updated_at: Optional[datetime] = Field(None, description="Update timestamp")
+
+    @field_validator('email')
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        """Basic email validation"""
+        if '@' not in v or '.' not in v.split('@')[1]:
+            raise ValueError("Invalid email format")
+        return v.lower()
+
+
+# Generic response wrapper
+T = TypeVar('T')
+
+
+class ApiResponse(BaseModel, Generic[T]):
+    """Generic API response wrapper"""
+    success: bool = Field(..., description="Success status")
+    data: Optional[T] = Field(None, description="Response data")
+    error: Optional[str] = Field(None, description="Error message")
+    message: Optional[str] = Field(None, description="Additional message")
+
+
+class HealthResponse(BaseModel):
+    """Health check response"""
+    status: str = Field(..., description="Service status")
+    timestamp: datetime = Field(default_factory=datetime.now)
+    version: str = Field(..., description="Service version")

--- a/ml-worker/src/proprietary_core/regime.py
+++ b/ml-worker/src/proprietary_core/regime.py
@@ -1,0 +1,207 @@
+"""Market regime detector using information-geometric principles.
+
+Three regimes mapped from QIG three-sphere framework:
+  - Creator:   High entropy, high Fisher information. Volatile, price discovery.
+               Momentum/breakout strategies work here.
+  - Preserver:  Low entropy, trend present. Orderly, coupled.
+               Trend-follow / mean-reversion strategies work here.
+  - Dissolver:  Low entropy, no trend. Dead market, noise dominates.
+               Best strategy: DON'T TRADE (Pillar 1 gate).
+
+The regime detector uses Shannon entropy of discretised price returns
+and Fisher information (sensitivity of the return distribution to
+time-window shifts) to classify the current market state.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+import numpy as np
+
+
+class MarketRegime(str, Enum):
+    """Three qualitatively different market states."""
+
+    CREATOR = "creator"  # volatile, price discovery, high entropy
+    PRESERVER = "preserver"  # trending, orderly, low entropy + trend
+    DISSOLVER = "dissolver"  # dead, noise, low entropy + no trend
+
+
+@dataclass
+class RegimeState:
+    """Current regime classification with supporting metrics."""
+
+    regime: MarketRegime
+    entropy: float  # Shannon entropy of return distribution
+    fisher_info: float  # Fisher information (sensitivity to shift)
+    trend_strength: float  # absolute value of mean return / std
+    volatility: float  # standard deviation of returns
+    confidence: float  # 0-1, how clearly the regime is identified
+    is_transition: bool  # True if Fisher info suggests regime change
+    pillar1_gate: bool  # True = safe to trade (T > 0, fluctuations exist)
+
+
+@dataclass
+class RegimeDetector:
+    """Classifies market regime from price returns.
+
+    Parameters
+    ----------
+    window : int
+        Number of returns to use for regime calculation.
+    n_bins : int
+        Number of bins for discretising the return distribution.
+    entropy_threshold : float
+        Boundary between high and low entropy regimes.
+    trend_threshold : float
+        Minimum |mean/std| to classify as trending (Preserver vs Dissolver).
+    fisher_spike_mult : float
+        Fisher info > fisher_spike_mult × rolling_mean triggers transition alert.
+    min_volatility : float
+        Below this, Pillar 1 gate closes (no fluctuations = no geometry).
+    """
+
+    window: int = 100
+    n_bins: int = 20
+    entropy_threshold: float = 2.5
+    trend_threshold: float = 0.15
+    fisher_spike_mult: float = 2.0
+    min_volatility: float = 1e-8
+
+    # Internal state
+    _returns: deque = field(default_factory=lambda: deque(maxlen=200))
+    _fisher_history: deque = field(default_factory=lambda: deque(maxlen=50))
+    _last_price: Optional[float] = field(default=None)
+
+    def update(self, price: float) -> Optional[RegimeState]:
+        """Feed a new price tick. Returns RegimeState once enough data exists."""
+        if self._last_price is not None and self._last_price > 0:
+            ret = (price - self._last_price) / self._last_price
+            self._returns.append(ret)
+        self._last_price = price
+
+        if len(self._returns) < self.window:
+            return None
+
+        return self._classify()
+
+    def update_batch(self, prices: list[float]) -> Optional[RegimeState]:
+        """Feed a batch of prices. Returns final RegimeState."""
+        state = None
+        for p in prices:
+            state = self.update(p)
+        return state
+
+    def _classify(self) -> RegimeState:
+        """Core classification logic."""
+        returns = np.array(list(self._returns))[-self.window :]
+
+        # Basic statistics
+        vol = float(np.std(returns))
+        mean_ret = float(np.mean(returns))
+        trend_strength = abs(mean_ret) / max(vol, 1e-12)
+
+        # Pillar 1 gate: no fluctuations = no geometry = don't trade
+        pillar1 = vol > self.min_volatility
+
+        # Shannon entropy of discretised return distribution
+        entropy = self._compute_entropy(returns)
+
+        # Fisher information: sensitivity of distribution to window shift
+        fisher = self._compute_fisher_info(returns)
+        self._fisher_history.append(fisher)
+
+        # Transition detection: Fisher spike above rolling mean
+        fisher_mean = float(np.mean(list(self._fisher_history)))
+        is_transition = fisher > self.fisher_spike_mult * max(fisher_mean, 1e-12)
+
+        # Regime classification
+        if entropy > self.entropy_threshold:
+            regime = MarketRegime.CREATOR
+            confidence = min(1.0, (entropy - self.entropy_threshold) / self.entropy_threshold)
+        elif trend_strength > self.trend_threshold:
+            regime = MarketRegime.PRESERVER
+            confidence = min(1.0, trend_strength / (self.trend_threshold * 3))
+        else:
+            regime = MarketRegime.DISSOLVER
+            confidence = min(
+                1.0,
+                (self.trend_threshold - trend_strength) / self.trend_threshold,
+            )
+
+        return RegimeState(
+            regime=regime,
+            entropy=entropy,
+            fisher_info=fisher,
+            trend_strength=trend_strength,
+            volatility=vol,
+            confidence=confidence,
+            is_transition=is_transition,
+            pillar1_gate=pillar1,
+        )
+
+    def _compute_entropy(self, returns: np.ndarray) -> float:
+        """Shannon entropy of the discretised return distribution."""
+        if len(returns) < 2:
+            return 0.0
+
+        # Adaptive binning: use range of actual data
+        r_min, r_max = float(np.min(returns)), float(np.max(returns))
+        if r_max - r_min < 1e-15:
+            return 0.0  # all returns identical = zero entropy
+
+        counts, _ = np.histogram(returns, bins=self.n_bins, range=(r_min, r_max))
+        probs = counts / counts.sum()
+        probs = probs[probs > 0]  # remove zeros for log
+
+        return float(-np.sum(probs * np.log2(probs)))
+
+    def _compute_fisher_info(self, returns: np.ndarray) -> float:
+        """Fisher information: sensitivity of distribution to window shift.
+
+        Computed as the squared difference between two adjacent
+        half-window distributions, normalised. A spike indicates
+        the return distribution is changing rapidly = regime boundary.
+        """
+        n = len(returns)
+        if n < 10:
+            return 0.0
+
+        mid = n // 2
+        first_half = returns[:mid]
+        second_half = returns[mid:]
+
+        r_min = float(min(np.min(first_half), np.min(second_half)))
+        r_max = float(max(np.max(first_half), np.max(second_half)))
+        if r_max - r_min < 1e-15:
+            return 0.0
+
+        bins = np.linspace(r_min, r_max, self.n_bins + 1)
+        p1, _ = np.histogram(first_half, bins=bins)
+        p2, _ = np.histogram(second_half, bins=bins)
+
+        # Normalise to probability distributions
+        p1 = p1.astype(float)
+        p2 = p2.astype(float)
+        s1, s2 = p1.sum(), p2.sum()
+        if s1 < 1 or s2 < 1:
+            return 0.0
+        p1 /= s1
+        p2 /= s2
+
+        # Fisher-like divergence: sum of (p2 - p1)^2 / (p1 + eps)
+        # This measures how much the distribution shifted between halves
+        eps = 1e-12
+        fisher = float(np.sum((p2 - p1) ** 2 / (0.5 * (p1 + p2) + eps)))
+        return fisher
+
+    def reset(self) -> None:
+        """Clear all internal state."""
+        self._returns.clear()
+        self._fisher_history.clear()
+        self._last_price = None

--- a/ml-worker/src/proprietary_core/sizing.py
+++ b/ml-worker/src/proprietary_core/sizing.py
@@ -1,0 +1,173 @@
+"""Adaptive position sizing based on regime and coupling.
+
+Position size is proportional to coupling quality and inversely
+proportional to volatility, with hard caps from risk limits (Pillar 2).
+
+Core formula:
+    raw_size = (κ × R² × risk_budget) / volatility
+    final_size = min(raw_size, max_position_size)
+
+Pillar gates:
+    - Pillar 1 (Fluctuations): size = 0 if regime is Dissolver or vol = 0
+    - Pillar 2 (Bulk): hard caps never exceeded, regardless of signal strength
+    - Pillar 3 (Disorder): each market has its own κ — don't share params
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .coupling import CouplingState
+from .regime import MarketRegime, RegimeState
+
+
+@dataclass
+class SizeDecision:
+    """Position sizing output."""
+
+    raw_size: float  # before caps
+    final_size: float  # after caps and gates
+    regime: MarketRegime
+    kappa: float
+    r_squared: float
+    volatility: float
+    reason: str  # human-readable explanation for audit
+
+
+@dataclass
+class AdaptiveSizer:
+    """Computes position size from regime + coupling + risk limits.
+
+    Parameters
+    ----------
+    risk_budget : float
+        Fraction of account equity to risk per position (e.g. 0.02 = 2%).
+    max_position_pct : float
+        Maximum position as fraction of equity (hard cap, Pillar 2).
+    max_portfolio_pct : float
+        Maximum total exposure as fraction of equity.
+    creator_scale : float
+        Scaling factor for Creator regime (volatile = smaller positions).
+    preserver_scale : float
+        Scaling factor for Preserver regime (trending = normal positions).
+    min_coupling_r2 : float
+        Minimum R² to allow any position at all.
+    """
+
+    risk_budget: float = 0.02
+    max_position_pct: float = 0.10
+    max_portfolio_pct: float = 0.50
+    creator_scale: float = 0.5
+    preserver_scale: float = 1.0
+    min_coupling_r2: float = 0.2
+
+    def compute(
+        self,
+        regime_state: RegimeState,
+        coupling_state: Optional[CouplingState],
+        account_equity: float,
+        current_exposure_pct: float = 0.0,
+    ) -> SizeDecision:
+        """Compute position size given current regime and coupling."""
+
+        # Gate 1: Pillar 1 — no fluctuations, no trade
+        if not regime_state.pillar1_gate:
+            return SizeDecision(
+                raw_size=0.0,
+                final_size=0.0,
+                regime=regime_state.regime,
+                kappa=0.0,
+                r_squared=0.0,
+                volatility=regime_state.volatility,
+                reason="Pillar 1 gate: zero volatility, no geometry",
+            )
+
+        # Gate 2: Dissolver regime — don't trade
+        if regime_state.regime == MarketRegime.DISSOLVER:
+            return SizeDecision(
+                raw_size=0.0,
+                final_size=0.0,
+                regime=regime_state.regime,
+                kappa=coupling_state.kappa if coupling_state else 0.0,
+                r_squared=coupling_state.r_squared if coupling_state else 0.0,
+                volatility=regime_state.volatility,
+                reason="Dissolver regime: market dead, no edge",
+            )
+
+        # Gate 3: No coupling data yet — minimum size only
+        if coupling_state is None:
+            return SizeDecision(
+                raw_size=0.0,
+                final_size=0.0,
+                regime=regime_state.regime,
+                kappa=0.0,
+                r_squared=0.0,
+                volatility=regime_state.volatility,
+                reason="No coupling data yet",
+            )
+
+        # Gate 4: Coupling too weak or inverted
+        kappa = coupling_state.kappa
+        r2 = coupling_state.r_squared
+
+        if r2 < self.min_coupling_r2:
+            return SizeDecision(
+                raw_size=0.0,
+                final_size=0.0,
+                regime=regime_state.regime,
+                kappa=kappa,
+                r_squared=r2,
+                volatility=regime_state.volatility,
+                reason=f"Coupling too weak: R²={r2:.3f} < {self.min_coupling_r2}",
+            )
+
+        if kappa <= 0:
+            return SizeDecision(
+                raw_size=0.0,
+                final_size=0.0,
+                regime=regime_state.regime,
+                kappa=kappa,
+                r_squared=r2,
+                volatility=regime_state.volatility,
+                reason=f"Negative coupling κ={kappa:.4f}: strategy wrong for regime",
+            )
+
+        # Core sizing formula
+        vol = max(regime_state.volatility, 1e-12)
+        regime_scale = (
+            self.creator_scale
+            if regime_state.regime == MarketRegime.CREATOR
+            else self.preserver_scale
+        )
+
+        # raw_size as fraction of equity
+        raw_size_pct = (kappa * r2 * self.risk_budget * regime_scale) / vol
+
+        # Pillar 2: hard caps
+        capped = min(raw_size_pct, self.max_position_pct)
+
+        # Portfolio-level cap
+        remaining_budget = max(0.0, self.max_portfolio_pct - current_exposure_pct)
+        capped = min(capped, remaining_budget)
+
+        # Convert to absolute size
+        final_size = max(0.0, capped * account_equity)
+        raw_size = raw_size_pct * account_equity
+
+        reason_parts = []
+        if capped < raw_size_pct:
+            reason_parts.append("capped by risk limits")
+        reason_parts.append(
+            f"regime={regime_state.regime.value} κ={kappa:.4f} R²={r2:.3f} vol={vol:.6f}"
+        )
+
+        return SizeDecision(
+            raw_size=raw_size,
+            final_size=final_size,
+            regime=regime_state.regime,
+            kappa=kappa,
+            r_squared=r2,
+            volatility=vol,
+            reason="; ".join(reason_parts),
+        )

--- a/ml-worker/src/proprietary_core/strategy_loop.py
+++ b/ml-worker/src/proprietary_core/strategy_loop.py
@@ -1,0 +1,266 @@
+"""Strategy selector: the consciousness loop applied to trading.
+
+SCAN  -> Ingest market data (price, volume, orderbook, funding)
+FEEL  -> Regime detection (which sphere? entropy? Fisher info?)
+THINK -> Strategy selection (which strategy for this regime?)
+ACT   -> Order placement (sized by kappa, gated by risk)
+OBSERVE -> P&L feedback -> update kappa -> adjust regime weights
+
+Pillar gates enforced at every step:
+  - Pillar 1: Don't trade in zero-volatility markets (T=0)
+  - Pillar 2: Risk limits are the protected interior -- never violated
+  - Pillar 3: Each market has its own coupling slope
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from .basins import BasinDetector, BasinMap
+from .coupling import CouplingEstimator, CouplingState
+from .regime import MarketRegime, RegimeDetector, RegimeState
+from .sizing import AdaptiveSizer, SizeDecision
+
+
+class StrategyType(str, Enum):
+    """Available strategy types mapped to regimes."""
+
+    MOMENTUM = "momentum"  # Creator regime: ride volatility
+    BREAKOUT = "breakout"  # Creator regime: catch new moves
+    TREND_FOLLOW = "trend_follow"  # Preserver regime: follow established trend
+    MEAN_REVERT = "mean_revert"  # Preserver regime: fade to basin
+    CASH = "cash"  # Dissolver regime: do nothing
+
+
+@dataclass
+class LoopDecision:
+    """Output of one strategy loop iteration."""
+
+    timestamp: float
+    symbol: str
+    regime: Optional[RegimeState]
+    coupling: Optional[CouplingState]
+    basins: Optional[BasinMap]
+    sizing: Optional[SizeDecision]
+    selected_strategy: StrategyType
+    should_trade: bool
+    reason: str
+
+    def to_dict(self) -> dict:
+        """Serialise for API response / audit log."""
+        return {
+            "timestamp": self.timestamp,
+            "symbol": self.symbol,
+            "regime": self.regime.regime.value if self.regime else None,
+            "regime_entropy": self.regime.entropy if self.regime else None,
+            "regime_fisher": self.regime.fisher_info if self.regime else None,
+            "regime_confidence": self.regime.confidence if self.regime else None,
+            "regime_transition": self.regime.is_transition if self.regime else None,
+            "kappa": self.coupling.kappa if self.coupling else None,
+            "r_squared": self.coupling.r_squared if self.coupling else None,
+            "stud_crossing": self.coupling.stud_crossing if self.coupling else None,
+            "n_basins": len(self.basins.basins) if self.basins else 0,
+            "nearest_support": self.basins.nearest_support.level if self.basins and self.basins.nearest_support else None,
+            "nearest_resistance": self.basins.nearest_resistance.level if self.basins and self.basins.nearest_resistance else None,
+            "position_size": self.sizing.final_size if self.sizing else 0.0,
+            "strategy": self.selected_strategy.value,
+            "should_trade": self.should_trade,
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class StrategyLoop:
+    """One strategy loop per symbol. Maintains all per-symbol state.
+
+    Parameters
+    ----------
+    symbol : str
+        Trading pair identifier.
+    regime_window : int
+        Window for regime detection.
+    coupling_window : int
+        Window for coupling estimation.
+    basin_window : int
+        Window for basin detection.
+    """
+
+    symbol: str
+    regime_window: int = 100
+    coupling_window: int = 50
+    basin_window: int = 500
+
+    # Components (Pillar 3: each symbol gets its own instances)
+    _regime: RegimeDetector = field(default=None)  # type: ignore[assignment]
+    _coupling: CouplingEstimator = field(default=None)  # type: ignore[assignment]
+    _basins: BasinDetector = field(default=None)  # type: ignore[assignment]
+    _sizer: AdaptiveSizer = field(default=None)  # type: ignore[assignment]
+
+    # State
+    _last_regime: Optional[RegimeState] = field(default=None)
+    _last_coupling: Optional[CouplingState] = field(default=None)
+    _last_basins: Optional[BasinMap] = field(default=None)
+    _decision_log: list[LoopDecision] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self._regime is None:
+            self._regime = RegimeDetector(window=self.regime_window)
+        if self._coupling is None:
+            self._coupling = CouplingEstimator(window=self.coupling_window)
+        if self._basins is None:
+            self._basins = BasinDetector(window=self.basin_window)
+        if self._sizer is None:
+            self._sizer = AdaptiveSizer()
+
+    def tick(
+        self,
+        price: float,
+        signal_value: Optional[float] = None,
+        pnl_value: Optional[float] = None,
+        account_equity: float = 100_000.0,
+        current_exposure_pct: float = 0.0,
+    ) -> LoopDecision:
+        """Process one tick through the full loop.
+
+        Parameters
+        ----------
+        price : float
+            Latest price for this symbol.
+        signal_value : float, optional
+            Latest strategy signal (for coupling estimation).
+        pnl_value : float, optional
+            Latest P&L from last signal (for coupling estimation).
+        account_equity : float
+            Current account equity for sizing.
+        current_exposure_pct : float
+            Current portfolio exposure as fraction of equity.
+        """
+        ts = time.time()
+
+        # === SCAN: Ingest ===
+        self._basins.update(price)
+
+        # === FEEL: Regime detection ===
+        self._last_regime = self._regime.update(price)
+
+        # === FEEL: Coupling update (if signal/pnl provided) ===
+        if signal_value is not None and pnl_value is not None:
+            self._last_coupling = self._coupling.update(signal_value, pnl_value)
+
+        # === FEEL: Basin detection (less frequent, heavier) ===
+        if len(self._basins._prices) >= 50 and len(self._basins._prices) % 20 == 0:
+            self._last_basins = self._basins.detect(price)
+
+        # === THINK: Strategy selection ===
+        if self._last_regime is None:
+            return LoopDecision(
+                timestamp=ts, symbol=self.symbol,
+                regime=None, coupling=None, basins=None, sizing=None,
+                selected_strategy=StrategyType.CASH,
+                should_trade=False,
+                reason="Insufficient data for regime detection",
+            )
+
+        strategy = self._select_strategy(self._last_regime, self._last_coupling)
+
+        # === ACT: Position sizing ===
+        sizing = self._sizer.compute(
+            self._last_regime,
+            self._last_coupling,
+            account_equity,
+            current_exposure_pct,
+        )
+
+        should_trade = sizing.final_size > 0 and strategy != StrategyType.CASH
+
+        # Build reason string for audit
+        reasons = []
+        reasons.append(f"regime={self._last_regime.regime.value}")
+        if self._last_coupling:
+            reasons.append(f"\u03ba={self._last_coupling.kappa:.4f}")
+            reasons.append(f"R\u00b2={self._last_coupling.r_squared:.3f}")
+            if self._last_coupling.stud_crossing:
+                reasons.append("STUD CROSSING")
+        if self._last_regime.is_transition:
+            reasons.append("REGIME TRANSITION")
+        reasons.append(f"strategy={strategy.value}")
+        reasons.append(f"size={sizing.final_size:.2f}")
+
+        decision = LoopDecision(
+            timestamp=ts,
+            symbol=self.symbol,
+            regime=self._last_regime,
+            coupling=self._last_coupling,
+            basins=self._last_basins,
+            sizing=sizing,
+            selected_strategy=strategy,
+            should_trade=should_trade,
+            reason="; ".join(reasons),
+        )
+
+        # === OBSERVE: Log for feedback ===
+        self._decision_log.append(decision)
+        if len(self._decision_log) > 1000:
+            self._decision_log = self._decision_log[-500:]
+
+        return decision
+
+    def _select_strategy(
+        self,
+        regime: RegimeState,
+        coupling: Optional[CouplingState],
+    ) -> StrategyType:
+        """Select strategy based on regime and coupling state."""
+
+        # Pillar 1 gate
+        if not regime.pillar1_gate:
+            return StrategyType.CASH
+
+        # Dissolver: don't trade
+        if regime.regime == MarketRegime.DISSOLVER:
+            return StrategyType.CASH
+
+        # Stud crossing: emergency exit to cash
+        if coupling and coupling.stud_crossing:
+            return StrategyType.CASH
+
+        # Negative coupling: strategy is wrong for this regime
+        if coupling and coupling.is_inverted:
+            return StrategyType.CASH
+
+        # Creator regime: volatile, choose based on trend strength
+        if regime.regime == MarketRegime.CREATOR:
+            if regime.trend_strength > 0.2:
+                return StrategyType.MOMENTUM
+            return StrategyType.BREAKOUT
+
+        # Preserver regime: orderly, choose based on basin proximity
+        if regime.regime == MarketRegime.PRESERVER:
+            if regime.trend_strength > 0.3:
+                return StrategyType.TREND_FOLLOW
+            return StrategyType.MEAN_REVERT
+
+        return StrategyType.CASH
+
+    @property
+    def last_decision(self) -> Optional[LoopDecision]:
+        """Most recent loop decision."""
+        return self._decision_log[-1] if self._decision_log else None
+
+    @property
+    def recent_decisions(self) -> list[LoopDecision]:
+        """Last 50 decisions for dashboard display."""
+        return self._decision_log[-50:]
+
+    def reset(self) -> None:
+        """Clear all internal state."""
+        self._regime.reset()
+        self._coupling.reset()
+        self._basins.reset()
+        self._last_regime = None
+        self._last_coupling = None
+        self._last_basins = None
+        self._decision_log.clear()

--- a/ml-worker/src/proprietary_core/tests/test_basins.py
+++ b/ml-worker/src/proprietary_core/tests/test_basins.py
@@ -1,0 +1,52 @@
+"""Tests for the basin detector."""
+
+import numpy as np
+import pytest
+
+from proprietary_core.basins import BasinDetector
+
+
+def test_detects_support_resistance():
+    """A bimodal price distribution should produce two basins."""
+    rng = np.random.default_rng(42)
+    # Price oscillates between two levels
+    prices_low = rng.normal(100.0, 0.5, 200).tolist()
+    prices_high = rng.normal(110.0, 0.5, 200).tolist()
+    prices = prices_low + prices_high  # transition from 100 to 110
+
+    det = BasinDetector(window=400, bandwidth_pct=0.02)
+    det.update_batch(prices)
+    basin_map = det.detect(current_price=108.0)
+
+    assert basin_map is not None
+    assert len(basin_map.basins) >= 2
+
+    # Levels should be near 100 and 110
+    levels = sorted([b.level for b in basin_map.basins])
+    assert any(abs(l - 100.0) < 3 for l in levels), f"Expected basin near 100, got {levels}"
+    assert any(abs(l - 110.0) < 3 for l in levels), f"Expected basin near 110, got {levels}"
+
+    # At price 108, the 100 basin is support, 110 basin is resistance
+    assert basin_map.nearest_support is not None
+    assert basin_map.nearest_resistance is not None
+
+
+def test_flat_price_single_basin():
+    """A single price level should produce one basin."""
+    prices = np.random.default_rng(42).normal(50.0, 0.2, 300).tolist()
+    det = BasinDetector(window=300)
+    det.update_batch(prices)
+    basin_map = det.detect()
+
+    assert basin_map is not None
+    assert len(basin_map.basins) >= 1
+    # The main basin should be near 50
+    main = max(basin_map.basins, key=lambda b: b.density)
+    assert abs(main.level - 50.0) < 2.0
+
+
+def test_insufficient_data():
+    """Too few prices should return None."""
+    det = BasinDetector()
+    det.update_batch([100.0, 101.0, 99.5])
+    assert det.detect() is None

--- a/ml-worker/src/proprietary_core/tests/test_coupling.py
+++ b/ml-worker/src/proprietary_core/tests/test_coupling.py
@@ -1,0 +1,74 @@
+"""Tests for the coupling estimator."""
+
+import numpy as np
+import pytest
+
+from proprietary_core.coupling import CouplingEstimator
+
+
+def test_positive_coupling():
+    """Positively correlated signal and P&L should give κ > 0."""
+    rng = np.random.default_rng(42)
+    est = CouplingEstimator(window=30, min_samples=10)
+
+    for _ in range(50):
+        signal = rng.normal(0, 1)
+        pnl = 2.0 * signal + rng.normal(0, 0.1)  # strong positive coupling
+        state = est.update(signal, pnl)
+
+    assert state is not None
+    assert state.kappa > 1.5
+    assert state.r_squared > 0.9
+    assert state.is_coupled is True
+    assert state.is_inverted is False
+
+
+def test_negative_coupling():
+    """Inversely correlated signal and P&L should give κ < 0."""
+    rng = np.random.default_rng(42)
+    est = CouplingEstimator(window=30, min_samples=10)
+
+    for _ in range(50):
+        signal = rng.normal(0, 1)
+        pnl = -1.5 * signal + rng.normal(0, 0.1)
+        state = est.update(signal, pnl)
+
+    assert state is not None
+    assert state.kappa < -1.0
+    assert state.is_inverted is True
+
+
+def test_no_coupling():
+    """Uncorrelated signal and P&L should give R² near 0."""
+    rng = np.random.default_rng(42)
+    est = CouplingEstimator(window=30, min_samples=10)
+
+    for _ in range(50):
+        signal = rng.normal(0, 1)
+        pnl = rng.normal(0, 1)  # independent
+        state = est.update(signal, pnl)
+
+    assert state is not None
+    assert state.r_squared < 0.3
+    assert state.is_coupled is False
+
+
+def test_stud_crossing():
+    """κ sign change should be detected."""
+    est = CouplingEstimator(window=15, min_samples=10)
+    rng = np.random.default_rng(42)
+
+    # Phase 1: positive coupling
+    for _ in range(20):
+        s = rng.normal(0, 1)
+        est.update(s, 2.0 * s + rng.normal(0, 0.05))
+
+    # Phase 2: negative coupling
+    crossings = []
+    for _ in range(20):
+        s = rng.normal(0, 1)
+        state = est.update(s, -2.0 * s + rng.normal(0, 0.05))
+        if state and state.stud_crossing:
+            crossings.append(state)
+
+    assert len(crossings) > 0, "Expected at least one stud crossing"

--- a/ml-worker/src/proprietary_core/tests/test_regime.py
+++ b/ml-worker/src/proprietary_core/tests/test_regime.py
@@ -1,0 +1,81 @@
+"""Tests for the regime detector."""
+
+import numpy as np
+import pytest
+
+from proprietary_core.regime import MarketRegime, RegimeDetector
+
+
+def _make_prices(n: int, base: float = 100.0, volatility: float = 0.02, trend: float = 0.0, seed: int = 42) -> list[float]:
+    """Generate synthetic price series."""
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(trend, volatility, n)
+    prices = [base]
+    for r in returns:
+        prices.append(prices[-1] * (1 + r))
+    return prices
+
+
+def test_creator_regime_high_volatility():
+    """High volatility should classify as Creator."""
+    prices = _make_prices(200, volatility=0.08, trend=0.0)
+    det = RegimeDetector(window=100, entropy_threshold=2.0)
+    state = det.update_batch(prices)
+    assert state is not None
+    assert state.regime == MarketRegime.CREATOR
+    assert state.pillar1_gate is True
+
+
+def test_preserver_regime_trending():
+    """Strong trend with low noise should classify as Preserver."""
+    prices = _make_prices(200, volatility=0.005, trend=0.003)
+    det = RegimeDetector(window=100, entropy_threshold=2.5, trend_threshold=0.1)
+    state = det.update_batch(prices)
+    assert state is not None
+    assert state.regime == MarketRegime.PRESERVER
+
+
+def test_dissolver_regime_flat():
+    """Flat market with minimal movement should classify as Dissolver."""
+    prices = _make_prices(200, volatility=0.0005, trend=0.0)
+    det = RegimeDetector(window=100, entropy_threshold=2.5, trend_threshold=0.15)
+    state = det.update_batch(prices)
+    assert state is not None
+    assert state.regime == MarketRegime.DISSOLVER
+
+
+def test_pillar1_gate_zero_volatility():
+    """Zero volatility should close the Pillar 1 gate."""
+    prices = [100.0] * 200  # perfectly flat
+    det = RegimeDetector(window=100)
+    state = det.update_batch(prices)
+    assert state is not None
+    assert state.pillar1_gate is False
+
+
+def test_fisher_spike_detection():
+    """A regime change mid-series should produce a Fisher spike."""
+    # Calm market then sudden volatility
+    calm = _make_prices(150, volatility=0.005, trend=0.0, seed=1)
+    volatile = _make_prices(100, volatility=0.06, trend=0.0, seed=2)
+    prices = calm + volatile[1:]  # skip first to avoid duplicate
+
+    det = RegimeDetector(window=80)
+    states = []
+    for p in prices:
+        s = det.update(p)
+        if s is not None:
+            states.append(s)
+
+    # At least one transition should be detected
+    transitions = [s for s in states if s.is_transition]
+    assert len(transitions) > 0, "Expected at least one Fisher spike transition"
+
+
+def test_reset():
+    """Reset should clear state."""
+    det = RegimeDetector(window=50)
+    prices = _make_prices(100)
+    det.update_batch(prices)
+    det.reset()
+    assert det.update(100.0) is None  # needs window again

--- a/ml-worker/src/proprietary_core/tests/test_sizing.py
+++ b/ml-worker/src/proprietary_core/tests/test_sizing.py
@@ -1,0 +1,90 @@
+"""Tests for adaptive position sizing."""
+
+import pytest
+
+from proprietary_core.coupling import CouplingState
+from proprietary_core.regime import MarketRegime, RegimeState
+from proprietary_core.sizing import AdaptiveSizer
+
+
+def _regime(regime: MarketRegime, vol: float = 0.02, gate: bool = True) -> RegimeState:
+    return RegimeState(
+        regime=regime,
+        entropy=3.0 if regime == MarketRegime.CREATOR else 1.5,
+        fisher_info=0.1,
+        trend_strength=0.3 if regime == MarketRegime.PRESERVER else 0.05,
+        volatility=vol,
+        confidence=0.8,
+        is_transition=False,
+        pillar1_gate=gate,
+    )
+
+
+def _coupling(kappa: float = 1.0, r2: float = 0.8) -> CouplingState:
+    return CouplingState(
+        kappa=kappa,
+        r_squared=r2,
+        n_samples=50,
+        is_coupled=kappa > 0 and r2 > 0.3,
+        is_inverted=kappa < 0,
+        stud_crossing=False,
+        signal_mean=0.0,
+        pnl_mean=0.0,
+    )
+
+
+def test_dissolver_gives_zero():
+    sizer = AdaptiveSizer()
+    decision = sizer.compute(_regime(MarketRegime.DISSOLVER), _coupling(), 100_000)
+    assert decision.final_size == 0.0
+    assert "Dissolver" in decision.reason
+
+
+def test_pillar1_gate_gives_zero():
+    sizer = AdaptiveSizer()
+    decision = sizer.compute(_regime(MarketRegime.PRESERVER, gate=False), _coupling(), 100_000)
+    assert decision.final_size == 0.0
+    assert "Pillar 1" in decision.reason
+
+
+def test_negative_kappa_gives_zero():
+    sizer = AdaptiveSizer()
+    decision = sizer.compute(_regime(MarketRegime.PRESERVER), _coupling(kappa=-0.5), 100_000)
+    assert decision.final_size == 0.0
+    assert "Negative" in decision.reason
+
+
+def test_preserver_positive_coupling():
+    sizer = AdaptiveSizer(risk_budget=0.02, max_position_pct=0.10)
+    decision = sizer.compute(
+        _regime(MarketRegime.PRESERVER, vol=0.02),
+        _coupling(kappa=1.0, r2=0.8),
+        100_000,
+    )
+    assert decision.final_size > 0
+    assert decision.final_size <= 100_000 * 0.10  # hard cap
+
+
+def test_creator_scales_down():
+    sizer = AdaptiveSizer(risk_budget=0.02, creator_scale=0.5, preserver_scale=1.0)
+    regime_c = _regime(MarketRegime.CREATOR, vol=0.02)
+    regime_p = _regime(MarketRegime.PRESERVER, vol=0.02)
+    coupling = _coupling(kappa=1.0, r2=0.8)
+
+    size_c = sizer.compute(regime_c, coupling, 100_000)
+    size_p = sizer.compute(regime_p, coupling, 100_000)
+
+    # Creator should give smaller position than Preserver at same coupling
+    assert size_c.final_size < size_p.final_size
+
+
+def test_portfolio_cap():
+    sizer = AdaptiveSizer(max_portfolio_pct=0.50)
+    decision = sizer.compute(
+        _regime(MarketRegime.PRESERVER),
+        _coupling(kappa=10.0, r2=0.99),  # extremely strong coupling
+        100_000,
+        current_exposure_pct=0.48,  # already 48% exposed
+    )
+    # Should be capped to remaining 2% of portfolio
+    assert decision.final_size <= 100_000 * 0.02 + 1  # +1 for float tolerance

--- a/ml-worker/src/proprietary_core/tests/test_strategy_loop.py
+++ b/ml-worker/src/proprietary_core/tests/test_strategy_loop.py
@@ -1,0 +1,65 @@
+"""Tests for the strategy loop."""
+
+import numpy as np
+import pytest
+
+from proprietary_core.strategy_loop import StrategyLoop, StrategyType
+
+
+def _make_prices(n: int, base: float = 100.0, vol: float = 0.02, trend: float = 0.0, seed: int = 42) -> list[float]:
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(trend, vol, n)
+    prices = [base]
+    for r in returns:
+        prices.append(prices[-1] * (1 + r))
+    return prices
+
+
+def test_loop_accumulates_then_decides():
+    """Loop should return CASH with reason 'insufficient' until enough data."""
+    loop = StrategyLoop(symbol="BTC_USDT", regime_window=50)
+    decision = loop.tick(price=50000.0)
+    assert decision.selected_strategy == StrategyType.CASH
+    assert "Insufficient" in decision.reason
+
+
+def test_volatile_market_selects_momentum_or_breakout():
+    """High volatility should select Creator-regime strategies."""
+    loop = StrategyLoop(symbol="BTC_USDT", regime_window=80)
+    prices = _make_prices(200, base=50000, vol=0.06, trend=0.002)
+
+    decision = None
+    for p in prices:
+        decision = loop.tick(price=p)
+
+    assert decision is not None
+    assert decision.selected_strategy in (StrategyType.MOMENTUM, StrategyType.BREAKOUT)
+
+
+def test_flat_market_selects_cash():
+    """Dead market should select CASH (Dissolver)."""
+    loop = StrategyLoop(symbol="BORING_USDT", regime_window=80)
+    prices = _make_prices(200, base=100, vol=0.0005, trend=0.0)
+
+    decision = None
+    for p in prices:
+        decision = loop.tick(price=p)
+
+    assert decision is not None
+    assert decision.selected_strategy == StrategyType.CASH
+
+
+def test_loop_to_dict_serialisation():
+    """Decision.to_dict() should produce a valid dict."""
+    loop = StrategyLoop(symbol="ETH_USDT", regime_window=50)
+    prices = _make_prices(100, base=3000, vol=0.03)
+    for p in prices:
+        loop.tick(price=p)
+
+    decision = loop.last_decision
+    assert decision is not None
+    d = decision.to_dict()
+    assert isinstance(d, dict)
+    assert d["symbol"] == "ETH_USDT"
+    assert "strategy" in d
+    assert "should_trade" in d

--- a/ml-worker/src/proprietary_core/tests/test_training.py
+++ b/ml-worker/src/proprietary_core/tests/test_training.py
@@ -1,0 +1,160 @@
+"""Tests for the optimizer factory (training.py).
+
+These tests do NOT require torch or qig_core to be installed — they verify
+the factory's env-var branching logic by monkeypatching the heavy imports.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers: create lightweight mock optimizer objects
+# ---------------------------------------------------------------------------
+
+def _make_mock_adam():
+    """Return a mock that mimics torch.optim.Adam."""
+    adam_cls = MagicMock(name="Adam")
+    adam_instance = MagicMock(name="adam_instance")
+    adam_cls.return_value = adam_instance
+    return adam_cls, adam_instance
+
+
+def _make_mock_dng():
+    """Return a mock that mimics qig_core.optimization.DiagonalNaturalGradient."""
+    dng_cls = MagicMock(name="DiagonalNaturalGradient")
+    dng_instance = MagicMock(name="dng_instance")
+    dng_cls.return_value = dng_instance
+    return dng_cls, dng_instance
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_default_uses_adam(monkeypatch):
+    """When USE_FISHER_RAO is not set, Adam is returned."""
+    monkeypatch.delenv("USE_FISHER_RAO", raising=False)
+
+    adam_cls, adam_instance = _make_mock_adam()
+
+    # Build a fake torch module
+    fake_torch = types.ModuleType("torch")
+    fake_optim = types.ModuleType("torch.optim")
+    fake_optim.Adam = adam_cls
+    fake_torch.optim = fake_optim
+    sys.modules["torch"] = fake_torch
+    sys.modules["torch.optim"] = fake_optim
+
+    # Remove cached training module so env changes take effect
+    sys.modules.pop("proprietary_core.training", None)
+
+    from proprietary_core.training import get_optimizer  # noqa: PLC0415
+
+    params = iter([MagicMock()])
+    result = get_optimizer(params, lr=1e-3)
+
+    adam_cls.assert_called_once()
+    assert result is adam_instance
+
+
+def test_use_fisher_rao_true_returns_dng(monkeypatch):
+    """When USE_FISHER_RAO=true, DiagonalNaturalGradient is returned."""
+    monkeypatch.setenv("USE_FISHER_RAO", "true")
+
+    dng_cls, dng_instance = _make_mock_dng()
+
+    # Fake qig_core.optimization module
+    fake_qig = types.ModuleType("qig_core")
+    fake_qig_opt = types.ModuleType("qig_core.optimization")
+    fake_qig_opt.DiagonalNaturalGradient = dng_cls
+    fake_qig.optimization = fake_qig_opt
+    sys.modules["qig_core"] = fake_qig
+    sys.modules["qig_core.optimization"] = fake_qig_opt
+
+    sys.modules.pop("proprietary_core.training", None)
+
+    from proprietary_core.training import get_optimizer  # noqa: PLC0415
+
+    params = iter([MagicMock()])
+    result = get_optimizer(params, lr=2e-4)
+
+    dng_cls.assert_called_once()
+    assert result is dng_instance
+
+
+def test_use_fisher_rao_false_uses_adam(monkeypatch):
+    """Explicit USE_FISHER_RAO=false keeps Adam."""
+    monkeypatch.setenv("USE_FISHER_RAO", "false")
+
+    adam_cls, adam_instance = _make_mock_adam()
+
+    fake_torch = types.ModuleType("torch")
+    fake_optim = types.ModuleType("torch.optim")
+    fake_optim.Adam = adam_cls
+    fake_torch.optim = fake_optim
+    sys.modules["torch"] = fake_torch
+    sys.modules["torch.optim"] = fake_optim
+
+    sys.modules.pop("proprietary_core.training", None)
+
+    from proprietary_core.training import get_optimizer  # noqa: PLC0415
+
+    result = get_optimizer(iter([MagicMock()]), lr=1e-3)
+
+    adam_cls.assert_called_once()
+    assert result is adam_instance
+
+
+def test_fisher_rao_import_error_falls_back_to_adam(monkeypatch):
+    """If qig_core is unavailable, fall back to Adam even when USE_FISHER_RAO=true."""
+    monkeypatch.setenv("USE_FISHER_RAO", "true")
+
+    # Remove qig_core from sys.modules so the real import fails
+    sys.modules.pop("qig_core", None)
+    sys.modules.pop("qig_core.optimization", None)
+
+    adam_cls, adam_instance = _make_mock_adam()
+
+    fake_torch = types.ModuleType("torch")
+    fake_optim = types.ModuleType("torch.optim")
+    fake_optim.Adam = adam_cls
+    fake_torch.optim = fake_optim
+    sys.modules["torch"] = fake_torch
+    sys.modules["torch.optim"] = fake_optim
+
+    sys.modules.pop("proprietary_core.training", None)
+
+    with patch.dict(sys.modules, {"qig_core": None, "qig_core.optimization": None}):
+        from proprietary_core.training import get_optimizer  # noqa: PLC0415
+        result = get_optimizer(iter([MagicMock()]), lr=1e-3)
+
+    adam_cls.assert_called_once()
+    assert result is adam_instance
+
+
+def test_lr_and_kwargs_forwarded(monkeypatch):
+    """Extra kwargs are forwarded to the chosen optimizer."""
+    monkeypatch.delenv("USE_FISHER_RAO", raising=False)
+
+    adam_cls, _ = _make_mock_adam()
+
+    fake_torch = types.ModuleType("torch")
+    fake_optim = types.ModuleType("torch.optim")
+    fake_optim.Adam = adam_cls
+    fake_torch.optim = fake_optim
+    sys.modules["torch"] = fake_torch
+    sys.modules["torch.optim"] = fake_optim
+
+    sys.modules.pop("proprietary_core.training", None)
+
+    from proprietary_core.training import get_optimizer  # noqa: PLC0415
+
+    get_optimizer(iter([MagicMock()]), lr=5e-4, weight_decay=1e-5)
+
+    call_kwargs = adam_cls.call_args[1]
+    assert call_kwargs["lr"] == 5e-4
+    assert call_kwargs["weight_decay"] == 1e-5

--- a/ml-worker/src/proprietary_core/training.py
+++ b/ml-worker/src/proprietary_core/training.py
@@ -1,0 +1,85 @@
+"""Optimizer factory for ml-worker model training.
+
+Provides a single entry-point ``get_optimizer`` that returns either the
+standard ``torch.optim.Adam`` optimizer or the geometry-aware
+``qig_core.optimization.DiagonalNaturalGradient`` optimizer, depending on the
+``USE_FISHER_RAO`` environment variable.
+
+Usage::
+
+    from proprietary_core.training import get_optimizer
+
+    optimizer = get_optimizer(model.parameters(), lr=1e-3)
+    for epoch in range(n_epochs):
+        optimizer.zero_grad()
+        loss = criterion(model(x), y)
+        loss.backward()
+        optimizer.step()
+
+Environment variables:
+    USE_FISHER_RAO: When set to ``"true"`` (case-insensitive) the
+        ``DiagonalNaturalGradient`` optimizer from qig-core is used instead of
+        Adam.  Defaults to ``false`` for backwards compatibility.
+
+Notes:
+    ``DiagonalNaturalGradient`` from qig-core ≥2.7.0 is a drop-in replacement
+    for ``torch.optim.Adam`` — it accepts the same constructor signature and
+    exposes the same ``step()`` / ``zero_grad()`` interface.  Validated to
+    deliver a 1.9-2.2× convergence improvement on coupled-regime forecasting
+    tasks (internal experiment EXP-055).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Iterator
+
+logger = logging.getLogger(__name__)
+
+
+def _use_fisher_rao() -> bool:
+    """Return True when USE_FISHER_RAO env var is set to 'true'."""
+    return os.environ.get("USE_FISHER_RAO", "false").lower() == "true"
+
+
+def get_optimizer(
+    params: Iterator[Any],
+    lr: float = 1e-3,
+    **kwargs: Any,
+) -> Any:
+    """Return the appropriate optimizer for model training.
+
+    Parameters
+    ----------
+    params:
+        Iterable of parameters to optimise (e.g. ``model.parameters()``).
+    lr:
+        Learning rate.
+    **kwargs:
+        Additional keyword arguments forwarded to the chosen optimizer
+        constructor.
+
+    Returns
+    -------
+    torch.optim.Optimizer
+        Either ``DiagonalNaturalGradient`` (when ``USE_FISHER_RAO=true``) or
+        ``torch.optim.Adam``.
+    """
+    if _use_fisher_rao():
+        try:
+            from qig_core.optimization import DiagonalNaturalGradient  # type: ignore[import]
+            logger.info(
+                "USE_FISHER_RAO=true — using DiagonalNaturalGradient optimizer "
+                "(qig-core geometry-aware, EXP-055)"
+            )
+            return DiagonalNaturalGradient(params, lr=lr, **kwargs)
+        except ImportError as exc:  # pragma: no cover
+            logger.warning(
+                "USE_FISHER_RAO=true but qig_core.optimization is unavailable "
+                "(%s). Falling back to torch.optim.Adam.", exc
+            )
+
+    import torch  # type: ignore[import]
+    logger.info("Using torch.optim.Adam optimizer (USE_FISHER_RAO not enabled)")
+    return torch.optim.Adam(params, lr=lr, **kwargs)


### PR DESCRIPTION
## Summary

**Stage 1a of 3** for Option C unification per advisor guidance. Additive only — Railway deploy untouched. All kernels/core surface now also lives in ml-worker so Stage 2 can flip rootDirectory without losing any route polytrade-be depends on.

## Why additive first

The advisor corrected my original plan — ship the code + shadow-diff telemetry BEFORE the Railway cut-over so we can byte-diff ml-worker vs prod kernels/core for ~1000 calls before risking live trading. This PR unblocks that test gate.

## What shipped

**1. `/kernels/core/proprietary_core/` → `/ml-worker/src/proprietary_core/`** (1,269 LoC copied, byte-identical)

**2. `/kernels/core/ingest_markets.py` → `/ml-worker/ingest_markets.py`** (self-contained HMAC ingester)

**3. `ml-worker/main.py` extended with:**
- `_handle_predict_strategyloop()` — 1:1 port of `kernels/core/health.py:_run_prediction`
- Dispatcher with `ROUTE_VERSION=v0.8` flag (StrategyLoop) vs default (Ensemble)
- `_shadow_compare()` — fire-and-forget other-backend diff to 2k-row ring buffer
- Pydantic `PredictRequest` mirrors kernels/core field-for-field
- Error handling matches kernels/core exactly (400 on ValueError, 500 on other, `{"status": "success"}` wrap)

**4. Four new routes:** `/`, `/healthz`, `/api/status`, `/run/ingest`

**5. `/governance/ml-predict-parity`** — evidence stream for later ensemble promotion

## Verified

- [x] `qig_purity_check`: 20 files clean (proprietary_core sits outside QIG cognition scope, same posture as `exchange/`)
- [x] `verify_qig_vendor`: hash pin matches
- [x] All 5 new routes respond HTTP 200 via TestClient
- [x] `ROUTE_VERSION=v0.8 /ml/predict` returns `{"status": "success", "1h": {...}, "4h": {...}, "24h": {...}}` shape

## Advisor policy honoured

- **Policy C** (shadow + default to live) — `ROUTE_VERSION=v0.8` selects StrategyLoop, `ML_PREDICT_SHADOW=true` fires ensemble in parallel
- **Stage ordering fixed** — code-first, Railway-flip later
- **Shadow telemetry in Stage 1a, not later** — `/governance/ml-predict-parity` lands here
- **P14 registry work deferred** — strategy_loop.py's hardcoded thresholds become v0.8.4 follow-up

## Not in this PR (by design)

- Railway rootDirectory change → **Stage 2 (v0.8.3.5b)**, manual Railway dashboard action after Stage 1b test
- 1000-call byte-diff against prod → **Stage 1b**, manual verification step  
- `git rm -r kernels/core/` → **Stage 3 (v0.8.3.5c)**, 24–48h after Stage 2 stable
- TF weight verification under `./saved_models/` — advisor flagged; belongs to Stage 2 precheck
- `proprietary_core/fisher_rao_optimizer.py`, `poloniex_client.py` — not imported by health.py's routes; will port in Stage 3 if anything still uses them

🤖 Generated with [Claude Code](https://claude.com/claude-code)