### PR TITLE
fix(monkey): HEDGE-mode side labeling + sibling setLeverage call sites

### DIFF
--- a/apps/api/src/routes/futures.ts
+++ b/apps/api/src/routes/futures.ts
@@ -398,6 +398,26 @@ router.get('/leverage/:symbol', authenticateToken, async (req: Request, res: Res
 
 /**
  * POST /api/futures/leverage - Set leverage for symbol
+ *
+ * HEDGE-mode posSide handling:
+ *   When the account is in HEDGE position-direction mode, Poloniex v3
+ *   rejects /v3/position/leverage with code=11011 ("Position mode and
+ *   posSide do not match") if the body omits posSide. The dashboard
+ *   leverage slider hits this every time after PR #611 flipped prod
+ *   accounts to HEDGE.
+ *
+ *   Resolution order for posSide:
+ *     1. If the caller passes ``posSide`` (or ``side`` ∈ {'long','short'})
+ *        in the body, honour it verbatim.
+ *     2. Otherwise detect the account mode via getPositionDirectionMode.
+ *        If HEDGE, derive posSide from the existing position's qty sign
+ *        (Math.sign(qty) — same authoritative pattern as
+ *        stateReconciliationService.ts:152). If no position is open the
+ *        caller must pass posSide explicitly because the exchange has
+ *        no way to know which side of the hedge book to apply leverage
+ *        to (we surface a 400 with a helpful message).
+ *     3. ONE_WAY accounts: posSide stays undefined and the service omits
+ *        it from the body (exchange defaults to BOTH).
  */
 router.post('/leverage', authenticateToken, async (req: Request, res: Response) => {
   try {
@@ -410,7 +430,7 @@ router.post('/leverage', authenticateToken, async (req: Request, res: Response) 
       });
     }
 
-    const { symbol, leverage } = req.body;
+    const { symbol, leverage, posSide: posSideIn, side: sideIn, mgnMode } = req.body;
 
     if (!symbol || !leverage) {
       return res.status(400).json({
@@ -418,7 +438,76 @@ router.post('/leverage', authenticateToken, async (req: Request, res: Response) 
       });
     }
 
-    const result = await poloniexFuturesService.setLeverage(credentials, symbol, leverage);
+    // 1. Caller-supplied posSide takes precedence.
+    let posSide: 'LONG' | 'SHORT' | undefined;
+    if (posSideIn) {
+      const upper = String(posSideIn).toUpperCase();
+      if (upper === 'LONG' || upper === 'SHORT') posSide = upper;
+    } else if (sideIn) {
+      const lower = String(sideIn).toLowerCase();
+      if (lower === 'long') posSide = 'LONG';
+      else if (lower === 'short') posSide = 'SHORT';
+    }
+
+    // 2. If still unset, probe account mode + derive from existing position.
+    if (!posSide) {
+      let mode: 'HEDGE' | 'ONE_WAY' | undefined;
+      try {
+        const modeResp = await poloniexFuturesService.getPositionDirectionMode(credentials);
+        const detected = String(
+          (modeResp as { posMode?: unknown })?.posMode
+          ?? (modeResp as { data?: { posMode?: unknown } })?.data?.posMode
+          ?? '',
+        ).toUpperCase();
+        if (detected === 'HEDGE' || detected === 'ONE_WAY') {
+          mode = detected;
+        }
+      } catch (modeErr) {
+        // Fail-soft — fall through to omit posSide. ONE_WAY accounts
+        // never needed it; HEDGE accounts will get the explicit 400
+        // below if mode probe also fails AND no position exists.
+        logger.debug('Leverage route: position-mode probe failed', {
+          err: modeErr instanceof Error ? modeErr.message : String(modeErr),
+        });
+      }
+
+      if (mode === 'HEDGE') {
+        try {
+          const positions = await poloniexFuturesService.getPositions(credentials, symbol);
+          const list = Array.isArray(positions) ? positions : [];
+          const open = list.find(
+            (p: Record<string, unknown>) =>
+              String(p.symbol ?? '') === symbol
+              && Number(p.qty ?? p.size ?? 0) !== 0,
+          ) as Record<string, unknown> | undefined;
+          if (open) {
+            const qtyNum = Number(open.qty ?? open.size ?? 0);
+            posSide = qtyNum < 0 ? 'SHORT' : 'LONG';
+          } else {
+            // HEDGE account, no open position, no caller-supplied side.
+            // Rather than guess, ask the client to pass posSide so the
+            // exchange knows which lane to apply leverage to.
+            return res.status(400).json({
+              error:
+                'Account is in HEDGE mode and no open position exists for this symbol. '
+                + 'Pass `posSide` ("LONG"|"SHORT") or `side` ("long"|"short") in the request body.',
+              hedgeMode: true,
+            });
+          }
+        } catch (posErr) {
+          logger.warn('Leverage route: HEDGE-mode posSide derivation failed', {
+            symbol,
+            err: posErr instanceof Error ? posErr.message : String(posErr),
+          });
+        }
+      }
+    }
+
+    const opts: { posSide?: 'LONG' | 'SHORT'; mgnMode?: 'CROSS' | 'ISOLATED' } = {};
+    if (posSide) opts.posSide = posSide;
+    if (mgnMode === 'CROSS' || mgnMode === 'ISOLATED') opts.mgnMode = mgnMode;
+
+    const result = await poloniexFuturesService.setLeverage(credentials, symbol, leverage, opts);
     res.json(result);
   } catch (error: unknown) {
     logger.error('Error setting leverage:', error);

--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -1349,8 +1349,8 @@ class FullyAutonomousTrader extends EventEmitter {
       const activePositions = Array.isArray(positions) ? positions : [];
 
       for (const position of activePositions) {
-        const qty = parseFloat(position.qty || position.positionAmt || '0');
-        if (qty === 0) continue;
+        const qtyNum = Number(position.qty ?? position.size ?? position.positionAmt ?? 0);
+        if (qtyNum === 0) continue;
 
         const symbol = position.symbol;
         const markPx = parseFloat(position.markPx || position.markPrice || '0');
@@ -1360,7 +1360,38 @@ class FullyAutonomousTrader extends EventEmitter {
         // margin), sign carries direction. Prefer it when present; falls
         // back to price-move computation (markPx vs entryPrice) when not.
         const uplRatioRaw = parseFloat(position.uplRatio || '0');
-        const isLong = qty > 0;
+        // HEDGE-mode side derivation. Background:
+        //   In v3 HEDGE mode `position.side` is the next-action label
+        //   (BUY/SELL — i.e. the order side that would close the
+        //   position), NOT the position direction. Prior code computed
+        //   `isLong = qty > 0` which silently mislabeled SHORT positions
+        //   as LONG when Poloniex returned a HEDGE position with positive
+        //   `qty` magnitude + a separate `posSide=SHORT` field.
+        //
+        //   Canonical resolution order (per
+        //   apps/api/docs/poloniex-v3-reference.md §Position):
+        //     1. `posSide` field — LONG/SHORT in HEDGE responses, BOTH in
+        //        ONE_WAY responses. When LONG/SHORT, this is authoritative.
+        //     2. `Math.sign(qty)` — used by stateReconciliationService
+        //        ts:152 and loop.ts::fetchAccountContext for ONE_WAY
+        //        accounts (qty is signed there: +X long, -X short).
+        //
+        //   Production log evidence (2026-04-30):
+        //     [FAT] ETH_USDT_PERP LONG priceMove=0.305% roi=-5.63% lev=20x
+        //   The +0.305% priceMove + -5.63% roi at 20x is unambiguously a
+        //   SHORT losing as price rises. The accompanying "pnl formula
+        //   divergence" WARN was the parity invariant catching the
+        //   mislabel; with this fix that WARN no longer fires after the
+        //   side is resolved correctly.
+        const posSideRaw = String(
+          (position as Record<string, unknown>).posSide ?? ''
+        ).toUpperCase();
+        const isLong = posSideRaw === 'LONG' || posSideRaw === 'SHORT'
+          ? posSideRaw === 'LONG'
+          : qtyNum >= 0;
+        // Keep `qty` for downstream sizing math (formerly parseFloat(qty));
+        // the sign is now authoritative via qtyNum + posSide above.
+        const qty = qtyNum;
 
         // Compute price-move % directly from mark/entry. Avoids the
         // `entry * qty` notional trap: Poloniex qty is in CONTRACTS (e.g.
@@ -1429,7 +1460,10 @@ class FullyAutonomousTrader extends EventEmitter {
             if (pnlPercent < -slPercent) return { shouldClose: true, reason: 'stop_loss' };
             if (pnlPercent > tpPercent) return { shouldClose: true, reason: 'take_profit' };
             if (pnlPercent > trailingTrigger && analysis) {
-              const isLong = qty > 0;
+              // Use the outer-scope `isLong` (HEDGE-aware via posSide +
+              // qty-sign); the prior `const isLong = qty > 0` shadowing
+              // bypassed that and produced the same mislabel as the
+              // [FAT] log line on HEDGE accounts.
               if ((isLong && analysis.trend === 'bearish') ||
                   (!isLong && analysis.trend === 'bullish')) {
                 return { shouldClose: true, reason: 'trend_reversal' };
@@ -1479,8 +1513,10 @@ class FullyAutonomousTrader extends EventEmitter {
         if (pnlPercent > trailingTrigger) {
           const analysis = analyses.get(symbol);
           if (analysis) {
-            // If trend reverses, close position
-            const isLong = qty > 0;
+            // If trend reverses, close position. Use outer-scope `isLong`
+            // (HEDGE-aware via posSide + qty-sign) — the previous
+            // `const isLong = qty > 0` shadow had the same mislabel bug as
+            // the [FAT] logger above.
             if ((isLong && analysis.trend === 'bearish') || (!isLong && analysis.trend === 'bullish')) {
               logger.info(`Trend reversal detected for ${symbol}, closing position`);
               await this.closePosition(userId, symbol, 'trend_reversal');

--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -184,6 +184,23 @@ export class LiveSignalEngine extends EventEmitter {
   private processedBanditIdsOrder: string[] = [];
   private static readonly PROCESSED_BANDIT_IDS_MAX = 500;
 
+  /**
+   * Cached Poloniex v3 position-direction mode (HEDGE | ONE_WAY).
+   *
+   * Detected lazily on first submitOrder via getPositionDirectionMode and
+   * cached for the lifetime of the engine. Mirror of the loop.ts pattern at
+   * ``Monkey.positionDirectionMode``. We need this so setLeverage/placeOrder
+   * knows whether to send ``posSide: LONG | SHORT`` (HEDGE) or omit it
+   * (ONE_WAY → BOTH default). After PR #611 flipped prod accounts to HEDGE
+   * the exchange started returning code=11011
+   *   "Position mode and posSide do not match"
+   * on every /v3/position/leverage call from this engine because the body
+   * lacked posSide. ``undefined`` until detected; fail-soft to undefined
+   * on error so we keep trading the historic ONE_WAY shape if detection
+   * fails.
+   */
+  private positionDirectionMode: 'HEDGE' | 'ONE_WAY' | undefined = undefined;
+
   async start(options: StartOptions = {}): Promise<void> {
     this.symbols = options.symbols ?? [...DEFAULT_WATCH_SYMBOLS];
     this.dryRun = options.dryRun ?? false;
@@ -980,6 +997,54 @@ export class LiveSignalEngine extends EventEmitter {
   }
 
   /**
+   * Detect (once) and cache the Poloniex v3 position-direction mode
+   * (HEDGE | ONE_WAY). Idempotent: re-entry is a no-op once the mode is
+   * cached. Fail-soft: detection errors leave the cache as ``undefined``
+   * so subsequent setLeverage / placeOrder calls fall back to the
+   * historic ONE_WAY-omits-posSide wire shape.
+   *
+   * Mirror of Monkey.detectPositionDirectionMode (loop.ts:1557). Kept
+   * here on the engine instance rather than as a shared helper so each
+   * engine's mode cache is independent — they may run on different
+   * accounts in future.
+   */
+  private async ensurePositionDirectionMode(
+    credentials: { apiKey: string; apiSecret: string; passphrase?: string },
+  ): Promise<void> {
+    if (this.positionDirectionMode !== undefined) return;
+    try {
+      const resp = await poloniexFuturesService.getPositionDirectionMode(credentials);
+      const detected = String(
+        (resp as Record<string, unknown>)?.posMode
+        ?? '',
+      ).toUpperCase();
+      if (detected === 'HEDGE' || detected === 'ONE_WAY') {
+        this.positionDirectionMode = detected;
+        logger.info('[LiveSignal] position-mode detected', { mode: detected });
+        return;
+      }
+      // Some response shapes nest under .data — try once more.
+      const data = (resp as Record<string, unknown>)?.data;
+      const nested = String(
+        (data && typeof data === 'object' ? (data as Record<string, unknown>).posMode : '')
+        ?? '',
+      ).toUpperCase();
+      if (nested === 'HEDGE' || nested === 'ONE_WAY') {
+        this.positionDirectionMode = nested;
+        logger.info('[LiveSignal] position-mode detected (nested)', { mode: nested });
+      } else {
+        logger.info('[LiveSignal] position-mode detect: unrecognized response', {
+          raw: detected,
+        });
+      }
+    } catch (err) {
+      logger.debug('[LiveSignal] position-mode detect failed (fail-soft)', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
    * Place the order on the exchange, persist it to the DB, and
    * publish an outcome event for ml-worker training. Sequence:
    *
@@ -1130,13 +1195,35 @@ export class LiveSignalEngine extends EventEmitter {
       signal,
     });
 
+    // Lazily detect Poloniex position-direction mode (HEDGE | ONE_WAY) and
+    // cache it on the engine. Same pattern as Monkey.detectPositionDirectionMode
+    // — see loop.ts:1557. Needed so the setLeverage body below carries
+    // ``posSide`` on HEDGE accounts (Poloniex returns code=11011
+    // "Position mode and posSide do not match" otherwise).
+    await this.ensurePositionDirectionMode(credentials);
+
+    // Derive posSide from the intended order direction. In HEDGE mode this
+    // MUST be sent on /v3/position/leverage; in ONE_WAY mode we omit so
+    // the exchange defaults to BOTH (sending LONG/SHORT on a one-way
+    // account triggers the same 11011 error in reverse).
+    const posSide: 'LONG' | 'SHORT' | undefined =
+      this.positionDirectionMode === 'HEDGE'
+        ? (order.side === 'long' ? 'LONG' : 'SHORT')
+        : undefined;
+
     // 1. Leverage — non-fatal if exchange rejects; order still proceeds.
     try {
-      await poloniexFuturesService.setLeverage(credentials, order.symbol, order.leverage);
+      await poloniexFuturesService.setLeverage(
+        credentials,
+        order.symbol,
+        order.leverage,
+        posSide ? { posSide } : {},
+      );
     } catch (levErr) {
       logger.warn('[LiveSignal] setLeverage failed (non-fatal)', {
         symbol: order.symbol,
         leverage: order.leverage,
+        posSide,
         err: levErr instanceof Error ? levErr.message : String(levErr),
       });
     }

--- a/apps/api/src/tests/fullyAutonomousTrader.sideLabel.test.ts
+++ b/apps/api/src/tests/fullyAutonomousTrader.sideLabel.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the FAT (FullyAutonomousTrader) HEDGE-mode side labeling fix.
+ *
+ * Background (2026-04-30, post PR #611 HEDGE flip):
+ *   The `[FAT] {symbol} LONG/SHORT pnl=… priceMove=… roi=… lev=…` log line
+ *   was mislabelling SHORT positions as LONG. Production evidence:
+ *     [FAT] ETH_USDT_PERP LONG pnl=-0.0636u priceMove=0.305% roi=-5.63% lev=20x
+ *     [FAT] pnl formula divergence: priceMove=0.305% vs roi/lev=-0.281% Δ=0.586%
+ *   priceMove +0.305% with roi -5.63% at 20x is unambiguously a SHORT
+ *   losing as price rises; the divergence WARN was the parity invariant
+ *   detecting the mislabel.
+ *
+ *   Root cause: managePositions read `qty > 0` to derive `isLong`, but
+ *   in v3 HEDGE responses the position object can carry positive `qty`
+ *   magnitude alongside a `posSide=SHORT` field. Same class of bug as
+ *   the loop.ts/stateReconciliationService fixes — the canonical
+ *   resolution order is `posSide` field first, `Math.sign(qty)` fallback.
+ *
+ * Coverage:
+ *   1. LONG label — positive qty (one-way OR HEDGE+posSide=LONG).
+ *   2. SHORT label — negative qty (one-way) AND HEDGE+posSide=SHORT
+ *      with positive qty magnitude (the production failure shape).
+ *   3. Divergence WARN suppression — once side is correctly labeled,
+ *      the priceMove and roi/leverage agree on sign, so the parity
+ *      invariant no longer fires.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mock heavy dependencies (mirrors fullyAutonomousTraderPyBridge.test.ts) ──
+vi.mock('../db/connection.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) }
+}));
+vi.mock('../services/poloniexFuturesService.js', () => ({
+  default: {
+    getPositions: vi.fn(),
+    closePosition: vi.fn().mockResolvedValue({}),
+    normalizeSymbol: vi.fn((s: string) => s),
+    getAccountBalance: vi.fn().mockResolvedValue({ eq: '10000' }),
+  }
+}));
+vi.mock('../services/riskService.js', () => ({ default: {} }));
+vi.mock('../services/mlPredictionService.js', () => ({ default: {} }));
+vi.mock('../services/apiCredentialsService.js', () => ({
+  apiCredentialsService: { getCredentials: vi.fn() }
+}));
+vi.mock('../utils/marketDataValidator.js', () => ({ validateMarketData: vi.fn() }));
+vi.mock('../services/marketCatalog.js', () => ({ getPrecisions: vi.fn() }));
+vi.mock('../services/monitoringService.js', () => ({
+  monitoringService: { recordPipelineHeartbeat: vi.fn(), recordTradeEvent: vi.fn() }
+}));
+vi.mock('../utils/engineVersion.js', () => ({ getEngineVersion: () => 'v-test' }));
+vi.mock('../services/backtestingEngine.js', () => ({ default: {} }));
+vi.mock('../services/simpleMlService.js', () => ({ default: {} }));
+vi.mock('../services/monkey/kernel_client.js', () => ({
+  callExitDecide: vi.fn(),
+  callReconcile: vi.fn(),
+  isExitShadowEnabled: vi.fn(() => false),
+  logExitParityDiff: vi.fn(),
+  logReconcileParityDiff: vi.fn(),
+}));
+vi.mock('../services/signalGenome.js', () => ({
+  buildIndicatorMap: vi.fn(() => new Map()),
+  evaluateGenomeEntry: vi.fn(() => ({ action: 'HOLD', score: 0 })),
+}));
+
+import { FullyAutonomousTrader } from '../services/fullyAutonomousTrader.js';
+import poloniexFuturesService from '../services/poloniexFuturesService.js';
+import { apiCredentialsService } from '../services/apiCredentialsService.js';
+import { logger } from '../utils/logger.js';
+
+/** Access private members for testing without TS complaints. */
+function priv(t: FullyAutonomousTrader) {
+  return t as unknown as {
+    managePositions: (
+      userId: string,
+      analyses: Map<string, unknown>,
+    ) => Promise<void>;
+    configs: Map<string, unknown>;
+  };
+}
+
+const USER = 'test-user-side-label';
+
+/** Capture every logger.info / logger.warn call into structured records. */
+function captureLogs() {
+  const infos: string[] = [];
+  const warns: string[] = [];
+  const infoSpy = vi.spyOn(logger, 'info').mockImplementation(((msg: unknown) => {
+    if (typeof msg === 'string') infos.push(msg);
+  }) as typeof logger.info);
+  const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(((msg: unknown) => {
+    if (typeof msg === 'string') warns.push(msg);
+  }) as typeof logger.warn);
+  return { infos, warns, infoSpy, warnSpy };
+}
+
+describe('FAT [FAT] side-label — HEDGE-mode fix', () => {
+  let trader: FullyAutonomousTrader;
+
+  beforeEach(() => {
+    trader = new FullyAutonomousTrader();
+    vi.mocked(apiCredentialsService.getCredentials).mockResolvedValue({
+      apiKey: 'k', apiSecret: 's',
+    } as never);
+    // Set a baseline config so managePositions doesn't bail on missing user.
+    priv(trader).configs.set(USER, {
+      stopLossPercent: 99,         // wide enough to never trigger
+      takeProfitPercent: 99,       // wide enough to never trigger
+      initialCapital: 10_000,
+    });
+    // Disable ROI gates so the test focuses on the [FAT] log line + parity.
+    process.env.ROI_TP_PERCENT = '999';
+    process.env.ROI_SL_PERCENT = '999';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.ROI_TP_PERCENT;
+    delete process.env.ROI_SL_PERCENT;
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 1. LONG label — winning long with positive qty (one-way OR HEDGE+LONG).
+  // ──────────────────────────────────────────────────────────────────────────
+  it('labels positive-qty position as LONG', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      {
+        symbol: 'BTC_USDT_PERP',
+        qty: '0.001',                   // positive magnitude
+        posSide: 'LONG',
+        markPx: '50500',
+        openAvgPx: '50000',
+        upl: '0.5',
+        uplRatio: '0.05',               // +5% ROI on margin
+        lever: '5',
+      },
+    ] as never);
+    const { infos } = captureLogs();
+    await priv(trader).managePositions(USER, new Map());
+
+    const fatLine = infos.find(s => s.startsWith('[FAT] BTC_USDT_PERP'));
+    expect(fatLine).toBeDefined();
+    expect(fatLine).toContain('LONG');
+    expect(fatLine).not.toContain('SHORT');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 2. SHORT label — the production HEDGE failure shape.
+  //
+  // Poloniex v3 HEDGE response: positive qty magnitude + posSide=SHORT.
+  // Pre-fix code computed `isLong = qty > 0` → mislabel LONG.
+  // Post-fix: posSide is read first; falls back to qty-sign for ONE_WAY.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('labels HEDGE-mode SHORT (positive qty + posSide=SHORT) as SHORT', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      {
+        symbol: 'ETH_USDT_PERP',
+        qty: '0.05',                    // positive magnitude (HEDGE shape)
+        posSide: 'SHORT',
+        markPx: '2259.4',
+        openAvgPx: '2252.54',
+        upl: '-0.0636',
+        uplRatio: '-0.0563',            // -5.63% ROI — losing
+        lever: '20',
+      },
+    ] as never);
+    const { infos } = captureLogs();
+    await priv(trader).managePositions(USER, new Map());
+
+    const fatLine = infos.find(s => s.startsWith('[FAT] ETH_USDT_PERP'));
+    expect(fatLine).toBeDefined();
+    expect(fatLine).toContain('SHORT');
+    expect(fatLine).not.toContain(' LONG ');
+  });
+
+  it('labels ONE_WAY-mode short (negative qty, no posSide) as SHORT', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      {
+        symbol: 'ETH_USDT_PERP',
+        qty: '-0.05',                   // negative magnitude (ONE_WAY shape)
+        markPx: '2259.4',
+        openAvgPx: '2252.54',
+        upl: '-0.0636',
+        uplRatio: '-0.0563',
+        lever: '20',
+      },
+    ] as never);
+    const { infos } = captureLogs();
+    await priv(trader).managePositions(USER, new Map());
+
+    const fatLine = infos.find(s => s.startsWith('[FAT] ETH_USDT_PERP'));
+    expect(fatLine).toBeDefined();
+    expect(fatLine).toContain('SHORT');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 3. Divergence WARN suppression.
+  //
+  // Once the side label is correct, priceMove and roi/leverage agree
+  // (within float noise), so the "pnl formula divergence" parity invariant
+  // no longer fires on this position.
+  //
+  // Using the exact production numbers:
+  //   entry=2252.54 mark=2259.4 → priceMove (correctly as SHORT) = -0.305%
+  //   roi=-5.63%, lev=20 → impliedPriceMove = -0.281%
+  //   |Δ| = 0.024% < 0.5% threshold → no WARN.
+  //
+  // The check itself stays active (it's load-bearing for future Poloniex
+  // shape drift), but doesn't fire on this corrected case.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('does NOT emit divergence WARN once SHORT is labeled correctly', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      {
+        symbol: 'ETH_USDT_PERP',
+        qty: '0.05',
+        posSide: 'SHORT',
+        markPx: '2259.4',
+        openAvgPx: '2252.54',
+        upl: '-0.0636',
+        uplRatio: '-0.0563',
+        lever: '20',
+      },
+    ] as never);
+    const { warns } = captureLogs();
+    await priv(trader).managePositions(USER, new Map());
+
+    const divergenceWarn = warns.find(s => s.includes('pnl formula divergence'));
+    expect(divergenceWarn).toBeUndefined();
+  });
+});

--- a/apps/api/src/tests/futures.leverage.test.ts
+++ b/apps/api/src/tests/futures.leverage.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the POST /api/futures/leverage HEDGE-mode posSide plumbing.
+ *
+ * Background: same root cause as the LiveSignalEngine + Monkey kernel
+ * fixes — Poloniex /v3/position/leverage rejects the call with code=11011
+ * ("Position mode and posSide do not match") on a HEDGE account when the
+ * body omits posSide. This route is the manual UI path (the dashboard
+ * leverage slider POSTs to it), so users hit the error every time they
+ * tried to change leverage post-PR-#611 HEDGE flip.
+ *
+ * Resolution order in the route:
+ *   1. Caller-supplied `posSide` or `side` in body → honour verbatim.
+ *   2. HEDGE account + open position → derive from `Math.sign(qty)`.
+ *   3. ONE_WAY account → omit posSide (exchange defaults to BOTH).
+ *
+ * Coverage:
+ *   1. Caller passes posSide=LONG → forwarded to setLeverage.
+ *   2. HEDGE + existing short position (qty<0) → posSide=SHORT derived
+ *      from qty-sign; setLeverage receives it.
+ *   3. ONE_WAY mode → setLeverage receives no posSide (empty opts).
+ *   4. HEDGE + no open position + no caller posSide → 400 with helpful
+ *      message (can't guess which lane to apply leverage to).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+vi.mock('../middleware/auth.js', () => ({
+  // Pass-through middleware so the route handler is invoked directly.
+  authenticateToken: (req: Request & { user?: { id: string } }, _res: Response, next: () => void) => {
+    req.user = { id: 'test-user' };
+    next();
+  },
+}));
+vi.mock('../services/apiCredentialsService.js', () => ({
+  apiCredentialsService: {
+    getCredentials: vi.fn().mockResolvedValue({ apiKey: 'k', apiSecret: 's' }),
+  },
+}));
+vi.mock('../services/poloniexFuturesService.js', () => ({
+  default: {
+    setLeverage: vi.fn().mockResolvedValue({ ok: true }),
+    getPositionDirectionMode: vi.fn(),
+    getPositions: vi.fn(),
+  },
+}));
+
+import futuresRouter from '../routes/futures.js';
+import poloniexFuturesService from '../services/poloniexFuturesService.js';
+
+/**
+ * Locate the POST /leverage handler from the router stack so we can
+ * invoke it directly with mock req/res (no supertest needed).
+ */
+function findLeverageHandler(): (req: Request, res: Response) => Promise<void> | void {
+  // express.Router exposes a `.stack` of layers; each layer has `.route`
+  // for routed handlers. Walk it to find the POST /leverage handler.
+  const stack = (futuresRouter as unknown as { stack: Array<{ route?: { path: string; methods: Record<string, boolean>; stack: Array<{ handle: (req: Request, res: Response) => Promise<void> | void }> } }> }).stack;
+  for (const layer of stack) {
+    const route = layer.route;
+    if (route && route.path === '/leverage' && route.methods.post) {
+      // The handler chain is [authenticateToken, routeHandler]; the last
+      // layer's `.handle` is the actual route handler we wrote.
+      const last = route.stack[route.stack.length - 1];
+      return last.handle.bind(last);
+    }
+  }
+  throw new Error('POST /leverage handler not found in router stack');
+}
+
+const handler = findLeverageHandler();
+
+/** Build a Response mock that records status + json calls. */
+function mockRes() {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res as unknown as Response & { statusCode: number; body: unknown };
+}
+
+/** Build a Request mock with `.user` already populated (auth bypassed). */
+function mockReq(body: Record<string, unknown>) {
+  return { user: { id: 'test-user' }, body } as unknown as Request;
+}
+
+describe('POST /api/futures/leverage — HEDGE-mode posSide handling', () => {
+  beforeEach(() => {
+    vi.mocked(poloniexFuturesService.setLeverage).mockClear().mockResolvedValue({ ok: true } as never);
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockReset();
+    vi.mocked(poloniexFuturesService.getPositions).mockReset();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 1. Caller-supplied posSide → forwarded verbatim.
+  //
+  // (Mode probe + position lookup short-circuited; this is the path the
+  //  client uses when it already knows which lane to apply leverage to.)
+  // ──────────────────────────────────────────────────────────────────────────
+  it('caller-supplied posSide=LONG → forwarded to setLeverage', async () => {
+    const res = mockRes();
+    await handler(mockReq({ symbol: 'BTC_USDT_PERP', leverage: 10, posSide: 'LONG' }), res);
+
+    expect(poloniexFuturesService.setLeverage).toHaveBeenCalledTimes(1);
+    const [, , , opts] = vi.mocked(poloniexFuturesService.setLeverage).mock.calls[0];
+    expect(opts).toEqual({ posSide: 'LONG' });
+    expect(res.statusCode).toBe(200);
+    // Mode probe should NOT have been called when caller already gave us
+    // posSide — small but real latency win on the manual-UI path.
+    expect(poloniexFuturesService.getPositionDirectionMode).not.toHaveBeenCalled();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 2. HEDGE + open SHORT (qty<0) → posSide=SHORT derived from qty sign.
+  //
+  // This is the dashboard-slider use case: user wants to bump leverage on
+  // an existing short. We probe the mode, find HEDGE, find the open
+  // position, and derive posSide from `Math.sign(qty)` (same authoritative
+  // pattern as stateReconciliationService.ts:152).
+  // ──────────────────────────────────────────────────────────────────────────
+  it('HEDGE + existing SHORT (qty<0) → setLeverage gets posSide=SHORT', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'HEDGE' } as never);
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      { symbol: 'ETH_USDT_PERP', qty: '-0.05' },
+    ] as never);
+
+    const res = mockRes();
+    await handler(mockReq({ symbol: 'ETH_USDT_PERP', leverage: 20 }), res);
+
+    expect(poloniexFuturesService.setLeverage).toHaveBeenCalledTimes(1);
+    const [, , , opts] = vi.mocked(poloniexFuturesService.setLeverage).mock.calls[0];
+    expect(opts).toEqual({ posSide: 'SHORT' });
+    expect(res.statusCode).toBe(200);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 3. ONE_WAY mode → setLeverage receives empty opts.
+  //
+  // The historic ONE_WAY-on-prod wire shape is `{ symbol, lever, mgnMode }`
+  // with no posSide. Sending posSide on a ONE_WAY account gives the same
+  // 11011 error in reverse, so we explicitly omit.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('ONE_WAY mode → setLeverage gets empty opts (no posSide)', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'ONE_WAY' } as never);
+
+    const res = mockRes();
+    await handler(mockReq({ symbol: 'BTC_USDT_PERP', leverage: 5 }), res);
+
+    expect(poloniexFuturesService.setLeverage).toHaveBeenCalledTimes(1);
+    const [, , , opts] = vi.mocked(poloniexFuturesService.setLeverage).mock.calls[0];
+    expect(opts).toEqual({});
+    expect(opts).not.toHaveProperty('posSide');
+    expect(res.statusCode).toBe(200);
+    // We never need to look up positions on ONE_WAY accounts.
+    expect(poloniexFuturesService.getPositions).not.toHaveBeenCalled();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 4. HEDGE + no open position + no caller posSide → 400.
+  //
+  // The exchange has no way to know which lane to apply leverage to, and
+  // we refuse to guess (guessing produces silent leverage drift on the
+  // wrong side of the book).
+  // ──────────────────────────────────────────────────────────────────────────
+  it('HEDGE + no open position + no caller side → 400 with helpful message', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'HEDGE' } as never);
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([] as never);
+
+    const res = mockRes();
+    await handler(mockReq({ symbol: 'BTC_USDT_PERP', leverage: 5 }), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(poloniexFuturesService.setLeverage).not.toHaveBeenCalled();
+    expect((res.body as { hedgeMode?: boolean }).hedgeMode).toBe(true);
+    expect((res.body as { error: string }).error).toMatch(/HEDGE/);
+  });
+});

--- a/apps/api/src/tests/liveSignalEngine.setLeverage.test.ts
+++ b/apps/api/src/tests/liveSignalEngine.setLeverage.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for LiveSignalEngine.submitOrder HEDGE-mode posSide plumbing.
+ *
+ * Background (PR #611 HEDGE flip + post-deploy 11011 errors):
+ *   /v3/position/leverage on a HEDGE account requires `posSide: LONG|SHORT`
+ *   in the body. Without it Poloniex returns code=11011 and leverage stays
+ *   at the exchange default. The Monkey kernel already plumbs this through
+ *   (loop.ts:2126-2154); this engine was the missing call site.
+ *
+ * Coverage:
+ *   1. HEDGE + long entry → setLeverage receives `{ posSide: 'LONG' }`.
+ *   2. HEDGE + short entry → setLeverage receives `{ posSide: 'SHORT' }`.
+ *   3. ONE_WAY entry → setLeverage receives `{}` (posSide omitted, exchange
+ *      defaults to BOTH which is correct for one-way accounts).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock heavy dependencies ──────────────────────────────────────────────────
+vi.mock('../db/connection.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) }
+}));
+vi.mock('../services/poloniexFuturesService.js', () => ({
+  default: {
+    setLeverage: vi.fn().mockResolvedValue({}),
+    placeOrder: vi.fn().mockResolvedValue({ ordId: 'mock-order-id' }),
+    getPositionDirectionMode: vi.fn(),
+    getPositions: vi.fn().mockResolvedValue([]),
+    getAccountBalance: vi.fn().mockResolvedValue({ totalBalance: '1000', availableBalance: '900' }),
+  }
+}));
+vi.mock('../services/apiCredentialsService.js', () => ({
+  apiCredentialsService: { getCredentials: vi.fn() }
+}));
+vi.mock('../services/marketCatalog.js', () => ({
+  getPrecisions: vi.fn().mockResolvedValue({ lotSize: 0.001 }),
+  getMaxLeverage: vi.fn().mockResolvedValue(100),
+}));
+vi.mock('../services/mlPredictionService.js', () => ({ default: {} }));
+vi.mock('../services/monitoringService.js', () => ({
+  monitoringService: { recordPipelineHeartbeat: vi.fn(), recordTradeEvent: vi.fn() }
+}));
+vi.mock('../services/thompsonBandit.js', () => ({
+  bucketOfLeverage: vi.fn(() => 'low'),
+  sampleBeta: vi.fn(() => 0.5),
+}));
+vi.mock('../services/monkey/loop.js', () => ({
+  allMonkeyKernels: () => [],
+  getFreshestMonkeyBasinSnapshot: vi.fn(),
+}));
+vi.mock('../services/monkey/kernel_client.js', () => ({
+  callLiveDecide: vi.fn(),
+  isLiveSignalShadowEnabled: vi.fn(() => false),
+}));
+vi.mock('../services/executionModeService.js', () => ({
+  getCurrentExecutionMode: vi.fn(() => 'auto'),
+}));
+vi.mock('../services/riskKernel.js', () => ({
+  evaluatePreTradeVetoes: vi.fn(),
+}));
+vi.mock('../utils/engineVersion.js', () => ({ getEngineVersion: () => 'v-test' }));
+
+import { LiveSignalEngine } from '../services/liveSignalEngine.js';
+import poloniexFuturesService from '../services/poloniexFuturesService.js';
+
+/** Access private members for testing. */
+function priv(e: LiveSignalEngine) {
+  return e as unknown as {
+    submitOrder: (
+      order: { symbol: string; side: 'long' | 'short'; notional: number; leverage: number; price: number },
+      signal: Record<string, unknown>,
+      atr: number,
+      userId: string,
+      credentials: { apiKey: string; apiSecret: string; passphrase?: string },
+    ) => Promise<void>;
+    positionDirectionMode: 'HEDGE' | 'ONE_WAY' | undefined;
+  };
+}
+
+const CREDS = { apiKey: 'k', apiSecret: 's' };
+const SIGNAL = {
+  symbol: 'BTC_USDT_PERP',
+  signal: 'BUY' as const,
+  strength: 0.5,
+  reason: 'test',
+  timestamp: Date.now(),
+  signalKey: 'k',
+  regime: 'trending',
+  leverageBucket: 'low' as const,
+};
+
+describe('LiveSignalEngine.submitOrder — HEDGE-mode setLeverage posSide', () => {
+  let engine: LiveSignalEngine;
+
+  beforeEach(() => {
+    engine = new LiveSignalEngine();
+    vi.mocked(poloniexFuturesService.setLeverage).mockClear();
+    vi.mocked(poloniexFuturesService.placeOrder).mockClear().mockResolvedValue({ ordId: 'mock-order-id' } as never);
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockReset();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 1. HEDGE + long → posSide=LONG.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('HEDGE + long order → setLeverage called with posSide=LONG', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'HEDGE' } as never);
+
+    const order = { symbol: 'BTC_USDT_PERP', side: 'long' as const, notional: 50, leverage: 10, price: 50000 };
+    await priv(engine).submitOrder(order, SIGNAL, 100, 'user-1', CREDS);
+
+    expect(poloniexFuturesService.setLeverage).toHaveBeenCalledTimes(1);
+    const [, , , opts] = vi.mocked(poloniexFuturesService.setLeverage).mock.calls[0];
+    expect(opts).toEqual({ posSide: 'LONG' });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 2. HEDGE + short → posSide=SHORT.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('HEDGE + short order → setLeverage called with posSide=SHORT', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'HEDGE' } as never);
+
+    const order = { symbol: 'ETH_USDT_PERP', side: 'short' as const, notional: 50, leverage: 20, price: 2250 };
+    await priv(engine).submitOrder(order, SIGNAL, 100, 'user-1', CREDS);
+
+    expect(poloniexFuturesService.setLeverage).toHaveBeenCalledTimes(1);
+    const [, , , opts] = vi.mocked(poloniexFuturesService.setLeverage).mock.calls[0];
+    expect(opts).toEqual({ posSide: 'SHORT' });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 3. ONE_WAY → posSide omitted (exchange defaults to BOTH).
+  // ──────────────────────────────────────────────────────────────────────────
+  it('ONE_WAY mode → setLeverage called with empty opts (posSide omitted)', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'ONE_WAY' } as never);
+
+    const order = { symbol: 'BTC_USDT_PERP', side: 'long' as const, notional: 50, leverage: 10, price: 50000 };
+    await priv(engine).submitOrder(order, SIGNAL, 100, 'user-1', CREDS);
+
+    expect(poloniexFuturesService.setLeverage).toHaveBeenCalledTimes(1);
+    const [, , , opts] = vi.mocked(poloniexFuturesService.setLeverage).mock.calls[0];
+    expect(opts).toEqual({});
+    expect(opts).not.toHaveProperty('posSide');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Bonus: detection runs once and is cached across submitOrder calls.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('caches positionDirectionMode after first detection', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'HEDGE' } as never);
+
+    const order1 = { symbol: 'BTC_USDT_PERP', side: 'long' as const, notional: 50, leverage: 10, price: 50000 };
+    const order2 = { symbol: 'ETH_USDT_PERP', side: 'short' as const, notional: 50, leverage: 5, price: 2250 };
+    await priv(engine).submitOrder(order1, SIGNAL, 100, 'user-1', CREDS);
+    await priv(engine).submitOrder(order2, SIGNAL, 100, 'user-1', CREDS);
+
+    // Mode probe should have been called once across both submitOrder calls.
+    expect(poloniexFuturesService.getPositionDirectionMode).toHaveBeenCalledTimes(1);
+    expect(priv(engine).positionDirectionMode).toBe('HEDGE');
+  });
+});


