### PR TITLE
feat(monkey): v0.8.6 wire memory + sync literals to parameter registry

### DIFF
--- a/apps/api/database/migrations/035_memory_sync_parameters.sql
+++ b/apps/api/database/migrations/035_memory_sync_parameters.sql
@@ -1,0 +1,35 @@
+-- 035_memory_sync_parameters.sql
+--
+-- v0.8.6 — seed the remaining operational + safety-bound constants that
+-- v0.8.1's migration 034 didn't cover yet. These are consumed by
+-- self_observation, working_memory, and basin_sync after this PR wires
+-- them in.
+--
+-- Adding rows only; no schema change. Each value matches the current
+-- hardcoded default exactly, so behavior is byte-identical
+-- registry-on vs -off.
+
+BEGIN;
+
+INSERT INTO monkey_parameters (name, category, value, bounds_low, bounds_high, justification)
+VALUES
+  ('self_obs.min_sample_for_bias', 'SAFETY_BOUND', 3, 1, 50,
+   'Minimum closed-trade count per (mode, side) bucket before applying win-rate bias. Below this threshold self-observation defers to neutral 1.0. Lower values overfit to noise; higher values make the kernel slow to learn.'),
+
+  ('wm.default_bubble_lifetime_ms', 'OPERATIONAL', 900000, 60000, 7200000,
+   'Default bubble lifetime in working memory (15 min). Bubbles older than this auto-pop regardless of Φ. Shorter = more memory churn; longer = stale bubbles bias adaptive thresholds.'),
+
+  ('basin_sync.stale_window_ms', 'OPERATIONAL', 120000, 10000, 600000,
+   'Peer basin-sync staleness threshold (2 min). Peers older than this are ignored when applying observer-effect pull. Shorter = more responsive to live peers; longer = more tolerant of lagging sub-kernels.'),
+
+  ('wm.bootstrap_pop_threshold', 'SAFETY_BOUND', 0.15, 0.05, 0.5,
+   'Fallback pop-threshold used before working memory has 10+ Φ samples to derive the 25th percentile from. Controls how aggressively newborn WM evicts low-Φ bubbles.'),
+
+  ('wm.bootstrap_promote_threshold', 'SAFETY_BOUND', 0.70, 0.5, 0.95,
+   'Fallback promote-threshold used before WM has 10+ Φ samples. Bubbles with Φ above this auto-promote to the resonance bank during bootstrap.'),
+
+  ('wm.bootstrap_merge_threshold', 'SAFETY_BOUND', 0.15, 0.05, 0.5,
+   'Fallback pairwise-FR-distance threshold for merging alive bubbles during bootstrap, before real pairwise stats exist.')
+ON CONFLICT (name) DO NOTHING;
+
+COMMIT;

