### PR TITLE
feat(trading): v0.8.7c-1 port exit-decision pure fns + /live/exit-decide

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -757,6 +757,12 @@ from trading.live_signal import (  # noqa: E402
     normalise_signal as _normalise_signal,
     signal_passes_entry_gate as _signal_passes_entry_gate,
 )
+from trading.exit_decisions import (  # noqa: E402
+    ExitConfig as _ExitConfig,
+    MarketAnalysis as _MarketAnalysis,
+    PositionSnapshot as _PositionSnapshot,
+    decide_exit as _decide_exit,
+)
 
 
 @app.post("/risk/evaluate")
@@ -921,6 +927,82 @@ async def live_decide(request: Request):
         "atr": atr,
         "entryGate": {"passed": gate.passed, "reason": gate.reason},
         "order": order_payload,
+    }
+
+
+# ---------------------------------------------------------------------------
+# v0.8.7c-1 — POST /live/exit-decide — managePositions exit chain
+# ---------------------------------------------------------------------------
+#
+# Pure position-exit logic ported from fullyAutonomousTrader.
+# managePositions. Shadow-mode parity path for the TS side — same
+# input, same decision, same reason string shape.
+#
+# Caller passes the already-fetched position + analysis + config;
+# no Poloniex/DB calls here. Priority-ordered: stop_loss →
+# take_profit → trailing/trend_reversal → hold.
+
+
+@app.post("/live/exit-decide")
+async def live_exit_decide(request: Request):
+    """Evaluate exit decision for one open position.
+
+    Request body (camelCase to match TS convention):
+      {
+        "position": {
+          "symbol":        "BTC_USDT_PERP",
+          "qty":           1.0,          // signed: +long / -short
+          "entryPrice":    75000,
+          "unrealizedPnl": 50.0           // USDT
+        },
+        "config": {
+          "stopLossPercent":   2.0,       // e.g. 2 = 2%
+          "takeProfitPercent": 4.0
+        },
+        "analysis": {                     // optional
+          "trend": "bullish"|"bearish"|"neutral"|"unknown"
+        }
+      }
+
+    Response: {
+      "shouldClose":        bool,
+      "reason":             "stop_loss"|"take_profit"|"trend_reversal"|"hold",
+      "explanation":        str,
+      "pnlPercent":         float,
+      "stopLossThreshold":  float,
+      "takeProfitThreshold": float
+    }
+    """
+    body = await request.json()
+    try:
+        p = body["position"]
+        position = _PositionSnapshot(
+            symbol=str(p["symbol"]),
+            qty=float(p["qty"]),
+            entry_price=float(p["entryPrice"]),
+            unrealized_pnl=float(p["unrealizedPnl"]),
+        )
+        c = body.get("config") or {}
+        config = _ExitConfig(
+            stop_loss_percent=float(c.get("stopLossPercent", 2.0)),
+            take_profit_percent=float(c.get("takeProfitPercent", 4.0)),
+        )
+        a_raw = body.get("analysis")
+        analysis = (
+            _MarketAnalysis(trend=str(a_raw["trend"]))
+            if a_raw and "trend" in a_raw else None
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"bad exit-decide input: {exc}") from exc
+
+    decision = _decide_exit(position, config, analysis)
+    return {
+        "shouldClose": decision.should_close,
+        "reason": decision.reason,
+        "explanation": decision.explanation,
+        "pnlPercent": decision.pnl_percent,
+        "stopLossThreshold": decision.stop_loss_threshold,
+        "takeProfitThreshold": decision.take_profit_threshold,
     }
 
 

--- a/ml-worker/src/trading/__init__.py
+++ b/ml-worker/src/trading/__init__.py
@@ -31,8 +31,21 @@ from .risk_kernel import (
     check_unrealized_drawdown,
     evaluate_pre_trade_vetoes,
 )