### PR DESCRIPTION
## Summary

Three fixes sharing the same HEDGE-mode root cause: code reading `p.side` from Poloniex Futures v3 gets the wrong answer because in v3 HEDGE mode `p.side` is the next-action label (BUY/SELL), not position direction. Authoritative direction is `Math.sign(p.qty)` OR `p.posSide` (preferred when present).

## Issues fixed

### 1. FAT logger mislabels SHORT as LONG (HIGH)

Production log self-reported the bug via the `pnl formula divergence` WARN:
```
[FAT] ETH_USDT_PERP LONG pnl=-0.0636u priceMove=0.305% roi=-5.63% lev=20x
[FAT] pnl formula divergence: priceMove=0.305% vs roi/lev=-0.281% (Δ=0.586%)
```

`apps/api/src/services/fullyAutonomousTrader.ts:1351-1374` resolved via posSide-first / qty-sign-fallback canonical pattern (mirroring `stateReconciliationService.ts:152` and `loop.ts::fetchAccountContext`). Subagent also caught and fixed two sibling `const isLong = qty > 0` shadows at L1463 + L1517 that would have caused identical mislabeling on trend-reversal exits.

### 2. `liveSignalEngine.submitOrder` setLeverage missing posSide (MEDIUM)

`apps/api/src/services/liveSignalEngine.ts:1133-1151` — same pattern as `loop.ts:2126-2154` fixed in PR #615. Added `positionDirectionMode` instance cache + `ensurePositionDirectionMode()` lazy-detect mirroring Monkey kernel's pattern. posSide derived from `order.side` on HEDGE, omitted on ONE_WAY.