--- a/ml-worker/src/monkey_kernel/basin_sync.py
+++ b/ml-worker/src/monkey_kernel/basin_sync.py
@@ -36,9 +36,23 @@ from qig_core_local.geometry.fisher_rao import (
 from .parameters import get_registry
 
 _registry = get_registry()
-# Default used when DATABASE_URL is unset or the row is missing. Matches
-# v0.8.1 migration-034 seed value exactly.
+# Defaults used when DATABASE_URL is unset or the row is missing. Match
+# v0.8.1/v0.8.6 migration seed values exactly.
 _DEFAULT_MAX_EFFECTIVE_STRENGTH = 0.30
+_DEFAULT_STALE_WINDOW_MS = 120_000  # 2 minutes
+
+
+def get_stale_window_ms() -> int:
+    """Return the currently-governed peer-state staleness threshold.
+
+    Readers (caller of apply_observer_effect or equivalent orchestration
+    layer) should filter peer_states older than this against their own
+    clock before passing in. Read per call so governance edits apply
+    immediately.
+    """
+    return int(_registry.get(
+        "basin_sync.stale_window_ms", default=_DEFAULT_STALE_WINDOW_MS,
+    ))
 
 
 @dataclass

--- a/ml-worker/src/monkey_kernel/self_observation.py
+++ b/ml-worker/src/monkey_kernel/self_observation.py
@@ -123,6 +123,18 @@ def _normalise_side(raw: str) -> Side:
 # ─── Public API ───
 
 
+def _min_sample_for_bias() -> int:
+    """Fetch the bucket-sample floor from the registry.
+
+    Read on every aggregation call (not once at import) so governance
+    edits take effect on next rebuild without a restart. In-memory
+    cache absorbs the overhead.
+    """
+    return int(_registry.get(
+        "self_obs.min_sample_for_bias", default=_DEFAULT_MIN_SAMPLE_FOR_BIAS,
+    ))
+
+
 def aggregate_and_bias(
     rows: Iterable[ClosedTradeRow],
     *,
@@ -178,17 +190,20 @@ def aggregate_and_bias(
     all_w = side_pooled["long"]["wins"] + side_pooled["short"]["wins"]
     global_win_rate = all_w / all_t if all_t > 0 else 0.0
 
+    # Registry-backed per P14: live-governed SAFETY_BOUND. Cached in
+    # local `n` so the four-branch fallback below doesn't re-query.
+    n = _min_sample_for_bias()
     bias = _neutral_bias()
     for mode in ALL_MODES:
         for side in SIDES:
             bucket = by_ms[mode][side]
-            if bucket.trades >= MIN_SAMPLE_FOR_BIAS:
+            if bucket.trades >= n:
                 bias[mode][side] = _win_rate_to_bias(bucket.win_rate)
-            elif mode_pooled[mode]["trades"] >= MIN_SAMPLE_FOR_BIAS:
+            elif mode_pooled[mode]["trades"] >= n:
                 bias[mode][side] = _win_rate_to_bias(mode_pooled[mode]["win_rate"])
-            elif side_pooled[side]["trades"] >= MIN_SAMPLE_FOR_BIAS:
+            elif side_pooled[side]["trades"] >= n:
                 bias[mode][side] = _win_rate_to_bias(side_pooled[side]["win_rate"])
-            elif all_t >= MIN_SAMPLE_FOR_BIAS:
+            elif all_t >= n:
                 bias[mode][side] = _win_rate_to_bias(global_win_rate)
 
     return SelfObservation(

--- a/ml-worker/src/monkey_kernel/working_memory.py
+++ b/ml-worker/src/monkey_kernel/working_memory.py
@@ -34,6 +34,19 @@ from qig_core_local.geometry.fisher_rao import (
     frechet_mean,
 )
 
+from .parameters import get_registry
+
+_registry = get_registry()
+
+# Pre-registry defaults. Match v0.8.1/v0.8.6 migration seed values
+# exactly so behaviour is byte-identical registry-on vs -off.
+_DEFAULT_PHI_HISTORY_MAX = 200
+_DEFAULT_MAX_BUBBLES = 500
+_DEFAULT_BUBBLE_LIFETIME_MS = 15 * 60 * 1000.0
+_DEFAULT_BOOTSTRAP_POP = 0.15
+_DEFAULT_BOOTSTRAP_PROMOTE = 0.70
+_DEFAULT_BOOTSTRAP_MERGE = 0.15
+
 BubbleStatus = Literal["alive", "merged", "popped", "promoted"]
 
 
@@ -82,24 +95,57 @@ class WorkingMemory:
     Bootstrap defaults (permissive) until we have ≥ 10 samples.
     """
 
-    PHI_HISTORY_MAX: int = 200
+    # Registry-backed class attribute — read at init so each kernel
+    # instance picks up the current governance setting.
+    PHI_HISTORY_MAX: int = _DEFAULT_PHI_HISTORY_MAX
 
     def __init__(
         self,
         *,
-        default_lifetime_ms: float = 15 * 60 * 1000.0,
-        max_bubbles: int = 500,
+        default_lifetime_ms: Optional[float] = None,
+        max_bubbles: Optional[int] = None,
     ) -> None:
+        # All three knobs honour caller override first, then registry,
+        # then the hardcoded default. Caller override is only used by
+        # tests that need a deterministic fixture; production paths
+        # leave them None to let the registry govern.
         self.bubbles: list[Bubble] = []
-        self.default_lifetime_ms = default_lifetime_ms
-        self.max_bubbles = max_bubbles
+        self.default_lifetime_ms = (
+            float(default_lifetime_ms) if default_lifetime_ms is not None
+            else float(_registry.get(
+                "wm.default_bubble_lifetime_ms",
+                default=_DEFAULT_BUBBLE_LIFETIME_MS,
+            ))
+        )
+        self.max_bubbles = (
+            int(max_bubbles) if max_bubbles is not None
+            else int(_registry.get("wm.max_bubbles", default=_DEFAULT_MAX_BUBBLES))
+        )
+        self.PHI_HISTORY_MAX = int(_registry.get(
+            "wm.phi_history_max", default=_DEFAULT_PHI_HISTORY_MAX,
+        ))
         self._phi_history: list[float] = []
 
     # ─── adaptive thresholds (P25) ───
 
     def _adaptive_thresholds(self) -> dict[str, float]:
         if len(self._phi_history) < 10:
-            return {"pop": 0.15, "promote": 0.70, "merge": 0.15}
+            # Bootstrap phase — registry-backed SAFETY_BOUND fallbacks.
+            # These only apply until enough Φ history accumulates to
+            # derive the 25th/75th percentiles.
+            return {
+                "pop": _registry.get(
+                    "wm.bootstrap_pop_threshold", default=_DEFAULT_BOOTSTRAP_POP,
+                ),
+                "promote": _registry.get(
+                    "wm.bootstrap_promote_threshold",
+                    default=_DEFAULT_BOOTSTRAP_PROMOTE,
+                ),
+                "merge": _registry.get(
+                    "wm.bootstrap_merge_threshold",
+                    default=_DEFAULT_BOOTSTRAP_MERGE,
+                ),
+            }
 
         sorted_phi = sorted(self._phi_history)
 


### PR DESCRIPTION
Migration 035 adds 6 new SAFETY_BOUND / OPERATIONAL rows. Python side (self_observation, working_memory, basin_sync) now reads them at call/init time with hardcoded fallback defaults matching seeds exactly. Zero behavior change registry-on vs -off.