### PR TITLE
feat(trading): v0.8.7c-2 port position reconciliation + /live/reconcile

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -763,6 +763,11 @@ from trading.exit_decisions import (  # noqa: E402
     PositionSnapshot as _PositionSnapshot,
     decide_exit as _decide_exit,
 )
+from trading.reconciliation import (  # noqa: E402
+    ExchangePosition as _ExchangePosition,
+    TrackedPosition as _TrackedPosition,
+    reconcile_positions as _reconcile_positions,
+)
 
 
 @app.post("/risk/evaluate")
@@ -1003,6 +1008,70 @@ async def live_exit_decide(request: Request):
         "pnlPercent": decision.pnl_percent,
         "stopLossThreshold": decision.stop_loss_threshold,
         "takeProfitThreshold": decision.take_profit_threshold,
+    }
+
+
+# ---------------------------------------------------------------------------
+# v0.8.7c-2 — POST /live/reconcile — pure DB-vs-exchange diff
+# ---------------------------------------------------------------------------
+#
+# Ported from fullyAutonomousTrader.reconcilePositions. Caller hands
+# us the DB open-rows + exchange getPositions result; we return a
+# structured report with phantom_db / orphan_exchange / matched
+# symbol lists.
+#
+# The mutation side (UPDATE autonomous_trades SET status='closed' on
+# phantoms, logAgentEvent on orphans) stays TS — v0.8.7c-3 ports the
+# actual writes. Shadow-mode parity against TS side only compares
+# the diff output, which this endpoint exposes as a pure function.
+
+
+@app.post("/live/reconcile")
+async def live_reconcile(request: Request):
+    """Diff DB open positions against exchange open positions.
+
+    Request body:
+      {
+        "dbRows":  [{"symbol", "orderId"?}...],
+        "exchangePositions": [{"symbol", "qty"}...]
+      }
+
+    Response:
+      {
+        "matchedSymbols":         [str...],  // in both, healthy
+        "phantomDbSymbols":       [str...],  // DB says open, exchange doesn't
+        "orphanExchangeSymbols":  [str...],  // exchange has, DB doesn't
+        "hasDrift":               bool       // true iff any phantom/orphan
+      }
+
+    All symbol lists sorted ascending. Zero-qty exchange entries are
+    filtered out (matches TS behaviour at fullyAutonomousTrader:1174).
+    """
+    body = await request.json()
+    try:
+        db_rows = [
+            _TrackedPosition(
+                symbol=str(r["symbol"]),
+                order_id=str(r.get("orderId") or ""),
+            )
+            for r in (body.get("dbRows") or [])
+        ]
+        exchange_positions = [
+            _ExchangePosition(
+                symbol=str(p["symbol"]),
+                qty=float(p.get("qty") or 0),
+            )
+            for p in (body.get("exchangePositions") or [])
+        ]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"bad reconcile input: {exc}") from exc
+
+    report = _reconcile_positions(db_rows, exchange_positions)
+    return {
+        "matchedSymbols": report.matched_symbols,
+        "phantomDbSymbols": report.phantom_db_symbols,
+        "orphanExchangeSymbols": report.orphan_exchange_symbols,
+        "hasDrift": report.has_drift,
     }
 
 

--- a/ml-worker/src/trading/__init__.py
+++ b/ml-worker/src/trading/__init__.py
@@ -41,8 +41,15 @@ from .exit_decisions import (
     Trend,
     decide_exit,
 )
