### PR TITLE
fix(hedge): closePosition uses posSide-first / qty-sign-fallback

### DIFF
--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -1515,8 +1515,17 @@ class FullyAutonomousTrader extends EventEmitter {
       const entryPrice = parseFloat(position.openAvgPx || position.entryPrice || '0');
       const pnl = parseFloat(position.unrealPnl || position.unrealisedPnl || '0');
 
-      // Use Poloniex close position endpoint for cleaner execution
-      const closeType = qty > 0 ? 'close_long' : 'close_short';
+      // Use Poloniex close position endpoint for cleaner execution.
+      // posSide-first / qty-sign-fallback — same canonical pattern as
+      // the FAT label and trend-reversal exits (PR #616). v3 HEDGE
+      // returns positive qty + posSide; ONE_WAY returns signed qty.
+      const posSideRaw = String(
+        (position as { posSide?: string }).posSide ?? '',
+      ).toUpperCase();
+      const isLong = posSideRaw === 'LONG' || posSideRaw === 'SHORT'
+        ? posSideRaw === 'LONG'
+        : qty > 0;
+      const closeType = isLong ? 'close_long' : 'close_short';
       await poloniexFuturesService.closePosition(credentials, symbol, closeType);
 
       // ─── Python short-circuit: delegate DB write to ml-worker ───


### PR DESCRIPTION
Final HEDGE-mode side-labeling sibling. `closePosition` at `fullyAutonomousTrader.ts:1519` was deriving `closeType` via `qty > 0 ? 'close_long' : 'close_short'` — same bug pattern as the FAT logger and trend-reversal exits fixed in PR #616.

In v3 HEDGE mode Poloniex returns positive qty magnitude + a `posSide` field; the qty-only check would mislabel a SHORT close as 'close_long' on HEDGE. ONE_WAY (signed qty) still works via the fallback branch.

11-line change, follows the canonical pattern established in PR #616. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct closeType determination to prioritize posSide and fall back to qty sign so HEDGE-mode short positions are not mislabeled as long closes.