### PR TITLE
fix(monkey): lane-budget size=0 regression + HEDGE flip

### DIFF
--- a/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
+++ b/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   LANE_PARAMETER_DEFAULTS,
+  chooseLane,
   currentPositionSize,
   laneBudgetFraction,
   laneParam,
@@ -90,12 +91,13 @@ describe('Lane parameter envelope (proposal #10)', () => {
 });
 
 
-describe('currentPositionSize lane-budget shrinkage', () => {
+describe('currentPositionSize lane-budget cap (post fix/lane-budget-size-zero-regression)', () => {
   it('threads lane and lane budget into derivation', () => {
     const result = currentPositionSize(
       basinState(0.5), 200, 1, 5, 10, MonkeyMode.INVESTIGATION, 'swing',
     );
     expect(result.derivation.laneBudgetFrac).toBeCloseTo(0.5, 9);
+    expect(result.derivation.laneMarginCap).toBeCloseTo(0.5 * 200, 6);
   });
 
   it('scalp + swing both at default 0.5 produce comparable margins', () => {
@@ -115,12 +117,13 @@ describe('currentPositionSize lane-budget shrinkage', () => {
     expect(result.value).toBe(0);
   });
 
-  it('scalp lane size never exceeds 50% of lane-budgeted equity', () => {
+  it('scalp lane margin never exceeds the lane budget cap', () => {
     const equity = 1000;
     const result = currentPositionSize(
       basinState(0.7, 0.7), equity, 1, 10, 50, MonkeyMode.INVESTIGATION, 'scalp',
     );
-    const cap = 0.5 * laneBudgetFraction('scalp') * equity;
+    // Cap is laneBudgetFraction × equity (margin cap, not equity haircut).
+    const cap = laneBudgetFraction('scalp') * equity;
     expect(result.value).toBeLessThanOrEqual(cap + 1e-6);
   });
 });
@@ -231,7 +234,8 @@ describe('Cross-lane non-interference (proposal #10 invariant)', () => {
     const scalp = currentPositionSize(
       basinState(0.7, 0.7), equity, 1, 10, 50, MonkeyMode.INVESTIGATION, 'scalp',
     );
-    const cap = 0.5 * laneBudgetFraction('scalp') * equity;
+    // Margin cap is laneBudgetFraction × equity = 0.5 × 1000 = 500.
+    const cap = laneBudgetFraction('scalp') * equity;
     expect(scalp.value).toBeLessThanOrEqual(cap + 1e-6);
   });
 
@@ -244,5 +248,132 @@ describe('Cross-lane non-interference (proposal #10 invariant)', () => {
     expect(LANE_PARAMETER_DEFAULTS.swing.slPct).toBeLessThanOrEqual(0.025);
     expect(LANE_PARAMETER_DEFAULTS.trend.slPct).toBeGreaterThanOrEqual(0.025);
     expect(LANE_PARAMETER_DEFAULTS.trend.slPct).toBeLessThanOrEqual(0.06);
+  });
+});
+
+
+// ─── fix/lane-budget-size-zero-regression — flat-account regression ───
+//
+// Pre-fix behaviour (PR #610): currentPositionSize multiplied
+// availableEquity by laneBudgetFraction BEFORE the formula and the
+// v0.6.6 lift-to-min, halving the pool the sizer had to work with.
+// On small accounts (per-symbol exposure cap leaves ~$5 free) this
+// pushed required_frac past the 0.5 safety clamp → no lift fired and
+// every entry returned size=0. Trend lane (budget=0) collapsed every
+// tick where chooseLane picked it.
+//
+// Post-fix: laneBudgetFraction caps the FINAL margin (after lift-to-
+// min); equity is not haircut. Trend (cap=0) still collapses to 0;
+// scalp/swing on flat accounts size > 0 down to exchange minimum.
+describe('Flat-account sizing regression (fix/lane-budget-size-zero-regression)', () => {
+  it('flat account, swing lane, ETH min — sizes > 0 (live alert symptom)', () => {
+    const result = currentPositionSize(
+      basinState(0.55, 0.5), 90, 22.49, 14, 0, MonkeyMode.INVESTIGATION, 'swing',
+    );
+    expect(result.value).toBeGreaterThan(0);
+    const notional = result.value * 14;
+    expect(notional).toBeGreaterThanOrEqual(22.49);
+  });
+
+  it('flat account, scalp lane, BTC min — sizes > 0 (live alert symptom)', () => {
+    const result = currentPositionSize(
+      basinState(0.55, 0.5), 90, 75.78, 14, 0, MonkeyMode.INTEGRATION, 'scalp',
+    );
+    expect(result.value).toBeGreaterThan(0);
+    const notional = result.value * 14;
+    expect(notional).toBeGreaterThanOrEqual(75.78);
+  });
+
+  it('small account ($5 equity) — lift-to-min reaches min notional post-fix', () => {
+    // Pre-fix: equity halved to $2.50 → required_frac=0.643 → no lift
+    // → size=0. Post-fix: full $5 → required_frac=0.337 → lift fires.
+    const result = currentPositionSize(
+      basinState(0.55, 0.5), 5, 22.49, 14, 0, MonkeyMode.INVESTIGATION, 'swing',
+    );
+    expect(result.value).toBeGreaterThan(0);
+    expect(result.derivation.liftedToMin).toBe(1);
+  });
+
+  it('cold-start (bank=0, sovereignty=0, low phi) still sizes via exploration floor', () => {
+    const result = currentPositionSize(
+      basinState(0.20, 0.0), 90, 22.49, 14, 0, MonkeyMode.INVESTIGATION, 'swing',
+    );
+    expect(result.value).toBeGreaterThan(0);
+    const notional = result.value * 14;
+    expect(notional).toBeGreaterThanOrEqual(22.49);
+  });
+
+  it('trend lane (budget=0) still collapses to 0 — opt-in promise preserved', () => {
+    const result = currentPositionSize(
+      basinState(0.55, 0.5), 1000, 22.49, 14, 20, MonkeyMode.INVESTIGATION, 'trend',
+    );
+    expect(result.value).toBe(0);
+    expect(result.derivation.laneMarginCap).toBe(0);
+  });
+
+  it('lane margin cap surfaces in derivation', () => {
+    const result = currentPositionSize(
+      basinState(0.5), 200, 1, 5, 10, MonkeyMode.INVESTIGATION, 'swing',
+    );
+    expect(result.derivation.laneMarginCap).toBeCloseTo(100, 6);
+  });
+
+  it('scalp and swing report identical caps when budgets match', () => {
+    const scalp = currentPositionSize(
+      basinState(0.6), 400, 1, 5, 20, MonkeyMode.INVESTIGATION, 'scalp',
+    );
+    const swing = currentPositionSize(
+      basinState(0.6), 400, 1, 5, 20, MonkeyMode.INVESTIGATION, 'swing',
+    );
+    expect(scalp.derivation.laneMarginCap)
+      .toBeCloseTo(swing.derivation.laneMarginCap, 6);
+  });
+
+  it('chooseLane never returns a zero-budget position lane', () => {
+    // High sovereignty + strong tape pushes raw trend score to dominate;
+    // softmax with τ=1/κ would otherwise pick "trend" (budget=0). The
+    // structural-zero fallback must redirect to scalp/swing.
+    const bs = basinState(0.9, 0.9);
+    const result = chooseLane(bs, 1.0);
+    expect(result.value).not.toBe('trend');
+    if (result.value !== 'observe') {
+      expect(laneBudgetFraction(result.value)).toBeGreaterThan(0);
+    }
+  });
+
+  it('chooseLane keeps observe (it is decision-only, not capital-bearing)', () => {
+    // High basinVelocity should let observe win the softmax. The
+    // fallback is restricted to position-bearing lanes; observe must
+    // surface so the loop can map it to swing for sizing.
+    const bs = { ...basinState(0.4, 0.5), basinVelocity: 0.95 };
+    const result = chooseLane(bs as any, 0.0);
+    expect(['scalp', 'swing', 'trend', 'observe']).toContain(result.value);
+  });
+
+  it('mid-trade sizing on a single lane unaffected by other-lane existence', () => {
+    // Sanity: changing leverage on a flat account still yields a sane
+    // size; the lane cap binds independently of whatever else is going
+    // on for this symbol.
+    const bs = basinState(0.55, 0.5);
+    const a = currentPositionSize(bs, 90, 22.49, 14, 0, MonkeyMode.INVESTIGATION, 'swing');
+    const b = currentPositionSize(bs, 90, 22.49, 20, 0, MonkeyMode.INVESTIGATION, 'swing');
+    expect(a.value).toBeGreaterThan(0);
+    expect(b.value).toBeGreaterThan(0);
+    // Higher leverage doesn't INCREASE margin (formula is leverage-
+    // agnostic on the formula side; leverage matters only for notional
+    // & lift-to-min). Both should be capped by the same lane cap.
+    expect(a.derivation.laneMarginCap).toBe(b.derivation.laneMarginCap);
+  });
+
+  it('regression: pre-fix size=0 case from production logs', () => {
+    // Direct reproduction of the bug from the production log:
+    //   $90 equity, mode=integration, swing lane, ETH min $22.49, lev 14.
+    // Pre-fix this returned 0; post-fix it must clear min notional.
+    const bs = basinState(0.55, 0.5);
+    const result = currentPositionSize(
+      bs, 90, 22.49, 14, 0, MonkeyMode.INTEGRATION, 'swing',
+    );
+    expect(result.value).toBeGreaterThan(0);
+    expect(result.value * 14).toBeGreaterThanOrEqual(22.49);
   });
 });

--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -168,13 +168,33 @@ export function currentPositionSize(
   mode: MonkeyMode = MonkeyMode.INVESTIGATION,
   lane: 'scalp' | 'swing' | 'trend' = 'swing',
 ): ExecutiveDecision<number> {
-  // Proposal #10 — per-lane capital budget. Each lane sees only its
-  // share of available equity for sizing, so a held swing-long no
-  // longer paralyzes a scalp-short on the same symbol. A zero-budget
-  // lane (default for "trend" until governance bumps it) is sized to
-  // zero — capital is not allocated to it this tick.
+  // ─── Proposal #10 lane-budget — applied as a MARGIN CAP, not an
+  // equity haircut (fix/lane-budget-size-zero-regression).
+  //
+  // Original PR #610 implementation multiplied availableEquityUsdt by
+  // laneFrac BEFORE the size formula. That double-dipped against the
+  // already-cap'd availableEquity (loop.ts already shrinks it via
+  // sizeFraction × kernel-share) and broke the v0.6.6 lift-to-min
+  // path on small accounts: with $90 equity → halved to $45 the
+  // requiredFrac for a $75.78 BTC min at 14x was 0.126 (fine), but
+  // the loop's per-symbol cap further reduces availableEquity below
+  // the size-fraction-relief floor, so the effective pool seen here
+  // routinely fell to ~$5 on production. Halving that to $2.50
+  // pushed requiredFrac past the 0.5 safety clamp → no lift fired
+  // and every entry returned size=0. Trend lane (budget=0) also
+  // collapsed every tick where chooseLane picked it — there is no
+  // "softmax fall-through" to a positive-budget lane.
+  //
+  // The correct semantic: budgetFrac caps the MARGIN a single
+  // position can claim against full equity. Sizing math sees the
+  // full available pool; the final margin is min(formula, cap).
+  // This preserves the "trend is opt-in" promise (budget=0 → cap=0
+  // → margin=0) AND lets lift-to-min reach the exchange minimum on
+  // small accounts AND preserves the cross-lane partition invariant
+  // (scalp's margin ≤ 50% of equity even when scalp+swing both
+  // active).
   const laneFrac = laneBudgetFraction(lane);
-  availableEquityUsdt = availableEquityUsdt * laneFrac;
+  const laneMarginCap = laneFrac * availableEquityUsdt;
   const nc = s.neurochemistry;
   // Lived-experience scaling. 0 at birth, 1 after ~20 witnessed trades.
   const maturity = Math.min(1, bankSize / 20);
@@ -214,17 +234,31 @@ export function currentPositionSize(
     }
   }
 
+  // Apply lane margin cap AFTER lift-to-min. Trend lane (cap=0) still
+  // collapses to 0 — it remains opt-in. For scalp/swing on a flat
+  // account, cap = 0.5 × equity which is identical to the existing
+  // safety clamp, so the binding constraint is unchanged in the common
+  // case. The cap matters when both lanes hold positions: the second
+  // lane's budget enforces the partition.
+  let cappedByLane = false;
+  if (margin > laneMarginCap) {
+    margin = laneMarginCap;
+    notional = margin * Math.max(1, leverage);
+    cappedByLane = true;
+  }
+
   const sized = notional >= minNotionalUsdt ? margin : 0;
 
   return {
     value: sized,
-    reason: `size[${lane}] = ${liftedToMin ? 'lifted-to-min ' : ''}floor(${explorationFloor.toFixed(3)}) or Φ×S×M(${(s.phi * s.sovereignty * maturity).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)}) × equity(${availableEquityUsdt.toFixed(2)}) @ ${leverage}x → margin ${margin.toFixed(2)}, notional ${notional.toFixed(2)} vs min ${minNotionalUsdt.toFixed(2)} = ${sized.toFixed(2)}`,
+    reason: `size[${lane}] = ${liftedToMin ? 'lifted-to-min ' : ''}${cappedByLane ? 'lane-capped ' : ''}floor(${explorationFloor.toFixed(3)}) or Φ×S×M(${(s.phi * s.sovereignty * maturity).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)}) × equity(${availableEquityUsdt.toFixed(2)}) @ ${leverage}x → margin ${margin.toFixed(2)} (lane-cap ${laneMarginCap.toFixed(2)}), notional ${notional.toFixed(2)} vs min ${minNotionalUsdt.toFixed(2)} = ${sized.toFixed(2)}`,
     derivation: {
       phi: s.phi, sovereignty: s.sovereignty, maturity, bankSize,
       dopamine: nc.dopamine, serotonin: nc.serotonin, gaba: nc.gaba,
       explorationFloor, rawFrac, frac, margin, leverage, notional,
       minNotional: minNotionalUsdt, sized, liftedToMin: liftedToMin ? 1 : 0,
       laneBudgetFrac: laneFrac,
+      laneMarginCap, cappedByLane: cappedByLane ? 1 : 0,
     },
   };
 }
@@ -757,15 +791,44 @@ export function chooseLane(
     }
   }
 
+  // ─── fix/lane-budget-size-zero-regression: structural-zero fallback ───
+  //
+  // If the chosen position-bearing lane has budgetFrac=0 (e.g. trend is
+  // opt-in via the parameter registry and defaults to 0), the upstream
+  // sizer collapses every entry to 0. Fall through to the next-highest
+  // lane that is *capable* of holding capital. 'observe' is decision-
+  // only and stays as-is (the loop maps it to swing for sizing).
+  const isZeroBudgetPosLane = (l: LaneType): boolean =>
+    (l === 'scalp' || l === 'swing' || l === 'trend') && laneBudgetFraction(l) === 0;
+  let fallbackFrom: LaneType | null = null;
+  if (isZeroBudgetPosLane(lane)) {
+    fallbackFrom = lane;
+    let nextProb = -1;
+    let next: LaneType = lane;
+    for (const [k, v] of Object.entries(probs) as [LaneType, number][]) {
+      if (k === lane) continue;
+      if (k === 'observe') continue;
+      if (isZeroBudgetPosLane(k)) continue;
+      if (v > nextProb) {
+        nextProb = v;
+        next = k;
+      }
+    }
+    if (next !== lane) {
+      lane = next;
+    }
+  }
+
   return {
     value: lane,
-    reason: `lane=${lane} (tau=${tau.toFixed(4)}, scalp=${probs.scalp.toFixed(3)} swing=${probs.swing.toFixed(3)} trend=${probs.trend.toFixed(3)} observe=${probs.observe.toFixed(3)})`,
+    reason: `lane=${lane}${fallbackFrom && fallbackFrom !== lane ? ` (fallback from ${fallbackFrom}, budget=0)` : ''} (tau=${tau.toFixed(4)}, scalp=${probs.scalp.toFixed(3)} swing=${probs.swing.toFixed(3)} trend=${probs.trend.toFixed(3)} observe=${probs.observe.toFixed(3)})`,
     derivation: {
       tau,
       phi: s.phi,
       sovereignty: s.sovereignty,
       basinVelocity: s.basinVelocity,
       tapeTrend,
+      fallbackFromZeroBudget: fallbackFrom && fallbackFrom !== lane ? 1 : 0,
     },
   };
 }

--- a/ml-worker/src/monkey_kernel/executive.py
+++ b/ml-worker/src/monkey_kernel/executive.py
@@ -314,14 +314,27 @@ def current_position_size(
     mode: MonkeyMode = MonkeyMode.INVESTIGATION,
     lane: str = "swing",
 ) -> dict[str, Any]:
-    # Proposal #10: per-lane capital budget. Each lane sees only its
-    # share of available equity for sizing, so a held swing-long can no
-    # longer paralyze a scalp-short on the same symbol. The lane budget
-    # is a live-governed risk parameter (executive.lane.<lane>.budget_frac).
-    # A zero-budget lane (default for "trend" until governance bumps it)
-    # is sized to zero — capital is not allocated to it this tick.
+    # ─── Proposal #10 lane-budget — applied as a MARGIN CAP, not an
+    # equity haircut (fix/lane-budget-size-zero-regression).
+    #
+    # Original PR #610 implementation multiplied available_equity_usdt
+    # by lane_frac BEFORE the size formula. That double-dipped against
+    # the already-cap'd available_equity (the caller already shrinks it
+    # via size_fraction × kernel-share) and broke the v0.6.6 lift-to-
+    # min path on small accounts: when the per-symbol exposure cap left
+    # ~$5 in the pool, halving to $2.50 pushed required_frac past the
+    # 0.5 max_fraction clamp → no lift fired and every entry returned
+    # size=0. Trend lane (budget=0) also collapsed every tick where
+    # choose_lane picked it.
+    #
+    # The correct semantic: budget_frac caps the MARGIN a single
+    # position can claim against full equity. Sizing math sees the
+    # full available pool; the final margin is min(formula, cap). This
+    # preserves "trend is opt-in" (cap=0 → margin=0), preserves
+    # cross-lane partition (scalp's margin ≤ 50% of equity), and
+    # restores lift-to-min behaviour on small accounts.
     lane_frac = lane_budget_fraction(lane)
-    available_equity_usdt = available_equity_usdt * lane_frac
+    lane_margin_cap = lane_frac * available_equity_usdt
     nc = s.neurochemistry
     maturity = min(1.0, bank_size / 20.0)
     base_frac = s.phi * s.sovereignty * maturity
@@ -364,16 +377,29 @@ def current_position_size(
             notional = margin * leverage
             lifted = True
 
+    # Apply lane margin cap AFTER lift-to-min. Trend lane (cap=0) still
+    # collapses to 0 — it remains opt-in. For scalp/swing on a flat
+    # account, cap = 0.5 × equity which is identical to the existing
+    # safety clamp, so the binding constraint is unchanged in the
+    # common case.
+    capped_by_lane = False
+    if margin > lane_margin_cap:
+        margin = lane_margin_cap
+        notional = margin * max(1.0, leverage)
+        capped_by_lane = True
+
     sized = margin if notional >= min_notional_usdt else 0.0
 
     return {
         "value": sized,
         "reason": (
             f"size[{lane}] = {'lifted-to-min ' if lifted else ''}"
+            f"{'lane-capped ' if capped_by_lane else ''}"
             f"floor({exploration_floor:.3f}) or PhixSxM({base_frac:.3f}) "
             f"x reward({reward_mult:.2f}) x stab({stability_mult:.2f}) "
             f"x equity({available_equity_usdt:.2f}) @ {leverage:.0f}x "
-            f"-> margin {margin:.2f}, notional {notional:.2f} vs min {min_notional_usdt:.2f} "
+            f"-> margin {margin:.2f} (lane-cap {lane_margin_cap:.2f}), "
+            f"notional {notional:.2f} vs min {min_notional_usdt:.2f} "
             f"= {sized:.2f}"
         ),
         "derivation": {
@@ -392,6 +418,8 @@ def current_position_size(
             "lifted_to_min": 1 if lifted else 0,
             "lane": lane,
             "lane_budget_frac": lane_frac,
+            "lane_margin_cap": lane_margin_cap,
+            "capped_by_lane": 1 if capped_by_lane else 0,
         },
     }
 
@@ -1151,10 +1179,44 @@ def choose_lane(
     # Pick lane with highest probability
     lane: LaneType = max(probs, key=lambda k: probs[k])  # type: ignore[arg-type]
 
+    # ─── fix/lane-budget-size-zero-regression: structural-zero fallback ───
+    #
+    # If the chosen position-bearing lane has budget_frac=0 (e.g. trend
+    # is opt-in via the parameter registry and defaults to 0), the
+    # upstream sizer collapses every entry to 0. Fall through to the
+    # next-highest position-bearing lane that is *capable* of holding
+    # capital. 'observe' is decision-only and stays as-is.
+    fallback_from: Optional[LaneType] = None
+
+    def _is_zero_budget_pos_lane(l: LaneType) -> bool:
+        return l in ("scalp", "swing", "trend") and lane_budget_fraction(l) == 0.0
+
+    if _is_zero_budget_pos_lane(lane):
+        fallback_from = lane
+        next_prob = -1.0
+        next_lane: LaneType = lane
+        for k, v in probs.items():
+            if k == lane:
+                continue
+            if k == "observe":
+                continue
+            if _is_zero_budget_pos_lane(k):  # type: ignore[arg-type]
+                continue
+            if v > next_prob:
+                next_prob = v
+                next_lane = k  # type: ignore[assignment]
+        if next_lane != lane:
+            lane = next_lane
+
+    fallback_note = (
+        f" (fallback from {fallback_from}, budget=0)"
+        if fallback_from and fallback_from != lane else ""
+    )
+
     return {
         "value": lane,
         "reason": (
-            f"lane={lane} (tau={tau:.4f}, "
+            f"lane={lane}{fallback_note} (tau={tau:.4f}, "
             f"scalp={probs.get('scalp', 0):.3f} swing={probs.get('swing', 0):.3f} "
             f"trend={probs.get('trend', 0):.3f} observe={probs.get('observe', 0):.3f})"
         ),
@@ -1166,5 +1228,8 @@ def choose_lane(
             "sovereignty": s.sovereignty,
             "basin_velocity": s.basin_velocity,
             "tape_trend": tape_trend,
+            "fallback_from_zero_budget": (
+                1 if fallback_from and fallback_from != lane else 0
+            ),
         },
     }

--- a/ml-worker/tests/monkey_kernel/test_lane_isolation.py
+++ b/ml-worker/tests/monkey_kernel/test_lane_isolation.py
@@ -37,6 +37,7 @@ if _SRC not in sys.path:
 from monkey_kernel.executive import (  # noqa: E402
     ExecBasinState,
     _LANE_PARAMETER_DEFAULTS,
+    choose_lane,
     current_position_size,
     lane_budget_fraction,
     lane_param,
@@ -391,15 +392,169 @@ class TestCrossLaneNonInterference:
 
     def test_scalp_size_never_eats_swing_capital(self) -> None:
         bs = _basin_state(phi=0.7)
-        # If both lanes ran on the same available_equity_usdt, scalp's
-        # margin would be no more than its budget fraction × equity.
+        # Per fix/lane-budget-size-zero-regression: lane budget acts as
+        # a MARGIN CAP, not an equity haircut. Scalp's margin cap is
+        # lane_budget_fraction(scalp) × equity = 0.5 × 1000 = 500.
         equity = 1000.0
         scalp = current_position_size(
             bs, available_equity_usdt=equity, min_notional_usdt=1.0,
             leverage=10, bank_size=50, mode=MonkeyMode.INVESTIGATION,
             lane="scalp",
         )
-        # Even at maximum (max_fraction=0.5 of LANE-budgeted equity),
-        # scalp can't take more than 0.5 * 0.5 * 1000 = 250.
-        max_possible = 0.5 * lane_budget_fraction("scalp") * equity
+        max_possible = lane_budget_fraction("scalp") * equity
         assert scalp["value"] <= max_possible + 1e-6
+
+
+# ── 8. fix/lane-budget-size-zero-regression — flat-account sizing ──
+
+
+class TestFlatAccountLaneSizing:
+    """Regression suite for the size=0 bug introduced by PR #610 (proposal
+    #10). Pre-fix behaviour: ``current_position_size`` haircut available
+    equity by ``lane_budget_fraction`` BEFORE the formula AND lift-to-min,
+    which on small accounts pushed required_frac past the safety clamp,
+    producing margin=0 for every entry on a fresh-flat account.
+
+    Post-fix: lane budget is a MARGIN CAP applied AFTER lift-to-min. Trend
+    lane (cap=0) still collapses to 0; scalp/swing on flat accounts size
+    > 0 down to the exchange minimum notional.
+    """
+
+    def test_flat_account_swing_lane_clears_eth_min_notional(self) -> None:
+        """The exact ETH symptom from the live alert: $90 equity, $22.49
+        min, lev 14, mode=INVESTIGATION, swing lane → must size > 0."""
+        bs = _basin_state(phi=0.55)
+        result = current_position_size(
+            bs, available_equity_usdt=90.0, min_notional_usdt=22.49,
+            leverage=14, bank_size=0, mode=MonkeyMode.INVESTIGATION,
+            lane="swing",
+        )
+        assert result["value"] > 0, (
+            f"Flat-account swing sizing must be non-zero; got reason={result['reason']}"
+        )
+        # Notional must clear the exchange minimum.
+        notional = result["value"] * 14
+        assert notional + 1e-9 >= 22.49
+
+    def test_flat_account_scalp_lane_clears_btc_min_notional(self) -> None:
+        """The BTC symptom: $90 equity, $75.78 min, lev 14, scalp lane."""
+        bs = _basin_state(phi=0.55)
+        result = current_position_size(
+            bs, available_equity_usdt=90.0, min_notional_usdt=75.78,
+            leverage=14, bank_size=0, mode=MonkeyMode.INTEGRATION,
+            lane="scalp",
+        )
+        assert result["value"] > 0, (
+            f"Flat-account scalp sizing must be non-zero; got reason={result['reason']}"
+        )
+        notional = result["value"] * 14
+        assert notional + 1e-9 >= 75.78
+
+    def test_small_account_lift_to_min_works_post_fix(self) -> None:
+        """Reproduces the pre-fix small-account regression: with $5
+        equity (per-symbol cap path on production), lev 14, ETH min
+        $22.49, the v0.6.6 lift-to-min must reach min notional. Pre-fix:
+        equity was halved to $2.50 → required_frac=0.643 > 0.5 → no
+        lift → size=0. Post-fix: full $5 → required_frac=0.337 < 0.5 →
+        lift fires."""
+        bs = _basin_state(phi=0.55)
+        result = current_position_size(
+            bs, available_equity_usdt=5.0, min_notional_usdt=22.49,
+            leverage=14, bank_size=0, mode=MonkeyMode.INVESTIGATION,
+            lane="swing",
+        )
+        assert result["value"] > 0
+        assert result["derivation"]["lifted_to_min"] == 1
+
+    def test_empty_bank_zero_sovereignty_still_sizes_above_min(self) -> None:
+        """Cold-start: bank_size=0, sovereignty=0, phi small. Must reach
+        min notional via the exploration floor + lift-to-min."""
+        bs = _basin_state(phi=0.20)
+        bs.sovereignty = 0.0
+        result = current_position_size(
+            bs, available_equity_usdt=90.0, min_notional_usdt=22.49,
+            leverage=14, bank_size=0, mode=MonkeyMode.INVESTIGATION,
+            lane="swing",
+        )
+        assert result["value"] > 0
+        notional = result["value"] * 14
+        assert notional + 1e-9 >= 22.49
+
+    def test_trend_lane_still_zero_post_fix(self) -> None:
+        """Trend lane budget=0 must still collapse to 0 — the opt-in
+        promise survives the fix. Cap = 0 × equity = 0 binds."""
+        bs = _basin_state(phi=0.55)
+        result = current_position_size(
+            bs, available_equity_usdt=1000.0, min_notional_usdt=22.49,
+            leverage=14, bank_size=20, mode=MonkeyMode.INVESTIGATION,
+            lane="trend",
+        )
+        assert result["value"] == 0.0
+        assert result["derivation"]["lane_margin_cap"] == 0.0
+
+    def test_pre_fix_haircut_account_now_sizes_above_zero(self) -> None:
+        """Direct reproduction of the pre-fix size=0 case: $4.50 equity
+        (mimicking the per-symbol cap × size_fraction path on small
+        accounts), ETH min $22.49, lev 14. Pre-fix: $4.50 × 0.5 lane
+        = $2.25 → required_frac = (22.49 × 1.05) / (14 × 2.25) = 0.749 >
+        0.5 max_fraction → no lift → size=0. Post-fix: full $4.50
+        → required_frac = 0.374 < 0.5 → lift fires → size > 0."""
+        bs = _basin_state(phi=0.55)
+        result = current_position_size(
+            bs, available_equity_usdt=4.50, min_notional_usdt=22.49,
+            leverage=14, bank_size=0, mode=MonkeyMode.INVESTIGATION,
+            lane="swing",
+        )
+        assert result["value"] > 0
+        assert result["derivation"]["lifted_to_min"] == 1
+
+    def test_lane_margin_cap_in_derivation(self) -> None:
+        bs = _basin_state(phi=0.5)
+        result = current_position_size(
+            bs, available_equity_usdt=200.0, min_notional_usdt=1.0,
+            leverage=5, bank_size=10, mode=MonkeyMode.INVESTIGATION,
+            lane="swing",
+        )
+        # 0.5 budget × $200 = $100 cap.
+        assert result["derivation"]["lane_margin_cap"] == pytest.approx(100.0)
+
+    def test_scalp_swing_caps_match_when_budgets_match(self) -> None:
+        """Both default to budget_frac=0.5; both should report the same
+        margin cap, demonstrating the fair partition."""
+        bs = _basin_state(phi=0.6)
+        scalp = current_position_size(
+            bs, available_equity_usdt=400.0, min_notional_usdt=1.0,
+            leverage=5, bank_size=20, mode=MonkeyMode.INVESTIGATION,
+            lane="scalp",
+        )
+        swing = current_position_size(
+            bs, available_equity_usdt=400.0, min_notional_usdt=1.0,
+            leverage=5, bank_size=20, mode=MonkeyMode.INVESTIGATION,
+            lane="swing",
+        )
+        assert scalp["derivation"]["lane_margin_cap"] == pytest.approx(
+            swing["derivation"]["lane_margin_cap"]
+        )
+
+    def test_choose_lane_falls_back_when_top_pick_has_zero_budget(self) -> None:
+        """choose_lane must NEVER return a position-bearing lane with
+        budget_frac=0 (e.g. trend at default). With sovereignty high and
+        tape strong, raw trend score dominates — but the fallback should
+        push us into the next-highest positive-budget lane (swing/scalp)."""
+        bs = _basin_state(phi=0.9)
+        bs.sovereignty = 0.9  # high sov
+        # tape_trend=1.0 maximises trend_score = phi × sov × 1 = 0.81
+        result = choose_lane(bs, tape_trend=1.0)
+        # Trend has budget=0, so we MUST land on a positive-budget lane.
+        assert result["value"] != "trend"
+        assert lane_budget_fraction(result["value"]) > 0.0
+
+    def test_choose_lane_keeps_observe_unchanged(self) -> None:
+        """observe is decision-only; the fallback is for position-bearing
+        lanes only. observe winning the softmax must still surface."""
+        bs = _basin_state(phi=0.4)
+        bs.basin_velocity = 0.95  # huge velocity → observe dominates
+        result = choose_lane(bs, tape_trend=0.0)
+        # observe must remain a valid output even though its budget is 0.
+        # (It's a decision-only lane; loop.ts maps it to swing for sizing.)
+        assert result["value"] in ("scalp", "swing", "trend", "observe")

--- a/ml-worker/tests/monkey_kernel/test_lane_selection.py
+++ b/ml-worker/tests/monkey_kernel/test_lane_selection.py
@@ -109,10 +109,23 @@ class TestChooseLane:
         assert result["value"] == "scalp"
 
     def test_high_phi_sovereignty_trend_favors_trend(self) -> None:
-        """phi≈1, sovereignty≈1, strong tape_trend → trend."""
+        """phi≈1, sovereignty≈1, strong tape_trend → trend score wins
+        the softmax. Per fix/lane-budget-size-zero-regression, when the
+        trend lane has budget_frac=0 (default opt-in), the chooser
+        falls through to the next-highest position-bearing lane so the
+        sizer doesn't collapse every entry to 0. The raw softmax probs
+        still show trend dominating; the surfaced .value is the
+        fallback selection."""
         s = _make_state(phi=0.95, sovereignty=0.95, basin_velocity=0.05, kappa=KAPPA_STAR)
         result = choose_lane(s, tape_trend=0.9)
-        assert result["value"] == "trend"
+        # Raw softmax: trend score = 0.95 × 0.95 × 0.9 ≈ 0.81 dominates.
+        probs = result["derivation"]["softmax_probs"]
+        assert probs["trend"] >= max(probs["scalp"], probs["swing"], probs["observe"])
+        # But the surfaced lane is a positive-budget fallback (swing or
+        # scalp), never the structurally-zero trend.
+        assert result["value"] != "trend"
+        assert result["value"] in ("scalp", "swing")
+        assert result["derivation"]["fallback_from_zero_budget"] == 1
 
     def test_high_basin_velocity_favors_observe(self) -> None:
         """bv >> 0 → observe (chaos)."""

--- a/scripts/flip_position_mode_to_hedge.js
+++ b/scripts/flip_position_mode_to_hedge.js
@@ -1,0 +1,184 @@
+/**
+ * flip_position_mode_to_hedge.js — one-shot operational script for
+ * flipping the live Poloniex futures account from ONE_WAY to HEDGE
+ * position-direction mode.
+ *
+ * Why
+ * ───
+ * Proposal #10 (PR #610) introduced lane-isolated positions: a swing-
+ * long and a scalp-short can coexist on the same symbol as two
+ * independent positions. This requires Poloniex's HEDGE mode (LONG +
+ * SHORT books per symbol) instead of ONE_WAY (single net position).
+ * The PR shipped the kernel-side machinery (lane param envelope,
+ * per-lane SymbolState dicts, posSide-on-HEDGE order plumbing) and
+ * deferred the actual exchange flip until positions closed.
+ *
+ * As of 2026-04-30 the live account is FLAT — no open K positions —
+ * so Poloniex's "no positions open" precondition for the flip is
+ * satisfied. The user has authorized the flip; this script is the
+ * idempotent one-shot to do it.
+ *
+ * What it does
+ * ────────────
+ * 1. Loads POLONIEX_API_KEY + POLONIEX_API_SECRET from the
+ *    environment (Railway production shell or local .env).
+ * 2. Reads the current posMode via GET /v3/position/mode.
+ * 3. If already HEDGE, logs and exits 0 (idempotent).
+ * 4. Otherwise calls POST /v3/position/mode body { posMode: 'HEDGE' }.
+ * 5. Re-reads the mode to verify the flip stuck.
+ * 6. Logs every response body verbatim (no redaction beyond the API
+ *    key prefix in step 1) for the runbook trail.
+ *
+ * Exit codes
+ * ──────────
+ *   0 = current mode HEDGE (either pre-existing or freshly set)
+ *   1 = credentials missing
+ *   2 = read-mode call failed
+ *   3 = set-mode call failed (e.g. Poloniex rejected with positions
+ *       still open, or 4xx auth)
+ *   4 = post-flip verification disagreed with what we just set
+ *
+ * Run
+ * ───
+ *   Local with .env loaded (apps/api/.env or repo root .env):
+ *     node scripts/flip_position_mode_to_hedge.js
+ *
+ *   Railway production (preferred — uses the actual live creds):
+ *     railway run --service polytrade-be \
+ *       node scripts/flip_position_mode_to_hedge.js
+ *
+ *   Or with explicit env vars:
+ *     POLONIEX_API_KEY=xxx POLONIEX_API_SECRET=yyy \
+ *       node scripts/flip_position_mode_to_hedge.js
+ *
+ * Note: the parent worktree must have built apps/api at least once so
+ * dist/services/poloniexFuturesService.js exists. Railway builds it
+ * automatically as part of the deploy step.
+ */
+
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+import { existsSync } from 'node:fs';
+
+// dotenv is best-effort: if running under Railway, env is already
+// injected by the platform; we just want local dev to also work.
+try {
+  await import('dotenv/config');
+} catch {
+  /* optional — env vars already in process */
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function loadService() {
+  // poloniexFuturesService is an ESM module; we resolve to a file URL
+  // and dynamic-import it. Prefer the built dist (production parity)
+  // and fall back to src (local dev) if dist is missing.
+  const candidates = [
+    path.resolve(__dirname, '..', 'apps', 'api', 'dist', 'services', 'poloniexFuturesService.js'),
+    path.resolve(__dirname, '..', 'apps', 'api', 'src', 'services', 'poloniexFuturesService.js'),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) {
+      const mod = await import(pathToFileURL(p).href);
+      return { mod, source: p };
+    }
+  }
+  throw new Error(
+    'poloniexFuturesService.js not found in apps/api/{dist,src}/services/. '
+    + 'Run `yarn workspace @poloniex-platform/api build` first, or run this '
+    + 'script from a built deployment (Railway production has dist baked in).',
+  );
+}
+
+async function main() {
+  const apiKey = process.env.POLONIEX_API_KEY || '';
+  const apiSecret = process.env.POLONIEX_API_SECRET || '';
+  if (!apiKey || !apiSecret) {
+    console.error('[flip_position_mode_to_hedge] POLONIEX_API_KEY / POLONIEX_API_SECRET not set');
+    console.error('  In Railway:  railway run --service polytrade-be node scripts/flip_position_mode_to_hedge.js');
+    console.error('  Locally  :   put creds in apps/api/.env or export them in this shell');
+    process.exit(1);
+  }
+  const credentials = { apiKey, apiSecret };
+  console.log(`[flip_position_mode_to_hedge] credentials loaded (key prefix: ${apiKey.slice(0, 6)}...)`);
+
+  const { mod, source } = await loadService();
+  console.log(`[flip_position_mode_to_hedge] loaded service from ${source}`);
+  const svc = mod.default;
+  if (!svc || typeof svc.getPositionDirectionMode !== 'function'
+      || typeof svc.setPositionDirectionMode !== 'function') {
+    console.error('[flip_position_mode_to_hedge] service is missing getPositionDirectionMode / setPositionDirectionMode');
+    console.error('  exports keys:', Object.keys(mod));
+    process.exit(2);
+  }
+
+  // 1. Read current mode.
+  let currentResp;
+  try {
+    currentResp = await svc.getPositionDirectionMode(credentials);
+  } catch (err) {
+    console.error('[flip_position_mode_to_hedge] read-mode call failed:', err && err.message);
+    if (err && err.response) {
+      console.error('  status:', err.response.status);
+      console.error('  body  :', JSON.stringify(err.response.data || {}, null, 2));
+    }
+    process.exit(2);
+  }
+  console.log('[flip_position_mode_to_hedge] current mode response:', JSON.stringify(currentResp, null, 2));
+
+  const currentMode =
+    (currentResp && currentResp.data && currentResp.data.posMode)
+    || (currentResp && currentResp.posMode)
+    || null;
+  console.log(`[flip_position_mode_to_hedge] resolved currentMode = ${currentMode}`);
+
+  if (currentMode === 'HEDGE') {
+    console.log('[flip_position_mode_to_hedge] account is already in HEDGE mode — nothing to do');
+    process.exit(0);
+  }
+
+  // 2. Flip to HEDGE.
+  let setResp;
+  try {
+    setResp = await svc.setPositionDirectionMode(credentials, 'HEDGE');
+  } catch (err) {
+    console.error('[flip_position_mode_to_hedge] set-mode call failed:', err && err.message);
+    if (err && err.response) {
+      console.error('  status:', err.response.status);
+      console.error('  body  :', JSON.stringify(err.response.data || {}, null, 2));
+      console.error('  hint  : Poloniex rejects mode changes when positions are open;');
+      console.error('          confirm the account is FLAT before retrying.');
+    }
+    process.exit(3);
+  }
+  console.log('[flip_position_mode_to_hedge] set-mode response:', JSON.stringify(setResp, null, 2));
+
+  // 3. Verify.
+  let verifyResp;
+  try {
+    verifyResp = await svc.getPositionDirectionMode(credentials);
+  } catch (err) {
+    console.error('[flip_position_mode_to_hedge] post-flip read failed:', err && err.message);
+    process.exit(4);
+  }
+  console.log('[flip_position_mode_to_hedge] verify response:', JSON.stringify(verifyResp, null, 2));
+  const verifyMode =
+    (verifyResp && verifyResp.data && verifyResp.data.posMode)
+    || (verifyResp && verifyResp.posMode)
+    || null;
+
+  if (verifyMode === 'HEDGE') {
+    console.log('[flip_position_mode_to_hedge] SUCCESS — account is now in HEDGE mode');
+    process.exit(0);
+  }
+
+  console.error(`[flip_position_mode_to_hedge] FAILED — verify reports posMode=${verifyMode}, expected HEDGE`);
+  process.exit(4);
+}
+
+main().catch((err) => {
+  console.error('[flip_position_mode_to_hedge] uncaught error:', err);
+  process.exit(5);
+});


### PR DESCRIPTION
## Summary

Fixes the size=0 regression introduced by PR #610 (proposal #10 lane-isolated positions) that paused live trading for ~1 hour. Also flips the live Poloniex account from ONE_WAY → HEDGE, unlocking the multi-horizon coexistence the proposal-#10 architecture was designed for.

## Root cause

PR #610 added per-lane capital budgets but enforced them by **haircutting available_equity** before the sizer ran:

```
available_equity_usdt = available_equity_usdt * lane_budget_fraction(lane)
```

This double-dipped against the already-cap'd equity pool the loop passed in (which already factored `sizeFraction × kernel_share`). On small accounts where the per-symbol exposure cap leaves ~\$5 free, halving to \$2.50 pushed the v0.6.6 lift-to-min `required_frac` past the 0.5 `max_fraction` safety clamp — so the lift never fired and every entry sized to 0.

Independently, when `choose_lane` picked the **trend lane** (budget_frac=0 by design — opt-in via parameter registry), the entire equity pool became 0 and sized 0 with no fallback.

## The fix

**1. Lane budget as MARGIN CAP, not equity haircut**

- `apps/api/src/services/monkey/executive.ts:162-230` — `currentPositionSize` (TS)
- `ml-worker/src/monkey_kernel/executive.py:307-413` — `current_position_size` (Python)

Sizing formula and lift-to-min now run against full equity. Final margin is clamped by `lane_budget_fraction × equity`. Trend (cap=0) still collapses to 0 deliberately. Scalp/swing on a flat account see the full pool. Both surface `lane_margin_cap` + `capped_by_lane` in derivation.

**2. `choose_lane` structural-zero fallback**

- `apps/api/src/services/monkey/executive.ts:719-792` — `chooseLane` (TS)
- `ml-worker/src/monkey_kernel/executive.py:1101-1230` — `choose_lane` (Python)

When the highest-scoring position-bearing lane has `budget_frac=0`, redirect to the next-highest positive-budget lane. Surfaces `fallback_from_zero_budget` in derivation.

## HEDGE flip — DONE LIVE

Executed via `railway ssh --service polytrade-be` from the Railway production IP (Poloniex API keys are IP-restricted to Railway egress, so local-machine flip returns 401 \"Illegal of ip\"). Sequence:

```
GET  /v3/position/mode        → {"posMode": "ONE_WAY"}
POST /v3/position/mode {posMode:'HEDGE'}  → 200 OK, body {}
GET  /v3/position/mode        → {"posMode": "HEDGE"} ✓
```

`scripts/flip_position_mode_to_hedge.js` is committed for runbook reference. Idempotent — exits 0 if already HEDGE.

## Tests

- **Python**: 530 pass (+10 new for lane-budget regression + fallback)
- **TS**: 890 pass (+11 new), 2 pre-existing fails unchanged (`resonance_bank_lane`)
- **QIG purity**: 35 files clean
- **TS build**: clean

## Effect on live trading

Once merged + Railway redeploys:
1. Sizer correctly produces non-zero margin on flat accounts → kernel resumes entering trades
2. With HEDGE already active, swing-long + scalp-short can coexist on-exchange per proposal #10's design
3. Multi-horizon trading goes from architecturally-supported to operationally-active

## Judgment calls

- Two existing tests in `laneIsolation.test.ts` and `test_lane_selection.py` baked in the BUGGY semantic; I rewrote them to assert the FIXED semantic (cap = `lane_budget_fraction × equity`, not equity haircut). Test intents preserved.
- Considered plumbing `other_lanes_reserved_usdt` for fair partition but rejected as scope creep — the existing `max_fraction=0.5` safety clamp already enforces partition. Natural follow-up when live multi-lane traffic emerges: path (b) from #610's commit body — arbiter allocation across `(agent, lane)` tuples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix lane-budget sizing semantics to prevent zero-size orders on small accounts and add operational support for HEDGE position mode on Poloniex.

Bug Fixes:
- Treat per-lane budgets as a post-sizer margin cap instead of an equity haircut to restore non-zero sizing and lift-to-min behaviour on flat and small accounts.
- Ensure lane selection never returns a zero-budget position-bearing lane by falling back to the next valid lane when needed.

Enhancements:
- Expose lane margin caps and lane-cap application in sizing derivations and reasons for better observability of lane budgeting.
- Refine lane selection reasoning metadata to record when a fallback from a zero-budget lane occurs.

Documentation:
- Add extensive in-code documentation and regression notes around lane-budget semantics, flat-account sizing, and lane selection behaviour.

Tests:
- Expand Python and TypeScript test suites with regression cases for flat-account sizing, lane budget caps, and zero-budget lane fallbacks, updating existing tests to assert the corrected semantics.

Chores:
- Add a one-off operational Node.js script to flip the live Poloniex futures account from ONE_WAY to HEDGE position mode in an idempotent, verifiable way.