### PR TITLE
fix(hedge): drop reduceOnly on HEDGE close orders (was code 400 — trades couldn't close)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1894,14 +1894,23 @@ export class MonkeyKernel extends EventEmitter {
       // Proposal #10 — in HEDGE mode the close must specify which side
       // of the hedge book it's reducing, otherwise the exchange may
       // route against the wrong leg.
+      //
+      // HEDGE close: posSide=LONG|SHORT, NO reduceOnly — Poloniex v3
+      // rejects reduceOnly in HEDGE with "Param error reduceOnly cannot
+      // be set to true in hedge" (prod incident 2026-04-30). The
+      // poloniexFuturesService strips reduceOnly for HEDGE mode, but we
+      // also pass `positionMode` explicitly so the contract is obvious
+      // at the call site.
+      const isHedge = this.positionDirectionMode === 'HEDGE';
       const closePosSide: 'LONG' | 'SHORT' | undefined =
-        this.positionDirectionMode === 'HEDGE'
-          ? (heldSide === 'long' ? 'LONG' : 'SHORT')
-          : undefined;
+        isHedge ? (heldSide === 'long' ? 'LONG' : 'SHORT') : undefined;
       const exchangeOrder = await poloniexFuturesService.placeOrder(credentials, {
         symbol, side: closeSide, type: 'market', size: formattedSize, lotSize: symbolLotSize,
         reduceOnly: true,
-      }, closePosSide ? { posSide: closePosSide } : {});
+      }, {
+        positionMode: isHedge ? 'HEDGE' : 'ONE_WAY',
+        ...(closePosSide ? { posSide: closePosSide } : {}),
+      });
       orderId =
         exchangeOrder?.ordId ?? exchangeOrder?.orderId ??
         exchangeOrder?.id ?? exchangeOrder?.clientOid ?? null;

--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -585,6 +585,24 @@ class PoloniexFuturesService {
    * `type: 'market'`, `size: <base asset>`); this method normalises
    * to v3 wire form. `lotSize` in the optional 4th arg (or the
    * catalog lookup) tells us how to convert size → sz.
