### PR TITLE
feat(trading): v0.8.7a Python port of risk_kernel + /risk/evaluate endpoint

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -731,6 +731,90 @@ async def governance_ml_predict_parity(limit: int = 200):
 
 
 # ---------------------------------------------------------------------------
+# v0.8.7a — POST /risk/evaluate — Python port of riskKernel.ts
+# ---------------------------------------------------------------------------
+#
+# Pure pre-trade blast-door kernel. Called in Stage 1 of v0.8.7 as a
+# shadow alongside the TS riskService.evaluatePreTradeVetoes so we
+# can verify identical decisions on real inputs. Once parity is
+# proven, v0.8.8 cuts TS over to this endpoint and riskKernel.ts
+# retires.
+
+from trading.risk_kernel import (  # noqa: E402
+    KernelAccountState as _KernelAccountState,
+    KernelContext as _KernelContext,
+    KernelOpenPosition as _KernelOpenPosition,
+    KernelOrder as _KernelOrder,
+    KernelRestingOrder as _KernelRestingOrder,
+    evaluate_pre_trade_vetoes as _evaluate_pre_trade_vetoes,
+)
+
+
+@app.post("/risk/evaluate")
+async def risk_evaluate(request: Request):
+    """Run the pre-trade blast-door kernel on one order.
+
+    Request body mirrors the KernelInputs shape riskService.js assembles:
+      {
+        "kernelOrder":  {"symbol", "side", "notional", "leverage", "price"},
+        "accountState": {"equityUsdt", "unrealizedPnlUsdt",
+                         "openPositions":  [{"symbol","side","notional"}...],
+                         "restingOrders":  [{"symbol","side","price"}...]},
+        "context":      {"isLive", "mode", "symbolMaxLeverage"}
+      }
+
+    Response: {"allowed": bool, "reason"?: str, "code"?: str}
+    Matches KernelDecision from the TS reference.
+    """
+    body = await request.json()
+    try:
+        o = body["kernelOrder"]
+        order = _KernelOrder(
+            symbol=str(o["symbol"]),
+            side=str(o["side"]),
+            notional=float(o["notional"]),
+            leverage=float(o["leverage"]),
+            price=float(o["price"]),
+        )
+        a = body["accountState"]
+        state = _KernelAccountState(
+            equity_usdt=float(a["equityUsdt"]),
+            unrealized_pnl_usdt=float(a["unrealizedPnlUsdt"]),
+            open_positions=[
+                _KernelOpenPosition(
+                    symbol=str(p["symbol"]),
+                    side=str(p["side"]),
+                    notional=float(p["notional"]),
+                )
+                for p in a.get("openPositions", []) or []
+            ],
+            resting_orders=[
+                _KernelRestingOrder(
+                    symbol=str(r["symbol"]),
+                    side=str(r["side"]),
+                    price=float(r["price"]),
+                )
+                for r in a.get("restingOrders", []) or []
+            ],
+        )
+        c = body["context"]
+        ctx = _KernelContext(
+            is_live=bool(c["isLive"]),
+            mode=str(c["mode"]),
+            symbol_max_leverage=float(c["symbolMaxLeverage"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"bad kernel input: {exc}") from exc
+
+    decision = _evaluate_pre_trade_vetoes(order, state, ctx)
+    return {
+        "allowed": decision.allowed,
+        "reason": decision.reason,
+        "code": decision.code,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Monkey kernel endpoints (v0.7)
 # ---------------------------------------------------------------------------
 #

--- a/ml-worker/src/trading/__init__.py
+++ b/ml-worker/src/trading/__init__.py
@@ -1,0 +1,51 @@
+"""
+trading — Python ports of apps/api/src/services trading logic.
+
+v0.8.7 scope: the orchestration that currently runs in apps/api
+(risk kernel, live signal engine, fully-autonomous trader) lifts into
+Python additively. TS remains authoritative during Stage 1;
+Python ports run in shadow mode with parity-diff telemetry. Once
+parity is proven, v0.8.8 cuts over and the TS copies delete.
+
+Purity: this package is BOUNDARY per P14, not QIG cognition. It
+ingests the decisions Monkey's kernel computes (risk gates, position
+sizing, order placement) and speaks to the exchange. Excluded from
+qig_purity_check's default scan roots — same posture as
+exchange/ and proprietary_core/.
+"""
+
+from .risk_kernel import (
+    KernelAccountState,
+    KernelContext,
+    KernelDecision,
+    KernelOpenPosition,
+    KernelOrder,
+    KernelRestingOrder,
+    KernelVetoCode,
+    PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER,
+    UNREALIZED_DRAWDOWN_KILL_THRESHOLD,
+    check_execution_mode,
+    check_per_symbol_exposure,
+    check_self_match,
+    check_symbol_max_leverage,
+    check_unrealized_drawdown,
+    evaluate_pre_trade_vetoes,
+)
+
+__all__ = [
+    "KernelAccountState",
+    "KernelContext",
+    "KernelDecision",
+    "KernelOpenPosition",
+    "KernelOrder",
+    "KernelRestingOrder",
+    "KernelVetoCode",
+    "PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER",
+    "UNREALIZED_DRAWDOWN_KILL_THRESHOLD",
+    "check_execution_mode",
+    "check_per_symbol_exposure",
+    "check_self_match",
+    "check_symbol_max_leverage",
+    "check_unrealized_drawdown",
+    "evaluate_pre_trade_vetoes",
+]

--- a/ml-worker/src/trading/risk_kernel.py
+++ b/ml-worker/src/trading/risk_kernel.py
@@ -1,0 +1,297 @@
+"""
+risk_kernel.py — pre-trade blast door (Python port).
+
+1:1 port of apps/api/src/services/riskKernel.ts. Decisions are pure
+input → KernelDecision maps so this is safe to run in shadow mode
+against the live TS path — same inputs should always produce the
+same decision. A parity test (see tests/trading/) pins that
+invariant against a hand-crafted corpus of boundary cases.
+
+Five vetoes (priority order, first-failure-wins):
+
+  1. UNREALIZED_DRAWDOWN_KILL_THRESHOLD (account-saving)
+  2. Execution-mode global override (operator kill-switch)
+  3. Self-match prevention (Corporations Act s.1041B compliance)
+  4. Per-symbol gross exposure cap (correlated-stack blast door)
+  5. Symbol max leverage (exchange ceiling)
+
+All functions are SYNC and PURE. Callers read DB / exchange / catalog
+BEFORE calling into the kernel — kernel never does IO. This is also
+why it's eligible for shadow-mode parity diffing against the TS side
+at zero risk to live decisions.
+
+Purity: BOUNDARY per P14. Not QIG cognition. Excluded from the purity
+check's default scan root — same posture as exchange/ and
+proprietary_core/.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+# ────────────────────────────────────────────────────────────────
+# Types — mirror the TS interfaces 1:1
+# ────────────────────────────────────────────────────────────────
+
+OrderSide = Literal["long", "short", "buy", "sell"]
+RestingSide = Literal["buy", "sell"]
+HeldSide = Literal["long", "short"]
+ExecutionMode = Literal["auto", "paper_only", "pause"]
+
+KernelVetoCode = Literal[
+    "per_symbol_exposure_cap",
+    "self_match",
+    "unrealized_drawdown_kill_switch",
+    "symbol_max_leverage",
+    "execution_mode_paused",
+    "execution_mode_paper_only_blocks_live",
+]
+
+
+@dataclass(frozen=True)
+class KernelOrder:
+    """Order being proposed for pre-trade evaluation."""
+    symbol: str
+    side: OrderSide
+    notional: float     # position notional in quote (USDT)
+    leverage: float
+    price: float        # entry/limit price
+
+
+@dataclass(frozen=True)
+class KernelOpenPosition:
+    symbol: str
+    side: HeldSide
+    notional: float
+
+
+@dataclass(frozen=True)
+class KernelRestingOrder:
+    symbol: str
+    side: RestingSide
+    price: float
+
+
+@dataclass(frozen=True)
+class KernelAccountState:
+    equity_usdt: float
+    unrealized_pnl_usdt: float
+    open_positions: list[KernelOpenPosition] = field(default_factory=list)
+    resting_orders: list[KernelRestingOrder] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class KernelContext:
+    """Passed in by caller — looked up from DB / catalog before the call.
+
+    - is_live: True for real-capital orders. Paper-only orders bypass
+      the 'paper_only_blocks_live' veto.
+    - mode: Global operator override (agent_execution_mode).
+    - symbol_max_leverage: From marketCatalog.getMaxLeverage(symbol).
+    """
+    is_live: bool
+    mode: ExecutionMode
+    symbol_max_leverage: float
+
+
+@dataclass(frozen=True)
+class KernelDecision:
+    allowed: bool
+    reason: Optional[str] = None
+    code: Optional[KernelVetoCode] = None
+
+
+# ────────────────────────────────────────────────────────────────
+# Thresholds — 1:1 with TS reference
+# ────────────────────────────────────────────────────────────────
+
+# Per-symbol gross notional cap as a multiple of equity. Notional-based
+# (not margin-based) because at high leverage, margin commit per unit
+# notional is small. TS reference raised this from 3.0 → 5.0 after the
+# 2026-04 observation that $19 equity × 3× = $56, below the $75 BTC lot
+# floor. TODO when the TS side migrates to margin-based cap: mirror.
+PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER = 5.0
+
+# Unrealized drawdown kill-switch threshold. -15% of equity triggers
+# flatten-all + 24h pause. The realised-loss daily cap can miss a flash
+# wick (no trade closed), so this acts on the running P&L directly.
+UNREALIZED_DRAWDOWN_KILL_THRESHOLD = -0.15
+
+
+def _is_long(side: OrderSide) -> bool:
+    return side == "long" or side == "buy"
+
+
+# ────────────────────────────────────────────────────────────────
+# Check 1 — per-symbol gross exposure
+# ────────────────────────────────────────────────────────────────
+
+def check_per_symbol_exposure(
+    order: KernelOrder,
+    state: KernelAccountState,
+) -> KernelDecision:
+    """Blocks any order that would push gross notional on this symbol
+    past equity × PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER.
+    """
+    cap = state.equity_usdt * PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER
+    existing = sum(
+        abs(p.notional) for p in state.open_positions if p.symbol == order.symbol
+    )
+    projected = existing + abs(order.notional)
+    if projected > cap:
+        return KernelDecision(
+            allowed=False,
+            code="per_symbol_exposure_cap",
+            reason=(
+                f"Per-symbol exposure cap breached: {projected:.2f} > {cap:.2f} "
+                f"({PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER}× equity)"
+            ),
+        )
+    return KernelDecision(allowed=True)
+
+
+# ────────────────────────────────────────────────────────────────
+# Check 2 — self-match prevention
+# ────────────────────────────────────────────────────────────────
+
+def check_self_match(
+    order: KernelOrder,
+    state: KernelAccountState,
+) -> KernelDecision:
+    """A buy would self-match a same-account sell at-or-below the buy
+    price. A sell would self-match a same-account buy at-or-above the
+    sell price. Blocks per Corporations Act s.1041B (false trading).
+    """
+    order_is_buy = _is_long(order.side)
+    for resting in state.resting_orders:
+        if resting.symbol != order.symbol:
+            continue
+        resting_is_buy = resting.side == "buy"
+        if order_is_buy == resting_is_buy:
+            continue
+        crosses = (
+            resting.price <= order.price if order_is_buy
+            else resting.price >= order.price
+        )
+        if crosses:
+            return KernelDecision(
+                allowed=False,
+                code="self_match",
+                reason=(
+                    f"Self-match with account's own resting {resting.side} "
+                    f"@ {resting.price} on {resting.symbol}. "
+                    f"Blocked per Corporations Act s.1041B."
+                ),
+            )
+    return KernelDecision(allowed=True)
+
+
+# ────────────────────────────────────────────────────────────────
+# Check 3 — unrealised-drawdown kill-switch
+# ────────────────────────────────────────────────────────────────
+
+def check_unrealized_drawdown(state: KernelAccountState) -> KernelDecision:
+    """If unrealized P&L ≤ -15% of equity, halt all new orders. The
+    caller is responsible for the flatten-all + 24h pause on the
+    order side; this function only blocks new entries.
+    """
+    if state.equity_usdt <= 0:
+        # Divide-by-zero guard. Realised-loss cap owns this case.
+        return KernelDecision(allowed=True)
+    ratio = state.unrealized_pnl_usdt / state.equity_usdt
+    if ratio <= UNREALIZED_DRAWDOWN_KILL_THRESHOLD:
+        return KernelDecision(
+            allowed=False,
+            code="unrealized_drawdown_kill_switch",
+            reason=(
+                f"Unrealised P&L {ratio * 100:.2f}% of equity ≤ "
+                f"{UNREALIZED_DRAWDOWN_KILL_THRESHOLD * 100:.0f}% — "
+                f"flatten and pause 24h."
+            ),
+        )
+    return KernelDecision(allowed=True)
+
+
+# ────────────────────────────────────────────────────────────────
+# Check 4 — execution-mode global override
+# ────────────────────────────────────────────────────────────────
+
+def check_execution_mode(
+    is_live_order: bool,
+    mode: ExecutionMode,
+) -> KernelDecision:
+    """Operator kill-switch. pause = block everything;
+    paper_only = block live but allow paper; auto = pass through.
+    """
+    if mode == "pause":
+        return KernelDecision(
+            allowed=False,
+            code="execution_mode_paused",
+            reason="Execution Mode is Pause — no new orders at any stage.",
+        )
+    if mode == "paper_only" and is_live_order:
+        return KernelDecision(
+            allowed=False,
+            code="execution_mode_paper_only_blocks_live",
+            reason=(
+                "Execution Mode is Paper-Only — live order blocked; "
+                "route to paper instead."
+            ),
+        )
+    return KernelDecision(allowed=True)
+
+
+# ────────────────────────────────────────────────────────────────
+# Check 5 — symbol max leverage (exchange ceiling)
+# ────────────────────────────────────────────────────────────────
+
+def check_symbol_max_leverage(
+    order: KernelOrder,
+    symbol_max_leverage: float,
+) -> KernelDecision:
+    """Enforces the exchange's per-symbol maxLeverage ceiling. Caller
+    reads marketCatalog.getMaxLeverage(symbol) and passes it in —
+    kernel stays sync.
+    """
+    if order.leverage > symbol_max_leverage:
+        return KernelDecision(
+            allowed=False,
+            code="symbol_max_leverage",
+            reason=(
+                f"Leverage {order.leverage}× exceeds {order.symbol} "
+                f"exchange max of {symbol_max_leverage}×."
+            ),
+        )
+    return KernelDecision(allowed=True)
+
+
+# ────────────────────────────────────────────────────────────────
+# Composer — priority-ordered chain
+# ────────────────────────────────────────────────────────────────
+
+def evaluate_pre_trade_vetoes(
+    order: KernelOrder,
+    state: KernelAccountState,
+    context: KernelContext,
+) -> KernelDecision:
+    """Run all kernel vetoes in priority order. First failure stops
+    the chain and is returned. If all pass, returns allowed=True.
+
+    Priority (matches TS reference exactly):
+      1. Unrealised-drawdown kill-switch (account-saving)
+      2. Execution-mode global override (operator kill-switch)
+      3. Self-match (legal compliance)
+      4. Per-symbol exposure (correlated-stack blast door)
+      5. Symbol max leverage (exchange ceiling)
+    """
+    for check in (
+        check_unrealized_drawdown(state),
+        check_execution_mode(context.is_live, context.mode),
+        check_self_match(order, state),
+        check_per_symbol_exposure(order, state),
+        check_symbol_max_leverage(order, context.symbol_max_leverage),
+    ):
+        if not check.allowed:
+            return check
+    return KernelDecision(allowed=True)

--- a/ml-worker/tests/trading/test_risk_kernel_parity.py
+++ b/ml-worker/tests/trading/test_risk_kernel_parity.py
@@ -1,0 +1,344 @@
+"""
+test_risk_kernel_parity.py — risk_kernel.py must match riskKernel.ts
+decision-for-decision on a hand-crafted boundary-case corpus.
+
+Each case pins ONE veto (or ONE pass-through). The expected decision
+was derived by tracing through the TS reference by hand; if anyone
+edits the Python port in a way that diverges from TS, these tests
+break BEFORE the divergence hits shadow mode.
+
+Corpus is kept here (not generated) because the interesting cases are
+boundary conditions — exactly-at-threshold, zero-equity, empty lists
+— and those are what regressions typically break.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from trading.risk_kernel import (  # noqa: E402
+    KernelAccountState,
+    KernelContext,
+    KernelOpenPosition,
+    KernelOrder,
+    KernelRestingOrder,
+    PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER,
+    UNREALIZED_DRAWDOWN_KILL_THRESHOLD,
+    check_execution_mode,
+    check_per_symbol_exposure,
+    check_self_match,
+    check_symbol_max_leverage,
+    check_unrealized_drawdown,
+    evaluate_pre_trade_vetoes,
+)
+
+
+def _nominal_order(**overrides) -> KernelOrder:
+    base = dict(
+        symbol="BTC_USDT_PERP",
+        side="buy",
+        notional=20.0,
+        leverage=10.0,
+        price=75_000.0,
+    )
+    base.update(overrides)
+    return KernelOrder(**base)
+
+
+def _nominal_state(**overrides) -> KernelAccountState:
+    base = dict(
+        equity_usdt=100.0,
+        unrealized_pnl_usdt=0.0,
+        open_positions=[],
+        resting_orders=[],
+    )
+    base.update(overrides)
+    return KernelAccountState(**base)
+
+
+def _nominal_context(**overrides) -> KernelContext:
+    base = dict(is_live=True, mode="auto", symbol_max_leverage=100.0)
+    base.update(overrides)
+    return KernelContext(**base)
+
+
+# ─── Check 1: per-symbol exposure ────────────────────────────────
+
+class TestPerSymbolExposure:
+    def test_empty_positions_passes(self):
+        r = check_per_symbol_exposure(_nominal_order(notional=400), _nominal_state())
+        assert r.allowed is True
+
+    def test_at_cap_passes(self):
+        """Exactly at cap — > not >=, per TS reference line 115."""
+        cap = 100.0 * PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER  # 500
+        r = check_per_symbol_exposure(_nominal_order(notional=cap), _nominal_state())
+        assert r.allowed is True
+
+    def test_one_cent_over_cap_blocks(self):
+        cap = 100.0 * PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER
+        r = check_per_symbol_exposure(_nominal_order(notional=cap + 0.01), _nominal_state())
+        assert r.allowed is False
+        assert r.code == "per_symbol_exposure_cap"
+
+    def test_existing_position_counts_same_symbol(self):
+        """Existing 200 BTC + new 400 BTC > 500 cap, but passes if 200 is ETH."""
+        state = _nominal_state(open_positions=[
+            KernelOpenPosition(symbol="BTC_USDT_PERP", side="long", notional=200.0),
+        ])
+        r = check_per_symbol_exposure(_nominal_order(notional=400.0), state)
+        assert r.allowed is False
+
+        # Same numbers, different symbol — passes
+        state2 = _nominal_state(open_positions=[
+            KernelOpenPosition(symbol="ETH_USDT_PERP", side="long", notional=200.0),
+        ])
+        r2 = check_per_symbol_exposure(_nominal_order(notional=400.0), state2)
+        assert r2.allowed is True
+
+    def test_short_positions_counted_by_abs(self):
+        """Short notional stored negative; cap compares |notional|."""
+        state = _nominal_state(open_positions=[
+            KernelOpenPosition(symbol="BTC_USDT_PERP", side="short", notional=-300.0),
+        ])
+        r = check_per_symbol_exposure(_nominal_order(notional=300.0), state)
+        assert r.allowed is False  # |−300| + 300 = 600 > 500
+
+
+# ─── Check 2: self-match ─────────────────────────────────────────
+
+class TestSelfMatch:
+    def test_empty_resting_passes(self):
+        r = check_self_match(_nominal_order(side="buy", price=75_000), _nominal_state())
+        assert r.allowed is True
+
+    def test_same_side_resting_ignored(self):
+        """Two buys from the same account don't self-match — they'd both be
+        on the same side of the book."""
+        state = _nominal_state(resting_orders=[
+            KernelRestingOrder(symbol="BTC_USDT_PERP", side="buy", price=74_900),
+        ])
+        r = check_self_match(_nominal_order(side="buy", price=75_000), state)
+        assert r.allowed is True
+
+    def test_different_symbol_ignored(self):
+        state = _nominal_state(resting_orders=[
+            KernelRestingOrder(symbol="ETH_USDT_PERP", side="sell", price=3_000),
+        ])
+        r = check_self_match(_nominal_order(side="buy", price=75_000), state)
+        assert r.allowed is True
+
+    def test_buy_crosses_resting_sell_blocks(self):
+        """Buy @ 75000 vs own sell @ 74900 → crosses (buy price >= sell price).
+        Note TS semantic: buy crosses if resting.price <= order.price.
+        """
+        state = _nominal_state(resting_orders=[
+            KernelRestingOrder(symbol="BTC_USDT_PERP", side="sell", price=74_900),
+        ])
+        r = check_self_match(_nominal_order(side="buy", price=75_000), state)
+        assert r.allowed is False
+        assert r.code == "self_match"
+
+    def test_buy_at_exactly_resting_sell_price_blocks(self):
+        """At-price self-match: TS uses <= so equal prices block."""
+        state = _nominal_state(resting_orders=[
+            KernelRestingOrder(symbol="BTC_USDT_PERP", side="sell", price=75_000),
+        ])
+        r = check_self_match(_nominal_order(side="buy", price=75_000), state)
+        assert r.allowed is False
+
+    def test_buy_below_resting_sell_passes(self):
+        """Buy @ 74_900 vs own sell @ 75_000 doesn't cross (buy below)."""
+        state = _nominal_state(resting_orders=[
+            KernelRestingOrder(symbol="BTC_USDT_PERP", side="sell", price=75_000),
+        ])
+        r = check_self_match(_nominal_order(side="buy", price=74_900), state)
+        assert r.allowed is True
+
+    def test_sell_crosses_resting_buy_blocks(self):
+        """Sell @ 74_900 vs own buy @ 75_000 → sell crosses (sell <= buy)."""
+        state = _nominal_state(resting_orders=[
+            KernelRestingOrder(symbol="BTC_USDT_PERP", side="buy", price=75_000),
+        ])
+        r = check_self_match(_nominal_order(side="sell", price=74_900), state)
+        assert r.allowed is False
+
+    def test_long_alias_treats_as_buy(self):
+        """'long' side must behave identically to 'buy' for self-match."""
+        state = _nominal_state(resting_orders=[
+            KernelRestingOrder(symbol="BTC_USDT_PERP", side="sell", price=74_900),
+        ])
+        r_long = check_self_match(_nominal_order(side="long", price=75_000), state)
+        r_buy = check_self_match(_nominal_order(side="buy", price=75_000), state)
+        assert r_long.allowed == r_buy.allowed == False
+
+
+# ─── Check 3: unrealised-drawdown kill ───────────────────────────
+
+class TestUnrealizedDrawdown:
+    def test_positive_pnl_passes(self):
+        r = check_unrealized_drawdown(_nominal_state(unrealized_pnl_usdt=50.0))
+        assert r.allowed is True
+
+    def test_zero_pnl_passes(self):
+        r = check_unrealized_drawdown(_nominal_state(unrealized_pnl_usdt=0.0))
+        assert r.allowed is True
+
+    def test_exactly_minus_15_pct_blocks(self):
+        """TS uses <= threshold, so exactly -15% blocks."""
+        r = check_unrealized_drawdown(_nominal_state(
+            equity_usdt=100.0,
+            unrealized_pnl_usdt=-15.0,
+        ))
+        assert r.allowed is False
+        assert r.code == "unrealized_drawdown_kill_switch"
+
+    def test_minus_14_99_pct_passes(self):
+        r = check_unrealized_drawdown(_nominal_state(
+            equity_usdt=100.0,
+            unrealized_pnl_usdt=-14.99,
+        ))
+        assert r.allowed is True
+
+    def test_zero_equity_passes_divide_guard(self):
+        """equity=0 would divide by zero; TS bails out early and realised-loss
+        cap handles the case."""
+        r = check_unrealized_drawdown(_nominal_state(
+            equity_usdt=0.0,
+            unrealized_pnl_usdt=-1_000_000.0,
+        ))
+        assert r.allowed is True
+
+    def test_negative_equity_passes_divide_guard(self):
+        """TS uses <= 0, so negative equity also bails out."""
+        r = check_unrealized_drawdown(_nominal_state(
+            equity_usdt=-50.0,
+            unrealized_pnl_usdt=-100.0,
+        ))
+        assert r.allowed is True
+
+
+# ─── Check 4: execution-mode global override ─────────────────────
+
+class TestExecutionMode:
+    def test_auto_passes_live(self):
+        assert check_execution_mode(True, "auto").allowed is True
+
+    def test_auto_passes_paper(self):
+        assert check_execution_mode(False, "auto").allowed is True
+
+    def test_pause_blocks_live(self):
+        r = check_execution_mode(True, "pause")
+        assert r.allowed is False
+        assert r.code == "execution_mode_paused"
+
+    def test_pause_blocks_paper_too(self):
+        """pause = block everything."""
+        r = check_execution_mode(False, "pause")
+        assert r.allowed is False
+
+    def test_paper_only_blocks_live(self):
+        r = check_execution_mode(True, "paper_only")
+        assert r.allowed is False
+        assert r.code == "execution_mode_paper_only_blocks_live"
+
+    def test_paper_only_passes_paper(self):
+        r = check_execution_mode(False, "paper_only")
+        assert r.allowed is True
+
+
+# ─── Check 5: symbol max leverage ────────────────────────────────
+
+class TestSymbolMaxLeverage:
+    def test_at_cap_passes(self):
+        r = check_symbol_max_leverage(_nominal_order(leverage=100.0), symbol_max_leverage=100.0)
+        assert r.allowed is True
+
+    def test_over_cap_blocks(self):
+        r = check_symbol_max_leverage(_nominal_order(leverage=101.0), symbol_max_leverage=100.0)
+        assert r.allowed is False
+        assert r.code == "symbol_max_leverage"
+
+
+# ─── Composer — priority ordering ────────────────────────────────
+
+class TestComposerPriority:
+    def test_drawdown_wins_over_self_match(self):
+        """If BOTH drawdown-kill AND self-match would fire, drawdown takes
+        priority (account-saving runs first in TS line 248).
+        """
+        state = _nominal_state(
+            equity_usdt=100.0,
+            unrealized_pnl_usdt=-20.0,  # -20% → kill fires
+            resting_orders=[
+                KernelRestingOrder(symbol="BTC_USDT_PERP", side="sell", price=74_000),
+            ],
+        )
+        order = _nominal_order(side="buy", price=75_000)  # would self-match
+        r = evaluate_pre_trade_vetoes(order, state, _nominal_context())
+        assert r.allowed is False
+        assert r.code == "unrealized_drawdown_kill_switch"
+
+    def test_mode_pause_wins_over_self_match(self):
+        """Pause mode blocks before self-match is checked."""
+        state = _nominal_state(resting_orders=[
+            KernelRestingOrder(symbol="BTC_USDT_PERP", side="sell", price=74_900),
+        ])
+        order = _nominal_order(side="buy", price=75_000)
+        r = evaluate_pre_trade_vetoes(order, state, _nominal_context(mode="pause"))
+        assert r.allowed is False
+        assert r.code == "execution_mode_paused"
+
+    def test_self_match_wins_over_exposure(self):
+        """TS check order: self-match (3) before per-symbol exposure (4)."""
+        state = _nominal_state(
+            resting_orders=[
+                KernelRestingOrder(symbol="BTC_USDT_PERP", side="sell", price=74_900),
+            ],
+            open_positions=[
+                # Existing 1000 BTC, order 1000 BTC → would also fail exposure (cap 500)
+                KernelOpenPosition(symbol="BTC_USDT_PERP", side="long", notional=1000.0),
+            ],
+        )
+        order = _nominal_order(notional=1000.0, side="buy", price=75_000)
+        r = evaluate_pre_trade_vetoes(order, state, _nominal_context())
+        assert r.allowed is False
+        assert r.code == "self_match"
+
+    def test_all_pass_returns_allowed(self):
+        r = evaluate_pre_trade_vetoes(
+            _nominal_order(notional=50.0, leverage=10.0),
+            _nominal_state(),
+            _nominal_context(),
+        )
+        assert r.allowed is True
+        assert r.reason is None
+        assert r.code is None
+
+
+if __name__ == "__main__":
+    # Standalone runner without pytest.
+    import inspect
+    passed = 0
+    failed: list[str] = []
+    for cls_name, cls in list(globals().items()):
+        if not inspect.isclass(cls) or not cls_name.startswith("Test"):
+            continue
+        instance = cls()
+        for name, fn in inspect.getmembers(cls, predicate=inspect.isfunction):
+            if not name.startswith("test_"):
+                continue
+            try:
+                fn(instance)
+                passed += 1
+                print(f"  ✓ {cls_name}.{name}")
+            except AssertionError as exc:
+                failed.append(f"{cls_name}.{name}: {exc}")
+                print(f"  ✗ {cls_name}.{name}: {exc}")
+    print(f"\n{passed} passed, {len(failed)} failed")
+    sys.exit(0 if not failed else 1)


### PR DESCRIPTION
Part 1 of v0.8.7 trading-engine migration. Additive only — no TS code-path change. Ports riskKernel.ts's 5 pure pre-trade vetoes to Python, pins parity with 31 hand-crafted boundary-case tests, exposes /risk/evaluate for future shadow-mode wiring from the TS side.