+from .exit_decisions import (
+    ExitConfig,
+    ExitDecision,
+    ExitReason,
+    MarketAnalysis,
+    PositionSnapshot,
+    Side as PositionSide,
+    Trend,
+    decide_exit,
+)
 
 __all__ = [
+    "ExitConfig",
+    "ExitDecision",
+    "ExitReason",
     "KernelAccountState",
     "KernelContext",
     "KernelDecision",
@@ -40,12 +53,17 @@ __all__ = [
     "KernelOrder",
     "KernelRestingOrder",
     "KernelVetoCode",
+    "MarketAnalysis",
     "PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER",
+    "PositionSide",
+    "PositionSnapshot",
+    "Trend",
     "UNREALIZED_DRAWDOWN_KILL_THRESHOLD",
     "check_execution_mode",
     "check_per_symbol_exposure",
     "check_self_match",
     "check_symbol_max_leverage",
     "check_unrealized_drawdown",
+    "decide_exit",
     "evaluate_pre_trade_vetoes",
 ]

--- a/ml-worker/src/trading/exit_decisions.py
+++ b/ml-worker/src/trading/exit_decisions.py
@@ -1,0 +1,177 @@
+"""
+exit_decisions.py — pure position-exit logic (v0.8.7c-1).
+
+Ports the stateless pieces of fullyAutonomousTrader.managePositions
+that decide WHETHER a position should close and WHY. The orchestration
+layer (reading exchange positions, writing exit orders, updating DB)
+stays TS until v0.8.7c-3 — this module only produces exit decisions
+given already-fetched position + market state.
+
+Three exit triggers, priority-ordered (first-hit-wins matches the TS
+if/else-if chain in managePositions):
+
+  1. STOP_LOSS      pnl_percent ≤ -config.stop_loss_percent
+  2. TAKE_PROFIT    pnl_percent ≥ config.take_profit_percent
+  3. TREND_REVERSAL pnl_percent ≥ trailing_trigger AND trend flipped
+                    (trailing_trigger == stop_loss_percent per TS
+                     line 1231: "start trailing stop when profit
+                     exceeds SL distance")
+
+This is the natural per-position analogue to risk_kernel's pre-trade
+chain: same "first failure wins" composer, same pure function shape.
+Keeps shadow-mode parity cheap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+# ────────────────────────────────────────────────────────────────
+# Types mirror TS reference — camelCase → snake_case at the boundary
+# ────────────────────────────────────────────────────────────────
+
+ExitReason = Literal[
+    "stop_loss",
+    "take_profit",
+    "trend_reversal",
+    "hold",  # sentinel: no exit this tick
+]
+
+Trend = Literal["bullish", "bearish", "neutral", "unknown"]
+Side = Literal["long", "short"]
+
+
+@dataclass(frozen=True)
+class ExitConfig:
+    """Per-user trading config passed in by orchestration layer.
+    Sourced from agent_config / TradingConfig in the TS side.
+    """
+    stop_loss_percent: float = 2.0    # e.g. 2 = 2%
+    take_profit_percent: float = 4.0
+
+
+@dataclass(frozen=True)
+class PositionSnapshot:
+    """Position state at decision time. Caller fetches from Poloniex
+    (TS: poloniexFuturesService.getPositions) and maps field names —
+    keeps this module IO-free.
+    """
+    symbol: str
+    qty: float              # signed: positive = long, negative = short
+    entry_price: float
+    unrealized_pnl: float   # USDT
+
+    @property
+    def side(self) -> Side:
+        return "long" if self.qty > 0 else "short"
+
+    def pnl_percent(self) -> float:
+        """Return P&L as a percent of cost basis (same formula as TS
+        managePositions line 1247: unrealizedPnL / (entry × |qty|) * 100).
+
+        Zero entry or zero qty → 0 (divide-by-zero guard matches TS).
+        """
+        if self.entry_price <= 0 or self.qty == 0:
+            return 0.0
+        return (self.unrealized_pnl / (self.entry_price * abs(self.qty))) * 100.0
+
+
+@dataclass(frozen=True)
+class MarketAnalysis:
+    """Slice of MarketAnalysis the exit-decision needs. TS type has
+    many more fields (volatility, momentum, etc.); we only take what
+    drives the exit logic.
+    """
+    trend: Trend
+
+
+@dataclass(frozen=True)
+class ExitDecision:
+    """Structured output. Carries enough context that the orchestration
+    layer can log + audit without needing to re-derive thresholds.
+    """
+    should_close: bool
+    reason: ExitReason
+    explanation: str
+    pnl_percent: float
+    stop_loss_threshold: float
+    take_profit_threshold: float
+
+
+def decide_exit(
+    position: PositionSnapshot,
+    config: ExitConfig,
+    analysis: Optional[MarketAnalysis] = None,
+) -> ExitDecision:
+    """Run the three-gate exit chain. First-trigger-wins matches the
+    TS managePositions flow. `analysis` is optional because in TS it's
+    a .get() lookup that may miss — in that case trend-reversal can't
+    fire but stop_loss / take_profit still can.
+
+    Returns ExitDecision(should_close=False, reason='hold', …) when no
+    trigger fires — caller continues holding.
+    """
+    pnl_pct = position.pnl_percent()
+    sl_thr = config.stop_loss_percent
+    tp_thr = config.take_profit_percent
+    trailing_trigger = sl_thr  # TS line 1231: "start trailing stop when profit exceeds SL distance"
+
+    # Gate 1: stop-loss (account-saving; runs first)
+    if pnl_pct < -sl_thr:
+        return ExitDecision(
+            should_close=True,
+            reason="stop_loss",
+            explanation=(
+                f"Stop loss triggered: {pnl_pct:.2f}% < -{sl_thr:.2f}%"
+            ),
+            pnl_percent=pnl_pct,
+            stop_loss_threshold=sl_thr,
+            take_profit_threshold=tp_thr,
+        )
+
+    # Gate 2: take-profit
+    if pnl_pct > tp_thr:
+        return ExitDecision(
+            should_close=True,
+            reason="take_profit",
+            explanation=(
+                f"Take profit triggered: {pnl_pct:.2f}% > {tp_thr:.2f}%"
+            ),
+            pnl_percent=pnl_pct,
+            stop_loss_threshold=sl_thr,
+            take_profit_threshold=tp_thr,
+        )
+
+    # Gate 3: trailing stop via trend reversal (needs analysis present)
+    if pnl_pct > trailing_trigger and analysis is not None:
+        is_long = position.qty > 0
+        reversed_against_us = (
+            (is_long and analysis.trend == "bearish")
+            or (not is_long and analysis.trend == "bullish")
+        )
+        if reversed_against_us:
+            return ExitDecision(
+                should_close=True,
+                reason="trend_reversal",
+                explanation=(
+                    f"Trailing stop + trend reversal: pnl={pnl_pct:.2f}% > "
+                    f"trigger {trailing_trigger:.2f}%, trend={analysis.trend} "
+                    f"vs {position.side}"
+                ),
+                pnl_percent=pnl_pct,
+                stop_loss_threshold=sl_thr,
+                take_profit_threshold=tp_thr,
+            )
+
+    return ExitDecision(
+        should_close=False,
+        reason="hold",
+        explanation=(
+            f"Hold: pnl={pnl_pct:.2f}% in "
+            f"[-{sl_thr:.2f}%, {tp_thr:.2f}%]"
+        ),
+        pnl_percent=pnl_pct,
+        stop_loss_threshold=sl_thr,
+        take_profit_threshold=tp_thr,
+    )

--- a/ml-worker/tests/trading/test_exit_decisions_parity.py
+++ b/ml-worker/tests/trading/test_exit_decisions_parity.py
@@ -1,0 +1,243 @@
+"""
+test_exit_decisions_parity.py — pin exit_decisions.py to
+fullyAutonomousTrader.managePositions TS behavior.
+
+Each test traces one TS-side path through the if/else-if chain with
+hand-derived expected outcomes. Boundary cases (exactly-at-threshold,
+no analysis, tp_percent = sl_percent, zero quantity) are explicit.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from trading.exit_decisions import (  # noqa: E402
+    ExitConfig,
+    ExitDecision,
+    MarketAnalysis,
+    PositionSnapshot,
+    decide_exit,
+)
+
+
+def _long_pos(*, entry: float = 100.0, qty: float = 1.0, pnl: float = 0.0) -> PositionSnapshot:
+    return PositionSnapshot(symbol="BTC_USDT_PERP", qty=qty, entry_price=entry, unrealized_pnl=pnl)
+
+
+def _short_pos(*, entry: float = 100.0, qty: float = -1.0, pnl: float = 0.0) -> PositionSnapshot:
+    return PositionSnapshot(symbol="BTC_USDT_PERP", qty=qty, entry_price=entry, unrealized_pnl=pnl)
+
+
+def _cfg(*, sl: float = 2.0, tp: float = 4.0) -> ExitConfig:
+    return ExitConfig(stop_loss_percent=sl, take_profit_percent=tp)
+
+
+# ─── P&L calculation ─────────────────────────────────────────────
+
+class TestPnLPercent:
+    def test_long_positive(self):
+        """Long entry $100 × 1 qty, +$5 unreal → +5%."""
+        p = _long_pos(entry=100, qty=1, pnl=5)
+        assert p.pnl_percent() == pytest.approx(5.0)
+
+    def test_short_positive(self):
+        """Short entry $100 × -1 qty, +$5 unreal → +5% (abs(qty))."""
+        p = _short_pos(entry=100, qty=-1, pnl=5)
+        assert p.pnl_percent() == pytest.approx(5.0)
+
+    def test_long_negative(self):
+        p = _long_pos(entry=100, qty=1, pnl=-3)
+        assert p.pnl_percent() == pytest.approx(-3.0)
+
+    def test_zero_entry_returns_zero(self):
+        p = _long_pos(entry=0, qty=1, pnl=10)
+        assert p.pnl_percent() == 0.0
+
+    def test_zero_qty_returns_zero(self):
+        p = _long_pos(entry=100, qty=0, pnl=10)
+        assert p.pnl_percent() == 0.0
+
+
+# ─── Stop-loss gate ──────────────────────────────────────────────
+
+class TestStopLoss:
+    def test_below_stop_loss_triggers(self):
+        """Long -3% with sl=2% → stop_loss fires."""
+        r = decide_exit(_long_pos(pnl=-3), _cfg(sl=2, tp=4))
+        assert r.should_close is True
+        assert r.reason == "stop_loss"
+
+    def test_exactly_at_minus_sl_does_not_trigger(self):
+        """TS uses pnlPercent < -slPercent, strict — exactly-at stays open."""
+        r = decide_exit(_long_pos(pnl=-2), _cfg(sl=2, tp=4))
+        assert r.should_close is False
+        assert r.reason == "hold"
+
+    def test_one_cent_below_minus_sl_triggers(self):
+        r = decide_exit(_long_pos(pnl=-2.01), _cfg(sl=2, tp=4))
+        assert r.should_close is True
+        assert r.reason == "stop_loss"
+
+    def test_short_stop_loss_on_price_rise(self):
+        """Short losing money when price moves up → unreal_pnl goes negative."""
+        r = decide_exit(_short_pos(qty=-1, entry=100, pnl=-3), _cfg(sl=2))
+        assert r.should_close is True
+        assert r.reason == "stop_loss"
+
+
+# ─── Take-profit gate ────────────────────────────────────────────
+
+class TestTakeProfit:
+    def test_above_tp_triggers(self):
+        r = decide_exit(_long_pos(pnl=5), _cfg(sl=2, tp=4))
+        assert r.should_close is True
+        assert r.reason == "take_profit"
+
+    def test_exactly_at_tp_does_not_trigger(self):
+        """TS uses pnlPercent > tpPercent, strict."""
+        r = decide_exit(_long_pos(pnl=4), _cfg(sl=2, tp=4))
+        # 4% is NOT > 4% → no TP, but 4% IS > trailing_trigger=2% …
+        # However trend reversal needs analysis; without it → hold.
+        assert r.reason != "take_profit"
+
+    def test_one_cent_above_tp_triggers(self):
+        r = decide_exit(_long_pos(pnl=4.01), _cfg(sl=2, tp=4))
+        assert r.should_close is True
+        assert r.reason == "take_profit"
+
+
+# ─── Trailing-stop / trend-reversal gate ─────────────────────────
+
+class TestTrailingReversal:
+    def test_long_profit_bearish_trend_closes(self):
+        """Long at +3% (above trailing_trigger=sl=2), bearish analysis → close."""
+        r = decide_exit(
+            _long_pos(pnl=3),
+            _cfg(sl=2, tp=4),
+            analysis=MarketAnalysis(trend="bearish"),
+        )
+        assert r.should_close is True
+        assert r.reason == "trend_reversal"
+
+    def test_short_profit_bullish_trend_closes(self):
+        """Short at +3%, bullish analysis → close."""
+        r = decide_exit(
+            _short_pos(qty=-1, pnl=3),
+            _cfg(sl=2, tp=4),
+            analysis=MarketAnalysis(trend="bullish"),
+        )
+        assert r.should_close is True
+        assert r.reason == "trend_reversal"
+
+    def test_long_profit_bullish_trend_holds(self):
+        """Long at +3%, bullish analysis → aligned, hold."""
+        r = decide_exit(
+            _long_pos(pnl=3),
+            _cfg(sl=2, tp=4),
+            analysis=MarketAnalysis(trend="bullish"),
+        )
+        assert r.should_close is False
+        assert r.reason == "hold"
+
+    def test_missing_analysis_skips_trailing(self):
+        """pnl above trailing but no analysis → can't evaluate reversal."""
+        r = decide_exit(_long_pos(pnl=3), _cfg(sl=2, tp=4), analysis=None)
+        assert r.should_close is False
+        assert r.reason == "hold"
+
+    def test_neutral_trend_holds(self):
+        r = decide_exit(
+            _long_pos(pnl=3),
+            _cfg(sl=2, tp=4),
+            analysis=MarketAnalysis(trend="neutral"),
+        )
+        assert r.should_close is False
+
+    def test_below_trailing_trigger_holds(self):
+        """pnl=1% with sl=2 → below trailing_trigger=2 → no reversal check."""
+        r = decide_exit(
+            _long_pos(pnl=1),
+            _cfg(sl=2, tp=4),
+            analysis=MarketAnalysis(trend="bearish"),
+        )
+        assert r.should_close is False
+
+
+# ─── Priority ordering ───────────────────────────────────────────
+
+class TestPriorityOrdering:
+    def test_stop_loss_wins_over_take_profit(self):
+        """Impossible in reality but tests strict priority.
+        If stop_loss_percent > take_profit_percent somehow, SL runs first."""
+        r = decide_exit(_long_pos(pnl=-10), _cfg(sl=5, tp=1))
+        # -10 < -5 → SL fires first (even though -10 is also not > 1)
+        assert r.reason == "stop_loss"
+
+    def test_take_profit_wins_over_trailing(self):
+        """+5% with sl=2, tp=4 AND bearish trend → TP gate fires FIRST
+        (pnl=5 > 4 → TP), trailing never evaluated.
+        """
+        r = decide_exit(
+            _long_pos(pnl=5),
+            _cfg(sl=2, tp=4),
+            analysis=MarketAnalysis(trend="bearish"),
+        )
+        assert r.reason == "take_profit"
+
+    def test_sl_wins_over_trailing(self):
+        """-3% → SL fires even if we had analysis (pnl negative so trailing
+        wouldn't fire anyway, but priority test)."""
+        r = decide_exit(
+            _long_pos(pnl=-3),
+            _cfg(sl=2, tp=4),
+            analysis=MarketAnalysis(trend="bearish"),
+        )
+        assert r.reason == "stop_loss"
+
+
+# ─── Hold path (no exit) ─────────────────────────────────────────
+
+class TestHoldPath:
+    def test_within_band_holds(self):
+        """Small profit, no trend signal → hold."""
+        r = decide_exit(_long_pos(pnl=1), _cfg(sl=2, tp=4))
+        assert r.should_close is False
+        assert r.reason == "hold"
+
+    def test_flat_position_holds(self):
+        r = decide_exit(_long_pos(pnl=0), _cfg(sl=2, tp=4))
+        assert r.should_close is False
+
+    def test_hold_decision_carries_thresholds(self):
+        """Decision exposes thresholds so caller can log / audit."""
+        r = decide_exit(_long_pos(pnl=1), _cfg(sl=2, tp=4))
+        assert r.stop_loss_threshold == 2.0
+        assert r.take_profit_threshold == 4.0
+        assert r.pnl_percent == pytest.approx(1.0)
+
+
+if __name__ == "__main__":
+    import inspect
+    passed = 0
+    failed: list[str] = []
+    for cls_name, cls in list(globals().items()):
+        if not inspect.isclass(cls) or not cls_name.startswith("Test"):
+            continue
+        instance = cls()
+        for name, fn in inspect.getmembers(cls, predicate=inspect.isfunction):
+            if not name.startswith("test_"):
+                continue
+            try:
+                fn(instance)
+                passed += 1
+                print(f"  ✓ {cls_name}.{name}")
+            except AssertionError as exc:
+                failed.append(f"{cls_name}.{name}: {exc}")
+                print(f"  ✗ {cls_name}.{name}: {exc}")
+    print(f"\n{passed} passed, {len(failed)} failed")
+    sys.exit(0 if not failed else 1)


### PR DESCRIPTION
Third stateless port in the v0.8.7 chain. Ports managePositions's exit logic (stop_loss → take_profit → trend_reversal → hold) as pure functions with 24 parity tests. No order placement or DB writes in this PR — those are v0.8.7c-2/3.