### PR TITLE
feat(monkey): proposal #10 — lane-isolated position lifecycle

### DIFF
--- a/apps/api/database/migrations/042_lane_position_key.sql
+++ b/apps/api/database/migrations/042_lane_position_key.sql
@@ -1,0 +1,34 @@
+-- Migration 042: Lane-isolated position lifecycle (proposal #10)
+--
+-- Position is now keyed by (agent, symbol, lane). A K_SWING_LONG and a
+-- K_SCALP_SHORT on BTC_USDT_PERP coexist as two distinct positions
+-- tracked independently with their own SL/TP, peak-PnL, DCA state, and
+-- capital share.
+--
+-- The user's design principle (proposal #10):
+--   "the kernel should still not be impacted by disagreement with ML
+--    they are separate. and its perfectly legitimate for a long term
+--    long to be held and isolated short short term trades to ride the
+--    bumps along the way and vice versa. its the difference between
+--    trend/swing trades and scalping."
+--
+-- Backward compatibility: every pre-#10 row is in the implicit "swing"
+-- lane via the column default. The reconciler keeps working without
+-- intervention; new rows specify their lane explicitly.
+
+ALTER TABLE autonomous_trades
+  ADD COLUMN IF NOT EXISTS lane TEXT NOT NULL DEFAULT 'swing';
+
+UPDATE autonomous_trades SET lane = 'swing' WHERE lane IS NULL;
+
+ALTER TABLE autonomous_trades
+  DROP CONSTRAINT IF EXISTS autonomous_trades_lane_check;
+ALTER TABLE autonomous_trades
+  ADD CONSTRAINT autonomous_trades_lane_check
+    CHECK (lane IN ('scalp', 'swing', 'trend'));
+
+-- Per-(agent, symbol, lane) lookup is the hot path for the lane-aware
+-- position lifecycle in monkey_kernel/loop.ts::findOpenMonkeyTrade and
+-- the reconciler.
+CREATE INDEX IF NOT EXISTS idx_autonomous_trades_agent_symbol_lane_status
+  ON autonomous_trades (agent, symbol, lane, status);

--- a/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
+++ b/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
@@ -1,0 +1,248 @@
+/**
+ * laneIsolation.test.ts — Proposal #10 lane-isolated position lifecycle
+ * (TypeScript parity with ml-worker/tests/monkey_kernel/test_lane_isolation.py).
+ *
+ * Validates the executive-side promises of proposal #10:
+ *   - Lane parameter envelope (scalp tighter than swing tighter than trend)
+ *   - currentPositionSize lane-budget shrinkage
+ *   - shouldScalpExit lane envelope widening (max(geometric, lane))
+ *   - shouldDCAAdd lane scope on the side-mismatch rejection
+ *   - Cross-lane non-interference (the core invariant)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  LANE_PARAMETER_DEFAULTS,
+  currentPositionSize,
+  laneBudgetFraction,
+  laneParam,
+  shouldDCAAdd,
+  shouldScalpExit,
+} from '../executive.js';
+import { BASIN_DIM } from '../basin.js';
+import { MonkeyMode } from '../modes.js';
+
+const NEUTRAL_NC = {
+  acetylcholine: 0.5, dopamine: 0.5, serotonin: 0.5,
+  norepinephrine: 0.5, gaba: 0.5, endorphins: 0.0,
+};
+
+function basinState(phi = 0.5, sovereignty = 0.5) {
+  const b = new Float64Array(BASIN_DIM).fill(1 / BASIN_DIM);
+  return {
+    basin: b as unknown as Float64Array,
+    identityBasin: b as unknown as Float64Array,
+    phi,
+    kappa: 64,
+    basinVelocity: 0.05,
+    regimeWeights: { quantum: 0.33, efficient: 0.33, equilibrium: 0.34 },
+    sovereignty,
+    neurochemistry: NEUTRAL_NC,
+  } as any;
+}
+
+describe('Lane parameter envelope (proposal #10)', () => {
+  it('scalp envelope tighter than swing', () => {
+    expect(laneParam('scalp', 'slPct')).toBeLessThan(laneParam('swing', 'slPct'));
+    expect(laneParam('scalp', 'tpPct')).toBeLessThan(laneParam('swing', 'tpPct'));
+  });
+
+  it('swing envelope tighter than trend', () => {
+    expect(laneParam('swing', 'slPct')).toBeLessThan(laneParam('trend', 'slPct'));
+    expect(laneParam('swing', 'tpPct')).toBeLessThan(laneParam('trend', 'tpPct'));
+  });
+
+  it('scalp SL is roughly 0.4%', () => {
+    const sl = laneParam('scalp', 'slPct');
+    expect(sl).toBeGreaterThanOrEqual(0.002);
+    expect(sl).toBeLessThanOrEqual(0.008);
+  });
+
+  it('swing SL is roughly 1.5%', () => {
+    const sl = laneParam('swing', 'slPct');
+    expect(sl).toBeGreaterThanOrEqual(0.010);
+    expect(sl).toBeLessThanOrEqual(0.025);
+  });
+
+  it('trend SL is 3-5%', () => {
+    const sl = laneParam('trend', 'slPct');
+    expect(sl).toBeGreaterThanOrEqual(0.025);
+    expect(sl).toBeLessThanOrEqual(0.06);
+  });
+
+  it('scalp + swing budgets sum to 1', () => {
+    expect(
+      laneBudgetFraction('scalp') + laneBudgetFraction('swing'),
+    ).toBeCloseTo(1.0, 9);
+  });
+
+  it('trend budget defaults to 0 (opt-in)', () => {
+    expect(laneBudgetFraction('trend')).toBe(0);
+  });
+
+  it('observe budget is 0', () => {
+    expect(laneBudgetFraction('observe')).toBe(0);
+  });
+
+  it('LANE_PARAMETER_DEFAULTS exposes the three position-bearing lanes', () => {
+    expect(Object.keys(LANE_PARAMETER_DEFAULTS).sort()).toEqual(['scalp', 'swing', 'trend']);
+  });
+});
+
+
+describe('currentPositionSize lane-budget shrinkage', () => {
+  it('threads lane and lane budget into derivation', () => {
+    const result = currentPositionSize(
+      basinState(0.5), 200, 1, 5, 10, MonkeyMode.INVESTIGATION, 'swing',
+    );
+    expect(result.derivation.laneBudgetFrac).toBeCloseTo(0.5, 9);
+  });
+
+  it('scalp + swing both at default 0.5 produce comparable margins', () => {
+    const scalp = currentPositionSize(
+      basinState(0.6), 100, 1, 10, 20, MonkeyMode.INVESTIGATION, 'scalp',
+    );
+    const swing = currentPositionSize(
+      basinState(0.6), 100, 1, 10, 20, MonkeyMode.INVESTIGATION, 'swing',
+    );
+    expect(scalp.value).toBeCloseTo(swing.value, 6);
+  });
+
+  it('trend budget=0 sizes to zero (opt-in lane)', () => {
+    const result = currentPositionSize(
+      basinState(0.5), 200, 1, 5, 10, MonkeyMode.INVESTIGATION, 'trend',
+    );
+    expect(result.value).toBe(0);
+  });
+
+  it('scalp lane size never exceeds 50% of lane-budgeted equity', () => {
+    const equity = 1000;
+    const result = currentPositionSize(
+      basinState(0.7, 0.7), equity, 1, 10, 50, MonkeyMode.INVESTIGATION, 'scalp',
+    );
+    const cap = 0.5 * laneBudgetFraction('scalp') * equity;
+    expect(result.value).toBeLessThanOrEqual(cap + 1e-6);
+  });
+});
+
+
+describe('shouldScalpExit lane envelope (proposal #10)', () => {
+  it('scalp lane = current geometric behavior (max keeps geometric)', () => {
+    const bs = basinState(0.5);
+    // 1% loss exceeds geometric SL for INVESTIGATION mode.
+    const result = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'scalp');
+    expect(result.value).toBe(true);
+    expect(String(result.reason)).toContain('stop_loss[scalp]');
+  });
+
+  it('swing lane absorbs a loss the scalp lane would exit on', () => {
+    const bs = basinState(0.5);
+    // 1% loss: scalp exits, swing holds (lane envelope 1.5% > geometric).
+    const scalp = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'scalp');
+    const swing = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'swing');
+    expect(scalp.value).toBe(true);
+    expect(swing.value).toBe(false);
+    expect(String(swing.reason)).toContain('scalp hold[swing]');
+  });
+
+  it('trend lane absorbs a loss the swing lane would exit on', () => {
+    const bs = basinState(0.5);
+    // 2.5% loss exceeds swing SL but fits inside trend envelope.
+    const swing = shouldScalpExit(-2.5, 100, bs, MonkeyMode.INVESTIGATION, 'swing');
+    const trend = shouldScalpExit(-2.5, 100, bs, MonkeyMode.INVESTIGATION, 'trend');
+    expect(swing.value).toBe(true);
+    expect(trend.value).toBe(false);
+  });
+
+  it('lane name surfaces into derivation', () => {
+    const bs = basinState(0.5);
+    const result = shouldScalpExit(0.05, 100, bs, MonkeyMode.INVESTIGATION, 'scalp');
+    expect(result.derivation.laneTpPct).toBe(laneParam('scalp', 'tpPct'));
+    expect(result.derivation.laneSlPct).toBe(laneParam('scalp', 'slPct'));
+  });
+
+  it('default lane is swing (back-compat with pre-#10 callers)', () => {
+    const bs = basinState(0.5);
+    const result = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION);
+    // Same as explicit swing — 1% loss holds in swing's wider envelope.
+    expect(result.value).toBe(false);
+  });
+});
+
+
+describe('shouldDCAAdd lane scope (proposal #10)', () => {
+  it('same-lane mismatch rejects with rule 1 + lane in reason', () => {
+    const result = shouldDCAAdd({
+      heldSide: 'long', sideCandidate: 'short',
+      currentPrice: 100, initialEntryPrice: 100,
+      addCount: 0, lastAddAtMs: 0, nowMs: 10_000_000,
+      sovereignty: 0.5, lane: 'swing',
+    });
+    expect(result.value).toBe(false);
+    expect(result.derivation.rule).toBe(1);
+    expect(String(result.reason)).toContain('lane swing');
+  });
+
+  it('same-side same-lane DCA allowed with lane in reason', () => {
+    // Held long at 100, current 98 (-2%, satisfies BETTER_PRICE_FRAC=0.01),
+    // cooldown elapsed, sovereignty above floor.
+    const result = shouldDCAAdd({
+      heldSide: 'long', sideCandidate: 'long',
+      currentPrice: 98, initialEntryPrice: 100,
+      addCount: 0, lastAddAtMs: 0, nowMs: 1e12,
+      sovereignty: 0.5, lane: 'scalp',
+    });
+    expect(result.value).toBe(true);
+    expect(String(result.reason)).toContain('DCA_OK[scalp]');
+  });
+
+  it('lane defaults to swing when omitted', () => {
+    const result = shouldDCAAdd({
+      heldSide: 'long', sideCandidate: 'short',
+      currentPrice: 100, initialEntryPrice: 100,
+      addCount: 0, lastAddAtMs: 0, nowMs: 10_000_000,
+      sovereignty: 0.5,
+    });
+    expect(String(result.reason)).toContain('lane swing');
+  });
+});
+
+
+describe('Cross-lane non-interference (proposal #10 invariant)', () => {
+  it('swing-long envelope does not exit on a loss scalp would close on', () => {
+    const bs = basinState(0.5);
+    // 1% loss — between geometric SL (~0.67%) and swing's 1.5%
+    const swingLong = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'swing');
+    const scalpShort = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'scalp');
+    expect(swingLong.value).toBe(false);
+    expect(scalpShort.value).toBe(true);
+  });
+
+  it('lane budgets partition capital (sum <= 1.0)', () => {
+    const total =
+      laneBudgetFraction('scalp')
+      + laneBudgetFraction('swing')
+      + laneBudgetFraction('trend');
+    expect(total).toBeLessThanOrEqual(1.0 + 1e-9);
+  });
+
+  it('scalp size never eats swing capital — lane budget caps separately', () => {
+    const equity = 1000;
+    const scalp = currentPositionSize(
+      basinState(0.7, 0.7), equity, 1, 10, 50, MonkeyMode.INVESTIGATION, 'scalp',
+    );
+    const cap = 0.5 * laneBudgetFraction('scalp') * equity;
+    expect(scalp.value).toBeLessThanOrEqual(cap + 1e-6);
+  });
+
+  it('lane parameter constants match the user-spec ranges', () => {
+    // Sanity: this catches accidental edits to LANE_PARAMETER_DEFAULTS
+    // that would drift away from the proposal #10 spec.
+    expect(LANE_PARAMETER_DEFAULTS.scalp.slPct).toBeGreaterThanOrEqual(0.002);
+    expect(LANE_PARAMETER_DEFAULTS.scalp.slPct).toBeLessThanOrEqual(0.008);
+    expect(LANE_PARAMETER_DEFAULTS.swing.slPct).toBeGreaterThanOrEqual(0.010);
+    expect(LANE_PARAMETER_DEFAULTS.swing.slPct).toBeLessThanOrEqual(0.025);
+    expect(LANE_PARAMETER_DEFAULTS.trend.slPct).toBeGreaterThanOrEqual(0.025);
+    expect(LANE_PARAMETER_DEFAULTS.trend.slPct).toBeLessThanOrEqual(0.06);
+  });
+});

--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -121,6 +121,44 @@ export function currentEntryThreshold(
  * in and respected — Monkey cannot place what the exchange won't
  * accept.
  */
+// ─── Proposal #10 — lane parameter envelope (TS parity) ────────────
+//
+// Two-lane initial split with trend as opt-in. SL/TP percentages give
+// each lane its own retreat tolerance:
+//   scalp ~0.4% adverse / 0.5% reward — fast tape harvesting
+//   swing ~1.5% adverse / 1.5% reward — absorbs retraces
+//   trend ~4% adverse / 4% reward — rides macro trend (opt-in)
+// Budget fractions sum to <= 1 across position-bearing lanes; trend
+// defaults to 0 in this batch and is governance-bumped via the param
+// registry once the arbiter has 5+ closed trades per lane.
+export const LANE_PARAMETER_DEFAULTS: Record<
+  'scalp' | 'swing' | 'trend',
+  { slPct: number; tpPct: number; budgetFrac: number }
+> = {
+  scalp: { slPct: 0.004, tpPct: 0.005, budgetFrac: 0.50 },
+  swing: { slPct: 0.015, tpPct: 0.015, budgetFrac: 0.50 },
+  trend: { slPct: 0.040, tpPct: 0.040, budgetFrac: 0.0 },
+};
+
+export function laneParam(
+  lane: 'scalp' | 'swing' | 'trend',
+  key: 'slPct' | 'tpPct' | 'budgetFrac',
+): number {
+  // Mirror to ml-worker/src/monkey_kernel/executive.py::lane_param.
+  // TS has no parameter registry yet — defaults stand until the registry
+  // ports across (one of the items behind the persistence-completion
+  // tracking issue). The Python kernel reads from monkey_parameters; TS
+  // reads from these in-code defaults. Both are kept in lockstep.
+  return LANE_PARAMETER_DEFAULTS[lane][key];
+}
+
+export function laneBudgetFraction(
+  lane: 'scalp' | 'swing' | 'trend' | 'observe',
+): number {
+  if (lane === 'observe') return 0;
+  return laneParam(lane, 'budgetFrac');
+}
+
 export function currentPositionSize(
   s: BasinState,
   availableEquityUsdt: number,
@@ -128,7 +166,15 @@ export function currentPositionSize(
   leverage: number = 1,
   bankSize: number = 0,
   mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+  lane: 'scalp' | 'swing' | 'trend' = 'swing',
 ): ExecutiveDecision<number> {
+  // Proposal #10 — per-lane capital budget. Each lane sees only its
+  // share of available equity for sizing, so a held swing-long no
+  // longer paralyzes a scalp-short on the same symbol. A zero-budget
+  // lane (default for "trend" until governance bumps it) is sized to
+  // zero — capital is not allocated to it this tick.
+  const laneFrac = laneBudgetFraction(lane);
+  availableEquityUsdt = availableEquityUsdt * laneFrac;
   const nc = s.neurochemistry;
   // Lived-experience scaling. 0 at birth, 1 after ~20 witnessed trades.
   const maturity = Math.min(1, bankSize / 20);
@@ -172,12 +218,13 @@ export function currentPositionSize(
 
   return {
     value: sized,
-    reason: `size = ${liftedToMin ? 'lifted-to-min ' : ''}floor(${explorationFloor.toFixed(3)}) or Φ×S×M(${(s.phi * s.sovereignty * maturity).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)}) × equity(${availableEquityUsdt.toFixed(2)}) @ ${leverage}x → margin ${margin.toFixed(2)}, notional ${notional.toFixed(2)} vs min ${minNotionalUsdt.toFixed(2)} = ${sized.toFixed(2)}`,
+    reason: `size[${lane}] = ${liftedToMin ? 'lifted-to-min ' : ''}floor(${explorationFloor.toFixed(3)}) or Φ×S×M(${(s.phi * s.sovereignty * maturity).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)}) × equity(${availableEquityUsdt.toFixed(2)}) @ ${leverage}x → margin ${margin.toFixed(2)}, notional ${notional.toFixed(2)} vs min ${minNotionalUsdt.toFixed(2)} = ${sized.toFixed(2)}`,
     derivation: {
       phi: s.phi, sovereignty: s.sovereignty, maturity, bankSize,
       dopamine: nc.dopamine, serotonin: nc.serotonin, gaba: nc.gaba,
       explorationFloor, rawFrac, frac, margin, leverage, notional,
       minNotional: minNotionalUsdt, sized, liftedToMin: liftedToMin ? 1 : 0,
+      laneBudgetFrac: laneFrac,
     },
   };
 }
@@ -344,14 +391,23 @@ export function shouldDCAAdd(req: {
   lastAddAtMs: number;
   nowMs: number;
   sovereignty: number;
+  /** Proposal #10: lane scope. The "side mismatch" rejection is now
+   *  internal to one lane — another lane on the same symbol can hold
+   *  the opposite side without blocking this lane's DCA decision. */
+  lane?: 'scalp' | 'swing' | 'trend';
 }): ExecutiveDecision<boolean> {
   const {
     heldSide, sideCandidate, currentPrice, initialEntryPrice,
     addCount, lastAddAtMs, nowMs, sovereignty,
   } = req;
+  const lane = req.lane ?? 'swing';
 
   if (heldSide !== sideCandidate) {
-    return { value: false, reason: `side mismatch (${sideCandidate} vs held ${heldSide})`, derivation: { rule: 1 } };
+    return {
+      value: false,
+      reason: `side mismatch in lane ${lane} (${sideCandidate} vs held ${heldSide})`,
+      derivation: { rule: 1, lane: lane === 'scalp' ? 0 : lane === 'swing' ? 1 : 2 },
+    };
   }
   if (addCount >= DCA_MAX_ADDS_PER_POSITION) {
     return { value: false, reason: `add cap reached (${addCount}/${DCA_MAX_ADDS_PER_POSITION})`, derivation: { rule: 4, addCount } };
@@ -376,7 +432,7 @@ export function shouldDCAAdd(req: {
   }
   return {
     value: true,
-    reason: `DCA_OK: ${(priceDelta * 100).toFixed(2)}% from entry, addCount=${addCount}, sov=${sovereignty.toFixed(2)}`,
+    reason: `DCA_OK[${lane}]: ${(priceDelta * 100).toFixed(2)}% from entry, addCount=${addCount}, sov=${sovereignty.toFixed(2)}`,
     derivation: { rule: 0, priceDelta, addCount, sovereignty },
   };
 }
@@ -512,6 +568,7 @@ export function shouldScalpExit(
   notionalUsdt: number,
   s: BasinState,
   mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+  lane: 'scalp' | 'swing' | 'trend' = 'swing',
 ): ExecutiveDecision<boolean> {
   if (notionalUsdt <= 0) {
     return { value: false, reason: 'no position notional', derivation: {} };
@@ -520,31 +577,50 @@ export function shouldScalpExit(
   const nc = s.neurochemistry;
   // Mode picks the baseline; Φ + dopamine modulate within that mode.
   const profile = MODE_PROFILES[mode];
-  const tpThr = Math.max(
+  const geometricTp = Math.max(
     0.003,
     profile.tpBaseFrac - 0.003 * nc.dopamine + 0.005 * s.phi,
   );
-  const slThr = tpThr * profile.slRatio;
+  const geometricSl = geometricTp * profile.slRatio;
+  // Proposal #10 — per-lane envelope. Take the wider of (geometric,
+  // lane) so the geometric fee-clear floor is never breached but the
+  // lane envelope can broaden tolerance when a swing/trend position
+  // needs room to absorb retraces.
+  const laneTp = laneParam(lane, 'tpPct');
+  const laneSl = laneParam(lane, 'slPct');
+  const tpThr = Math.max(geometricTp, laneTp);
+  const slThr = Math.max(geometricSl, laneSl);
 
   // Encode type as a bit (1=TP, -1=SL, 0=hold) to keep derivation map numeric.
   if (pnlFrac >= tpThr) {
     return {
       value: true,
-      reason: `take_profit: ${(pnlFrac * 100).toFixed(3)}% ≥ ${(tpThr * 100).toFixed(3)}%`,
-      derivation: { pnlFrac, tpThr, slThr, exitTypeBit: 1 },
+      reason: `take_profit[${lane}]: ${(pnlFrac * 100).toFixed(3)}% ≥ ${(tpThr * 100).toFixed(3)}%`,
+      derivation: {
+        pnlFrac, tpThr, slThr,
+        laneTpPct: laneTp, laneSlPct: laneSl,
+        exitTypeBit: 1,
+      },
     };
   }
   if (pnlFrac <= -slThr) {
     return {
       value: true,
-      reason: `stop_loss: ${(pnlFrac * 100).toFixed(3)}% ≤ -${(slThr * 100).toFixed(3)}%`,
-      derivation: { pnlFrac, tpThr, slThr, exitTypeBit: -1 },
+      reason: `stop_loss[${lane}]: ${(pnlFrac * 100).toFixed(3)}% ≤ -${(slThr * 100).toFixed(3)}%`,
+      derivation: {
+        pnlFrac, tpThr, slThr,
+        laneTpPct: laneTp, laneSlPct: laneSl,
+        exitTypeBit: -1,
+      },
     };
   }
   return {
     value: false,
-    reason: `scalp hold: pnl ${(pnlFrac * 100).toFixed(3)}% in [-${(slThr * 100).toFixed(3)}%, ${(tpThr * 100).toFixed(3)}%]`,
-    derivation: { pnlFrac, tpThr, slThr },
+    reason: `scalp hold[${lane}]: pnl ${(pnlFrac * 100).toFixed(3)}% in [-${(slThr * 100).toFixed(3)}%, ${(tpThr * 100).toFixed(3)}%]`,
+    derivation: {
+      pnlFrac, tpThr, slThr,
+      laneTpPct: laneTp, laneSlPct: laneSl,
+    },
   };
 }
 

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -95,8 +95,10 @@ import {
   shouldExit,
   shouldProfitHarvest,
   shouldScalpExit,
+  chooseLane,
   type BasinState,
   type Direction,
+  type LaneType,
 } from './executive.js';
 
 /** Default Monkey watchlist — matches liveSignalEngine for side-by-side. */
@@ -209,6 +211,15 @@ interface SymbolState {
    *  consumes this — trend-flip harvest fires only when streak >= 3
    *  so a single noise tick can't trigger an exit. */
   tapeFlipStreak: number;
+  /** Proposal #10 — per-lane bookkeeping. Each lane independently
+   *  tracks its peak unrealized PnL, the trade id it's peak-tracking,
+   *  and its tape-flip streak so a swing-long's history never bleeds
+   *  into a scalp-short on the same symbol. Lanes that never held
+   *  state stay absent from these maps; reads default to the legacy
+   *  scalar values for back-compat. */
+  peakPnlUsdtByLane: Record<string, number | null>;
+  peakTrackedTradeIdByLane: Record<string, string | null>;
+  tapeFlipStreakByLane: Record<string, number>;
   /** v0.8.7e: latest computed basinDir + tapeTrend from processSymbol, with
    *  timestamp. Exposed via getLatestBasinSnapshot() for LiveSignal's
    *  inter-engine agreement gate. Null until the first tick completes. */
@@ -262,6 +273,16 @@ export class MonkeyKernel extends EventEmitter {
    */
   private mlOutageStreak = 0;
   /**
+   * Proposal #10 — cached account-level position direction mode.
+   * Read once at kernel start via assertHedgeModeIfPossible. When
+   * 'HEDGE' the executor passes ``posSide: LONG | SHORT`` on entries
+   * so a swing-long and a scalp-short can coexist. When 'ONE_WAY' the
+   * executor omits posSide (Poloniex defaults to BOTH); lane discipline
+   * still works at the DB layer but two opposite-side lanes will net
+   * exchange-side. Defaults to 'ONE_WAY' (the historic configuration).
+   */
+  private positionDirectionMode: 'HEDGE' | 'ONE_WAY' = 'ONE_WAY';
+  /**
    * Arbiter — capital allocator between Agent K (kernel) and Agent M (ml).
    * Single instance per kernel. Settled trades flow back via
    * recordSettled from closeHeldPosition.
@@ -298,6 +319,14 @@ export class MonkeyKernel extends EventEmitter {
     for (const sym of this.symbols) {
       this.symbolStates.set(sym, this.newSymbolState());
     }
+    // Proposal #10 — detect (don't auto-flip) account position direction
+    // mode. Lane-isolated positions in HEDGE mode let a swing-long and a
+    // scalp-short coexist on the exchange; ONE_WAY mode nets opposite
+    // sides. We log the current mode here and ship the executor with
+    // posSide-aware order placement; the actual HEDGE flip is deferred
+    // to a manual op once current K positions close (see TODO in
+    // assertHedgeModeIfPossible).
+    await this.detectPositionDirectionMode();
     logger.info(`[${this.label}] kernel waking`, {
       instanceId: this.instanceId,
       timeframe: this.timeframe,
@@ -364,6 +393,9 @@ export class MonkeyKernel extends EventEmitter {
       dcaAddCount: 0,
       slDeferRemainingTicks: 0,
       tapeFlipStreak: 0,
+      peakPnlUsdtByLane: {},
+      peakTrackedTradeIdByLane: {},
+      tapeFlipStreakByLane: {},
       latestBasinSnapshot: null,
     };
   }
@@ -746,7 +778,19 @@ export class MonkeyKernel extends EventEmitter {
       ? 1.0
       : this.sizeFraction;
     const cappedEquity = availableEquity * effectiveSizeFraction;
-    const size = currentPositionSize(basinState, cappedEquity, minNotional, leverage.value, bankSize, mode);
+    // Proposal #10 — lane selection. Each tick picks the locally-optimal
+    // execution lane via softmax over basin features (parity with the
+    // Python kernel's choose_lane). The chosen lane gates size (per-lane
+    // budget fraction) AND, when a position is open, scopes the exit
+    // gate's TP/SL envelope.
+    const laneDecision = chooseLane(basinState, tapeTrend);
+    const chosenLane: LaneType = laneDecision.value;
+    const positionLane: 'scalp' | 'swing' | 'trend' =
+      chosenLane === 'observe' ? 'swing' : chosenLane;
+    const size = currentPositionSize(
+      basinState, cappedEquity, minNotional, leverage.value, bankSize, mode,
+      positionLane,
+    );
     const autoFlatten = shouldAutoFlatten(basinState, state.fHealthHistory);
 
     // 6. DECIDE — propose action
@@ -815,45 +859,58 @@ export class MonkeyKernel extends EventEmitter {
       //   3. Loop 2 regime-shift (shouldExit)
       let exitFired = false;
       const openRow = ownOpenRow;  // reuse the lookup from above
+      // Proposal #10 — the position lane comes from the open row's
+      // ``lane`` column (migration 042; existing rows defaulted to
+      // 'swing'). All exit gating below evaluates against this lane's
+      // envelope.
+      const heldLane: 'scalp' | 'swing' | 'trend' = openRow?.lane ?? 'swing';
+      derivation.heldLane = heldLane;
       if (openRow) {
         const positionNotional = Number(openRow.entry_price) * Number(openRow.quantity);
         const sidesign = heldSide === 'long' ? 1 : -1;
         const unrealizedPnl = (lastPrice - Number(openRow.entry_price)) * Number(openRow.quantity) * sidesign;
         const tradeId = String(openRow.id);
 
-        // Reset peak tracking when we detect a NEW trade vs what we
-        // were peak-tracking. (Covers reconciler-replaced rows.)
-        if (state.peakTrackedTradeId !== tradeId) {
-          state.peakPnlUsdt = unrealizedPnl;
-          state.peakTrackedTradeId = tradeId;
-          // Proposal #4 — reset streak on a fresh trade.
-          state.tapeFlipStreak = 0;
+        // Reset per-lane peak tracking when we detect a NEW trade vs
+        // what we were peak-tracking IN THIS LANE. (Covers reconciler-
+        // replaced rows.) Each lane's peak is independent.
+        const prevTracked = state.peakTrackedTradeIdByLane[heldLane] ?? null;
+        if (prevTracked !== tradeId) {
+          state.peakPnlUsdtByLane[heldLane] = unrealizedPnl;
+          state.peakTrackedTradeIdByLane[heldLane] = tradeId;
+          state.tapeFlipStreakByLane[heldLane] = 0;
         } else {
-          state.peakPnlUsdt = Math.max(state.peakPnlUsdt ?? 0, unrealizedPnl);
+          const prevPeak = state.peakPnlUsdtByLane[heldLane] ?? 0;
+          state.peakPnlUsdtByLane[heldLane] = Math.max(prevPeak, unrealizedPnl);
         }
+        // Mirror to legacy scalars so non-lane-aware readers keep working.
+        state.peakPnlUsdt = state.peakPnlUsdtByLane[heldLane];
+        state.peakTrackedTradeId = tradeId;
 
-        // Proposal #4 — maintain the sustained tape-flip streak. Use
-        // a fixed -0.25 threshold (matching the trend-flip threshold
-        // inside shouldProfitHarvest) for the streak gate.
+        // Proposal #4 — sustained tape-flip streak counter, per-lane.
         const alignmentNowForStreak = heldSide === 'long' ? tapeTrend : -tapeTrend;
+        const curStreak = state.tapeFlipStreakByLane[heldLane] ?? 0;
         if (alignmentNowForStreak <= -0.25) {
-          state.tapeFlipStreak += 1;
+          state.tapeFlipStreakByLane[heldLane] = curStreak + 1;
         } else {
-          state.tapeFlipStreak = 0;
+          state.tapeFlipStreakByLane[heldLane] = 0;
         }
+        state.tapeFlipStreak = state.tapeFlipStreakByLane[heldLane];
 
         // 1. Profit harvest — trailing stop + trend-flip, only while green.
         // Streak counter passed; harvest internally enforces #2 + #4.
+        const lanePeak = state.peakPnlUsdtByLane[heldLane] ?? 0;
+        const laneStreak = state.tapeFlipStreakByLane[heldLane] ?? 0;
         const harvest = shouldProfitHarvest(
           unrealizedPnl,
-          state.peakPnlUsdt ?? 0,
+          lanePeak,
           positionNotional,
           tapeTrend,
           heldSide,
           basinState,
-          state.tapeFlipStreak,
+          laneStreak,
         );
-        derivation.harvest = { ...harvest.derivation, unrealizedPnl, peakPnl: state.peakPnlUsdt, tradeId };
+        derivation.harvest = { ...harvest.derivation, unrealizedPnl, peakPnl: lanePeak, tradeId, lane: heldLane };
         if (harvest.value) {
           action = 'scalp_exit';  // executes via same close path
           reason = harvest.reason;
@@ -864,12 +921,13 @@ export class MonkeyKernel extends EventEmitter {
             unrealizedPnl,
             markPrice: lastPrice,
             tradeId,
+            lane: heldLane,
           };
         }
 
         // 2. Scalp TP/SL (only if harvest didn't fire)
         if (!exitFired) {
-          const scalp = shouldScalpExit(unrealizedPnl, positionNotional, basinState, mode);
+          const scalp = shouldScalpExit(unrealizedPnl, positionNotional, basinState, mode, heldLane);
           derivation.scalp = { ...scalp.derivation, unrealizedPnl, markPrice: lastPrice, tradeId };
           // Proposal #9 path 2: SL defer. If the latest tick prints a
           // strong hammer/inverted-hammer AGAINST a long-position SL
@@ -1113,6 +1171,13 @@ export class MonkeyKernel extends EventEmitter {
           isDCAAdd: isDCA,
           dcaAddIndex: isDCA ? state.dcaAddCount + 1 : 0,
           agent: 'K',
+          // Proposal #10 — when adding to an existing held position,
+          // route the entry into THAT lane so DCA stacks under one
+          // (agent, symbol, lane) row group. Otherwise use the lane
+          // chosen by chooseLane this tick.
+          lane: isDCA && heldSide
+            ? (ownOpenRow?.lane ?? positionLane)
+            : positionLane,
         }) : { executed: false, orderId: null, reason: 'k_arbiter_zero' };
         executed = execResult.executed;
         monkeyOrderId = execResult.orderId;
@@ -1140,6 +1205,11 @@ export class MonkeyKernel extends EventEmitter {
           exitTypeBit === 3 ? 'trend_flip_harvest' :
           'scalp_exit';
         const pnlAtDecision = Number(scalpDeriv?.unrealizedPnl ?? 0);
+        const scalpLane = (
+          scalpDeriv?.lane === 'scalp' || scalpDeriv?.lane === 'trend'
+            ? scalpDeriv.lane
+            : 'swing'
+        ) as 'scalp' | 'swing' | 'trend';
         if (tradeId) {
           const closeResult = await this.closeHeldPosition({
             symbol,
@@ -1148,11 +1218,17 @@ export class MonkeyKernel extends EventEmitter {
             markPrice: lastPrice,
             exitReason: exitType,
             pnlAtDecision,
+            lane: scalpLane,
           });
           executed = closeResult.executed;
           monkeyOrderId = closeResult.orderId;
           if (executed) {
-            // Clear trade-level state now the position is closed.
+            // Clear lane-scoped trade-level state now the lane closed.
+            // Other lanes' bookkeeping is preserved (proposal #10).
+            state.peakPnlUsdtByLane[scalpLane] = null;
+            state.peakTrackedTradeIdByLane[scalpLane] = null;
+            state.tapeFlipStreakByLane[scalpLane] = 0;
+            // Mirror legacy scalars for any non-lane-aware reader.
             state.peakPnlUsdt = null;
             state.peakTrackedTradeId = null;
             state.dcaAddCount = 0;
@@ -1189,6 +1265,7 @@ export class MonkeyKernel extends EventEmitter {
             markPrice: lastPrice,
             exitReason: 'override_reverse',
             pnlAtDecision,
+            lane: ownOpenRow?.lane ?? 'swing',
           });
           if (closeResult.executed) {
             state.peakPnlUsdt = null;
@@ -1210,6 +1287,9 @@ export class MonkeyKernel extends EventEmitter {
               trajectoryId: null,
               isDCAAdd: false,
               dcaAddIndex: 0,
+              // Reversal lands in the same lane the previous position
+              // occupied — REVERSION mode flips side, not lane.
+              lane: ownOpenRow?.lane ?? 'swing',
             });
             executed = execResult.executed;
             monkeyOrderId = execResult.orderId;
@@ -1444,6 +1524,72 @@ export class MonkeyKernel extends EventEmitter {
   }
 
   /**
+   * Proposal #10 — detect (don't flip) the live account's position
+   * direction mode. Caches the answer on the kernel so the executor's
+   * placeOrder path knows whether to send ``posSide: LONG | SHORT``
+   * (HEDGE) or omit it (ONE_WAY → BOTH). Fail-soft: any read failure
+   * leaves the cache at the historic 'ONE_WAY' default so the system
+   * keeps trading the way it used to.
+   *
+   * The actual HEDGE switch is deferred — current K positions are open
+   * and Poloniex rejects mode changes with live positions. Operator
+   * runbook: once all K rows close, an admin calls
+   *   poloniexFuturesService.setPositionDirectionMode(creds, 'HEDGE')
+   * via the futures route or a one-shot script. Restart the kernel and
+   * this method picks up the new mode.
+   *
+   * TODO: enable HEDGE mode in production after current K positions
+   *       close — call setPositionDirectionMode('HEDGE') at next AWAKE
+   *       startup.
+   */
+  private async detectPositionDirectionMode(): Promise<void> {
+    try {
+      const userRow = await pool.query(
+        `SELECT user_id FROM user_api_credentials WHERE exchange = 'poloniex' LIMIT 1`,
+      );
+      const userId = String((userRow.rows[0] as { user_id?: string } | undefined)?.user_id ?? '');
+      if (!userId) {
+        logger.info('[Monkey] position-mode detect: no creds, defaulting to ONE_WAY');
+        return;
+      }
+      const creds = await apiCredentialsService.getCredentials(userId, 'poloniex');
+      if (!creds) {
+        logger.info('[Monkey] position-mode detect: creds missing, defaulting to ONE_WAY');
+        return;
+      }
+      const resp = await poloniexFuturesService.getPositionDirectionMode(creds);
+      const detected = String(
+        (resp as Record<string, unknown>)?.posMode
+        ?? (resp as Record<string, unknown>)?.data
+        ?? '',
+      ).toUpperCase();
+      if (detected === 'HEDGE' || detected === 'ONE_WAY') {
+        this.positionDirectionMode = detected;
+        logger.info('[Monkey] position-mode detected', { mode: detected });
+      } else {
+        // Some response shapes nest under .data — try once more.
+        const data = (resp as Record<string, unknown>)?.data;
+        const nested = String(
+          (data && typeof data === 'object' ? (data as Record<string, unknown>).posMode : '')
+          ?? '',
+        ).toUpperCase();
+        if (nested === 'HEDGE' || nested === 'ONE_WAY') {
+          this.positionDirectionMode = nested;
+          logger.info('[Monkey] position-mode detected (nested)', { mode: nested });
+        } else {
+          logger.info('[Monkey] position-mode detect: unrecognized response, default ONE_WAY', {
+            raw: detected,
+          });
+        }
+      }
+    } catch (err) {
+      logger.debug('[Monkey] position-mode detect failed (fail-soft to ONE_WAY)', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
    * Look up Monkey's most recent open trade row for a symbol. Used by
    * the scalp-exit gate (v0.4) to compute unrealized P&L.
    */
@@ -1496,31 +1642,38 @@ export class MonkeyKernel extends EventEmitter {
   }
 
   private async findOpenMonkeyTrade(symbol: string): Promise<
-    | { id: string; entry_price: string; quantity: string; leverage: number; order_id: string | null; side: 'long' | 'short' }
+    | { id: string; entry_price: string; quantity: string; leverage: number; order_id: string | null; side: 'long' | 'short'; lane: 'scalp' | 'swing' | 'trend' }
     | null
   > {
+    // Aggregate over ALL open lanes (back-compat: callers that don't
+    // know about lanes still need a single open-row view). Returns the
+    // OLDEST lane's pseudo-row when multiple lanes hold positions; the
+    // proper lane-aware path uses ``findOpenMonkeyTradesByLane`` below.
     try {
       const reasonPattern = `monkey|kernel=${this.instanceId}|%`;
       const result = await pool.query(
-        `SELECT id, entry_price, quantity, leverage, order_id, side
+        `SELECT id, entry_price, quantity, leverage, order_id, side, lane
            FROM autonomous_trades
           WHERE reason LIKE $2 AND status = 'open' AND symbol = $1
           ORDER BY entry_time ASC`,
         [symbol, reasonPattern],
       );
       const rows = result.rows as Array<{
-        id: string; entry_price: string; quantity: string; leverage: number; order_id: string | null; side: string;
+        id: string; entry_price: string; quantity: string; leverage: number;
+        order_id: string | null; side: string; lane: string;
       }>;
       const normSide = (s: string): 'long' | 'short' =>
         s === 'buy' || s === 'long' ? 'long' : 'short';
+      const normLane = (l: string | null | undefined): 'scalp' | 'swing' | 'trend' =>
+        (l === 'scalp' || l === 'trend') ? l : 'swing';
       if (rows.length === 0) return null;
-      if (rows.length === 1) return { ...rows[0], side: normSide(rows[0].side) };
-      // v0.6.2: multi-row position (DCA). Return an AGGREGATE pseudo-row:
-      //   quantity = sum; entry_price = weighted average by quantity.
-      //   id/order_id carry the oldest row so harvest/scalp reference a
-      //   stable anchor across ticks. leverage = first row's leverage
-      //   (they should match; risk kernel enforces). side = oldest row's
-      //   side (DCA rows should share side; entry kernel enforces).
+      if (rows.length === 1) {
+        return { ...rows[0], side: normSide(rows[0].side), lane: normLane(rows[0].lane) };
+      }
+      // Multi-row: aggregate by quantity-weighted entry price across
+      // ALL rows for legacy callers. The lane-aware path operates per
+      // (lane) inside findOpenMonkeyTradesByLane and is the source of
+      // truth post-#10.
       const totalQty = rows.reduce((s, r) => s + Math.abs(Number(r.quantity) || 0), 0);
       const weightedPrice = rows.reduce(
         (s, r) => s + Number(r.entry_price) * Math.abs(Number(r.quantity) || 0),
@@ -1533,12 +1686,97 @@ export class MonkeyKernel extends EventEmitter {
         leverage: rows[0].leverage,
         order_id: rows[0].order_id,
         side: normSide(rows[0].side),
+        lane: normLane(rows[0].lane),
       };
     } catch (err) {
       logger.debug('[Monkey] findOpenMonkeyTrade failed', {
         err: err instanceof Error ? err.message : String(err),
       });
       return null;
+    }
+  }
+
+  /**
+   * Proposal #10 — per-lane open-position lookup. Returns one entry per
+   * lane that currently has an open Monkey row on this symbol; rows
+   * within a lane are aggregated (DCA adds collapse into a single
+   * pseudo-row per lane the same way the symbol-wide aggregation worked
+   * pre-#10).
+   *
+   * Used by processSymbol to thread lane-positions into TickInputs and
+   * by the entry path to gate "is THIS lane flat?" rather than the
+   * symbol-wide held-side question.
+   */
+  private async findOpenMonkeyTradesByLane(symbol: string): Promise<
+    Array<{
+      lane: 'scalp' | 'swing' | 'trend';
+      side: 'long' | 'short';
+      entry_price: number;
+      quantity: number;
+      trade_id: string;
+      order_id: string | null;
+      leverage: number;
+    }>
+  > {
+    try {
+      const reasonPattern = `monkey|kernel=${this.instanceId}|%`;
+      const result = await pool.query(
+        `SELECT id, entry_price, quantity, leverage, order_id, side, lane
+           FROM autonomous_trades
+          WHERE reason LIKE $2 AND status = 'open' AND symbol = $1
+          ORDER BY entry_time ASC`,
+        [symbol, reasonPattern],
+      );
+      const rows = result.rows as Array<{
+        id: string; entry_price: string; quantity: string; leverage: number;
+        order_id: string | null; side: string; lane: string;
+      }>;
+      const normSide = (s: string): 'long' | 'short' =>
+        s === 'buy' || s === 'long' ? 'long' : 'short';
+      const normLane = (l: string | null | undefined): 'scalp' | 'swing' | 'trend' =>
+        (l === 'scalp' || l === 'trend') ? l : 'swing';
+      // Group by lane, weighted-average within each lane (DCA roll-up).
+      const byLane: Map<string, typeof rows> = new Map();
+      for (const r of rows) {
+        const lane = normLane(r.lane);
+        if (!byLane.has(lane)) byLane.set(lane, []);
+        byLane.get(lane)!.push(r);
+      }
+      const out: Array<{
+        lane: 'scalp' | 'swing' | 'trend';
+        side: 'long' | 'short';
+        entry_price: number;
+        quantity: number;
+        trade_id: string;
+        order_id: string | null;
+        leverage: number;
+      }> = [];
+      for (const [laneStr, laneRows] of byLane) {
+        const lane = laneStr as 'scalp' | 'swing' | 'trend';
+        if (laneRows.length === 0) continue;
+        const totalQty = laneRows.reduce(
+          (s, r) => s + Math.abs(Number(r.quantity) || 0), 0);
+        if (totalQty === 0) continue;
+        const weightedPrice = laneRows.reduce(
+          (s, r) => s + Number(r.entry_price) * Math.abs(Number(r.quantity) || 0),
+          0,
+        ) / totalQty;
+        out.push({
+          lane,
+          side: normSide(laneRows[0].side),
+          entry_price: weightedPrice,
+          quantity: totalQty,
+          trade_id: laneRows[0].id,
+          order_id: laneRows[0].order_id,
+          leverage: laneRows[0].leverage,
+        });
+      }
+      return out;
+    } catch (err) {
+      logger.debug('[Monkey] findOpenMonkeyTradesByLane failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return [];
     }
   }
 
@@ -1555,8 +1793,14 @@ export class MonkeyKernel extends EventEmitter {
     markPrice: number;
     exitReason: string;
     pnlAtDecision: number;
+    /** Proposal #10: when provided, close only autonomous_trades rows
+     *  matching this lane (and send ``posSide`` on the exchange close
+     *  in HEDGE mode so the other lane stays untouched). When omitted,
+     *  legacy behavior — close all open rows under (kernel, symbol). */
+    lane?: 'scalp' | 'swing' | 'trend';
   }): Promise<{ executed: boolean; orderId: string | null; reason: string }> {
     const { symbol, tradeId, heldSide, markPrice, exitReason, pnlAtDecision } = req;
+    const closeLane = req.lane;
 
     // Load credentials + position to know size to close.
     let credentials: { apiKey: string; apiSecret: string; passphrase?: string };
@@ -1578,13 +1822,28 @@ export class MonkeyKernel extends EventEmitter {
 
     // Read exchange position size (tradeId's quantity may diverge from
     // actual exchange state if partial fills or reconciler updates).
+    // Proposal #10 — in HEDGE mode + lane scoped close, the exchange
+    // qty for *this side* must be used (the symbol may have an opposite
+    // side too); in ONE_WAY mode there's only one net position so the
+    // whole-symbol qty applies.
     let exchangeQty = 0;
     try {
       const positions = await poloniexFuturesService.getPositions(credentials);
-      const forSymbol = (Array.isArray(positions) ? positions : []).find(
+      const forSymbol = (Array.isArray(positions) ? positions : []).filter(
         (p: Record<string, unknown>) => String(p.symbol ?? '') === symbol,
       );
-      exchangeQty = Math.abs(Number(forSymbol?.qty ?? forSymbol?.size ?? 0));
+      if (this.positionDirectionMode === 'HEDGE' && closeLane) {
+        // Match by side — under HEDGE Poloniex returns one position per side.
+        const target = forSymbol.find((p: Record<string, unknown>) => {
+          const s = String(p.side ?? p.posSide ?? '').toUpperCase();
+          const want = heldSide === 'long' ? 'LONG' : 'SHORT';
+          return s === want;
+        }) ?? forSymbol[0];
+        exchangeQty = Math.abs(Number(target?.qty ?? target?.size ?? 0));
+      } else {
+        const target = forSymbol[0];
+        exchangeQty = Math.abs(Number(target?.qty ?? target?.size ?? 0));
+      }
     } catch (err) {
       return {
         executed: false, orderId: null,
@@ -1620,10 +1879,17 @@ export class MonkeyKernel extends EventEmitter {
 
     let orderId: string | null = null;
     try {
+      // Proposal #10 — in HEDGE mode the close must specify which side
+      // of the hedge book it's reducing, otherwise the exchange may
+      // route against the wrong leg.
+      const closePosSide: 'LONG' | 'SHORT' | undefined =
+        this.positionDirectionMode === 'HEDGE'
+          ? (heldSide === 'long' ? 'LONG' : 'SHORT')
+          : undefined;
       const exchangeOrder = await poloniexFuturesService.placeOrder(credentials, {
         symbol, side: closeSide, type: 'market', size: formattedSize, lotSize: symbolLotSize,
         reduceOnly: true,
-      });
+      }, closePosSide ? { posSide: closePosSide } : {});
       orderId =
         exchangeOrder?.ordId ?? exchangeOrder?.orderId ??
         exchangeOrder?.id ?? exchangeOrder?.clientOid ?? null;
@@ -1643,12 +1909,23 @@ export class MonkeyKernel extends EventEmitter {
     // share for that row goes back to the arbiter under that agent so
     // the rolling allocation reflects per-agent performance.
     try {
-      const openRows = await pool.query(
-        `SELECT id, quantity, agent FROM autonomous_trades
-          WHERE reason LIKE $1 AND status = 'open' AND symbol = $2
-          ORDER BY entry_time ASC`,
-        [`monkey|kernel=${this.instanceId}|%`, symbol],
-      );
+      // Proposal #10 — when a lane is scoped, only close that lane's
+      // open rows. Other lanes (e.g. swing-long while we're closing a
+      // scalp-short) keep their bookkeeping intact.
+      const openRows = closeLane
+        ? await pool.query(
+            `SELECT id, quantity, agent FROM autonomous_trades
+              WHERE reason LIKE $1 AND status = 'open' AND symbol = $2
+                AND lane = $3
+              ORDER BY entry_time ASC`,
+            [`monkey|kernel=${this.instanceId}|%`, symbol, closeLane],
+          )
+        : await pool.query(
+            `SELECT id, quantity, agent FROM autonomous_trades
+              WHERE reason LIKE $1 AND status = 'open' AND symbol = $2
+              ORDER BY entry_time ASC`,
+            [`monkey|kernel=${this.instanceId}|%`, symbol],
+          );
       const rows = openRows.rows as Array<{ id: string; quantity: string; agent: string | null }>;
       const totalQty = rows.reduce((s, r) => s + Math.abs(Number(r.quantity) || 0), 0);
       if (rows.length === 0 || totalQty === 0) {
@@ -1749,6 +2026,9 @@ export class MonkeyKernel extends EventEmitter {
      *  M = ml-only. Default 'K' for back-compat with the existing
      *  call sites. */
     agent?: 'K' | 'M';
+    /** Proposal #10: execution lane key. Default 'swing' = pre-#10 implicit
+     *  lane so existing call sites remain bit-identical. */
+    lane?: 'scalp' | 'swing' | 'trend';
   }): Promise<{ executed: boolean; orderId: string | null; reason: string }> {
     const { symbol, side, marginUsdt, leverage, entryPrice, minNotional } = req;
     const notionalUsdt = marginUsdt * leverage;
@@ -1840,11 +2120,21 @@ export class MonkeyKernel extends EventEmitter {
       });
     }
 
+    // Proposal #10 — when the live account is in HEDGE position-direction
+    // mode, we MUST send `posSide: LONG | SHORT` so the exchange opens
+    // the order on the correct side of the hedge book. In ONE_WAY mode,
+    // omit posSide (the service defaults to BOTH). The mode is detected
+    // once at startup (assertHedgeModeIfPossible) and cached on the
+    // kernel; we read that cache here.
+    const posSide: 'LONG' | 'SHORT' | undefined =
+      this.positionDirectionMode === 'HEDGE'
+        ? (req.side === 'long' ? 'LONG' : 'SHORT')
+        : undefined;
     let orderId: string | null = null;
     try {
       const exchangeOrder = await poloniexFuturesService.placeOrder(credentials, {
         symbol, side: exchangeSide, type: 'market', size: formattedSize, lotSize: symbolLotSize,
-      });
+      }, posSide ? { posSide } : {});
       orderId =
         exchangeOrder?.ordId ?? exchangeOrder?.orderId ??
         exchangeOrder?.id ?? exchangeOrder?.clientOid ?? null;
@@ -1863,23 +2153,24 @@ export class MonkeyKernel extends EventEmitter {
       };
     }
 
-    // Persist. Encode kernel + agent + Monkey's state into reason so
-    // the close-hook + reconciler + arbiter can recover attribution
+    // Persist. Encode kernel + agent + lane + Monkey's state into reason
+    // so the close-hook + reconciler + arbiter can recover attribution
     // cheaply.
-    // Format: monkey|kernel=<id>|agent=<K|M>|phi=...|kappa=...|sov=...|dca=<N>|src=<ver>
+    // Format: monkey|kernel=<id>|agent=<K|M>|lane=<scalp|swing|trend>|phi=...|kappa=...|sov=...|dca=<N>|src=<ver>
     const agentTag = req.agent ?? 'K';
+    const laneTag = req.lane ?? 'swing';
     try {
       const dcaTag = req.isDCAAdd ? `|dca=${req.dcaAddIndex ?? 1}` : '';
       const reasonEncoded =
-        `monkey|kernel=${this.instanceId}|agent=${agentTag}|phi=${req.phi.toFixed(3)}|kappa=${req.kappa.toFixed(2)}|sov=${req.sovereignty.toFixed(3)}${dcaTag}|src=v0.6.2`;
+        `monkey|kernel=${this.instanceId}|agent=${agentTag}|lane=${laneTag}|phi=${req.phi.toFixed(3)}|kappa=${req.kappa.toFixed(2)}|sov=${req.sovereignty.toFixed(3)}${dcaTag}|src=v0.10`;
       await pool.query(
         `INSERT INTO autonomous_trades
            (user_id, symbol, side, entry_price, quantity, leverage,
-            confidence, reason, order_id, paper_trade, engine_version, agent)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+            confidence, reason, order_id, paper_trade, engine_version, agent, lane)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
         [
           userId, symbol, exchangeSide, entryPrice, formattedSize, leverage,
-          req.phi, reasonEncoded, orderId, false, getEngineVersion(), agentTag,
+          req.phi, reasonEncoded, orderId, false, getEngineVersion(), agentTag, laneTag,
         ],
       );
     } catch (err) {

--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -407,6 +407,45 @@ class PoloniexFuturesService {
   }
 
   /**
+   * Get position direction mode (HEDGE | ONE_WAY).
+   * Endpoint: GET /v3/position/mode
+   *
+   * NOTE — distinct from `getPositionMode` above which historically returned
+   * the (mis-named) margin mode. Per the v3 reference (apps/api/docs/
+   * poloniex-v3-reference.md §Position) the canonical body field is
+   * `posMode`, returning `HEDGE` (LONG/SHORT two-way positions) or
+   * `ONE_WAY` (BOTH net position).
+   *
+   * Used by the lane-isolated position lifecycle (proposal #10) — hedge
+   * mode is required so a swing-long and a scalp-short can coexist on
+   * the same symbol as two independent positions.
+   */
+  async getPositionDirectionMode(credentials) {
+    return this.makeRequest(credentials, 'GET', '/position/mode', null, {});
+  }
+
+  /**
+   * Set position direction mode (HEDGE | ONE_WAY).
+   * Endpoint: POST /v3/position/mode  body { posMode }
+   *
+   * Idempotent — Poloniex returns the current mode if already set; we
+   * pass through the response. Throws on Poloniex 4xx errors (e.g. an
+   * attempted switch with open positions on the account is rejected
+   * exchange-side; the caller should defer until positions close).
+   *
+   * @param {Object} credentials
+   * @param {'HEDGE'|'ONE_WAY'} posMode
+   */
+  async setPositionDirectionMode(credentials, posMode) {
+    const upper = String(posMode).toUpperCase();
+    if (upper !== 'HEDGE' && upper !== 'ONE_WAY') {
+      throw new Error(`setPositionDirectionMode: invalid posMode ${posMode}`);
+    }
+    const body = { posMode: upper };
+    return this.makeRequest(credentials, 'POST', '/position/mode', body);
+  }
+
+  /**
    * Adjust margin for isolated margin trading positions
    * Endpoint: POST /v3/trade/position/margin
    */

--- a/ml-worker/src/monkey_kernel/executive.py
+++ b/ml-worker/src/monkey_kernel/executive.py
@@ -73,6 +73,74 @@ _DEFAULT_SCALP_TP_MIN_FLOOR = 0.003
 _DEFAULT_EXIT_ENTROPY_COLLAPSE = 0.4  # (referenced by should_auto_flatten semantic)
 _DEFAULT_DCA_MAX_ADDS = 1
 
+# ─── Proposal #10 — lane-isolated position lifecycle defaults ────
+#
+# Two-lane initial split (scalp + swing). Trend is left as a parameter
+# slot but defaults to budget=0 — opt-in via the parameter registry.
+# Each lane has its own SL/TP envelope and capital budget. SL/TP are
+# stored as positive *fractions of notional* (e.g. 0.004 = 0.4%); the
+# trade-side sign is applied at the call site. Budget fractions sum to
+# 1.0 across position-bearing lanes when fully active; values below sum
+# to 1.0 only because trend defaults to 0 in this batch.
+_DEFAULT_LANE_SCALP_SL_PCT = 0.004
+_DEFAULT_LANE_SCALP_TP_PCT = 0.005
+_DEFAULT_LANE_SCALP_BUDGET_FRAC = 0.50
+
+_DEFAULT_LANE_SWING_SL_PCT = 0.015
+_DEFAULT_LANE_SWING_TP_PCT = 0.015
+_DEFAULT_LANE_SWING_BUDGET_FRAC = 0.50
+
+_DEFAULT_LANE_TREND_SL_PCT = 0.040
+_DEFAULT_LANE_TREND_TP_PCT = 0.040
+_DEFAULT_LANE_TREND_BUDGET_FRAC = 0.0  # opt-in; bumped via parameter registry
+
+_LANE_PARAMETER_DEFAULTS: dict[str, dict[str, float]] = {
+    "scalp": {
+        "sl_pct": _DEFAULT_LANE_SCALP_SL_PCT,
+        "tp_pct": _DEFAULT_LANE_SCALP_TP_PCT,
+        "budget_frac": _DEFAULT_LANE_SCALP_BUDGET_FRAC,
+    },
+    "swing": {
+        "sl_pct": _DEFAULT_LANE_SWING_SL_PCT,
+        "tp_pct": _DEFAULT_LANE_SWING_TP_PCT,
+        "budget_frac": _DEFAULT_LANE_SWING_BUDGET_FRAC,
+    },
+    "trend": {
+        "sl_pct": _DEFAULT_LANE_TREND_SL_PCT,
+        "tp_pct": _DEFAULT_LANE_TREND_TP_PCT,
+        "budget_frac": _DEFAULT_LANE_TREND_BUDGET_FRAC,
+    },
+}
+
+
+def lane_param(lane: str, key: str) -> float:
+    """Read a lane parameter from the registry, falling back to the
+    code-level default. Names follow ``executive.lane.<lane>.<key>``.
+
+    Used by every lane-aware decision function so live tunes ride the
+    parameter registry without redeploys (P14 + P25 discipline).
+    """
+    if lane not in _LANE_PARAMETER_DEFAULTS:
+        # Unknown lane (e.g. 'observe'): no per-lane envelope — caller
+        # should never invoke a lane-aware decision for such lanes.
+        # Return a neutral pass-through so we don't blow up in tests.
+        return float(_LANE_PARAMETER_DEFAULTS["swing"].get(key, 0.0))
+    fallback = _LANE_PARAMETER_DEFAULTS[lane][key]
+    return float(_registry.get(f"executive.lane.{lane}.{key}", default=fallback))
+
+
+def lane_budget_fraction(lane: str) -> float:
+    """Risk-allocation share for a lane (per proposal #10 path (a)).
+
+    Path (a) — static per-lane budget. The arbiter route (b) is the
+    natural follow-up once each lane has 5+ closed trades. Returns 0
+    for non-position lanes ("observe") so the caller can short-circuit
+    sizing.
+    """
+    if lane not in _LANE_PARAMETER_DEFAULTS:
+        return 0.0
+    return lane_param(lane, "budget_frac")
+
 
 # ═══════════════════════════════════════════════════════════════
 #  BasinState — shape all executive functions consume
@@ -244,7 +312,16 @@ def current_position_size(
     leverage: float,
     bank_size: int,
     mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+    lane: str = "swing",
 ) -> dict[str, Any]:
+    # Proposal #10: per-lane capital budget. Each lane sees only its
+    # share of available equity for sizing, so a held swing-long can no
+    # longer paralyze a scalp-short on the same symbol. The lane budget
+    # is a live-governed risk parameter (executive.lane.<lane>.budget_frac).
+    # A zero-budget lane (default for "trend" until governance bumps it)
+    # is sized to zero — capital is not allocated to it this tick.
+    lane_frac = lane_budget_fraction(lane)
+    available_equity_usdt = available_equity_usdt * lane_frac
     nc = s.neurochemistry
     maturity = min(1.0, bank_size / 20.0)
     base_frac = s.phi * s.sovereignty * maturity
@@ -292,7 +369,7 @@ def current_position_size(
     return {
         "value": sized,
         "reason": (
-            f"size = {'lifted-to-min ' if lifted else ''}"
+            f"size[{lane}] = {'lifted-to-min ' if lifted else ''}"
             f"floor({exploration_floor:.3f}) or PhixSxM({base_frac:.3f}) "
             f"x reward({reward_mult:.2f}) x stab({stability_mult:.2f}) "
             f"x equity({available_equity_usdt:.2f}) @ {leverage:.0f}x "
@@ -313,6 +390,8 @@ def current_position_size(
             "min_notional": min_notional_usdt,
             "sized": sized,
             "lifted_to_min": 1 if lifted else 0,
+            "lane": lane,
+            "lane_budget_frac": lane_frac,
         },
     }
 
@@ -667,6 +746,7 @@ def should_scalp_exit(
     notional_usdt: float,
     s: ExecBasinState,
     mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+    lane: str = "swing",
 ) -> dict[str, Any]:
     if notional_usdt <= 0:
         return {"value": False, "reason": "no position notional", "derivation": {}}
@@ -688,34 +768,54 @@ def should_scalp_exit(
     tp_min_floor = _registry.get(
         "executive.scalp.tp_min_floor", default=_DEFAULT_SCALP_TP_MIN_FLOOR,
     )
-    tp_thr = max(tp_min_floor, profile.tp_base_frac - 0.003 * nc.dopamine + 0.005 * s.phi)
-    sl_thr = tp_thr * profile.sl_ratio
+    geometric_tp = max(
+        tp_min_floor,
+        profile.tp_base_frac - 0.003 * nc.dopamine + 0.005 * s.phi,
+    )
+    geometric_sl = geometric_tp * profile.sl_ratio
+    # Proposal #10: per-lane envelope. Scalp/swing/trend each carry
+    # their own SL/TP "retreat tolerance":
+    #   scalp ~0.4% adverse, fast tape harvesting
+    #   swing ~1.5% adverse, absorbs retraces
+    #   trend ~3-5% adverse, rides the macro trend
+    # We take the *wider* of (geometric, lane) so the geometric floor
+    # (e.g. fee-clear) is never breached but the lane envelope can
+    # broaden tolerance when configured to do so.
+    lane_tp = lane_param(lane, "tp_pct")
+    lane_sl = lane_param(lane, "sl_pct")
+    tp_thr = max(geometric_tp, lane_tp)
+    sl_thr = max(geometric_sl, lane_sl)
 
     if pnl_frac >= tp_thr:
         return {
             "value": True,
-            "reason": f"take_profit: {pnl_frac*100:.3f}% >= {tp_thr*100:.3f}%",
+            "reason": f"take_profit[{lane}]: {pnl_frac*100:.3f}% >= {tp_thr*100:.3f}%",
             "derivation": {
                 "pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr,
+                "lane": lane, "lane_tp_pct": lane_tp, "lane_sl_pct": lane_sl,
                 "exit_type_bit": 1,
             },
         }
     if pnl_frac <= -sl_thr:
         return {
             "value": True,
-            "reason": f"stop_loss: {pnl_frac*100:.3f}% <= -{sl_thr*100:.3f}%",
+            "reason": f"stop_loss[{lane}]: {pnl_frac*100:.3f}% <= -{sl_thr*100:.3f}%",
             "derivation": {
                 "pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr,
+                "lane": lane, "lane_tp_pct": lane_tp, "lane_sl_pct": lane_sl,
                 "exit_type_bit": -1,
             },
         }
     return {
         "value": False,
         "reason": (
-            f"scalp hold: pnl {pnl_frac*100:.3f}% in "
+            f"scalp hold[{lane}]: pnl {pnl_frac*100:.3f}% in "
             f"[-{sl_thr*100:.3f}%, {tp_thr*100:.3f}%]"
         ),
-        "derivation": {"pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr},
+        "derivation": {
+            "pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr,
+            "lane": lane, "lane_tp_pct": lane_tp, "lane_sl_pct": lane_sl,
+        },
     }
 
 
@@ -749,7 +849,18 @@ def should_dca_add(
     now_ms: float,
     sovereignty: float,
     s: Optional[ExecBasinState] = None,
+    lane: str = "swing",
 ) -> dict[str, Any]:
+    """Five-rail DCA-add gate, evaluated per (agent, symbol, lane).
+
+    Proposal #10: lane discipline. ``held_side`` is the side held *by
+    this lane* (not the symbol-wide held side). The legacy "side
+    mismatch (short vs held long)" rejection happens only inside the
+    same lane — a swing-long can hold while a scalp-short on the same
+    symbol DCA-adds, because they live in different lanes with their
+    own retreat tolerance.
+    """
+    _ = lane  # surfaced into derivation for telemetry; not gating logic
     # v0.8.4b — when ExecBasinState is provided, DCA cooldown / better-price
     # / min-sovereignty DERIVE from geometric state per P25. When not
     # provided, fall back to the hardcoded pre-derivation values so older
@@ -777,8 +888,11 @@ def should_dca_add(
     if held_side != side_candidate:
         return {
             "value": False,
-            "reason": f"side mismatch ({side_candidate} vs held {held_side})",
-            "derivation": {"rule": 1},
+            "reason": (
+                f"side mismatch in lane {lane} "
+                f"({side_candidate} vs held {held_side})"
+            ),
+            "derivation": {"rule": 1, "lane": lane},
         }
     # Live-governed SAFETY_BOUND — caps total risk exposure across
     # martingale-style averaging attempts on a single position.
@@ -828,7 +942,7 @@ def should_dca_add(
     return {
         "value": True,
         "reason": (
-            f"DCA_OK: {price_delta*100:.2f}% from entry, "
+            f"DCA_OK[{lane}]: {price_delta*100:.2f}% from entry, "
             f"addCount={add_count}, sov={sovereignty:.2f}"
         ),
         "derivation": {
@@ -836,6 +950,7 @@ def should_dca_add(
             "price_delta": price_delta,
             "add_count": add_count,
             "sovereignty": sovereignty,
+            "lane": lane,
         },
     }
 

--- a/ml-worker/src/monkey_kernel/state.py
+++ b/ml-worker/src/monkey_kernel/state.py
@@ -24,6 +24,11 @@ KAPPA_STAR: float = 64.0
 # conditioned reward. Default "swing" preserves backward-compat.
 LaneType = Literal["scalp", "swing", "trend", "observe"]
 
+# Position-bearing lanes — those that can carry a real autonomous_trades
+# row in the (agent, symbol, lane) position-lifecycle key. "observe" is a
+# decision label only; it never holds a position.
+POSITION_LANES: tuple[str, ...] = ("scalp", "swing", "trend")
+
 
 @dataclass
 class NeurochemicalState:

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -103,8 +103,29 @@ _registry = get_registry()
 # ── Input / output dataclasses ───────────────────────────────────
 
 @dataclass
+class LanePosition:
+    """Single-lane position snapshot used by the lane-aware tick path
+    (proposal #10). One ``LanePosition`` per (agent, symbol, lane) row
+    that is currently ``status='open'`` in autonomous_trades.
+    """
+    lane: str  # "scalp" | "swing" | "trend"
+    side: str  # "long" | "short"
+    entry_price: float
+    quantity: float
+    trade_id: str
+
+
+@dataclass
 class AccountContext:
-    """Snapshot of account / position state as seen by the caller."""
+    """Snapshot of account / position state as seen by the caller.
+
+    Pre-#10 shape kept for back-compat: ``exchange_held_side`` plus the
+    triplet of ``own_position_*`` fields describes a single, symbol-wide
+    K position. Proposal #10 adds ``lane_positions`` — a list of open
+    per-lane positions on this symbol. When non-empty, the caller is on
+    the lane-aware path and ``own_position_*`` should mirror the lane
+    aggregate (kept around for legacy single-position tests).
+    """
     equity_fraction: float
     margin_fraction: float
     open_positions: int
@@ -113,6 +134,10 @@ class AccountContext:
     own_position_entry_price: Optional[float] = None
     own_position_quantity: Optional[float] = None
     own_position_trade_id: Optional[str] = None
+    # Proposal #10 — per-lane open positions on this (agent, symbol).
+    # Empty when flat across all lanes; populated by the caller from
+    # the lane-keyed autonomous_trades query.
+    lane_positions: list[LanePosition] = field(default_factory=list)
 
 
 @dataclass
@@ -142,7 +167,13 @@ class TickInputs:
 
 @dataclass
 class SymbolState:
-    """Per-symbol state carried across ticks."""
+    """Per-symbol state carried across ticks.
+
+    Proposal #10: peak-tracking + DCA-bookkeeping + tape-flip streak
+    are now per-lane dicts keyed by lane name. Pre-#10 scalar attrs
+    are retained for back-compat (callers without a lane just read
+    the legacy field; the lane-aware path goes through the dicts).
+    """
     symbol: str
     identity_basin: np.ndarray
     last_basin: Optional[np.ndarray] = None
@@ -156,6 +187,8 @@ class SymbolState:
     # Tier 1 motivators integration history — (phi, i_q) tuples per tick.
     # Used by compute_motivators for the CV(Φ × I_Q) integration motivator.
     integration_history: list[tuple[float, float]] = field(default_factory=list)
+    # Pre-#10 scalar bookkeeping — preserved as the "default lane"
+    # (swing) view so existing tests + back-compat callers keep working.
     dca_add_count: int = 0
     last_entry_at_ms: Optional[float] = None
     peak_pnl_usdt: Optional[float] = None
@@ -167,6 +200,15 @@ class SymbolState:
     # single noise tick doesn't trigger an exit. Reset on every new
     # trade (peak_tracked_trade_id changes).
     tape_flip_streak: int = 0
+    # Proposal #10 — per-lane substates. Each lane independently tracks
+    # peak unrealized PnL, DCA add count, last-entry timestamp, and
+    # tape-flip streak so a swing-long's bookkeeping never bleeds into
+    # a scalp-short on the same symbol.
+    peak_pnl_usdt_by_lane: dict[str, float] = field(default_factory=dict)
+    peak_tracked_trade_id_by_lane: dict[str, Optional[str]] = field(default_factory=dict)
+    dca_add_count_by_lane: dict[str, int] = field(default_factory=dict)
+    last_entry_at_ms_by_lane: dict[str, Optional[float]] = field(default_factory=dict)
+    tape_flip_streak_by_lane: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -578,6 +620,19 @@ def run_tick(
         else inputs.size_fraction
     )
     capped_equity = inputs.account.available_equity * effective_size_fraction
+    # Lane is chosen further down (after entry/exit branches need a
+    # tentative answer); for sizing we read the lane choice up-front so
+    # the per-lane budget fraction can shape the proposed margin. The
+    # final lane stored on TickDecision may differ when phi-gate GRAPH
+    # mode overrides; size is recomputed only inside the *entry* path
+    # if the override changes lane (rare; deferred).
+    pre_lane_d = choose_lane(
+        basin_state,
+        tape_trend=tape_trend,
+        stud_reading=stud_reading,
+        stud_live=stud_live,
+    )
+    pre_lane = pre_lane_d["value"]
     size_d = current_position_size(
         basin_state,
         available_equity_usdt=capped_equity,
@@ -585,6 +640,7 @@ def run_tick(
         leverage=leverage_d["value"],
         bank_size=inputs.bank_size,
         mode=mode_enum,
+        lane=pre_lane if pre_lane in ("scalp", "swing", "trend") else "swing",
     )
     auto_flatten_d = should_auto_flatten(
         s=basin_state, recent_fhealths=state.fhealth_history,
@@ -721,6 +777,14 @@ def run_tick(
     )
     derivation["exchange_held_side"] = inputs.account.exchange_held_side
     derivation["monkey_held_side"] = held_side
+    # Proposal #10 — per-lane held-side map. When the caller populated
+    # ``lane_positions``, this is the authoritative view of which lanes
+    # currently hold a position. Empty dict (no lanes held) means the
+    # entry path is wide open across all lanes.
+    held_lanes: dict[str, str] = {
+        lp.lane: lp.side for lp in inputs.account.lane_positions
+    }
+    derivation["held_lanes"] = dict(held_lanes)
 
     # PR 1 — Ocean DREAM / ESCAPE handlers. ESCAPE forces flatten,
     # DREAM forces hold (skip executive). MUSHROOM_MICRO already
@@ -745,7 +809,45 @@ def run_tick(
         action = "flatten"
         reason = auto_flatten_d["reason"]
         derivation["auto_flatten"] = auto_flatten_d["derivation"]
+    elif (
+        # Proposal #10 — lane-aware entry path takes precedence when
+        # the target lane is flat even if another lane is currently
+        # holding a position on this symbol. A K_SWING_LONG and a
+        # K_SCALP_SHORT can coexist as two distinct positions, each
+        # with its own retreat tolerance and capital share.
+        inputs.account.lane_positions
+        and pre_lane in ("scalp", "swing", "trend")
+        and pre_lane not in held_lanes
+        and MODE_PROFILES[mode_enum].can_enter
+        and direction != "flat"
+        and kernel_should_enter(emotions=emo)
+        and size_d["value"] > 0
+    ):
+        action = "enter_long" if side_candidate == "long" else "enter_short"
+        notional = size_d["value"] * leverage_d["value"]
+        reason = (
+            f"[{mode}] kernel-entry-lane[{pre_lane}] "
+            f"conv={emo.confidence * (1 + emo.wonder):.3f}"
+            f" > hes={emo.anxiety + emo.confusion:.3f}; "
+            f"side={side_candidate}; "
+            f"margin={size_d['value']:.2f} lev={leverage_d['value']}x "
+            f"notional={notional:.2f}"
+        )
+        derivation["entry_threshold"] = entry_thr_d["derivation"]
+        derivation["size"] = size_d["derivation"]
+        derivation["leverage"] = leverage_d["derivation"]
     elif held_side:
+        # Proposal #10: resolve the lane this single-position decision
+        # belongs to. With ``lane_positions`` populated the lane is read
+        # from the (held side, lane) row matching held_side; otherwise
+        # we fall back to "swing" (pre-#10 behavior — every legacy
+        # position migrated to lane='swing' in migration 042).
+        position_lane = "swing"
+        if inputs.account.lane_positions:
+            for lp in inputs.account.lane_positions:
+                if lp.side == held_side:
+                    position_lane = lp.lane
+                    break
         action, reason, is_dca, is_reverse = _decide_with_position(
             inputs=inputs,
             state=state,
@@ -761,6 +863,7 @@ def run_tick(
             size_val=size_d["value"],
             leverage_val=leverage_d["value"],
             derivation=derivation,
+            position_lane=position_lane,
         )
     elif (
         MODE_PROFILES[mode_enum].can_enter
@@ -841,12 +944,10 @@ def run_tick(
             persistence.push_integration(symbol, last_phi, last_iq)
 
     # ── Lane selection ────────────────────────────────────────────
-    lane_d = choose_lane(
-        basin_state,
-        tape_trend=tape_trend,
-        stud_reading=stud_reading,
-        stud_live=stud_live,
-    )
+    # Reuse the pre-sizing lane choice (computed above so the per-lane
+    # budget fraction could shape the proposed margin). The phi-gate
+    # GRAPH branch below may override it when the routing flag is live.
+    lane_d = pre_lane_d
     lane = lane_d["value"]
     derivation["lane"] = lane_d["derivation"]
 
@@ -942,52 +1043,69 @@ def _decide_with_position(
     size_val: float,
     leverage_val: int,
     derivation: dict[str, Any],
+    position_lane: str = "swing",
 ) -> tuple[str, str, bool, bool]:
     """v0.6.1 exit gate order: profit harvest → scalp TP/SL → Loop 2 exit.
-    v0.7.1 override-reverse. v0.6.2 DCA.
+    v0.7.1 override-reverse. v0.6.2 DCA. Proposal #10: per-lane peak +
+    streak + DCA bookkeeping so each lane carries its own state.
     """
     entry_price = inputs.account.own_position_entry_price or last_price
     quantity = inputs.account.own_position_quantity or 0.0
     trade_id = inputs.account.own_position_trade_id or ""
+    # Proposal #10: when the caller populated lane_positions, override
+    # entry/qty/trade_id with the matching lane's row so the executive
+    # reasons over the right position even when multiple lanes hold.
+    if inputs.account.lane_positions:
+        for lp in inputs.account.lane_positions:
+            if lp.lane == position_lane and lp.side == held_side:
+                entry_price = lp.entry_price
+                quantity = lp.quantity
+                trade_id = lp.trade_id
+                break
     position_notional = entry_price * quantity
     side_sign = 1 if held_side == "long" else -1
     unrealized_pnl = (last_price - entry_price) * quantity * side_sign
 
-    if state.peak_tracked_trade_id != trade_id:
-        state.peak_pnl_usdt = unrealized_pnl
-        state.peak_tracked_trade_id = trade_id
-        # Proposal #4 — reset streak counter on a fresh trade.
-        state.tape_flip_streak = 0
+    # Per-lane peak tracking (proposal #10). The legacy scalar
+    # ``state.peak_pnl_usdt`` mirrors the active lane so older callers
+    # (and tick telemetry) keep reading sensible values.
+    prev_tracked = state.peak_tracked_trade_id_by_lane.get(position_lane)
+    if prev_tracked != trade_id:
+        state.peak_pnl_usdt_by_lane[position_lane] = unrealized_pnl
+        state.peak_tracked_trade_id_by_lane[position_lane] = trade_id
+        state.tape_flip_streak_by_lane[position_lane] = 0
     else:
-        state.peak_pnl_usdt = max(state.peak_pnl_usdt or 0.0, unrealized_pnl)
+        prev_peak = state.peak_pnl_usdt_by_lane.get(position_lane, 0.0)
+        state.peak_pnl_usdt_by_lane[position_lane] = max(prev_peak, unrealized_pnl)
 
-    # Proposal #4 — maintain the sustained tape-flip streak counter.
-    # Increment when the tape alignment is bearish vs the held side
-    # (i.e., alignment <= the trend-flip threshold). Reset otherwise.
-    # The trend-flip threshold inside should_profit_harvest is
-    # NE-modulated (-0.20..-0.30); use a fixed -0.25 here to avoid
-    # importing NE state — the streak is monotonic in tape direction
-    # so a slightly off threshold doesn't break the gate semantics.
+    # Mirror to legacy scalars so non-lane-aware readers keep working.
+    state.peak_pnl_usdt = state.peak_pnl_usdt_by_lane[position_lane]
+    state.peak_tracked_trade_id = trade_id
+
+    # Proposal #4 — sustained tape-flip streak counter, per-lane.
     alignment_now = tape_trend if held_side == "long" else -tape_trend
+    cur_streak = state.tape_flip_streak_by_lane.get(position_lane, 0)
     if alignment_now <= -0.25:
-        state.tape_flip_streak += 1
+        state.tape_flip_streak_by_lane[position_lane] = cur_streak + 1
     else:
-        state.tape_flip_streak = 0
+        state.tape_flip_streak_by_lane[position_lane] = 0
+    state.tape_flip_streak = state.tape_flip_streak_by_lane[position_lane]
 
     harvest = should_profit_harvest(
         unrealized_pnl_usdt=unrealized_pnl,
-        peak_pnl_usdt=state.peak_pnl_usdt or 0.0,
+        peak_pnl_usdt=state.peak_pnl_usdt_by_lane.get(position_lane, 0.0),
         notional_usdt=position_notional,
         tape_trend=tape_trend,
         held_side=held_side,
         s=basin_state,
-        tape_flip_streak=state.tape_flip_streak,
+        tape_flip_streak=state.tape_flip_streak_by_lane.get(position_lane, 0),
     )
     derivation["harvest"] = {
         **harvest["derivation"],
         "unrealized_pnl": unrealized_pnl,
-        "peak_pnl": state.peak_pnl_usdt,
+        "peak_pnl": state.peak_pnl_usdt_by_lane.get(position_lane, 0.0),
         "trade_id": trade_id,
+        "lane": position_lane,
     }
     if harvest["value"]:
         derivation["scalp"] = {
@@ -1003,6 +1121,7 @@ def _decide_with_position(
         notional_usdt=position_notional,
         s=basin_state,
         mode=mode_enum,
+        lane=position_lane,
     )
     derivation["scalp"] = {
         **scalp["derivation"],
@@ -1046,18 +1165,28 @@ def _decide_with_position(
         )
         return action, reason, False, True
 
-    # DCA add
+    # DCA add — lane-scoped (proposal #10). The DCA gate's "side mismatch"
+    # rejection now means a lane-internal mismatch only; another lane on
+    # the same symbol can hold the opposite side without blocking this
+    # lane's DCA decision.
     now_ms = time.time() * 1000.0
+    lane_add_count = state.dca_add_count_by_lane.get(
+        position_lane, state.dca_add_count,
+    )
+    lane_last_entry_ms = state.last_entry_at_ms_by_lane.get(
+        position_lane, state.last_entry_at_ms,
+    )
     dca = should_dca_add(
         held_side=held_side,
         side_candidate=side_candidate,
         current_price=last_price,
         initial_entry_price=entry_price,
-        add_count=state.dca_add_count,
-        last_add_at_ms=state.last_entry_at_ms or 0,
+        add_count=lane_add_count,
+        last_add_at_ms=lane_last_entry_ms or 0,
         now_ms=now_ms,
         sovereignty=inputs.sovereignty,
         s=basin_state,  # v0.8.4b — enables cooldown / better-price derivation from NC + bv
+        lane=position_lane,
     )
     derivation["dca"] = dca["derivation"]
     if (
@@ -1069,7 +1198,8 @@ def _decide_with_position(
     ):
         action = "enter_long" if side_candidate == "long" else "enter_short"
         reason = (
-            f"DCA_ADD[{state.dca_add_count + 1}/1] {dca['reason']} | "
+            f"DCA_ADD[{position_lane}|{lane_add_count + 1}/1] "
+            f"{dca['reason']} | "
             f"side={side_candidate} margin={size_val:.2f} lev={leverage_val}x"
         )
         return action, reason, True, False

--- a/ml-worker/tests/monkey_kernel/test_lane_isolation.py
+++ b/ml-worker/tests/monkey_kernel/test_lane_isolation.py
@@ -1,0 +1,405 @@
+"""test_lane_isolation.py — Proposal #10 lane-isolated position lifecycle.
+
+Validates the kernel-side promises of proposal #10:
+
+  1. Lane parameter envelope: each lane has its own SL/TP and budget
+     fraction, and the registry-backed defaults are read correctly.
+  2. ``current_position_size`` shrinks the available equity by the
+     lane's budget fraction (so a held swing-lane no longer paralyzes
+     a scalp-lane on the same symbol).
+  3. ``should_scalp_exit`` widens the TP/SL envelope to the *wider* of
+     (geometric, lane) so the geometric fee-clear floor is never
+     violated but a swing/trend lane can absorb retraces a scalp lane
+     would never tolerate.
+  4. ``should_dca_add`` rejects same-lane mismatched sides but is
+     unaware of (i.e. doesn't consult) cross-lane state — that's the
+     kernel-tick caller's job and is covered by SymbolState dict tests.
+  5. Per-lane SymbolState bookkeeping: peak PnL, tape-flip streak,
+     DCA add count are kept in lane-keyed dicts so two lanes never
+     bleed into one another.
+  6. Per-lane held-side map (LanePosition list) survives the
+     ``_decide_with_position`` path without cross-lane leakage.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from monkey_kernel.executive import (  # noqa: E402
+    ExecBasinState,
+    _LANE_PARAMETER_DEFAULTS,
+    current_position_size,
+    lane_budget_fraction,
+    lane_param,
+    should_dca_add,
+    should_scalp_exit,
+)
+from monkey_kernel.modes import MonkeyMode  # noqa: E402
+from monkey_kernel.state import NeurochemicalState  # noqa: E402
+from monkey_kernel.tick import LanePosition, SymbolState  # noqa: E402
+
+
+def _basin_state(*, phi: float = 0.5, kappa: float = 64.0) -> ExecBasinState:
+    nc = NeurochemicalState(
+        acetylcholine=0.5, dopamine=0.5, serotonin=0.5,
+        norepinephrine=0.5, gaba=0.5, endorphins=0.0,
+    )
+    basin = np.full(64, 1.0 / 64.0, dtype=np.float64)
+    return ExecBasinState(
+        basin=basin, identity_basin=basin.copy(),
+        phi=phi, kappa=kappa,
+        regime_weights={"quantum": 0.33, "efficient": 0.33, "equilibrium": 0.34},
+        sovereignty=0.5, basin_velocity=0.05, neurochemistry=nc,
+    )
+
+
+# ── 1. Lane parameter envelope ──────────────────────────────────────
+
+
+class TestLaneParameterEnvelope:
+    def test_scalp_envelope_tighter_than_swing(self) -> None:
+        assert lane_param("scalp", "sl_pct") < lane_param("swing", "sl_pct")
+        assert lane_param("scalp", "tp_pct") < lane_param("swing", "tp_pct")
+
+    def test_swing_envelope_tighter_than_trend(self) -> None:
+        assert lane_param("swing", "sl_pct") < lane_param("trend", "sl_pct")
+        assert lane_param("swing", "tp_pct") < lane_param("trend", "tp_pct")
+
+    def test_scalp_sl_about_quarter_percent(self) -> None:
+        assert 0.002 <= lane_param("scalp", "sl_pct") <= 0.008
+
+    def test_swing_sl_around_one_and_a_half_percent(self) -> None:
+        assert 0.010 <= lane_param("swing", "sl_pct") <= 0.025
+
+    def test_trend_sl_three_to_five_percent(self) -> None:
+        assert 0.025 <= lane_param("trend", "sl_pct") <= 0.06
+
+    def test_scalp_swing_budget_sums_to_one(self) -> None:
+        assert (
+            lane_budget_fraction("scalp")
+            + lane_budget_fraction("swing")
+            == pytest.approx(1.0, abs=1e-9)
+        )
+
+    def test_trend_budget_default_is_zero(self) -> None:
+        # Opt-in via parameter registry. Default 0 keeps initial batch
+        # to the two-lane (scalp + swing) split.
+        assert lane_budget_fraction("trend") == pytest.approx(0.0, abs=1e-9)
+
+    def test_observe_budget_is_zero(self) -> None:
+        # observe is decision-only; never holds capital.
+        assert lane_budget_fraction("observe") == 0.0
+
+    def test_unknown_lane_falls_back_to_swing_param(self) -> None:
+        # Defensive: unknown lane key returns the swing slot for the
+        # given param name so callers never blow up on enum drift.
+        assert lane_param("nonsense", "sl_pct") == _LANE_PARAMETER_DEFAULTS["swing"]["sl_pct"]
+
+
+# ── 2. current_position_size lane-budget shrinkage ──────────────────
+
+
+class TestPositionSizeLaneBudget:
+    def test_scalp_lane_sees_only_its_budget_share(self) -> None:
+        bs = _basin_state(phi=0.6)
+        result_scalp = current_position_size(
+            bs, available_equity_usdt=100.0, min_notional_usdt=1.0,
+            leverage=10, bank_size=20, mode=MonkeyMode.INVESTIGATION,
+            lane="scalp",
+        )
+        # The "full" view (no lane shrinkage emulated by bumping budget
+        # to 1.0 via swing) should be roughly 2x of the scalp view since
+        # both lanes default to 0.50.
+        result_swing = current_position_size(
+            bs, available_equity_usdt=100.0, min_notional_usdt=1.0,
+            leverage=10, bank_size=20, mode=MonkeyMode.INVESTIGATION,
+            lane="swing",
+        )
+        # Each lane sees the same 0.50 fraction by default → values
+        # match within the rounding noise from the base formula.
+        assert result_scalp["value"] == pytest.approx(result_swing["value"], rel=1e-9)
+
+    def test_lane_budget_frac_threaded_into_derivation(self) -> None:
+        bs = _basin_state()
+        result = current_position_size(
+            bs, available_equity_usdt=200.0, min_notional_usdt=1.0,
+            leverage=5, bank_size=10, mode=MonkeyMode.INVESTIGATION,
+            lane="swing",
+        )
+        assert result["derivation"]["lane"] == "swing"
+        assert result["derivation"]["lane_budget_frac"] == pytest.approx(0.5)
+
+    def test_trend_lane_zero_budget_makes_size_zero(self) -> None:
+        bs = _basin_state()
+        result = current_position_size(
+            bs, available_equity_usdt=200.0, min_notional_usdt=1.0,
+            leverage=5, bank_size=10, mode=MonkeyMode.INVESTIGATION,
+            lane="trend",
+        )
+        # Default trend budget=0 → effective equity=0 → sized=0.
+        assert result["value"] == 0.0
+
+
+# ── 3. should_scalp_exit lane envelope widening ─────────────────────
+
+
+class TestScalpExitLaneEnvelope:
+    def test_scalp_lane_matches_geometric_when_lane_tighter(self) -> None:
+        bs = _basin_state()
+        # The scalp lane's params (sl=0.4%, tp=0.5%) are TIGHTER than
+        # the geometric formula's INVESTIGATION-mode envelope (sl ~=
+        # 0.67% with default NCs). max(geometric, lane) keeps geometric,
+        # so scalp = "current behavior" — the user's design intent.
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-1.0,  # 1.0% loss, exceeds geometric ~0.67%
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+        )
+        assert result["value"] is True
+        assert "stop_loss[scalp]" in result["reason"]
+
+    def test_swing_lane_absorbs_loss_scalp_would_exit(self) -> None:
+        bs = _basin_state()
+        # 1.0% loss exits scalp (geometric wins, sl ~0.67%) but the
+        # swing lane envelope (sl=1.5%) overrides via max() — swing
+        # holds where scalp would close.
+        scalp = should_scalp_exit(
+            unrealized_pnl_usdt=-1.0,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+        )
+        swing = should_scalp_exit(
+            unrealized_pnl_usdt=-1.0,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+        )
+        assert scalp["value"] is True
+        assert swing["value"] is False
+        assert "scalp hold[swing]" in swing["reason"]
+
+    def test_trend_lane_absorbs_loss_swing_would_exit(self) -> None:
+        bs = _basin_state()
+        # 2.5% loss exceeds swing SL but is below trend's 4% → trend
+        # holds, swing exits.
+        swing = should_scalp_exit(
+            unrealized_pnl_usdt=-2.5,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+        )
+        trend = should_scalp_exit(
+            unrealized_pnl_usdt=-2.5,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="trend",
+        )
+        assert swing["value"] is True
+        assert trend["value"] is False
+
+    def test_geometric_floor_never_breached(self) -> None:
+        bs = _basin_state()
+        # Even if a (hypothetical) lane param said tp=0.0001%, the
+        # geometric fee-clear floor (~0.3%+) wins — verified via the
+        # max() composition. Use a real lane to test default behavior:
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=10.0,  # huge gain
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+        )
+        # 10% gain trivially clears any lane's TP.
+        assert result["value"] is True
+        # And the stored tp_thr exceeds the lane param (geometric won):
+        derivation = result["derivation"]
+        assert derivation["tp_thr"] >= derivation["lane_tp_pct"]
+
+    def test_lane_threaded_into_derivation(self) -> None:
+        bs = _basin_state()
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=0.05,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+        )
+        assert result["derivation"]["lane"] == "scalp"
+        assert result["derivation"]["lane_tp_pct"] == lane_param("scalp", "tp_pct")
+        assert result["derivation"]["lane_sl_pct"] == lane_param("scalp", "sl_pct")
+
+
+# ── 4. should_dca_add same-lane mismatch only ───────────────────────
+
+
+class TestDCALaneScope:
+    def test_same_lane_mismatch_rejects(self) -> None:
+        # held=long, candidate=short, same lane → reject with rule 1.
+        result = should_dca_add(
+            held_side="long", side_candidate="short",
+            current_price=100.0, initial_entry_price=100.0,
+            add_count=0, last_add_at_ms=0, now_ms=10_000_000,
+            sovereignty=0.5, lane="swing",
+        )
+        assert result["value"] is False
+        assert result["derivation"]["rule"] == 1
+        assert result["derivation"]["lane"] == "swing"
+
+    def test_lane_surfaced_into_derivation_on_ok(self) -> None:
+        # held=long, candidate=long, price -2% (long DCA OK),
+        # cooldown elapsed, sovereignty above floor.
+        result = should_dca_add(
+            held_side="long", side_candidate="long",
+            current_price=98.0, initial_entry_price=100.0,
+            add_count=0, last_add_at_ms=0, now_ms=10**12,
+            sovereignty=0.5, lane="scalp",
+        )
+        assert result["value"] is True
+        assert result["derivation"]["lane"] == "scalp"
+        assert "DCA_OK[scalp]" in result["reason"]
+
+    def test_lane_default_is_swing(self) -> None:
+        # No lane arg → defaults to swing for back-compat.
+        result = should_dca_add(
+            held_side="long", side_candidate="short",
+            current_price=100.0, initial_entry_price=100.0,
+            add_count=0, last_add_at_ms=0, now_ms=10_000_000,
+            sovereignty=0.5,
+        )
+        assert "swing" in result["reason"]
+
+
+# ── 5. SymbolState per-lane bookkeeping ─────────────────────────────
+
+
+class TestSymbolStateLaneSubstates:
+    def test_per_lane_dicts_initialize_empty(self) -> None:
+        identity = np.full(64, 1.0 / 64.0, dtype=np.float64)
+        s = SymbolState(symbol="BTC_USDT_PERP", identity_basin=identity)
+        assert s.peak_pnl_usdt_by_lane == {}
+        assert s.peak_tracked_trade_id_by_lane == {}
+        assert s.dca_add_count_by_lane == {}
+        assert s.last_entry_at_ms_by_lane == {}
+        assert s.tape_flip_streak_by_lane == {}
+
+    def test_two_lanes_track_peak_independently(self) -> None:
+        identity = np.full(64, 1.0 / 64.0, dtype=np.float64)
+        s = SymbolState(symbol="BTC_USDT_PERP", identity_basin=identity)
+        s.peak_pnl_usdt_by_lane["scalp"] = 5.0
+        s.peak_pnl_usdt_by_lane["swing"] = 12.0
+        s.peak_tracked_trade_id_by_lane["scalp"] = "trade-1"
+        s.peak_tracked_trade_id_by_lane["swing"] = "trade-2"
+        # Mutating the swing lane's peak does not touch scalp.
+        s.peak_pnl_usdt_by_lane["swing"] = 18.0
+        assert s.peak_pnl_usdt_by_lane["scalp"] == 5.0
+        assert s.peak_pnl_usdt_by_lane["swing"] == 18.0
+
+    def test_two_lanes_streak_counters_independent(self) -> None:
+        identity = np.full(64, 1.0 / 64.0, dtype=np.float64)
+        s = SymbolState(symbol="BTC_USDT_PERP", identity_basin=identity)
+        s.tape_flip_streak_by_lane["scalp"] = 3
+        s.tape_flip_streak_by_lane["swing"] = 0
+        assert s.tape_flip_streak_by_lane["scalp"] == 3
+        assert s.tape_flip_streak_by_lane["swing"] == 0
+
+    def test_dca_count_is_per_lane(self) -> None:
+        identity = np.full(64, 1.0 / 64.0, dtype=np.float64)
+        s = SymbolState(symbol="BTC_USDT_PERP", identity_basin=identity)
+        s.dca_add_count_by_lane["scalp"] = 1
+        s.dca_add_count_by_lane["swing"] = 0
+        # Each lane respects its own DCA cap independently.
+        assert s.dca_add_count_by_lane["scalp"] == 1
+        assert s.dca_add_count_by_lane["swing"] == 0
+
+
+# ── 6. LanePosition / AccountContext lane-aware shape ───────────────
+
+
+class TestLanePositionShape:
+    def test_lane_position_constructs_cleanly(self) -> None:
+        lp = LanePosition(
+            lane="scalp", side="short",
+            entry_price=100.5, quantity=0.001, trade_id="t-99",
+        )
+        assert lp.lane == "scalp"
+        assert lp.side == "short"
+        assert lp.entry_price == 100.5
+        assert lp.quantity == 0.001
+
+    def test_account_context_lane_positions_default_empty(self) -> None:
+        from monkey_kernel.tick import AccountContext
+        a = AccountContext(
+            equity_fraction=1.0, margin_fraction=0.0,
+            open_positions=0, available_equity=100.0,
+        )
+        assert a.lane_positions == []
+
+    def test_account_context_lane_positions_carry_through(self) -> None:
+        from monkey_kernel.tick import AccountContext
+        lps = [
+            LanePosition(lane="swing", side="long",
+                         entry_price=100.0, quantity=0.01, trade_id="t-1"),
+            LanePosition(lane="scalp", side="short",
+                         entry_price=101.0, quantity=0.005, trade_id="t-2"),
+        ]
+        a = AccountContext(
+            equity_fraction=1.0, margin_fraction=0.5,
+            open_positions=2, available_equity=50.0,
+            lane_positions=lps,
+        )
+        assert len(a.lane_positions) == 2
+        assert {lp.lane for lp in a.lane_positions} == {"swing", "scalp"}
+        assert {lp.side for lp in a.lane_positions} == {"long", "short"}
+
+
+# ── 7. Cross-lane non-interference invariant ────────────────────────
+
+
+class TestCrossLaneNonInterference:
+    """The kernel's promise from proposal #10: a swing-long held
+    position can never paralyze a scalp-short on the same symbol —
+    each lane has its own retreat tolerance and capital share.
+    """
+
+    def test_swing_long_envelope_independent_of_scalp_short_envelope(self) -> None:
+        bs = _basin_state()
+        # 1.0% loss — between geometric SL (~0.67%) and swing lane
+        # envelope (1.5%). Swing holds; scalp exits. Demonstrates the
+        # core proposal-#10 invariant: per-lane retreat tolerance.
+        swing_long = should_scalp_exit(
+            unrealized_pnl_usdt=-1.0, notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+        )
+        scalp_short = should_scalp_exit(
+            unrealized_pnl_usdt=-1.0, notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+        )
+        assert swing_long["value"] is False, "swing should hold its 1% drawdown"
+        assert scalp_short["value"] is True, "scalp should fire SL on 1% loss"
+
+    def test_lane_budgets_partition_capital(self) -> None:
+        # Two lanes' budgets should sum to <= 1.0 across position-bearing
+        # lanes so capital is partitioned, not double-counted.
+        total = (
+            lane_budget_fraction("scalp")
+            + lane_budget_fraction("swing")
+            + lane_budget_fraction("trend")
+        )
+        assert total <= 1.0 + 1e-9
+
+    def test_scalp_size_never_eats_swing_capital(self) -> None:
+        bs = _basin_state(phi=0.7)
+        # If both lanes ran on the same available_equity_usdt, scalp's
+        # margin would be no more than its budget fraction × equity.
+        equity = 1000.0
+        scalp = current_position_size(
+            bs, available_equity_usdt=equity, min_notional_usdt=1.0,
+            leverage=10, bank_size=50, mode=MonkeyMode.INVESTIGATION,
+            lane="scalp",
+        )
+        # Even at maximum (max_fraction=0.5 of LANE-budgeted equity),
+        # scalp can't take more than 0.5 * 0.5 * 1000 = 250.
+        max_possible = 0.5 * lane_budget_fraction("scalp") * equity
+        assert scalp["value"] <= max_possible + 1e-6


### PR DESCRIPTION
## Summary

Implements proposal #10: K can hold a swing-long and a scalp-short on the same symbol simultaneously, each in its own capital lane with independent SL/TP envelopes, peak-tracking, DCA gating, and position lifecycle. Solves the "kernel sees short signal but is paralyzed by held long" symptom observed live after PR #609.

User's design principle (verbatim):
> "longer term trades may have to absorb more retreat to not close out if overall the macro says its a long term trade etc. and short term scalps should be separate and not impact other trades."

## What ships

| Layer | Change |
|---|---|
| **Schema (042)** | `autonomous_trades.lane TEXT NOT NULL DEFAULT 'swing'`, CHECK constraint on `{scalp,swing,trend}`, hot-path index on `(agent, symbol, lane, status)` |
| **Python kernel** | `LanePosition` dataclass; per-lane dicts on `SymbolState` for peak/streak/trade-id; `lane_param()` + `lane_budget_fraction()` helpers; lane args threaded through `current_position_size`, `should_scalp_exit`, `should_dca_add`, `_decide_with_position` |
| **TS kernel** | Full parity; `chooseLane` invoked per tick in `loop.ts`; per-lane SymbolState dicts; `findOpenMonkeyTradesByLane` aggregator; `closeHeldPosition` lane-scoped DB update + posSide-aware exchange close |
| **Executor** | New `setPositionDirectionMode(creds, posMode)` + `getPositionDirectionMode(creds)` (distinct from existing mis-named `switchPositionMode` which actually toggles margin mode); `executeEntry` sends `posSide: LONG|SHORT` when account is in HEDGE mode |
| **Capital** | Path (a) — static per-lane budgets via parameter registry (`executive.lane.<name>.budget_frac`, defaults: scalp=0.5, swing=0.5, trend=0.0). Each lane sees `available_equity * budget_frac` for sizing |
| **Envelope composition** | `max(geometric_floor, lane_envelope)` — geometric ~0.3% fee-clear floor inviolable; lane widens tolerance: scalp ~0.67% SL, swing ~1.5%, trend ~4% |

## Tests

- **Python**: 520 pass, 0 fail (+30 new lane-isolation tests in `test_lane_isolation.py`)
- **TypeScript**: 879 pass, 2 fail (+25 new lane tests in `laneIsolation.test.ts`). The 2 fails are the pre-existing `resonance_bank_lane.test.ts` cases — not regressions.
- **QIG purity**: 29 files clean — geometric kernel decision logic stays Fisher-Rao; lane-budget allocation is risk allocation, not geometry
- **TS build**: clean

## Position-mode (HEDGE) toggle — DEFERRED to manual op

Code path shipped end-to-end. Kernel detects current mode at startup via `detectPositionDirectionMode()`, caches on `this.positionDirectionMode` (default `ONE_WAY`). When live mode is `HEDGE`, every entry/exit sends `posSide: LONG|SHORT` so opposite-side lanes coexist on-exchange.

**Why deferred**: Poloniex rejects position-mode flips with open positions. The current K positions on production are live. The toggle must run when account is flat:

```js
// Run once after current K positions close (manual op):
poloniexFuturesService.setPositionDirectionMode(creds, 'HEDGE')
// Then restart kernel; detectPositionDirectionMode picks up the new mode
```

Until that flip happens, lane discipline still works at the DB layer (each lane has its own SL/TP, peak, capital share, DCA state). Two opposite-side lanes would net at the exchange in `ONE_WAY` mode — which is exactly what's happening today, so the new code degrades gracefully into existing behavior.

## Judgment calls (all in commit body)

1. Envelope composition `max(geometric, lane)` — keeps fee-clear floor inviolable
2. Trend lane defaults to `budget_frac=0` — opt-in via parameter registry
3. Pre-#10 scalar SymbolState fields kept alongside new per-lane dicts for telemetry/parity-reader compatibility
4. Existing `switchPositionMode` (which actually toggles margin mode, not position mode — historical naming) left untouched; new method named `setPositionDirectionMode`
5. `_decide_with_position` manages one lane per tick currently; multi-lane simultaneous management is a follow-up once Python tick goes primary

## Architecture flow now

```
                ┌──────────────┐
                │ K (Δ⁶³ kernel) │
                └─────────────┬┘
                              │ chooseLane(basin, mode, regime)
                              ▼
              ┌──────────────────────────────┐
              │ scalp lane         swing lane│
              │ tight SL/TP        wide SL/TP│
              │ 50% budget         50% budget│
              │ peak/streak A      peak/streak B│
              └──────┬─────────────────┬─────┘
                     │                 │
                     ▼                 ▼
              [trade row K|BTC|scalp]  [trade row K|BTC|swing]
                     │                 │
                     ▼                 ▼
              [posSide: LONG|SHORT in HEDGE mode]
```

## Rollback

`git revert <commit>` and migration 042 has rollback SQL in commit body (drop column, drop constraint, drop index).

## Test plan

- [ ] Verify Railway deploys succeed for both `polytrade-be` and `ml-worker`
- [ ] Migration 042 applies cleanly on production
- [ ] `detectPositionDirectionMode` startup log appears with current mode
- [ ] Existing K positions continue ticking on the implicit `'swing'` lane (per migration default)
- [ ] **Manual op when current positions close**: run `setPositionDirectionMode('HEDGE')` and restart kernel; subsequent ticks should fire scalp-short alongside held swing-long without conflict
- [ ] After hedge mode active: confirm `posSide` field appears on placed orders (Poloniex API logs / order detail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce lane-isolated position lifecycle so scalp, swing, and trend trades on the same symbol are managed independently with per-lane capital, envelopes, and state, and wire this through the Python and TypeScript Monkey kernels, executor, Poloniex integration, and database schema.

New Features:
- Support multiple concurrent lane-specific positions (scalp, swing, trend) per symbol, each with its own SL/TP envelopes, peak tracking, DCA state, and lifecycle.
- Add per-lane capital budgeting so each lane sees only its configured equity share when sizing positions.
- Introduce Poloniex position-direction mode detection and optional HEDGE mode support so opposite-side lanes can coexist on-exchange.

Enhancements:
- Extend executive logic in Python and TypeScript with lane-aware sizing, exit, and DCA decisions, while preserving backward compatibility for legacy single-lane behavior.
- Augment SymbolState and account context structures with per-lane bookkeeping and lane-position snapshots to prevent cross-lane interference.
- Improve trade persistence metadata and reason encoding to include lane information for better attribution and reconciliation.

Documentation:
- Add SQL migration comments and in-code documentation explaining the lane-isolated position model, configuration defaults, and operational considerations for enabling HEDGE mode.

Tests:
- Add comprehensive Python and TypeScript test suites to validate lane parameter envelopes, lane-budget sizing, lane-scoped exits and DCA, SymbolState lane bookkeeping, and cross-lane non-interference invariants.

Chores:
- Add database migration to introduce a lane column with constraints and indexing for autonomous_trades, enabling efficient lane-scoped position lookups.