### PR TITLE
feat(trading): v0.8.7d-4 wire autonomous trader shadow (exit + reconcile)

### DIFF
--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -19,6 +19,13 @@ import { apiCredentialsService } from './apiCredentialsService.js';
 import backtestingEngine from './backtestingEngine.js';
 import { getPrecisions } from './marketCatalog.js';
 import mlPredictionService from './mlPredictionService.js';
+import {
+  callExitDecide,
+  callReconcile,
+  isExitShadowEnabled,
+  logExitParityDiff,
+  logReconcileParityDiff,
+} from './monkey/kernel_client.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
 import riskService from './riskService.js';
 import { buildIndicatorMap, evaluateGenomeEntry, type SignalGenome } from './signalGenome.js';
@@ -1187,6 +1194,39 @@ class FullyAutonomousTrader extends EventEmitter {
       const inDbNotExchange = [...dbSymbols].filter(s => !openSymbols.has(s));
       const inExchangeNotDb = ([...openSymbols] as string[]).filter(s => !dbSymbols.has(s));
 
+      // v0.8.7d-4: fire-and-forget shadow call to /live/reconcile. TS
+      // side's inDbNotExchange / inExchangeNotDb are authoritative; the
+      // Python side runs the same diff for parity verification. Default
+      // OFF via isExitShadowEnabled() (AUTONOMOUS_TRADER_PY_SHADOW).
+      // Shadow errors swallowed at debug — cannot impact reconcile.
+      if (isExitShadowEnabled()) {
+        const shadowDbRows = dbResult.rows.map((r: { symbol: string; order_id?: string }) => ({
+          symbol: r.symbol,
+          orderId: r.order_id,
+        }));
+        const shadowExchangePositions = (exchangePositions || [])
+          .map((p: Record<string, unknown>) => ({
+            symbol: String(p.symbol),
+            qty: Number(p.qty || p.currentQty || 0),
+          }));
+        void callReconcile({
+          dbRows: shadowDbRows,
+          exchangePositions: shadowExchangePositions,
+        }).then((py) => {
+          logReconcileParityDiff(
+            {
+              phantomDbSymbols: inDbNotExchange as string[],
+              orphanExchangeSymbols: inExchangeNotDb as string[],
+            },
+            py,
+          );
+        }).catch((err) => {
+          logger.debug('[reconcile-shadow] parity fetch failed', {
+            err: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
+
       if (inDbNotExchange.length > 0) {
         logger.warn(
           `[RECONCILE] DB shows open positions not on exchange: ${inDbNotExchange.join(', ')} — ` +
@@ -1245,6 +1285,51 @@ class FullyAutonomousTrader extends EventEmitter {
 
         // Calculate P&L percentage
         const pnlPercent = entryPrice > 0 ? (unrealizedPnL / (entryPrice * Math.abs(qty))) * 100 : 0;
+
+        // v0.8.7d-4: fire-and-forget shadow call to /live/exit-decide.
+        // TS exit-chain (below) remains authoritative; Python runs the
+        // same stop_loss → take_profit → trend_reversal → hold priority
+        // chain and logs divergence. Default OFF via isExitShadowEnabled.
+        //
+        // TS "shadow decision" inlined below for parity comparison — we
+        // can't capture what the TS code below is about to decide without
+        // evaluating it ourselves, because the `continue` statements make
+        // branch-taken unobservable from a post-decision hook.
+        if (isExitShadowEnabled()) {
+          const analysis = analyses.get(symbol);
+          const tsShadowDecision = ((): { shouldClose: boolean; reason: string } => {
+            if (pnlPercent < -slPercent) return { shouldClose: true, reason: 'stop_loss' };
+            if (pnlPercent > tpPercent) return { shouldClose: true, reason: 'take_profit' };
+            if (pnlPercent > trailingTrigger && analysis) {
+              const isLong = qty > 0;
+              if ((isLong && analysis.trend === 'bearish') ||
+                  (!isLong && analysis.trend === 'bullish')) {
+                return { shouldClose: true, reason: 'trend_reversal' };
+              }
+            }
+            return { shouldClose: false, reason: 'hold' };
+          })();
+          void callExitDecide({
+            position: {
+              symbol,
+              qty,
+              entryPrice,
+              unrealizedPnl: unrealizedPnL,
+            },
+            config: {
+              stopLossPercent: slPercent,
+              takeProfitPercent: tpPercent,
+            },
+            analysis: analysis ? { trend: analysis.trend as 'bullish' | 'bearish' | 'neutral' | 'unknown' } : undefined,
+          }).then((py) => {
+            logExitParityDiff(tsShadowDecision, py);
+          }).catch((err) => {
+            logger.debug('[exit-shadow] parity fetch failed', {
+              symbol,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          });
+        }
 
         // Check stop loss using config percentage
         if (pnlPercent < -slPercent) {


### PR DESCRIPTION
Final shadow-mode wire-up for v0.8.7. Completes TS→Python shadow surface on all four call sites.

Fire-and-forget shadow on:
- reconcilePositions → /live/reconcile (phantom/orphan diff compared as sets)
- managePositions per-position loop → /live/exit-decide (stop_loss/take_profit/trend_reversal/hold compared via logExitParityDiff)

Default OFF via AUTONOMOUS_TRADER_PY_SHADOW. Same safety pattern as prior wire-ups: shadow latency doesn't block live path, errors swallowed at debug.