### PR TITLE
chore(monkey): instrument size=0 path for live diagnosis

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -791,6 +791,18 @@ export class MonkeyKernel extends EventEmitter {
       basinState, cappedEquity, minNotional, leverage.value, bankSize, mode,
       positionLane,
     );
+    // Surgical diagnostic for live size=0 regression (post PR #611). Fires
+    // only when sizing collapses to zero AND the account is flat — surfaces
+    // the exact numeric inputs feeding currentPositionSize so we can
+    // grep `[size-zero-diag]` from Railway and trace which guard tripped.
+    if (size.value === 0 && exchangeHeldSide === null) {
+      logger.info('[size-zero-diag]', {
+        symbol, availableEquity, effectiveSizeFraction, cappedEquity,
+        minNotional, leverage: leverage.value, bankSize, mode,
+        sizeValue: size.value, lane: positionLane,
+        sizeDerivation: size.derivation,
+      });
+    }
     const autoFlatten = shouldAutoFlatten(basinState, state.fHealthHistory);
 
     // 6. DECIDE — propose action

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -642,6 +642,19 @@ def run_tick(
         mode=mode_enum,
         lane=pre_lane if pre_lane in ("scalp", "swing", "trend") else "swing",
     )
+    # Surgical diagnostic for live size=0 regression (post PR #611). Fires
+    # only when sizing collapses to zero AND the account is flat — surfaces
+    # the exact numeric inputs feeding current_position_size so we can grep
+    # `[size-zero-diag]` from Railway and trace which guard tripped.
+    if size_d["value"] == 0 and inputs.account.exchange_held_side is None:
+        logger.info(
+            "[size-zero-diag] symbol=%s avail=%.4f effFrac=%.4f cap=%.4f "
+            "minNot=%.4f lev=%s bank=%s mode=%s lane=%s size=%.4f deriv=%s",
+            inputs.symbol, inputs.account.available_equity,
+            effective_size_fraction, capped_equity, inputs.min_notional,
+            leverage_d["value"], inputs.bank_size, mode, pre_lane,
+            size_d["value"], size_d.get("derivation"),
+        )
     auto_flatten_d = should_auto_flatten(
         s=basin_state, recent_fhealths=state.fhealth_history,
     )


### PR DESCRIPTION
Surgical, additive-only logging to surface the actual numeric inputs at the size=0 codepath. PR #611's fix shipped but live trading remains paused; user confirmed Poloniex available balance $37.46 (sufficient for sizing math), so the bottleneck is elsewhere. This commit adds [size-zero-diag] log lines on both TS and Python sides so the next Monkey hold tick prints availableEquity, cappedEquity, frac, leverage, laneMarginCap, cappedByLane, liftedToMin, etc. Once on prod we grep [size-zero-diag] and identify the exact guard that's zeroing size.

25 lines additive, no logic changes, build clean, 518 Py + 890 TS pass (same 2 pre-existing fails).

## Summary by Sourcery

Add targeted logging around size=0 trade sizing to diagnose live regression without changing sizing logic.

Enhancements:
- Log detailed sizing inputs on the Python tick path when computed size is zero and the account is flat.
- Log detailed sizing inputs on the TypeScript loop path when computed size is zero and the account is flat.