+   *
+   * Position-mode semantics (verified on prod 2026-04-30 after the
+   * trailing_harvest close-rejection incident):
+   *   - HEDGE  account → close orders MUST carry `posSide: 'LONG' | 'SHORT'`
+   *     matching the side of the position being reduced, and MUST NOT
+   *     carry `reduceOnly`. Sending reduceOnly returns
+   *     code=400 "Param error  reduceOnly cannot be set to true in hedge"
+   *     and the position stays open.
+   *   - ONE_WAY account → close orders use `reduceOnly: true` and either
+   *     omit `posSide` or send `BOTH`.
+   *
+   * The caller signals which mode it's in either via the explicit
+   * `opts.positionMode` ('HEDGE' | 'ONE_WAY'), or implicitly by the
+   * presence/absence of `opts.posSide`. If the caller asked for
+   * `reduceOnly: true` while also being in HEDGE mode, this method
+   * silently drops `reduceOnly` (the posSide+side pair already tells
+   * the exchange "reduce that leg") rather than letting the request
+   * be rejected.
    */
   async placeOrder(credentials, orderData, opts = {}) {
     // Normalise side + type to UPPER per v3 spec.
@@ -615,12 +633,19 @@ class PoloniexFuturesService {
       szContracts = Math.round(Number(orderData.size));
     }
 
+    // Resolve effective position-direction mode. Explicit opt wins; otherwise
+    // infer from posSide (LONG/SHORT means HEDGE; absent or BOTH means ONE_WAY).
+    const posSideRaw = String(opts.posSide ?? orderData.posSide ?? '').toUpperCase();
+    const explicitMode = String(opts.positionMode ?? '').toUpperCase();
+    const isHedge = explicitMode === 'HEDGE'
+      || (explicitMode === '' && (posSideRaw === 'LONG' || posSideRaw === 'SHORT'));
+
     const body = {
       clOrdId: orderData.clientOid || orderData.clOrdId || this.generateClientOrderId(),
       symbol: orderData.symbol,
       side,                                                      // 'BUY' | 'SELL'
       mgnMode: (opts.mgnMode ?? orderData.mgnMode ?? 'CROSS').toUpperCase(),
-      posSide: (opts.posSide ?? orderData.posSide ?? 'BOTH').toUpperCase(),
+      posSide: posSideRaw || 'BOTH',
       type: typeUpper,                                           // 'MARKET' | 'LIMIT' | 'LIMIT_MAKER'
       sz: String(szContracts),                                   // STRING, in contracts
     };
@@ -630,7 +655,13 @@ class PoloniexFuturesService {
       if (orderData.price !== undefined) body.px = String(orderData.price);
       if (orderData.timeInForce) body.timeInForce = orderData.timeInForce;
     }
-    if (orderData.reduceOnly) body.reduceOnly = true;
+    // reduceOnly is HEDGE-incompatible. Poloniex v3 rejects it with
+    // "Param error  reduceOnly cannot be set to true in hedge" — silently
+    // drop it on HEDGE accounts. The posSide+side combination already
+    // tells the exchange to reduce the matching leg.
+    if (orderData.reduceOnly && !isHedge) {
+      body.reduceOnly = true;
+    }
 
     // Remove undefined values defensively.
     Object.keys(body).forEach(key => {

--- a/apps/api/src/tests/poloniexFuturesService.placeOrder.hedge.test.js
+++ b/apps/api/src/tests/poloniexFuturesService.placeOrder.hedge.test.js
@@ -1,0 +1,188 @@
+/**
+ * Locks the close-order body shape across HEDGE and ONE_WAY position-direction
+ * modes.
+ *
+ * Why this test exists:
+ *   On 2026-04-30 the live Monkey kernel logged a recurring close failure:
+ *
+ *     [Monkey] ETH_USDT_PERP [integration] scalp_exit
+ *       reason: trailing_harvest: peak 0.764% → now 0.061% < 0.382% floor |
+ *               close: close_exchange_rejected: Poloniex /v3/trade/order
+ *               returned code=400: Param error  reduceOnly cannot be set
+ *               to true in hedge
+ *
+ *   Trailing-harvest correctly identified a close opportunity, but the
+ *   placeOrder body carried `reduceOnly: true` even though the account is
+ *   in HEDGE mode. Poloniex v3 forbids reduceOnly in HEDGE — the close
+ *   must instead carry `posSide: LONG | SHORT` matching the leg being
+ *   reduced. The position kept failing to close and the rejection
+ *   repeated on every Monkey cycle.
+ *
+ *   PoloniexFuturesService.placeOrder now strips `reduceOnly` whenever
+ *   the account is in HEDGE mode, inferred from either the explicit
+ *   `opts.positionMode` flag or from `opts.posSide` being LONG|SHORT.
+ *   In ONE_WAY mode the historical behaviour is preserved (reduceOnly
+ *   passes through, posSide defaults to BOTH).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import poloniexFuturesService from '../services/poloniexFuturesService.js';
+
+describe('PoloniexFuturesService.placeOrder — HEDGE close body shape', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('HEDGE close LONG: body has posSide=LONG + side=SELL, no reduceOnly', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({ ordId: 'ord-1' });
+
+    await poloniexFuturesService.placeOrder(
+      { apiKey: 'k', apiSecret: 's' },
+      {
+        symbol: 'ETH_USDT_PERP',
+        side: 'sell',
+        type: 'market',
+        size: 0.1,
+        lotSize: 0.01,
+        reduceOnly: true,
+      },
+      { positionMode: 'HEDGE', posSide: 'LONG' },
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [, method, endpoint, body] = spy.mock.calls[0];
+    expect(method).toBe('POST');
+    expect(endpoint).toBe('/trade/order');
+    expect(body.side).toBe('SELL');
+    expect(body.posSide).toBe('LONG');
+    expect(body).not.toHaveProperty('reduceOnly');
+  });
+
+  it('HEDGE close SHORT: body has posSide=SHORT + side=BUY, no reduceOnly', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({ ordId: 'ord-2' });
+
+    await poloniexFuturesService.placeOrder(
+      { apiKey: 'k', apiSecret: 's' },
+      {
+        symbol: 'BTC_USDT_PERP',
+        side: 'buy',
+        type: 'market',
+        size: 0.005,
+        lotSize: 0.001,
+        reduceOnly: true,
+      },
+      { positionMode: 'HEDGE', posSide: 'SHORT' },
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body.side).toBe('BUY');
+    expect(body.posSide).toBe('SHORT');
+    expect(body).not.toHaveProperty('reduceOnly');
+  });
+
+  it('HEDGE inferred from posSide alone: still strips reduceOnly', async () => {
+    // Caller didn't pass positionMode but did pass posSide=LONG, which is
+    // only valid in HEDGE — service must infer and strip reduceOnly.
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({ ordId: 'ord-3' });
+
+    await poloniexFuturesService.placeOrder(
+      { apiKey: 'k', apiSecret: 's' },
+      {
+        symbol: 'ETH_USDT_PERP',
+        side: 'sell',
+        type: 'market',
+        size: 0.1,
+        lotSize: 0.01,
+        reduceOnly: true,
+      },
+      { posSide: 'LONG' },
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body.posSide).toBe('LONG');
+    expect(body).not.toHaveProperty('reduceOnly');
+  });
+
+  it('ONE_WAY close: body has reduceOnly=true and posSide=BOTH', async () => {
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({ ordId: 'ord-4' });
+
+    await poloniexFuturesService.placeOrder(
+      { apiKey: 'k', apiSecret: 's' },
+      {
+        symbol: 'ETH_USDT_PERP',
+        side: 'sell',
+        type: 'market',
+        size: 0.1,
+        lotSize: 0.01,
+        reduceOnly: true,
+      },
+      { positionMode: 'ONE_WAY' },
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body.side).toBe('SELL');
+    expect(body.reduceOnly).toBe(true);
+    // ONE_WAY: posSide is either omitted or the literal 'BOTH'. We default
+    // to 'BOTH' (Poloniex accepts either; the historical default is BOTH).
+    expect(body.posSide).toBe('BOTH');
+  });
+
+  it('ONE_WAY default (no opts): body has reduceOnly=true and posSide=BOTH', async () => {
+    // No positionMode and no posSide — historical default behaviour
+    // must be preserved so legacy callers (FAT SL/TP placements) keep
+    // working unchanged.
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({ ordId: 'ord-5' });
+
+    await poloniexFuturesService.placeOrder(
+      { apiKey: 'k', apiSecret: 's' },
+      {
+        symbol: 'ETH_USDT_PERP',
+        side: 'sell',
+        type: 'market',
+        size: 0.1,
+        lotSize: 0.01,
+        reduceOnly: true,
+      },
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body.reduceOnly).toBe(true);
+    expect(body.posSide).toBe('BOTH');
+  });
+
+  it('opening order in HEDGE (no reduceOnly): body has posSide and no reduceOnly', async () => {
+    // Sanity: an opening market order in HEDGE mode should still pass
+    // posSide through unchanged. reduceOnly was never set so there's
+    // nothing to strip.
+    const spy = vi
+      .spyOn(poloniexFuturesService, 'makeRequest')
+      .mockResolvedValue({ ordId: 'ord-6' });
+
+    await poloniexFuturesService.placeOrder(
+      { apiKey: 'k', apiSecret: 's' },
+      {
+        symbol: 'BTC_USDT_PERP',
+        side: 'buy',
+        type: 'market',
+        size: 0.005,
+        lotSize: 0.001,
+      },
+      { positionMode: 'HEDGE', posSide: 'LONG' },
+    );
+
+    const body = spy.mock.calls[0][3];
+    expect(body.side).toBe('BUY');
+    expect(body.posSide).toBe('LONG');
+    expect(body).not.toHaveProperty('reduceOnly');
+  });
+});


### PR DESCRIPTION
## Summary

Critical close-path bug. `closeHeldPosition` was passing `reduceOnly: true` unconditionally; Poloniex v3 forbids `reduceOnly` on HEDGE accounts. Every close attempt returned `code=400 'Param error reduceOnly cannot be set to true in hedge'` — trailing-harvest detected good exits but the close orders failed, positions stayed open, the loop retried every cycle.

Live evidence:
```
[Monkey] ETH_USDT_PERP scalp_exit
  reason: trailing_harvest: peak 0.764% → now 0.061% < 0.382% floor |
          close: close_exchange_rejected: Poloniex /v3/trade/order returned code=400:
          Param error  reduceOnly cannot be set to true in hedge
```

## Fix

Service-level so no caller can repeat the mistake:

- `apps/api/src/services/poloniexFuturesService.js:618-654` — `placeOrder` infers HEDGE mode (from explicit `opts.positionMode` or implied by `opts.posSide=LONG|SHORT`) and silently drops `reduceOnly` from HEDGE bodies.
- `apps/api/src/services/monkey/loop.ts:1892-1916` — `closeHeldPosition` passes `positionMode` explicitly for self-documentation.

## Tests

- 6 new in `poloniexFuturesService.placeOrder.hedge.test.js` (HEDGE close LONG, HEDGE close SHORT, HEDGE inferred from posSide, ONE_WAY explicit, ONE_WAY default, HEDGE open without reduceOnly)
- 43/43 adjacent existing tests still pass
- 309/311 Monkey tests pass (2 pre-existing `resonance_bank_lane` fails unchanged)
- tsc clean

## Judgment calls

- Service-level fix preserves existing call sites including FAT SL/TP placements at `fullyAutonomousTrader.ts:1057,1077` which were going to hit the same bug on HEDGE.
- ONE_WAY default kept as `posSide: 'BOTH'` for back-compat with the 26-test legacy suite.
- liveSignalEngine close path uses `closePosition()` (dedicated endpoint) so isn't affected. The two `reduceOnly: true` references at `liveSignalEngine.ts:1285,1301` are in `if (false && ...)` dead-code SL/TP blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle Poloniex hedge-mode semantics when placing close orders so hedge accounts can successfully close positions without exchange rejections.

Bug Fixes:
- Prevent hedge-mode close orders from being rejected by dropping reduceOnly on hedge accounts while retaining correct posSide semantics.

Enhancements:
- Infer position mode in Poloniex futures order placement from explicit configuration or posSide and propagate positionMode from the monkey loop close path for clarity.

Tests:
- Add hedge-specific placeOrder tests covering hedge vs one-way modes, explicit and inferred posSide, and open/close order combinations.