### PR TITLE
fix(monkey, ml-worker): HEDGE-mode setLeverage posSide + idle-timeout log noise

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2123,15 +2123,6 @@ export class MonkeyKernel extends EventEmitter {
       };
     }
 
-    // Set leverage (non-fatal), then place market order.
-    try {
-      await poloniexFuturesService.setLeverage(credentials, symbol, leverage);
-    } catch (levErr) {
-      logger.warn('[Monkey] setLeverage failed (non-fatal)', {
-        symbol, leverage, err: levErr instanceof Error ? levErr.message : String(levErr),
-      });
-    }
-
     // Proposal #10 — when the live account is in HEDGE position-direction
     // mode, we MUST send `posSide: LONG | SHORT` so the exchange opens
     // the order on the correct side of the hedge book. In ONE_WAY mode,
@@ -2142,6 +2133,26 @@ export class MonkeyKernel extends EventEmitter {
       this.positionDirectionMode === 'HEDGE'
         ? (req.side === 'long' ? 'LONG' : 'SHORT')
         : undefined;
+
+    // Set leverage (non-fatal), then place market order.
+    //
+    // After the HEDGE-mode flip Poloniex returns code=11011
+    // ("Position mode and posSide do not match") on /v3/position/leverage
+    // when the body omits posSide (the default landed as BOTH, which is
+    // an ONE_WAY-only value). Mirror the posSide derivation used for
+    // placeOrder so the exchange sees a consistent side on both calls.
+    try {
+      await poloniexFuturesService.setLeverage(
+        credentials, symbol, leverage,
+        posSide ? { posSide } : {},
+      );
+    } catch (levErr) {
+      logger.warn('[Monkey] setLeverage failed (non-fatal)', {
+        symbol, leverage, posSide,
+        err: levErr instanceof Error ? levErr.message : String(levErr),
+      });
+    }
+
     let orderId: string | null = null;
     try {
       const exchangeOrder = await poloniexFuturesService.placeOrder(credentials, {

--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -356,15 +356,26 @@ class PoloniexFuturesService {
    * Endpoint: POST /v3/position/leverage
    *
    * Poloniex V3 expects `lever` (stringified) NOT `leverage`, plus `mgnMode`
-   * (CROSS|ISOLATED). In one-way/`BOTH` position mode, `posSide` is optional
-   * but if supplied must be `BOTH`. Sending `{ symbol, leverage }` as we did
-   * previously produced `{ code: 400, msg: "Param error lever" }` on the
-   * live API (Railway prod, 2026-04-19), which caused every live tick to
-   * log a (non-fatal) leverage-set failure right before order placement.
+   * (CROSS|ISOLATED). Sending `{ symbol, leverage }` as we did previously
+   * produced `{ code: 400, msg: "Param error lever" }` on the live API
+   * (Railway prod, 2026-04-19), which caused every live tick to log a
+   * (non-fatal) leverage-set failure right before order placement.
+   *
+   * Position-mode semantics (verified on prod 2026-04-30 after the HEDGE
+   * flip in PR #611):
+   *   - HEDGE  account → body MUST carry `posSide: 'LONG' | 'SHORT'` matching
+   *     the side of the position about to be opened. Omitting it (or sending
+   *     `BOTH`) returns code=11011 "Position mode and posSide do not match"
+   *     and leverage stays at the exchange default — which in turn caused
+   *     the warn-log spam at every Monkey entry.
+   *   - ONE_WAY account → `posSide` is either omitted or `BOTH`. We default
+   *     to omitting it so the same call site works regardless of mode and
+   *     the caller (kernel/loop.ts) decides via its cached
+   *     ``positionDirectionMode`` whether to pass posSide.
    *
    * The web UI already used the correct shape — see
    * apps/web/src/context/FuturesContext.tsx::setLeverage which posts
-   * `{ symbol, lever, mgnMode }`. This brings the server-side call in line.
+   * `{ symbol, lever, mgnMode }`.
    *
    * @param {Object} credentials
    * @param {string} symbol             e.g. 'BTC_USDT_PERP'
@@ -373,8 +384,10 @@ class PoloniexFuturesService {
    * @param {'CROSS'|'ISOLATED'} [opts.mgnMode='CROSS']  margin mode;
    *   defaults to CROSS per shared/constants.ts::FUTURES_DEFAULTS
    *   and the agent dashboard default.
-   * @param {'LONG'|'SHORT'|'BOTH'} [opts.posSide]  position side; omitted
-   *   by default since the account runs in one-way (BOTH) mode.
+   * @param {'LONG'|'SHORT'|'BOTH'} [opts.posSide]  position side. Pass
+   *   `LONG` or `SHORT` when the account is in HEDGE mode — the
+   *   exchange rejects the call with code=11011 if this is missing on a
+   *   HEDGE account. Omit (or pass `BOTH`) on a ONE_WAY account.
    */
   async setLeverage(credentials, symbol, leverage, opts = {}) {
     const body = {
@@ -383,7 +396,8 @@ class PoloniexFuturesService {
       mgnMode: opts.mgnMode || 'CROSS',
     };
     if (opts.posSide) {
-      body.posSide = opts.posSide;
+      // Normalise to upper case so callers can pass 'long'/'short' too.
+      body.posSide = String(opts.posSide).toUpperCase();
     }
     return this.makeRequest(credentials, 'POST', '/position/leverage', body);
   }

--- a/apps/api/src/tests/poloniexFuturesService.setLeverage.test.js
+++ b/apps/api/src/tests/poloniexFuturesService.setLeverage.test.js
@@ -99,4 +99,114 @@ describe('PoloniexFuturesService.setLeverage body shape', () => {
     const body = spy.mock.calls[0][3];
     expect(body.posSide).toBe('LONG');
   });
+
+  // -------------------------------------------------------------------
+  // HEDGE-mode posSide tests (Poloniex code=11011 fix, 2026-04-30).
+  //
+  // After the HEDGE flip in PR #611 the exchange started returning
+  //   /v3/position/leverage code=11011: Position mode and posSide do not match
+  // because we were calling setLeverage without posSide while the account
+  // was HEDGE. The fix makes the kernel pass posSide derived from the
+  // entry side. These tests lock the wire shape per mode.
+  // -------------------------------------------------------------------
+
+  it('HEDGE+long: forwards posSide=LONG verbatim', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({});
+
+    await poloniexFuturesService.setLeverage(
+      { apiKey: 'k', apiSecret: 's' },
+      'BTC_USDT_PERP',
+      20,
+      { posSide: 'LONG' },
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body).toEqual({
+      symbol: 'BTC_USDT_PERP',
+      lever: '20',
+      mgnMode: 'CROSS',
+      posSide: 'LONG',
+    });
+  });
+
+  it('HEDGE+short: forwards posSide=SHORT verbatim', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({});
+
+    await poloniexFuturesService.setLeverage(
+      { apiKey: 'k', apiSecret: 's' },
+      'ETH_USDT_PERP',
+      15,
+      { posSide: 'SHORT' },
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body).toEqual({
+      symbol: 'ETH_USDT_PERP',
+      lever: '15',
+      mgnMode: 'CROSS',
+      posSide: 'SHORT',
+    });
+  });
+
+  it('ONE_WAY: omits posSide when caller passes empty opts', async () => {
+    // The kernel passes `{}` (no posSide) when its cached
+    // ``positionDirectionMode`` is 'ONE_WAY' so the body matches the
+    // historic ONE_WAY-on-prod shape `{ symbol, lever, mgnMode }`.
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({});
+
+    await poloniexFuturesService.setLeverage(
+      { apiKey: 'k', apiSecret: 's' },
+      'BTC_USDT_PERP',
+      10,
+      {},
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body).not.toHaveProperty('posSide');
+    expect(body).toEqual({
+      symbol: 'BTC_USDT_PERP',
+      lever: '10',
+      mgnMode: 'CROSS',
+    });
+  });
+
+  it('error pass-through: Poloniex 11011 propagates to caller', async () => {
+    const exchangeErr = Object.assign(
+      new Error('Poloniex /v3/position/leverage returned code=11011: Position mode and posSide do not match'),
+      { code: 11011 },
+    );
+    vi.spyOn(poloniexFuturesService, 'makeRequest').mockRejectedValue(exchangeErr);
+
+    await expect(
+      poloniexFuturesService.setLeverage(
+        { apiKey: 'k', apiSecret: 's' },
+        'BTC_USDT_PERP',
+        20,
+        { posSide: 'LONG' },
+      ),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('11011'),
+    });
+  });
+
+  it('lower-case posSide is normalised to upper case', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({});
+
+    await poloniexFuturesService.setLeverage(
+      { apiKey: 'k', apiSecret: 's' },
+      'BTC_USDT_PERP',
+      5,
+      { posSide: 'long' },
+    );
+
+    expect(spy.mock.calls[0][3].posSide).toBe('LONG');
+  });
 });

--- a/ml-worker/src/utils/redis_listener.py
+++ b/ml-worker/src/utils/redis_listener.py
@@ -152,6 +152,15 @@ def run_resilient_listener(
 
     backoff = config.initial_backoff
     attempt = 0
+    # Track consecutive idle timeouts (socket.timeout / TimeoutError on
+    # an empty pubsub channel). These are NORMAL and should not log at
+    # ERROR — that produced 60+ ERROR-level lines per minute on idle
+    # listeners (`ml-predict-request`, `trade-outcome`) and drowned out
+    # real connection failures. We only escalate after `idle_escalate_after`
+    # consecutive timeouts to surface the case where the channel is
+    # silent for unexpectedly long (could mean the producer is dead).
+    idle_timeout_streak = 0
+    idle_escalate_after = 100
     while stop_event is None or not stop_event.is_set():
         attempt += 1
         pubsub = None
@@ -168,6 +177,13 @@ def run_resilient_listener(
             )
             pubsub = client.pubsub(ignore_subscribe_messages=True)
             pubsub.subscribe(config.channel)
+            # NOTE: do NOT reset ``idle_timeout_streak`` here. A pubsub
+            # read timeout drops us out of ``listen()``, the finally
+            # block tears down the client, and the next loop iteration
+            # creates a fresh client + subscribes again — that path is
+            # how an idle channel looks to this code. Resetting the
+            # streak on subscribe would mask the silent-producer case
+            # the escalation logic exists to detect.
             logger.info(
                 "redis-listener-connected listener=%s channel=%s attempt=%d",
                 config.name,
@@ -197,6 +213,8 @@ def run_resilient_listener(
                     break
                 if message is None or message.get("type") != "message":
                     continue
+                # Got a real message — reset the idle streak.
+                idle_timeout_streak = 0
                 try:
                     raw = message["data"]
                     payload = json.loads(raw) if isinstance(raw, (bytes, str)) else raw
@@ -227,26 +245,62 @@ def run_resilient_listener(
                     except Exception:  # noqa: BLE001
                         pass
         except Exception as exc:  # noqa: BLE001
-            # ``OSError(EINVAL)`` ends up here. Log structurally; do
-            # NOT decrement attempt or short-circuit — we retry forever.
+            # Two distinct failure shapes land here:
+            #
+            # 1) Idle pubsub read timeout (socket_read_timeout elapsed
+            #    with no message). On an idle channel this is the NORMAL
+            #    steady-state path — Redis is healthy, the producer is
+            #    just quiet. Log at DEBUG and do not bump the
+            #    reconnecting status. After idle_escalate_after
+            #    consecutive timeouts we emit a single INFO-level line so
+            #    a stuck producer surfaces without spamming ERROR.
+            #
+            # 2) Real connection failure (OSError, ConnectionError, EINVAL,
+            #    ECONNRESET, …). These were the original PR #604 target.
+            #    Log at ERROR with errno so the diagnostic stays useful.
             errno = getattr(exc, "errno", None)
-            logger.error(
-                "redis-listener-crashed listener=%s attempt=%d errno=%s err=%s",
-                config.name,
-                attempt,
-                errno,
-                exc,
-                exc_info=False,
-            )
-            if config.health_key is not None and client is not None:
-                try:
-                    client.set(
-                        config.health_key,
-                        json.dumps({"status": "reconnecting"}),
-                        ex=config.health_ttl,
+            is_idle_timeout = _is_idle_read_timeout(exc, redis_module)
+            if is_idle_timeout:
+                idle_timeout_streak += 1
+                if idle_timeout_streak == idle_escalate_after:
+                    logger.info(
+                        "redis-listener-idle listener=%s channel=%s "
+                        "consecutive_timeouts=%d (channel quiet — "
+                        "verify producer is alive)",
+                        config.name,
+                        config.channel,
+                        idle_timeout_streak,
                     )
-                except Exception:  # noqa: BLE001
-                    pass
+                else:
+                    logger.debug(
+                        "redis-listener-idle-timeout listener=%s "
+                        "attempt=%d streak=%d err=%s",
+                        config.name,
+                        attempt,
+                        idle_timeout_streak,
+                        exc,
+                    )
+            else:
+                # A genuine connection failure resets the idle counter —
+                # the next subscribe starts a fresh idle window.
+                idle_timeout_streak = 0
+                logger.error(
+                    "redis-listener-crashed listener=%s attempt=%d errno=%s err=%s",
+                    config.name,
+                    attempt,
+                    errno,
+                    exc,
+                    exc_info=False,
+                )
+                if config.health_key is not None and client is not None:
+                    try:
+                        client.set(
+                            config.health_key,
+                            json.dumps({"status": "reconnecting"}),
+                            ex=config.health_ttl,
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
         finally:
             # Always tear down the client + pubsub before the next
             # attempt. Reusing a poisoned connection is the second
@@ -275,6 +329,54 @@ def run_resilient_listener(
         )
         sleep_fn(backoff)
         backoff = min(backoff * config.backoff_factor, config.max_backoff)
+
+
+def _is_idle_read_timeout(exc: BaseException, redis_module: Any) -> bool:
+    """Classify ``exc`` as an idle pubsub-read timeout vs a real failure.
+
+    On an idle channel ``pubsub.listen()`` blocks until either a message
+    arrives or ``socket_timeout`` elapses; the latter raises one of:
+
+    * ``socket.timeout`` — Python stdlib bare timeout
+    * ``redis.exceptions.TimeoutError`` — redis-py wraps the above when
+      the read hits ``socket_timeout``
+    * ``TimeoutError`` (builtin, Python 3.10+) — same kernel signal,
+      different alias
+
+    A real connection failure is ``redis.exceptions.ConnectionError``,
+    ``OSError``/``ConnectionError`` from the kernel, or EINVAL from
+    ``setsockopt``. Those continue to log at ERROR.
+
+    Distinguishing them by **type** rather than message keeps the check
+    robust across redis-py versions; the message-string fallback only
+    catches exotic ``RedisError`` subclasses that wrap the timeout
+    without inheriting from ``TimeoutError``.
+    """
+    # Builtin / stdlib timeouts.
+    if isinstance(exc, socket.timeout):
+        return True
+    if isinstance(exc, TimeoutError):
+        # Python 3.10+ unified ``TimeoutError`` covers ``socket.timeout``
+        # too, but on older runtimes the two are distinct.
+        return True
+    # redis-py timeout. Guard against missing module / attribute so the
+    # function never raises when redis is faked-out in tests.
+    redis_exc = getattr(redis_module, "exceptions", None) if redis_module else None
+    redis_timeout = getattr(redis_exc, "TimeoutError", None) if redis_exc else None
+    if redis_timeout is not None and isinstance(exc, redis_timeout):
+        # IMPORTANT: redis.exceptions.ConnectionError inherits from
+        # TimeoutError? No — it inherits from RedisError. So a positive
+        # match here is genuinely a timeout, not a closed socket.
+        return True
+    # Last-ditch: substring sniff. Only hit if the redis-py shipped a
+    # non-TimeoutError subclass that still says "Timeout reading from
+    # socket" — historic versions did. Keep it conservative: require
+    # both keywords so a generic "Timeout" connection error doesn't
+    # downgrade to DEBUG.
+    msg = str(exc)
+    if "Timeout reading from socket" in msg:
+        return True
+    return False
 
 
 def _probe_redis_connection(

--- a/ml-worker/tests/utils/test_redis_listener.py
+++ b/ml-worker/tests/utils/test_redis_listener.py
@@ -30,6 +30,7 @@ if _SRC not in sys.path:
 from utils.redis_listener import (  # noqa: E402
     ListenerConfig,
     _candidate_keepalive_options,
+    _is_idle_read_timeout,
     _probe_redis_connection,
     run_resilient_listener,
 )
@@ -386,6 +387,274 @@ def test_probe_returns_diag_on_einval():
     )
     assert ok is False
     assert "errno=22" in diag
+
+
+# =====================================================================
+# Idle-timeout log-level tests (2026-04-30 fix).
+#
+# PR #604 hardened the listener to retry forever, but every idle pubsub
+# read timeout still logged at ERROR ("redis-listener-crashed attempt=N
+# errno=None err=Timeout reading from socket"). On a quiet channel that
+# meant 60+ ERROR lines per minute on `ml-predict-request` and
+# `trade-outcome` — fake-alarm telemetry that drowned out genuine
+# connection failures. The fix classifies idle timeouts as DEBUG, leaves
+# real connection errors at ERROR, and emits one INFO line after
+# `idle_escalate_after` consecutive timeouts to surface a stuck producer.
+# =====================================================================
+
+
+class _IdleTimeoutScript:
+    """Test harness: connect once, raise a timeout on `pubsub.listen`,
+    optionally repeat for N attempts before yielding a real message.
+
+    This simulates Redis being healthy but the channel being quiet — the
+    exact scenario that produced the prod log spam.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeouts_before_message: int,
+        message: Optional[Dict[str, Any]] = None,
+        timeout_exc_factory=None,
+    ):
+        self._remaining_timeouts = timeouts_before_message
+        self._message = message
+        self._timeout_exc_factory = timeout_exc_factory or (
+            lambda: __import__("socket").timeout("Timeout reading from socket")
+        )
+        self.attempts = 0
+        self.exceptions = type("Exc", (), {"TimeoutError": __import__("socket").timeout})
+
+        outer = self
+
+        class _PS:
+            def __init__(self):
+                self.subscribed = []
+                self.closed = False
+
+            def subscribe(self, ch):
+                self.subscribed.append(ch)
+
+            def listen(self):
+                if outer._remaining_timeouts > 0:
+                    outer._remaining_timeouts -= 1
+                    raise outer._timeout_exc_factory()
+                if outer._message is not None:
+                    yield {"type": "message", "data": json.dumps(outer._message)}
+
+            def close(self):
+                self.closed = True
+
+        class _Client:
+            def __init__(self):
+                self.closed = False
+                self.set_calls: List[tuple] = []
+
+            def pubsub(self, ignore_subscribe_messages=False):
+                return _PS()
+
+            def set(self, key, value, ex=0):
+                self.set_calls.append((key, value, ex))
+
+            def ping(self):
+                return True
+
+            def close(self):
+                self.closed = True
+
+        class _Redis:
+            @staticmethod
+            def from_url(url, **kwargs):  # noqa: ARG004
+                outer.attempts += 1
+                return _Client()
+
+        self.Redis = _Redis
+
+
+def test_is_idle_read_timeout_classifies_socket_timeout():
+    """``socket.timeout`` is the canonical idle signal — must be DEBUG."""
+    import socket as _sock
+
+    fake = _FakeRedisModule(failures_before_success=0, message_batches=[[]])
+    assert _is_idle_read_timeout(_sock.timeout("Timeout reading from socket"), fake) is True
+
+
+def test_is_idle_read_timeout_classifies_real_connection_error():
+    """``OSError(ECONNRESET)`` is a real failure — must NOT match idle."""
+    fake = _FakeRedisModule(failures_before_success=0, message_batches=[[]])
+    err = OSError(104, "Connection reset by peer")
+    assert _is_idle_read_timeout(err, fake) is False
+
+
+def test_is_idle_read_timeout_classifies_einval():
+    """EINVAL from setsockopt is a real failure — keep at ERROR."""
+    fake = _FakeRedisModule(failures_before_success=0, message_batches=[[]])
+    err = OSError(22, "Invalid argument")
+    assert _is_idle_read_timeout(err, fake) is False
+
+
+def test_is_idle_read_timeout_classifies_message_substring_fallback():
+    """Some redis-py builds wrap timeouts in a non-TimeoutError class.
+    The substring match catches that legacy shape without downgrading
+    generic connection errors."""
+    fake = _FakeRedisModule(failures_before_success=0, message_batches=[[]])
+    weird = RuntimeError("Timeout reading from socket")
+    assert _is_idle_read_timeout(weird, fake) is True
+    not_idle = RuntimeError("Connection refused")
+    assert _is_idle_read_timeout(not_idle, fake) is False
+
+
+def test_idle_timeout_logs_debug_not_error(caplog):
+    """A single idle timeout must log at DEBUG, NOT ERROR. This is the
+    primary regression: prior to the fix every timeout produced an
+    ERROR-level line, which generated 60+ false alarms per minute on
+    quiet channels."""
+    import logging as _logging
+
+    msg = {"i": 1}
+    fake = _IdleTimeoutScript(
+        timeouts_before_message=1,
+        message=msg,
+    )
+    cfg = ListenerConfig(
+        name="idle-test", channel="ch",
+        initial_backoff=0.0001, max_backoff=0.001, backoff_factor=1.0,
+    )
+    received: List[Dict[str, Any]] = []
+
+    with caplog.at_level(_logging.DEBUG, logger="utils.redis_listener"):
+        _run_listener(fake=fake, cfg=cfg, received=received, expected_messages=1)
+
+    assert received == [msg]
+    # Filter to records emitted by the listener module under test.
+    listener_records = [r for r in caplog.records if r.name == "utils.redis_listener"]
+    error_records = [r for r in listener_records if r.levelno >= _logging.ERROR]
+    crashed_records = [
+        r for r in listener_records if "redis-listener-crashed" in r.getMessage()
+    ]
+    debug_idle_records = [
+        r for r in listener_records
+        if r.levelno == _logging.DEBUG
+        and "redis-listener-idle-timeout" in r.getMessage()
+    ]
+    # Must have at least one DEBUG idle entry.
+    assert debug_idle_records, "expected at least one DEBUG idle-timeout record"
+    # Must NOT have logged the idle as a crash at ERROR.
+    assert not crashed_records, (
+        f"idle timeouts should NOT log redis-listener-crashed; got {[r.getMessage() for r in error_records]}"
+    )
+
+
+def test_real_connection_error_logs_error(caplog):
+    """An actual ``OSError`` (errno=22, EINVAL, or any non-timeout
+    OSError raised on connect) must continue to log at ERROR."""
+    import logging as _logging
+
+    msg = {"x": 1}
+    # Reuse the existing _FakeRedisModule which raises OSError(errno=22)
+    # on `from_url` — that goes through the listener's `try` block as a
+    # real connect failure, NOT an idle pubsub timeout.
+    fake = _FakeRedisModule(
+        failures_before_success=2,  # probe + 1 listener attempt fail
+        message_batches=[[{"type": "message", "data": json.dumps(msg)}]],
+        errno=22,
+    )
+    cfg = ListenerConfig(
+        name="conn-err-test", channel="ch",
+        initial_backoff=0.0001, max_backoff=0.001, backoff_factor=1.0,
+    )
+    received: List[Dict[str, Any]] = []
+
+    with caplog.at_level(_logging.DEBUG, logger="utils.redis_listener"):
+        _run_listener(fake=fake, cfg=cfg, received=received, expected_messages=1)
+
+    assert received == [msg]
+    listener_records = [r for r in caplog.records if r.name == "utils.redis_listener"]
+    crashed_records = [
+        r for r in listener_records
+        if r.levelno == _logging.ERROR
+        and "redis-listener-crashed" in r.getMessage()
+        and "errno=22" in r.getMessage()
+    ]
+    assert crashed_records, (
+        "expected EINVAL OSError to log at ERROR with errno=22; "
+        f"got {[(r.levelno, r.getMessage()) for r in listener_records]}"
+    )
+
+
+def test_idle_timeout_escalates_to_info_after_threshold(caplog):
+    """After ``idle_escalate_after`` (default 100) consecutive idle
+    timeouts, the listener must emit ONE INFO-level ``redis-listener-idle``
+    line so a stuck producer surfaces — without spamming ERROR or
+    repeating the INFO every tick."""
+    import logging as _logging
+
+    # 100 idle timeouts exactly hits the escalation threshold; the 100th
+    # timeout fires the INFO line. Then a real message lets the listener
+    # loop terminate via the test's `expected_messages` stop hook.
+    fake = _IdleTimeoutScript(
+        timeouts_before_message=100,
+        message={"after": "idle"},
+    )
+    cfg = ListenerConfig(
+        name="escalate-test", channel="ch",
+        initial_backoff=0.00001, max_backoff=0.0001, backoff_factor=1.0,
+    )
+    received: List[Dict[str, Any]] = []
+
+    sleeps: List[float] = []
+    stop = threading.Event()
+
+    def _sleep(s: float) -> None:
+        sleeps.append(s)
+        time.sleep(0.0001)
+        # Hard cap so a regression in the escalation logic can't hang
+        # the test runner: 200 sleeps is well past the 100 threshold.
+        if len(sleeps) > 200:
+            stop.set()
+
+    def _on_message(_c: Any, payload: Dict[str, Any]) -> None:
+        received.append(payload)
+        stop.set()
+
+    with caplog.at_level(_logging.DEBUG, logger="utils.redis_listener"):
+        t = threading.Thread(
+            target=run_resilient_listener,
+            kwargs=dict(
+                redis_url="redis://fake/0",
+                config=cfg,
+                on_message=_on_message,
+                redis_module=fake,
+                sleep_fn=_sleep,
+                stop_event=stop,
+            ),
+            daemon=True,
+        )
+        t.start()
+        t.join(timeout=10.0)
+        if t.is_alive():
+            stop.set()
+            t.join(1.0)
+
+    listener_records = [r for r in caplog.records if r.name == "utils.redis_listener"]
+    info_idle_records = [
+        r for r in listener_records
+        if r.levelno == _logging.INFO and "redis-listener-idle " in r.getMessage()
+    ]
+    assert info_idle_records, (
+        "expected one INFO-level redis-listener-idle escalation line after "
+        "100 consecutive timeouts"
+    )
+    # And critically — even with 100 timeouts, no ERROR-level crash lines.
+    error_crashed = [
+        r for r in listener_records
+        if r.levelno == _logging.ERROR
+        and "redis-listener-crashed" in r.getMessage()
+    ]
+    assert not error_crashed, (
+        "100 idle timeouts must NOT produce ERROR-level crash lines"
+    )
 
 
 def test_keepalive_options_match_kernel_constants():


### PR DESCRIPTION
## Summary

Two production log issues from Railway diagnostic sweep.

## Issue 1 — `setLeverage` 11011 in HEDGE mode (HIGH; silent leverage drift)

After PR #611 flipped to HEDGE, every `/v3/position/leverage` call returned:
```
code=11011: Position mode and posSide do not match
```
Logged as WARN "non-fatal" so trading continued — but leverage stayed at Poloniex default instead of the kernel-intended 20x. Silent drift.

**Fix**: `apps/api/src/services/monkey/loop.ts:2126-2154` hoists the existing `posSide` derivation above the `setLeverage` call so both `setLeverage` and `placeOrder` ship the same `{ posSide }` opts under HEDGE; ONE_WAY accounts continue to omit it. `apps/api/src/services/poloniexFuturesService.js:354-401` normalises posSide casing.

## Issue 2 — ml-worker idle pubsub timeouts logged as ERROR (MEDIUM; log noise)

PR #604's hardening retried on every exception but logged all of them at ERROR, including normal `socket.timeout` from idle `pubsub.listen()`. Result: 60+ ERROR/min of false alarms drowning real failures. Both `ml-predict-request` and `trade-outcome` listeners hit attempt 62+ before this fix.

**Fix**: `ml-worker/src/utils/redis_listener.py:153-381` classifies exceptions by TYPE (not message). Idle `socket.timeout` / `TimeoutError` / `redis.TimeoutError` → DEBUG. Real `OSError` / connection errors → ERROR (unchanged). After 100 consecutive idle timeouts → one INFO "channel quiet" surface, then back to DEBUG.

## Tests

- **vitest** (apps/api setLeverage suite): 9 passing (5 new — HEDGE+long, HEDGE+short, ONE_WAY+omit, error pass-through, lowercase normalisation)
- **pytest** (ml-worker redis_listener suite): 19 passing (7 new — classifier, idle→DEBUG, real-error→ERROR, 100-timeout escalation, substring fallback)
- Full vitest: 903 pass, 2 pre-existing `resonance_bank_lane` fails (unchanged on `main`)

## Scope discipline / follow-up

Subagent flagged two out-of-scope sibling call sites that will hit the same 11011 if/when they execute on HEDGE:
- `apps/api/src/services/liveSignalEngine.ts:1135` (Agent M / ML entries)
- `apps/api/src/routes/futures.ts:421` (manual UI route)

Both call `setLeverage` without `posSide`. Recommend a follow-up PR to plumb posSide through those paths.

## Commits

- `f3dffe9` fix(monkey): pass posSide on setLeverage to fix HEDGE-mode 11011
- `d01df3a` fix(ml-worker): downgrade idle pubsub timeouts from ERROR to DEBUG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix leverage setting for HEDGE-mode Poloniex futures accounts and reduce ml-worker Redis listener log noise from idle timeouts.

Bug Fixes:
- Ensure Monkey kernel passes the correct posSide to Poloniex setLeverage in HEDGE mode so leverage updates succeed instead of returning code 11011.
- Classify idle Redis pubsub timeouts in ml-worker as non-error conditions to prevent spurious ERROR logs while keeping real connection failures at ERROR.

Enhancements:
- Normalize Poloniex setLeverage posSide values to upper case to accept more flexible caller input.
- Introduce explicit classification of Redis idle read timeouts versus real connection errors, with INFO-level escalation after prolonged idleness.

Tests:
- Add and extend vitest coverage for Poloniex setLeverage request bodies, posSide normalization, and error propagation.
- Add pytest coverage for Redis listener timeout classification, log-level behavior, and idle-timeout escalation.