### 3. `routes/futures.ts:421` setLeverage missing posSide (MEDIUM)

`apps/api/src/routes/futures.ts:399-512` — manual UI route hit 11011 on every HEDGE-account leverage change. Three-tier resolution: caller-supplied `posSide`/`side` wins; otherwise probe mode and derive from existing position qty-sign; HEDGE + no position + no caller side returns `400 { hedgeMode: true }` rather than guessing.

## Tests

- 4 `fullyAutonomousTrader.sideLabel.test.ts` (LONG, HEDGE+SHORT, ONE_WAY+SHORT, divergence WARN suppression)
- 4 `liveSignalEngine.setLeverage.test.ts` (HEDGE long/short, ONE_WAY, mode-detection caching)
- 4 `futures.leverage.test.ts` (caller passthrough, HEDGE qty-sign derivation, ONE_WAY omit, HEDGE+no-position 400)

**12 new, all passing.** Full vitest: 915 pass, 2 pre-existing `resonance_bank_lane` fails (verified on main).

## Out-of-scope follow-up

Subagent flagged `fullyAutonomousTrader.ts:1555` `closePosition` (`qty > 0 ? 'close_long' : 'close_short'`) — same bug class, explicitly skipped per scope. One-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix Poloniex HEDGE-mode handling by using authoritative position direction for labeling and by passing correct posSide to leverage calls across services and routes.

Bug Fixes:
- Correct FullyAutonomousTrader position side labeling in HEDGE mode by deriving direction from posSide or qty sign, preventing SHORT positions being reported as LONG.
- Ensure LiveSignalEngine leverage updates include posSide for HEDGE accounts and omit it for ONE_WAY accounts to avoid Poloniex 11011 errors.
- Fix the futures leverage API route to supply posSide when required in HEDGE mode, or return a clear 400 when it cannot be inferred, eliminating repeated leverage-change failures from the dashboard.

Tests:
- Add unit tests covering FAT HEDGE-mode side labeling and suppression of false pnl divergence warnings.
- Add tests for LiveSignalEngine.submitOrder leverage calls across HEDGE long/short and ONE_WAY modes, including positionDirectionMode caching.
- Add tests for the futures leverage route to verify caller passthrough, HEDGE qty-sign derivation, ONE_WAY omission, and HEDGE-without-position 400 responses.