+from .reconciliation import (
+    ExchangePosition,
+    ReconciliationReport,
+    TrackedPosition,
+    reconcile_positions,
+)
 
 __all__ = [
+    "ExchangePosition",
     "ExitConfig",
     "ExitDecision",
     "ExitReason",
@@ -57,6 +64,8 @@ __all__ = [
     "PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER",
     "PositionSide",
     "PositionSnapshot",
+    "ReconciliationReport",
+    "TrackedPosition",
     "Trend",
     "UNREALIZED_DRAWDOWN_KILL_THRESHOLD",
     "check_execution_mode",
@@ -66,4 +75,5 @@ __all__ = [
     "check_unrealized_drawdown",
     "decide_exit",
     "evaluate_pre_trade_vetoes",
+    "reconcile_positions",
 ]

--- a/ml-worker/src/trading/reconciliation.py
+++ b/ml-worker/src/trading/reconciliation.py
@@ -1,0 +1,112 @@
+"""
+reconciliation.py — pure position-reconciliation logic (v0.8.7c-2).
+
+Ports the diff engine from fullyAutonomousTrader.reconcilePositions
+(TS lines 1165-1219). The caller reads positions from Poloniex + the
+DB (both IO, stay TS-side); this module takes the two snapshots as
+input and returns a structured diff.
+
+Three drift categories:
+
+  1. PHANTOM_DB  — DB thinks position is open, exchange doesn't show.
+                   Caller marks the DB row closed with
+                   exit_reason='reconciliation: position not found on
+                   exchange'. Matches TS `inDbNotExchange` branch.
+
+  2. ORPHAN_EXCHANGE — Exchange has a position not tracked in DB.
+                       Caller logs a 'reconciliation_drift' agent
+                       event and alerts; does NOT auto-close because
+                       it may be a manual position from another
+                       system. Matches TS `inExchangeNotDb` branch.
+
+  3. MATCHED — Same symbol present in both. (Future extension point
+               for qty/side mismatch detection; current TS only
+               compares symbol presence, so v0.8.7c-2 mirrors that.)
+
+Purity: BOUNDARY per P14. Pure function: (db_rows, exchange_positions)
+→ ReconciliationReport. Excluded from qig_purity_check.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TrackedPosition:
+    """One row from the DB's autonomous_trades.status='open' view.
+    Only the fields the reconciler needs; caller can carry more
+    metadata but this module ignores it.
+    """
+    symbol: str
+    order_id: str = ""  # kept so caller can log which order was phantom-closed
+
+
+@dataclass(frozen=True)
+class ExchangePosition:
+    """One position entry returned by Poloniex getPositions.
+    qty is signed (positive=long, negative=short). The TS reconciler
+    filters zero-qty entries BEFORE passing in; this module trusts
+    the caller to have done that, but _also_ defensively ignores
+    zero-qty positions below so shadow parity is safe.
+    """
+    symbol: str
+    qty: float = 0.0
+
+
+@dataclass(frozen=True)
+class ReconciliationReport:
+    """Structured drift diff. Each symbol appears in exactly one of
+    the three lists. Empty lists mean no drift in that category.
+    """
+    matched_symbols: list[str] = field(default_factory=list)
+    phantom_db_symbols: list[str] = field(default_factory=list)
+    orphan_exchange_symbols: list[str] = field(default_factory=list)
+
+    @property
+    def has_drift(self) -> bool:
+        """Convenience for callers that only need to know if ANY drift
+        exists. Returns True when at least one phantom or orphan present.
+        """
+        return bool(self.phantom_db_symbols or self.orphan_exchange_symbols)
+
+
+def reconcile_positions(
+    db_rows: list[TrackedPosition],
+    exchange_positions: list[ExchangePosition],
+) -> ReconciliationReport:
+    """Diff DB against exchange. Pure. Matches TS reconcilePositions
+    lines 1172-1188 exactly:
+
+      - Exchange set = symbols with non-zero qty
+      - DB set = all tracked symbols passed in (caller already
+        filtered by status='open' AND paper_trade=false)
+      - Phantom = in DB, not in exchange
+      - Orphan = in exchange, not in DB
+      - Matched = intersection
+
+    Empty inputs: returns empty report (no drift). Does not mutate
+    inputs. Symbol comparison is case-sensitive (TS uses plain string
+    equality in Set membership; Poloniex symbols are always uppercase
+    on both sides so this never bites in practice).
+
+    Return lists are sorted ascending for deterministic output — the
+    TS reference uses Set iteration order which is insertion-order in
+    V8. Sorting here gives us stable test comparisons + a nicer audit
+    trail; shadow-mode parity compares sets-of-symbols, not order,
+    so this is safe.
+    """
+    exchange_symbols = {
+        pos.symbol for pos in exchange_positions if pos.qty != 0
+    }
+    db_symbols = {row.symbol for row in db_rows}
+
+    matched = sorted(db_symbols & exchange_symbols)
+    phantom_db = sorted(db_symbols - exchange_symbols)
+    orphan_exchange = sorted(exchange_symbols - db_symbols)
+
+    return ReconciliationReport(
+        matched_symbols=matched,
+        phantom_db_symbols=phantom_db,
+        orphan_exchange_symbols=orphan_exchange,
+    )

--- a/ml-worker/tests/trading/test_reconciliation_parity.py
+++ b/ml-worker/tests/trading/test_reconciliation_parity.py
@@ -1,0 +1,243 @@
+"""
+test_reconciliation_parity.py — pin reconciliation.py to
+fullyAutonomousTrader.reconcilePositions TS behavior.
+
+Boundary-cased against TS reference (lines 1172-1188). Covers
+happy-path, phantom-only, orphan-only, both, empty, and two edge
+cases the TS side handles defensively (zero-qty exchange rows;
+case-sensitive matching).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from trading.reconciliation import (  # noqa: E402
+    ExchangePosition,
+    ReconciliationReport,
+    TrackedPosition,
+    reconcile_positions,
+)
+
+
+# ─── Happy path ──────────────────────────────────────────────────
+
+class TestNoDrift:
+    def test_perfect_match_single_symbol(self):
+        r = reconcile_positions(
+            [TrackedPosition("BTC_USDT_PERP", order_id="o1")],
+            [ExchangePosition("BTC_USDT_PERP", qty=1.0)],
+        )
+        assert r.matched_symbols == ["BTC_USDT_PERP"]
+        assert r.phantom_db_symbols == []
+        assert r.orphan_exchange_symbols == []
+        assert r.has_drift is False
+
+    def test_perfect_match_multi_symbol(self):
+        r = reconcile_positions(
+            [
+                TrackedPosition("BTC_USDT_PERP"),
+                TrackedPosition("ETH_USDT_PERP"),
+                TrackedPosition("SOL_USDT_PERP"),
+            ],
+            [
+                ExchangePosition("ETH_USDT_PERP", qty=-0.5),
+                ExchangePosition("BTC_USDT_PERP", qty=0.001),
+                ExchangePosition("SOL_USDT_PERP", qty=10.0),
+            ],
+        )
+        # Sorted output regardless of input order
+        assert r.matched_symbols == ["BTC_USDT_PERP", "ETH_USDT_PERP", "SOL_USDT_PERP"]
+        assert r.has_drift is False
+
+
+# ─── Phantom DB rows (DB has it, exchange doesn't) ──────────────
+
+class TestPhantomDB:
+    def test_single_phantom(self):
+        """TS: inDbNotExchange triggers UPDATE ... SET status='closed'."""
+        r = reconcile_positions(
+            [TrackedPosition("BTC_USDT_PERP", order_id="o1")],
+            [],
+        )
+        assert r.phantom_db_symbols == ["BTC_USDT_PERP"]
+        assert r.matched_symbols == []
+        assert r.orphan_exchange_symbols == []
+        assert r.has_drift is True
+
+    def test_multiple_phantom(self):
+        r = reconcile_positions(
+            [
+                TrackedPosition("BTC_USDT_PERP"),
+                TrackedPosition("ETH_USDT_PERP"),
+            ],
+            [],
+        )
+        assert r.phantom_db_symbols == ["BTC_USDT_PERP", "ETH_USDT_PERP"]
+
+    def test_partial_phantom(self):
+        """DB has 2, exchange has 1 of them → 1 matched + 1 phantom."""
+        r = reconcile_positions(
+            [
+                TrackedPosition("BTC_USDT_PERP"),
+                TrackedPosition("ETH_USDT_PERP"),
+            ],
+            [ExchangePosition("BTC_USDT_PERP", qty=0.001)],
+        )
+        assert r.matched_symbols == ["BTC_USDT_PERP"]
+        assert r.phantom_db_symbols == ["ETH_USDT_PERP"]
+        assert r.has_drift is True
+
+
+# ─── Orphan exchange positions (exchange has it, DB doesn't) ─────
+
+class TestOrphanExchange:
+    def test_single_orphan(self):
+        """TS: inExchangeNotDb triggers logAgentEvent 'reconciliation_drift'.
+        Does NOT auto-close — might be manual position from another system.
+        """
+        r = reconcile_positions(
+            [],
+            [ExchangePosition("BTC_USDT_PERP", qty=0.001)],
+        )
+        assert r.orphan_exchange_symbols == ["BTC_USDT_PERP"]
+        assert r.phantom_db_symbols == []
+        assert r.has_drift is True
+
+    def test_multiple_orphans(self):
+        r = reconcile_positions(
+            [],
+            [
+                ExchangePosition("BTC_USDT_PERP", qty=0.001),
+                ExchangePosition("ETH_USDT_PERP", qty=-0.1),
+            ],
+        )
+        assert r.orphan_exchange_symbols == ["BTC_USDT_PERP", "ETH_USDT_PERP"]
+
+    def test_short_position_counts(self):
+        """Negative qty still counts (exchange position with short qty)."""
+        r = reconcile_positions(
+            [],
+            [ExchangePosition("BTC_USDT_PERP", qty=-0.5)],
+        )
+        assert r.orphan_exchange_symbols == ["BTC_USDT_PERP"]
+
+
+# ─── Both phantom AND orphan at once ─────────────────────────────
+
+class TestBothDriftCategories:
+    def test_disjoint_sets(self):
+        """DB tracks X, exchange has Y — both drift. Real scenario when
+        reconciler runs after a missed close-and-reopen cycle.
+        """
+        r = reconcile_positions(
+            [TrackedPosition("BTC_USDT_PERP", order_id="o1")],
+            [ExchangePosition("ETH_USDT_PERP", qty=0.1)],
+        )
+        assert r.matched_symbols == []
+        assert r.phantom_db_symbols == ["BTC_USDT_PERP"]
+        assert r.orphan_exchange_symbols == ["ETH_USDT_PERP"]
+        assert r.has_drift is True
+
+
+# ─── Edge cases the TS side handles defensively ──────────────────
+
+class TestEdgeCases:
+    def test_empty_empty_no_drift(self):
+        r = reconcile_positions([], [])
+        assert r.matched_symbols == []
+        assert r.phantom_db_symbols == []
+        assert r.orphan_exchange_symbols == []
+        assert r.has_drift is False
+
+    def test_zero_qty_exchange_entry_ignored(self):
+        """TS filter on line 1174: `Number(p.qty || p.currentQty || 0) !== 0`.
+        Exchange endpoints sometimes return stale zero-qty entries for
+        symbols the user has previously traded. Reconciler must treat
+        these as not-held, so we don't flag a DB row as matched when
+        the exchange position is actually flat.
+        """
+        r = reconcile_positions(
+            [TrackedPosition("BTC_USDT_PERP")],
+            [ExchangePosition("BTC_USDT_PERP", qty=0.0)],
+        )
+        # Zero qty filtered out → DB row becomes phantom
+        assert r.phantom_db_symbols == ["BTC_USDT_PERP"]
+        assert r.matched_symbols == []
+
+    def test_symbol_case_sensitive(self):
+        """Poloniex returns UPPERCASE. If caller fed mixed-case DB rows
+        (bug) they wouldn't match. Test pins the strict-equality semantic
+        so the bug would surface, not silently reconcile mismatched pairs.
+        """
+        r = reconcile_positions(
+            [TrackedPosition("btc_usdt_perp")],
+            [ExchangePosition("BTC_USDT_PERP", qty=0.001)],
+        )
+        assert r.matched_symbols == []
+        assert r.phantom_db_symbols == ["btc_usdt_perp"]
+        assert r.orphan_exchange_symbols == ["BTC_USDT_PERP"]
+
+    def test_duplicate_db_rows_dedup(self):
+        """DB could have two rows for same symbol under unusual conditions
+        (e.g., missed close-reconcile). Set semantics dedup — reconciler
+        treats the symbol as present once.
+        """
+        r = reconcile_positions(
+            [
+                TrackedPosition("BTC_USDT_PERP", order_id="o1"),
+                TrackedPosition("BTC_USDT_PERP", order_id="o2"),
+            ],
+            [ExchangePosition("BTC_USDT_PERP", qty=0.001)],
+        )
+        assert r.matched_symbols == ["BTC_USDT_PERP"]
+        assert r.has_drift is False
+
+
+# ─── Has-drift boolean shortcut ──────────────────────────────────
+
+class TestHasDriftShortcut:
+    def test_false_when_clean(self):
+        r = reconcile_positions([], [])
+        assert r.has_drift is False
+
+    def test_true_on_phantom_only(self):
+        r = reconcile_positions([TrackedPosition("X")], [])
+        assert r.has_drift is True
+
+    def test_true_on_orphan_only(self):
+        r = reconcile_positions([], [ExchangePosition("Y", qty=1)])
+        assert r.has_drift is True
+
+    def test_matched_alone_does_not_trigger_drift(self):
+        """Symbols in both sides → has_drift stays False."""
+        r = reconcile_positions(
+            [TrackedPosition("X")],
+            [ExchangePosition("X", qty=1)],
+        )
+        assert r.has_drift is False
+
+
+if __name__ == "__main__":
+    import inspect
+    passed = 0
+    failed: list[str] = []
+    for cls_name, cls in list(globals().items()):
+        if not inspect.isclass(cls) or not cls_name.startswith("Test"):
+            continue
+        instance = cls()
+        for name, fn in inspect.getmembers(cls, predicate=inspect.isfunction):
+            if not name.startswith("test_"):
+                continue
+            try:
+                fn(instance)
+                passed += 1
+                print(f"  ✓ {cls_name}.{name}")
+            except AssertionError as exc:
+                failed.append(f"{cls_name}.{name}: {exc}")
+                print(f"  ✗ {cls_name}.{name}: {exc}")
+    print(f"\n{passed} passed, {len(failed)} failed")
+    sys.exit(0 if not failed else 1)


### PR DESCRIPTION
Fourth stateless port in the v0.8.7 chain. Ports reconcilePositions's pure diff engine: phantom DB rows (DB thinks open, exchange doesn't show) + orphan exchange positions (exchange has, DB doesn't track). 17 parity tests. DB writes + agent event logging stay TS until v0.8.7c-3.