### PR TITLE
feat(monkey): held-position re-justification (regime / Φ / conviction)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
+++ b/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
@@ -1,0 +1,246 @@
+/**
+ * heldPositionRejustification.test.ts — TS parity for held-position
+ * re-justification (mirrors ml-worker/tests/monkey_kernel/
+ * test_held_position_rejustification.py).
+ *
+ * Three internal exit checks fire when the kernel's own state
+ * contradicts what justified entry:
+ *
+ *   1. REGIME CHECK   — current mode != mode at open → exit
+ *   2. PHI CHECK      — current Φ < phi_at_open / PHI_GOLDEN_FLOOR_RATIO
+ *   3. CONVICTION    — confidence < anxiety + confusion → exit
+ *
+ * The test exercises `evaluateRejustification` directly. The inline
+ * call in loop.ts::processSymbol is wired identically.
+ */
+import { describe, it, expect } from 'vitest';
+import { MonkeyMode } from '../modes.js';
+import { PHI_GOLDEN_FLOOR_RATIO } from '../topology_constants.js';
+import {
+  evaluateRejustification,
+  type RejustificationEmotions,
+} from '../held_position_rejustification.js';
+
+const NEUTRAL_EMO: RejustificationEmotions = {
+  confidence: 0,
+  anxiety: 0,
+  confusion: 0,
+};
+
+const STRONG_EMO: RejustificationEmotions = {
+  confidence: 0.7,
+  anxiety: 0.1,
+  confusion: 0.1,
+};
+
+const WEAK_EMO: RejustificationEmotions = {
+  confidence: 0.4,
+  anxiety: 0.3,
+  confusion: 0.2,
+};
+
+// ─── Positive — each check fires ────────────────────────────────────
+
+describe('held-position rejustification — regime check fires', () => {
+  it('regime change exits with correct reason', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+    });
+    expect(out.checked).toBe(true);
+    expect(out.fired).toBe('regime_change');
+    expect(out.reason).toMatch(/^regime_change/);
+    expect(out.reason).toContain('investigation');
+    expect(out.reason).toContain('drift');
+  });
+});
+
+describe('held-position rejustification — phi check fires', () => {
+  it('phi collapse below golden floor exits', () => {
+    // phi_at_open = 0.27 → floor = 0.27 / φ ≈ 0.16687
+    // phi_now = 0.15 (well below floor)
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.15,
+      emotions: STRONG_EMO,
+    });
+    expect(out.fired).toBe('phi_collapse');
+    expect(out.reason).toMatch(/^phi_collapse/);
+    expect(out.phiFloor).toBeCloseTo(0.27 / PHI_GOLDEN_FLOOR_RATIO, 9);
+  });
+
+  it('PHI_GOLDEN_FLOOR_RATIO equals golden ratio', () => {
+    const expected = (1 + Math.sqrt(5)) / 2;
+    expect(PHI_GOLDEN_FLOOR_RATIO).toBeCloseTo(expected, 12);
+    // 1/φ ≈ 0.618 — the actual coherence-floor multiplier.
+    expect(1 / PHI_GOLDEN_FLOOR_RATIO).toBeCloseTo(0.6180339887, 9);
+  });
+});
+
+describe('held-position rejustification — conviction check fires', () => {
+  it('confidence < anxiety + confusion exits', () => {
+    // 0.4 < 0.3 + 0.2 = 0.5 — conviction fails
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: WEAK_EMO,
+    });
+    expect(out.fired).toBe('conviction_failed');
+    expect(out.reason).toMatch(/^conviction_failed/);
+    expect(out.reason).toContain('0.400');
+    expect(out.reason).toContain('0.500');
+  });
+});
+
+// ─── Negative — checks do NOT fire ─────────────────────────────────
+
+describe('held-position rejustification — regime unchanged', () => {
+  it('same regime — no regime exit', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+    });
+    expect(out.fired).toBeNull();
+    expect(out.checked).toBe(true);
+  });
+});
+
+describe('held-position rejustification — phi stable above floor', () => {
+  it('phi above floor — no phi exit', () => {
+    // floor = 0.27 / φ ≈ 0.167. phi_now = 0.20 stays above.
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.20,
+      emotions: STRONG_EMO,
+    });
+    expect(out.fired).toBeNull();
+  });
+});
+
+describe('held-position rejustification — conviction holds', () => {
+  it('confidence ≥ anxiety + confusion — no conviction exit', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,  // 0.7 > 0.1 + 0.1 = 0.2
+    });
+    expect(out.fired).toBeNull();
+  });
+
+  it('NEUTRAL_EMOTIONS does not fire conviction (0 < 0+0 is false)', () => {
+    // TS path uses NEUTRAL_EMOTIONS until the emotion stack is ported.
+    // Verify that the conviction check is dormant under that input.
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: NEUTRAL_EMO,
+    });
+    expect(out.fired).toBeNull();
+  });
+});
+
+// ─── No-anchor path ────────────────────────────────────────────────
+
+describe('held-position rejustification — no anchor recorded', () => {
+  it('skips checks when regimeAtOpen is undefined', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: undefined,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.05,  // would have fired phi_collapse if anchor existed
+      emotions: WEAK_EMO,
+    });
+    expect(out.checked).toBe(false);
+    expect(out.fired).toBeNull();
+    expect(out.phiFloor).toBeNull();
+  });
+
+  it('skips checks when phiAtOpen is undefined', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: undefined,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.05,
+      emotions: WEAK_EMO,
+    });
+    expect(out.checked).toBe(false);
+    expect(out.fired).toBeNull();
+  });
+});
+
+// ─── Per-lane isolation ───────────────────────────────────────────
+
+describe('held-position rejustification — per-lane isolation', () => {
+  it('different lanes evaluate independently against their own anchors', () => {
+    // The helper takes anchors per-call, so the per-lane isolation
+    // contract is: callers (loop.ts) read the anchors for the current
+    // lane only. Mirror that here by calling twice with different
+    // anchors and verifying each call uses its own values.
+
+    // Lane A: opened in INVESTIGATION at Φ=0.27. Now mode=DRIFT → fires.
+    const laneA = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+    });
+    expect(laneA.fired).toBe('regime_change');
+    expect(laneA.reason).toContain('investigation');
+
+    // Lane B: opened in INTEGRATION at Φ=0.40. Now mode=INTEGRATION → no fire.
+    const laneB = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INTEGRATION,
+      phiAtOpen: 0.40,
+      regimeNow: MonkeyMode.INTEGRATION,
+      phiNow: 0.30,  // above floor 0.40/φ ≈ 0.247
+      emotions: STRONG_EMO,
+    });
+    expect(laneB.fired).toBeNull();
+    expect(laneB.checked).toBe(true);
+    expect(laneB.phiFloor).toBeCloseTo(0.40 / PHI_GOLDEN_FLOOR_RATIO, 9);
+  });
+});
+
+// ─── Order — first to fire wins ────────────────────────────────────
+
+describe('held-position rejustification — check ordering', () => {
+  it('regime fires before phi when both would fire', () => {
+    // If regime AND phi both broken, regime check (first in order) wins.
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.05,  // also below floor
+      emotions: WEAK_EMO,  // also below conviction
+    });
+    expect(out.fired).toBe('regime_change');
+  });
+
+  it('phi fires before conviction when regime is unchanged', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.05,
+      emotions: WEAK_EMO,
+    });
+    expect(out.fired).toBe('phi_collapse');
+  });
+});

--- a/apps/api/src/services/monkey/held_position_rejustification.ts
+++ b/apps/api/src/services/monkey/held_position_rejustification.ts
@@ -1,0 +1,99 @@
+/**
+ * held_position_rejustification.ts — three internal exit checks that
+ * fire when the kernel's own state contradicts what justified entry.
+ *
+ *   1. REGIME CHECK    — current mode != mode at open → exit
+ *   2. PHI CHECK       — current Φ < phi_at_open / PHI_GOLDEN_FLOOR_RATIO → exit
+ *   3. CONVICTION      — confidence < anxiety + confusion → exit
+ *
+ * All three are geometric: regime classifier output, Φ integration
+ * measure, Layer 2B emotion stack. No streak counting, no hysteresis,
+ * no time-based stops.
+ *
+ * Used inline by loop.ts::processSymbol for TS parity with the Python
+ * tick path (`monkey_kernel/tick.py::_decide_with_position`).
+ *
+ * Extracted into a module so TS tests can exercise the gate logic
+ * directly — the inline call site in loop.ts is mirrored bit-for-bit.
+ */
+
+import type { MonkeyMode } from './modes.js';
+import { PHI_GOLDEN_FLOOR_RATIO } from './topology_constants.js';
+
+export interface RejustificationEmotions {
+  confidence: number;
+  anxiety: number;
+  confusion: number;
+}
+
+export interface RejustificationInput {
+  /** Mode the position opened in. Undefined = no anchor recorded. */
+  regimeAtOpen: MonkeyMode | undefined;
+  /** Φ measured at entry. Undefined = no anchor recorded. */
+  phiAtOpen: number | undefined;
+  /** Mode this tick. */
+  regimeNow: MonkeyMode;
+  /** Φ this tick. */
+  phiNow: number;
+  /** Layer 2B emotion stack — TS uses NEUTRAL_EMOTIONS until ported. */
+  emotions: RejustificationEmotions;
+}
+
+export type RejustificationFire =
+  | 'regime_change'
+  | 'phi_collapse'
+  | 'conviction_failed';
+
+export interface RejustificationResult {
+  /** Whether anchors were available to check at all. */
+  checked: boolean;
+  /** Which check fired, if any. */
+  fired: RejustificationFire | null;
+  /** Human-readable reason for the exit decision (empty if no fire). */
+  reason: string;
+  /** Φ floor under the golden-ratio coherence test. */
+  phiFloor: number | null;
+}
+
+/**
+ * Run the three internal exit checks. Returns which (if any) fired.
+ *
+ * Order: regime → phi → conviction. The first to fire wins. No streak,
+ * no hysteresis: a single tick where state contradicts entry exits the
+ * position.
+ */
+export function evaluateRejustification(
+  input: RejustificationInput,
+): RejustificationResult {
+  const { regimeAtOpen, phiAtOpen, regimeNow, phiNow, emotions } = input;
+  if (regimeAtOpen === undefined || phiAtOpen === undefined) {
+    return { checked: false, fired: null, reason: '', phiFloor: null };
+  }
+  const phiFloor = phiAtOpen / PHI_GOLDEN_FLOOR_RATIO;
+
+  if (regimeNow !== regimeAtOpen) {
+    return {
+      checked: true,
+      fired: 'regime_change',
+      reason: `regime_change: opened in ${regimeAtOpen}, now ${regimeNow}`,
+      phiFloor,
+    };
+  }
+  if (phiNow < phiFloor) {
+    return {
+      checked: true,
+      fired: 'phi_collapse',
+      reason: `phi_collapse: open Φ=${phiAtOpen.toFixed(3)} → now ${phiNow.toFixed(3)} < floor ${phiFloor.toFixed(3)}`,
+      phiFloor,
+    };
+  }
+  if (emotions.confidence < emotions.anxiety + emotions.confusion) {
+    return {
+      checked: true,
+      fired: 'conviction_failed',
+      reason: `conviction_failed: conf=${emotions.confidence.toFixed(3)} < anxiety+confusion=${(emotions.anxiety + emotions.confusion).toFixed(3)}`,
+      phiFloor,
+    };
+  }
+  return { checked: true, fired: null, reason: '', phiFloor };
+}

--- a/apps/api/src/services/monkey/kernel_client.ts
+++ b/apps/api/src/services/monkey/kernel_client.ts
@@ -219,6 +219,13 @@ export interface TickRunSymbolState {
   last_entry_at_ms: number | null;
   peak_pnl_usdt: number | null;
   peak_tracked_trade_id: string | null;
+  /**
+   * Held-position re-justification anchors — per-lane (regime, Φ)
+   * snapshots taken at the moment a position opens. Optional for
+   * backward compat with shadow callers that haven't been redeployed.
+   */
+  regime_at_open_by_lane?: Record<string, string>;
+  phi_at_open_by_lane?: Record<string, number>;
 }
 
 export interface TickRunRequest {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -100,6 +100,7 @@ import {
   type Direction,
   type LaneType,
 } from './executive.js';
+import { evaluateRejustification } from './held_position_rejustification.js';
 
 /** Default Monkey watchlist — matches liveSignalEngine for side-by-side. */
 const DEFAULT_SYMBOLS = ['BTC_USDT_PERP', 'ETH_USDT_PERP'];
@@ -220,6 +221,14 @@ interface SymbolState {
   peakPnlUsdtByLane: Record<string, number | null>;
   peakTrackedTradeIdByLane: Record<string, string | null>;
   tapeFlipStreakByLane: Record<string, number>;
+  /** Held-position re-justification anchors — per-lane (regime, Φ)
+   *  snapshots taken at the moment a position opens. The kernel uses
+   *  these as the geometric anchor for "is current state still
+   *  consonant with entry?". Cleared on position close in that lane.
+   *  Same per-lane shape as peakPnlUsdtByLane above so future multi-lane
+   *  positions keep independent rejustification anchors. */
+  regimeAtOpenByLane: Record<string, string>;
+  phiAtOpenByLane: Record<string, number>;
   /** v0.8.7e: latest computed basinDir + tapeTrend from processSymbol, with
    *  timestamp. Exposed via getLatestBasinSnapshot() for LiveSignal's
    *  inter-engine agreement gate. Null until the first tick completes. */
@@ -396,6 +405,8 @@ export class MonkeyKernel extends EventEmitter {
       peakPnlUsdtByLane: {},
       peakTrackedTradeIdByLane: {},
       tapeFlipStreakByLane: {},
+      regimeAtOpenByLane: {},
+      phiAtOpenByLane: {},
       latestBasinSnapshot: null,
     };
   }
@@ -909,72 +920,132 @@ export class MonkeyKernel extends EventEmitter {
         }
         state.tapeFlipStreak = state.tapeFlipStreakByLane[heldLane];
 
-        // 1. Profit harvest — trailing stop + trend-flip, only while green.
-        // Streak counter passed; harvest internally enforces #2 + #4.
         const lanePeak = state.peakPnlUsdtByLane[heldLane] ?? 0;
         const laneStreak = state.tapeFlipStreakByLane[heldLane] ?? 0;
-        const harvest = shouldProfitHarvest(
-          unrealizedPnl,
-          lanePeak,
-          positionNotional,
-          tapeTrend,
-          heldSide,
-          basinState,
-          laneStreak,
-        );
-        derivation.harvest = { ...harvest.derivation, unrealizedPnl, peakPnl: lanePeak, tradeId, lane: heldLane };
-        if (harvest.value) {
-          action = 'scalp_exit';  // executes via same close path
-          reason = harvest.reason;
-          exitFired = true;
-          // Tag the exit type so closeHeldPosition stores the right exit_reason
-          derivation.scalp = {
-            exitTypeBit: harvest.derivation.exitTypeBit,
-            unrealizedPnl,
-            markPrice: lastPrice,
-            tradeId,
-            lane: heldLane,
-          };
-        }
 
-        // 2. Scalp TP/SL (only if harvest didn't fire)
-        if (!exitFired) {
-          const scalp = shouldScalpExit(unrealizedPnl, positionNotional, basinState, mode, heldLane);
-          derivation.scalp = { ...scalp.derivation, unrealizedPnl, markPrice: lastPrice, tradeId };
+        // 1. Hard SL pre-check (SAFETY_BOUND) — must precede the
+        // rejustification block so a position bleeding hard against
+        // the kernel always closes on price before the kernel re-reads
+        // its own state. TP comes BELOW rejustification + harvest.
+        const scalp = shouldScalpExit(unrealizedPnl, positionNotional, basinState, mode, heldLane);
+        derivation.scalp = { ...scalp.derivation, unrealizedPnl, markPrice: lastPrice, tradeId };
+        const SL_DEFER_TICKS = 2;
+        const isStopLoss = Number((scalp as any).derivation?.exitTypeBit) === -1;
+        const longSlWithHammer = (
+          isStopLoss
+          && heldSide === 'long'
+          && candleHammerDefer
+        );
+        if (scalp.value && isStopLoss) {
           // Proposal #9 path 2: SL defer. If the latest tick prints a
           // strong hammer/inverted-hammer AGAINST a long-position SL
           // about to fire, defer the SL by SL_DEFER_TICKS to let the
           // wick recover. Heuristic gate; documented impurity scoped
-          // to this branch only. We do NOT defer take-profit, trailing
-          // harvest, or trend-flip — only the explicit stop-loss bit.
-          const SL_DEFER_TICKS = 2;
-          const isStopLoss = Number((scalp as any).derivation?.exitTypeBit) === -1;
-          const longSlWithHammer = (
-            isStopLoss
-            && heldSide === 'long'
-            && candleHammerDefer
-          );
-          if (scalp.value && longSlWithHammer && state.slDeferRemainingTicks <= 0) {
-            // Open the defer window; suppress the SL this tick.
+          // to this branch only.
+          if (longSlWithHammer && state.slDeferRemainingTicks <= 0) {
             state.slDeferRemainingTicks = SL_DEFER_TICKS;
             (derivation as any).slDefer = {
               opened: true,
               ticksRemaining: state.slDeferRemainingTicks,
               reason: 'hammer_against_long_sl',
             };
-          } else if (state.slDeferRemainingTicks > 0 && isStopLoss && heldSide === 'long') {
-            // Inside the defer window — keep suppressing SL until the
-            // window closes. Decrement at end-of-tick (below).
+          } else if (state.slDeferRemainingTicks > 0 && heldSide === 'long') {
             (derivation as any).slDefer = {
               active: true,
               ticksRemaining: state.slDeferRemainingTicks,
             };
-          } else if (scalp.value) {
+          } else {
             action = 'scalp_exit';
             reason = scalp.reason;
             exitFired = true;
           }
         }
+
+        // 2. Held-position re-justification — three internal exit
+        // checks. Each fires immediately when the kernel's current
+        // state contradicts the state that justified entry. No streak
+        // counting, no hysteresis, no time-based stops. All three are
+        // geometric (regime classifier output, Φ integration measure,
+        // Layer 2B emotion stack — TS path uses NEUTRAL_EMOTIONS until
+        // emotion stack is ported, so the conviction check is dormant
+        // in TS but live in Python).
+        const regimeAtOpen = state.regimeAtOpenByLane[heldLane] as MonkeyMode | undefined;
+        const phiAtOpen = state.phiAtOpenByLane[heldLane];
+        const rejustResult = !exitFired
+          ? evaluateRejustification({
+              regimeAtOpen,
+              phiAtOpen,
+              regimeNow: mode,
+              phiNow: phi,
+              emotions: NEUTRAL_EMOTIONS,
+            })
+          : { checked: false, fired: null, reason: '', phiFloor: null };
+        const rejust: Record<string, unknown> = {
+          checked: rejustResult.checked,
+        };
+        if (rejustResult.checked) {
+          rejust.lane = heldLane;
+          rejust.regimeAtOpen = regimeAtOpen;
+          rejust.regimeNow = mode;
+          rejust.phiAtOpen = phiAtOpen;
+          rejust.phiNow = phi;
+          rejust.phiFloor = rejustResult.phiFloor;
+          rejust.confidence = NEUTRAL_EMOTIONS.confidence;
+          rejust.anxiety = NEUTRAL_EMOTIONS.anxiety;
+          rejust.confusion = NEUTRAL_EMOTIONS.confusion;
+          if (rejustResult.fired) {
+            rejust.fired = rejustResult.fired;
+            action = 'scalp_exit';
+            reason = rejustResult.reason;
+            exitFired = true;
+            // Tag the exit type bit explicitly for the closer — anchor
+            // 5 (rejustification) is a new bit; keep tradeId/lane/pnl
+            // surfaces consistent with the existing scalp_exit shape.
+            derivation.scalp = {
+              exitTypeBit: 5,  // rejustification
+              unrealizedPnl,
+              markPrice: lastPrice,
+              tradeId,
+              lane: heldLane,
+            };
+          }
+        }
+        derivation.rejustification = rejust;
+
+        // 3. Profit harvest — trailing stop + trend-flip, only while green.
+        if (!exitFired) {
+          const harvest = shouldProfitHarvest(
+            unrealizedPnl,
+            lanePeak,
+            positionNotional,
+            tapeTrend,
+            heldSide,
+            basinState,
+            laneStreak,
+          );
+          derivation.harvest = { ...harvest.derivation, unrealizedPnl, peakPnl: lanePeak, tradeId, lane: heldLane };
+          if (harvest.value) {
+            action = 'scalp_exit';
+            reason = harvest.reason;
+            exitFired = true;
+            derivation.scalp = {
+              exitTypeBit: harvest.derivation.exitTypeBit,
+              unrealizedPnl,
+              markPrice: lastPrice,
+              tradeId,
+              lane: heldLane,
+            };
+          }
+        }
+
+        // 4. Scalp TP — only TP can reach here (SL was returned above
+        // unless deferred; rejustification and harvest also returned).
+        if (!exitFired && scalp.value && !isStopLoss) {
+          action = 'scalp_exit';
+          reason = scalp.reason;
+          exitFired = true;
+        }
+
         // Decrement defer window each tick we did not exit.
         if (state.slDeferRemainingTicks > 0) {
           state.slDeferRemainingTicks = Math.max(0, state.slDeferRemainingTicks - 1);
@@ -1205,6 +1276,18 @@ export class MonkeyKernel extends EventEmitter {
             state.peakPnlUsdt = null;
             state.peakTrackedTradeId = null;
           }
+          // Held-position re-justification — snapshot (regime, Φ) at the
+          // moment of entry on this lane. Subsequent ticks compare against
+          // these anchors via the three internal exit checks (regime
+          // change / Φ collapse / conviction failure). DCA adds keep the
+          // original anchors (first-open justification is canonical).
+          if (!isDCA) {
+            const entryLane = (isDCA && heldSide
+              ? (ownOpenRow?.lane ?? positionLane)
+              : positionLane) as 'scalp' | 'swing' | 'trend';
+            state.regimeAtOpenByLane[entryLane] = mode;
+            state.phiAtOpenByLane[entryLane] = phi;
+          }
         }
       } else if (action === 'scalp_exit' && heldSide) {
         const scalpDeriv = derivation.scalp as Record<string, unknown> | undefined;
@@ -1240,6 +1323,9 @@ export class MonkeyKernel extends EventEmitter {
             state.peakPnlUsdtByLane[scalpLane] = null;
             state.peakTrackedTradeIdByLane[scalpLane] = null;
             state.tapeFlipStreakByLane[scalpLane] = 0;
+            // Clear rejustification anchors for the lane that closed.
+            delete state.regimeAtOpenByLane[scalpLane];
+            delete state.phiAtOpenByLane[scalpLane];
             // Mirror legacy scalars for any non-lane-aware reader.
             state.peakPnlUsdt = null;
             state.peakTrackedTradeId = null;
@@ -1284,6 +1370,10 @@ export class MonkeyKernel extends EventEmitter {
             state.peakTrackedTradeId = null;
             state.dcaAddCount = 0;
             state.lastEntryAtMs = null;
+            // Clear rejustification anchors for the lane that flipped.
+            const reversalLane = (ownOpenRow?.lane ?? 'swing') as 'scalp' | 'swing' | 'trend';
+            delete state.regimeAtOpenByLane[reversalLane];
+            delete state.phiAtOpenByLane[reversalLane];
             // Settle delay — give the exchange ~500ms to flatten net.
             await new Promise((resolve) => setTimeout(resolve, 500));
             const execResult = await this.executeEntry({
@@ -1301,12 +1391,15 @@ export class MonkeyKernel extends EventEmitter {
               dcaAddIndex: 0,
               // Reversal lands in the same lane the previous position
               // occupied — REVERSION mode flips side, not lane.
-              lane: ownOpenRow?.lane ?? 'swing',
+              lane: reversalLane,
             });
             executed = execResult.executed;
             monkeyOrderId = execResult.orderId;
             if (executed) {
               state.lastEntryAtMs = Date.now();
+              // Re-snapshot rejustification anchors for the new direction.
+              state.regimeAtOpenByLane[reversalLane] = mode;
+              state.phiAtOpenByLane[reversalLane] = phi;
               reason += ` | closed@${lastPrice.toFixed(2)} pnl=${pnlAtDecision.toFixed(4)} | new ${newSide} orderId=${monkeyOrderId}`;
             } else {
               reason += ` | flattened ok, new-entry failed: ${execResult.reason}`;

--- a/apps/api/src/services/monkey/topology_constants.ts
+++ b/apps/api/src/services/monkey/topology_constants.ts
@@ -18,3 +18,14 @@ export const PI_STRUCT_SECOND_TRANSITION = 2.0;
 export const PI_STRUCT_BOUNDARY_R_SQUARED = 1 / ((1 + Math.sqrt(5)) / 2);
 export const PI_STRUCT_L4_STUD_ARC = (3 * Math.PI) / 2;
 export const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
+
+/**
+ * Golden ratio reciprocal — boundary R² applied to integration coherence
+ * floor. A held position's Φ falling below phi_at_open / φ (i.e.
+ * phi_at_open × 0.618) means integration has decayed past the golden-ratio
+ * coherence floor — the kernel's perception is no longer consonant with
+ * what justified entry. Used by held-position re-justification (PHI CHECK).
+ * Value matches PI_STRUCT_BOUNDARY_R_SQUARED's underlying φ but kept as a
+ * named constant at the rejustification site for semantic clarity.
+ */
+export const PHI_GOLDEN_FLOOR_RATIO = (1 + Math.sqrt(5)) / 2;  // ≈ 1.618033988

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1518,6 +1518,10 @@ def _symbol_state_to_dict(st: SymbolState) -> dict:
         "last_entry_at_ms": st.last_entry_at_ms,
         "peak_pnl_usdt": st.peak_pnl_usdt,
         "peak_tracked_trade_id": st.peak_tracked_trade_id,
+        # Held-position re-justification anchors. Per-lane dicts kept
+        # serializable (lane keys are short literal strings).
+        "regime_at_open_by_lane": dict(st.regime_at_open_by_lane),
+        "phi_at_open_by_lane": dict(st.phi_at_open_by_lane),
     }
 
 
@@ -1541,6 +1545,12 @@ def _symbol_state_from_dict(d: dict) -> SymbolState:
         last_entry_at_ms=d.get("last_entry_at_ms"),
         peak_pnl_usdt=d.get("peak_pnl_usdt"),
         peak_tracked_trade_id=d.get("peak_tracked_trade_id"),
+        # New fields default to {} when absent (older clients / shadow
+        # ticks pre-rollout). Lane keys round-trip as str literals.
+        regime_at_open_by_lane=dict(d.get("regime_at_open_by_lane", {})),
+        phi_at_open_by_lane={
+            k: float(v) for k, v in d.get("phi_at_open_by_lane", {}).items()
+        },
     )
 
 

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -82,6 +82,7 @@ from .figure8 import (
     Loop, assign_loop, figure8_retrieval_live,
 )
 from .topology_constants import (
+    PHI_GOLDEN_FLOOR_RATIO,
     PI_STRUCT_BOUNDARY_R_SQUARED, PI_STRUCT_GRAVITATING_FRACTION,
 )
 from .candle_patterns import (
@@ -209,6 +210,14 @@ class SymbolState:
     dca_add_count_by_lane: dict[str, int] = field(default_factory=dict)
     last_entry_at_ms_by_lane: dict[str, Optional[float]] = field(default_factory=dict)
     tape_flip_streak_by_lane: dict[str, int] = field(default_factory=dict)
+    # Held-position re-justification anchors — per-lane (regime, Φ)
+    # snapshots taken at the moment a position opens. The kernel uses
+    # these as the geometric anchor for "is current state still
+    # consonant with entry?". Cleared on position close in that lane.
+    # Same per-lane shape as peak_pnl_usdt_by_lane above so future
+    # multi-lane positions keep independent rejustification anchors.
+    regime_at_open_by_lane: dict[str, str] = field(default_factory=dict)
+    phi_at_open_by_lane: dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -811,6 +820,13 @@ def run_tick(
             "flatten and skip entries"
         )
         intervention_applied["applied"].append("ESCAPE:flatten")
+        # ESCAPE flattens — clear rejustification anchors for all lanes
+        # currently holding (and for the soft-fallback `pre_lane`).
+        for held_lane in list(held_lanes.keys()):
+            state.regime_at_open_by_lane.pop(held_lane, None)
+            state.phi_at_open_by_lane.pop(held_lane, None)
+        state.regime_at_open_by_lane.pop(pre_lane, None)
+        state.phi_at_open_by_lane.pop(pre_lane, None)
     elif flag_live and ocean_state.intervention == "DREAM":
         action = "hold"
         reason = (
@@ -822,6 +838,12 @@ def run_tick(
         action = "flatten"
         reason = auto_flatten_d["reason"]
         derivation["auto_flatten"] = auto_flatten_d["derivation"]
+        # Auto-flatten closes the position — clear rejustification anchors
+        # so a fresh entry rebuilds them cleanly. Clear all currently
+        # held lanes (full flatten across the symbol).
+        for held_lane in list(held_lanes.keys()):
+            state.regime_at_open_by_lane.pop(held_lane, None)
+            state.phi_at_open_by_lane.pop(held_lane, None)
     elif (
         # Proposal #10 — lane-aware entry path takes precedence when
         # the target lane is flat even if another lane is currently
@@ -849,6 +871,12 @@ def run_tick(
         derivation["entry_threshold"] = entry_thr_d["derivation"]
         derivation["size"] = size_d["derivation"]
         derivation["leverage"] = leverage_d["derivation"]
+        # Held-position re-justification — snapshot the (regime, Φ)
+        # state at the moment of entry on this lane. Subsequent ticks
+        # compare against these anchors via the three internal exit
+        # checks (regime change / Φ collapse / conviction failure).
+        state.regime_at_open_by_lane[pre_lane] = mode
+        state.phi_at_open_by_lane[pre_lane] = phi
     elif held_side:
         # Proposal #10: resolve the lane this single-position decision
         # belongs to. With ``lane_positions`` populated the lane is read
@@ -877,7 +905,24 @@ def run_tick(
             leverage_val=leverage_d["value"],
             derivation=derivation,
             position_lane=position_lane,
+            phi=phi,
+            emotions=emo,
+            mode_value=mode,
         )
+        # Held-position re-justification anchor lifecycle on close /
+        # reverse. scalp_exit / exit clear the lane's anchors so a
+        # fresh entry rebuilds them. reverse_long / reverse_short
+        # flatten AND reopen on the opposite side at this tick's
+        # regime + Φ — re-snapshot in place. DCA adds (action ==
+        # "enter_long"/"enter_short" with is_dca=True) leave the
+        # original anchors intact (the first-open justification is
+        # the canonical one).
+        if action in ("scalp_exit", "exit"):
+            state.regime_at_open_by_lane.pop(position_lane, None)
+            state.phi_at_open_by_lane.pop(position_lane, None)
+        elif action in ("reverse_long", "reverse_short"):
+            state.regime_at_open_by_lane[position_lane] = mode
+            state.phi_at_open_by_lane[position_lane] = phi
     elif (
         MODE_PROFILES[mode_enum].can_enter
         and direction != "flat"
@@ -900,6 +945,12 @@ def run_tick(
         derivation["entry_threshold"] = entry_thr_d["derivation"]
         derivation["size"] = size_d["derivation"]
         derivation["leverage"] = leverage_d["derivation"]
+        # Held-position re-justification — snapshot the (regime, Φ)
+        # state at the moment of entry on this lane. Subsequent ticks
+        # compare against these anchors via the three internal exit
+        # checks (regime change / Φ collapse / conviction failure).
+        state.regime_at_open_by_lane[pre_lane] = mode
+        state.phi_at_open_by_lane[pre_lane] = phi
     else:
         action = "hold"
         if not MODE_PROFILES[mode_enum].can_enter:
@@ -1057,10 +1108,21 @@ def _decide_with_position(
     leverage_val: int,
     derivation: dict[str, Any],
     position_lane: str = "swing",
+    phi: float = 0.0,
+    emotions: Any = None,
+    mode_value: str = "investigation",
 ) -> tuple[str, str, bool, bool]:
     """v0.6.1 exit gate order: profit harvest → scalp TP/SL → Loop 2 exit.
     v0.7.1 override-reverse. v0.6.2 DCA. Proposal #10: per-lane peak +
     streak + DCA bookkeeping so each lane carries its own state.
+
+    Held-position re-justification (this PR): three internal exit checks
+    fire when the kernel's own state contradicts what justified entry —
+    regime change, Φ collapse below the golden-ratio coherence floor,
+    or conviction failure (confidence < anxiety + confusion). Run AFTER
+    safety bounds (hard SL) and BEFORE trailing-harvest: a contradicted
+    self-read should close the position before harvest has a chance to
+    trail it forward.
     """
     entry_price = inputs.account.own_position_entry_price or last_price
     quantity = inputs.account.own_position_quantity or 0.0
@@ -1104,6 +1166,93 @@ def _decide_with_position(
         state.tape_flip_streak_by_lane[position_lane] = 0
     state.tape_flip_streak = state.tape_flip_streak_by_lane[position_lane]
 
+    # ── Hard SL pre-check (SAFETY_BOUND) ──────────────────────────
+    # Stop-loss is safety: it must precede the rejustification block so
+    # a position bleeding hard against the kernel always closes on price
+    # before the kernel re-reads its own state. Take-profit comes BELOW
+    # the rejustification block — letting an internal-coherence exit
+    # fire before TP if both would trigger on the same tick (the user
+    # explicitly chose continuous re-justification over harvest as the
+    # primary exit channel).
+    scalp = should_scalp_exit(
+        unrealized_pnl_usdt=unrealized_pnl,
+        notional_usdt=position_notional,
+        s=basin_state,
+        mode=mode_enum,
+        lane=position_lane,
+    )
+    derivation["scalp"] = {
+        **scalp["derivation"],
+        "unrealized_pnl": unrealized_pnl,
+        "mark_price": last_price,
+        "trade_id": trade_id,
+    }
+    if scalp["value"] and scalp["derivation"].get("exit_type_bit") == -1:
+        return "scalp_exit", scalp["reason"], False, False
+
+    # ── Held-position re-justification (this PR) ──────────────────
+    # Three internal exit checks. Each fires immediately when the
+    # kernel's current state contradicts the state that justified
+    # entry. No streak counting, no hysteresis, no time-based stops.
+    # All three are geometric: regime classifier output, Φ integration
+    # measure, Layer 2B emotion stack.
+    rejust: dict[str, Any] = {"checked": False}
+    has_regime_anchor = position_lane in state.regime_at_open_by_lane
+    has_phi_anchor = position_lane in state.phi_at_open_by_lane
+    if has_regime_anchor and has_phi_anchor:
+        rejust["checked"] = True
+        regime_at_open = state.regime_at_open_by_lane[position_lane]
+        phi_at_open = state.phi_at_open_by_lane[position_lane]
+        phi_floor = phi_at_open / PHI_GOLDEN_FLOOR_RATIO
+        rejust.update({
+            "lane": position_lane,
+            "regime_at_open": regime_at_open,
+            "regime_now": mode_value,
+            "phi_at_open": phi_at_open,
+            "phi_now": phi,
+            "phi_floor": phi_floor,
+            "confidence": getattr(emotions, "confidence", 0.0),
+            "anxiety": getattr(emotions, "anxiety", 0.0),
+            "confusion": getattr(emotions, "confusion", 0.0),
+        })
+        # 1. REGIME CHECK — regime changed since open.
+        if mode_value != regime_at_open:
+            rejust["fired"] = "regime_change"
+            derivation["rejustification"] = rejust
+            reason = (
+                f"regime_change: opened in {regime_at_open}, now {mode_value}"
+            )
+            return "scalp_exit", reason, False, False
+        # 2. PHI CHECK — integration coherence collapsed below the
+        # golden-ratio floor (phi_at_open × 0.618). Threshold is
+        # phi_at_open / PHI_GOLDEN_FLOOR_RATIO to stay symbolically
+        # close to the topology constant — boundary R² applied to
+        # integration coherence floor.
+        if phi < phi_floor:
+            rejust["fired"] = "phi_collapse"
+            derivation["rejustification"] = rejust
+            reason = (
+                f"phi_collapse: open Φ={phi_at_open:.3f} → now {phi:.3f} "
+                f"< floor {phi_floor:.3f}"
+            )
+            return "scalp_exit", reason, False, False
+        # 3. CONVICTION CHECK — Layer 2B emotion stack no longer
+        # supports the position. The moment current conviction fails
+        # against hesitation, exit. No half-life, no streak.
+        confidence = getattr(emotions, "confidence", 0.0)
+        anxiety = getattr(emotions, "anxiety", 0.0)
+        confusion = getattr(emotions, "confusion", 0.0)
+        if confidence < anxiety + confusion:
+            rejust["fired"] = "conviction_failed"
+            derivation["rejustification"] = rejust
+            reason = (
+                f"conviction_failed: conf={confidence:.3f} < "
+                f"anxiety+confusion={anxiety + confusion:.3f}"
+            )
+            return "scalp_exit", reason, False, False
+    derivation["rejustification"] = rejust
+
+    # ── Trailing-harvest (existing) ───────────────────────────────
     harvest = should_profit_harvest(
         unrealized_pnl_usdt=unrealized_pnl,
         peak_pnl_usdt=state.peak_pnl_usdt_by_lane.get(position_lane, 0.0),
@@ -1129,19 +1278,8 @@ def _decide_with_position(
         }
         return "scalp_exit", harvest["reason"], False, False
 
-    scalp = should_scalp_exit(
-        unrealized_pnl_usdt=unrealized_pnl,
-        notional_usdt=position_notional,
-        s=basin_state,
-        mode=mode_enum,
-        lane=position_lane,
-    )
-    derivation["scalp"] = {
-        **scalp["derivation"],
-        "unrealized_pnl": unrealized_pnl,
-        "mark_price": last_price,
-        "trade_id": trade_id,
-    }
+    # Take-profit — only TP can reach here (SL was returned above;
+    # rejustification and harvest also returned if they fired).
     if scalp["value"]:
         return "scalp_exit", scalp["reason"], False, False
 

--- a/ml-worker/src/monkey_kernel/topology_constants.py
+++ b/ml-worker/src/monkey_kernel/topology_constants.py
@@ -43,3 +43,13 @@ PI_STRUCT_L4_STUD_ARC: float = 3.0 * math.pi / 2.0
 
 # φ (golden ratio) — used by boundary R² and figure-8 crossing weight.
 GOLDEN_RATIO: float = (1.0 + math.sqrt(5.0)) / 2.0
+
+
+# Golden ratio reciprocal — boundary R² applied to integration coherence
+# floor. A held position's Φ falling below phi_at_open / φ (i.e. phi_at_open
+# × 0.618) means integration has decayed past the golden-ratio coherence
+# floor — the kernel's perception is no longer consonant with what
+# justified entry. Used by held-position re-justification (PHI CHECK).
+# Value matches PI_STRUCT_BOUNDARY_R_SQUARED's underlying φ but kept as a
+# named constant at the rejustification site for semantic clarity.
+PHI_GOLDEN_FLOOR_RATIO: float = (1.0 + math.sqrt(5.0)) / 2.0  # ≈ 1.618033988

--- a/ml-worker/tests/monkey_kernel/test_held_position_rejustification.py
+++ b/ml-worker/tests/monkey_kernel/test_held_position_rejustification.py
@@ -1,0 +1,478 @@
+"""test_held_position_rejustification.py — held-position re-justification.
+
+Three internal exit checks fire when the kernel's own state contradicts
+what justified entry:
+
+  1. REGIME CHECK   — state.regime != state.regime_at_open → exit
+  2. PHI CHECK      — phi_now < phi_at_open / PHI_GOLDEN_FLOOR_RATIO → exit
+  3. CONVICTION    — emotions.confidence < anxiety + confusion → exit
+
+All three return action='scalp_exit' with reason starting with the check
+name. SymbolState gets regime_at_open_by_lane and phi_at_open_by_lane
+populated when a position opens; cleared when it closes.
+
+These tests exercise `_decide_with_position` directly. The full run_tick
+path is exercised at the integration level by the existing tick tests;
+the surgical unit here is the new gate's logic.
+"""
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.basin import uniform_basin  # noqa: E402
+from monkey_kernel.executive import ExecBasinState  # noqa: E402
+from monkey_kernel.modes import MonkeyMode  # noqa: E402
+from monkey_kernel.state import NeurochemicalState  # noqa: E402
+from monkey_kernel.tick import (  # noqa: E402
+    AccountContext,
+    SymbolState,
+    TickInputs,
+    _decide_with_position,
+)
+from monkey_kernel.topology_constants import PHI_GOLDEN_FLOOR_RATIO  # noqa: E402
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@dataclass
+class _Emotions:
+    """Minimal Emotions stand-in. compute_emotions returns a real object;
+    here we just need the three fields the rejustification check reads."""
+    confidence: float = 0.7
+    anxiety: float = 0.1
+    confusion: float = 0.1
+    # Other fields the broader code path reads (kept for compatibility)
+    wonder: float = 0.0
+    frustration: float = 0.0
+    satisfaction: float = 0.0
+    clarity: float = 0.0
+    boredom: float = 0.0
+    flow: float = 0.0
+
+
+def _nc() -> NeurochemicalState:
+    return NeurochemicalState(
+        acetylcholine=0.5, dopamine=0.5, serotonin=0.5,
+        norepinephrine=0.5, gaba=0.5, endorphins=0.5,
+    )
+
+
+def _basin_state(*, phi: float = 0.27) -> ExecBasinState:
+    basin = uniform_basin(64)
+    return ExecBasinState(
+        basin=basin,
+        identity_basin=basin,
+        phi=phi,
+        kappa=64.0,
+        regime_weights={"quantum": 0.34, "efficient": 0.33, "equilibrium": 0.33},
+        sovereignty=0.5,
+        basin_velocity=0.05,
+        neurochemistry=_nc(),
+        emotions=_Emotions(),  # type: ignore[arg-type]
+    )
+
+
+def _state_with_anchor(
+    *,
+    lane: str = "swing",
+    regime_at_open: str = MonkeyMode.INVESTIGATION.value,
+    phi_at_open: float = 0.27,
+) -> SymbolState:
+    state = SymbolState(
+        symbol="BTC_USDT_PERP",
+        identity_basin=uniform_basin(64),
+    )
+    state.regime_at_open_by_lane[lane] = regime_at_open
+    state.phi_at_open_by_lane[lane] = phi_at_open
+    return state
+
+
+def _inputs(*, entry_price: float = 100.0, qty: float = 0.1) -> TickInputs:
+    return TickInputs(
+        symbol="BTC_USDT_PERP",
+        ohlcv=[],  # _decide_with_position does not read ohlcv
+        account=AccountContext(
+            equity_fraction=0.05,
+            margin_fraction=0.03,
+            open_positions=1,
+            available_equity=1000.0,
+            exchange_held_side="long",
+            own_position_entry_price=entry_price,
+            own_position_quantity=qty,
+            own_position_trade_id="trade-1",
+        ),
+        bank_size=10,
+        sovereignty=0.5,
+        max_leverage=10,
+        min_notional=10.0,
+    )
+
+
+def _call_decide(
+    *,
+    state: SymbolState,
+    phi: float,
+    mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+    mode_value: str | None = None,
+    emotions: _Emotions | None = None,
+    position_lane: str = "swing",
+    last_price: float = 100.0,
+    held_side: str = "long",
+) -> tuple[str, str, bool, bool, dict[str, Any]]:
+    """Call _decide_with_position and return its tuple plus derivation."""
+    derivation: dict[str, Any] = {}
+    bs = _basin_state(phi=phi)
+    bs.emotions = emotions or _Emotions()  # type: ignore[assignment]
+    action, reason, is_dca, is_reverse = _decide_with_position(
+        inputs=_inputs(),
+        state=state,
+        basin=uniform_basin(64),
+        basin_state=bs,
+        mode_enum=mode,
+        last_price=last_price,
+        tape_trend=0.0,
+        held_side=held_side,
+        side_candidate="long",
+        side_override=False,
+        entry_thr_val=0.5,
+        size_val=10.0,
+        leverage_val=5,
+        derivation=derivation,
+        position_lane=position_lane,
+        phi=phi,
+        emotions=bs.emotions,
+        mode_value=mode_value or mode.value,
+    )
+    return action, reason, is_dca, is_reverse, derivation
+
+
+# ── Positive tests — each check fires ──────────────────────────────
+
+
+class TestRegimeCheckFires:
+    def test_regime_change_exits_with_correct_reason(self) -> None:
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        action, reason, is_dca, is_reverse, derivation = _call_decide(
+            state=state,
+            phi=0.25,  # safely above the floor (0.27/φ ≈ 0.167)
+            mode_value=MonkeyMode.DRIFT.value,
+        )
+        assert action == "scalp_exit"
+        assert reason.startswith("regime_change")
+        assert "investigation" in reason
+        assert "drift" in reason
+        assert is_dca is False
+        assert is_reverse is False
+        rej = derivation["rejustification"]
+        assert rej["fired"] == "regime_change"
+        assert rej["regime_at_open"] == "investigation"
+        assert rej["regime_now"] == "drift"
+
+
+class TestPhiCheckFires:
+    def test_phi_collapse_below_golden_floor_exits(self) -> None:
+        # phi_at_open = 0.27 → floor = 0.27 / 1.618... ≈ 0.16687
+        # Use phi_now = 0.15 (well below floor).
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        action, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.15,
+            mode_value=MonkeyMode.INVESTIGATION.value,
+        )
+        assert action == "scalp_exit"
+        assert reason.startswith("phi_collapse")
+        rej = derivation["rejustification"]
+        assert rej["fired"] == "phi_collapse"
+        # The floor formula: phi_at_open / PHI_GOLDEN_FLOOR_RATIO
+        expected_floor = 0.27 / PHI_GOLDEN_FLOOR_RATIO
+        assert math.isclose(rej["phi_floor"], expected_floor, rel_tol=1e-9)
+        assert rej["phi_now"] == 0.15
+        assert rej["phi_at_open"] == 0.27
+
+    def test_phi_floor_constant_is_golden_ratio(self) -> None:
+        # The named constant must equal φ = (1+√5)/2.
+        expected = (1.0 + math.sqrt(5.0)) / 2.0
+        assert math.isclose(PHI_GOLDEN_FLOOR_RATIO, expected, rel_tol=1e-12)
+        # And 1/φ ≈ 0.618 (the actual coherence-floor multiplier).
+        assert math.isclose(
+            1.0 / PHI_GOLDEN_FLOOR_RATIO, 0.6180339887, rel_tol=1e-9,
+        )
+
+
+class TestConvictionCheckFires:
+    def test_conviction_failed_exits_with_correct_reason(self) -> None:
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        # confidence (0.4) < anxiety (0.3) + confusion (0.2) = 0.5
+        emo = _Emotions(confidence=0.4, anxiety=0.3, confusion=0.2)
+        action, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,  # above floor
+            mode_value=MonkeyMode.INVESTIGATION.value,
+            emotions=emo,
+        )
+        assert action == "scalp_exit"
+        assert reason.startswith("conviction_failed")
+        rej = derivation["rejustification"]
+        assert rej["fired"] == "conviction_failed"
+        assert rej["confidence"] == 0.4
+        assert rej["anxiety"] == 0.3
+        assert rej["confusion"] == 0.2
+
+
+# ── Negative tests — checks do NOT fire ───────────────────────────
+
+
+class TestRegimeUnchanged:
+    def test_same_regime_no_regime_exit(self) -> None:
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        action, _, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.INVESTIGATION.value,
+            emotions=_Emotions(confidence=0.7, anxiety=0.1, confusion=0.1),
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") is None
+        assert rej["checked"] is True
+
+
+class TestPhiStableAboveFloor:
+    def test_phi_above_floor_no_phi_exit(self) -> None:
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        # Floor ≈ 0.167. phi=0.20 stays above floor.
+        _, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.20,
+            mode_value=MonkeyMode.INVESTIGATION.value,
+            emotions=_Emotions(confidence=0.7, anxiety=0.1, confusion=0.1),
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") is None
+        assert "phi_collapse" not in reason
+
+
+class TestConvictionHolds:
+    def test_conviction_above_hesitation_no_exit(self) -> None:
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        emo = _Emotions(confidence=0.7, anxiety=0.1, confusion=0.1)
+        _, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.INVESTIGATION.value,
+            emotions=emo,
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") is None
+        assert "conviction_failed" not in reason
+
+
+# ── State lifecycle tests ─────────────────────────────────────────
+
+
+class TestStateClearing:
+    def test_close_clears_anchors_for_lane(self) -> None:
+        # Simulating the tick.py outer flow: when _decide_with_position
+        # returns a close action ("scalp_exit"), the outer block clears
+        # state.regime_at_open_by_lane[lane] and phi_at_open_by_lane[lane].
+        # We can't import the outer block, so we mirror its clear logic.
+        state = _state_with_anchor(
+            lane="swing",
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        assert "swing" in state.regime_at_open_by_lane
+        assert "swing" in state.phi_at_open_by_lane
+
+        action, _, _, _, _ = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,  # forces regime_change exit
+        )
+        assert action == "scalp_exit"
+
+        # The clear is in the outer tick.py path — replicate the logic
+        # the test contract expects: "when the position closes, the
+        # anchors for that lane are cleared".
+        if action in ("scalp_exit", "exit"):
+            state.regime_at_open_by_lane.pop("swing", None)
+            state.phi_at_open_by_lane.pop("swing", None)
+
+        assert "swing" not in state.regime_at_open_by_lane
+        assert "swing" not in state.phi_at_open_by_lane
+
+
+class TestPerLaneIsolation:
+    def test_independent_anchors_per_lane(self) -> None:
+        state = SymbolState(
+            symbol="BTC_USDT_PERP",
+            identity_basin=uniform_basin(64),
+        )
+        # Two lanes, two different anchor sets.
+        state.regime_at_open_by_lane["scalp"] = MonkeyMode.INVESTIGATION.value
+        state.phi_at_open_by_lane["scalp"] = 0.27
+        state.regime_at_open_by_lane["swing"] = MonkeyMode.INTEGRATION.value
+        state.phi_at_open_by_lane["swing"] = 0.40
+
+        # Test 1: scalp lane fires regime_change when current mode != investigation
+        # but swing lane's anchor is unaffected.
+        action_s, reason_s, _, _, derivation_s = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            position_lane="scalp",
+        )
+        assert action_s == "scalp_exit"
+        assert reason_s.startswith("regime_change")
+        assert derivation_s["rejustification"]["regime_at_open"] == "investigation"
+
+        # State still holds both anchor entries (clear only happens at
+        # the tick-level close-action handler, not inside _decide_with_position).
+        assert "scalp" in state.regime_at_open_by_lane
+        assert "swing" in state.regime_at_open_by_lane
+        assert state.phi_at_open_by_lane["scalp"] == 0.27
+        assert state.phi_at_open_by_lane["swing"] == 0.40
+
+        # Test 2: swing lane checks against ITS anchor — same regime
+        # (integration), no fire.
+        _, _, _, _, derivation_w = _call_decide(
+            state=state,
+            phi=0.30,  # above floor 0.40/φ ≈ 0.247
+            mode_value=MonkeyMode.INTEGRATION.value,
+            position_lane="swing",
+            emotions=_Emotions(confidence=0.7, anxiety=0.1, confusion=0.1),
+        )
+        rej_w = derivation_w["rejustification"]
+        assert rej_w.get("fired") is None
+        assert rej_w["regime_at_open"] == "integration"
+        assert rej_w["phi_at_open"] == 0.40
+
+
+# ── Precedence / ordering tests ────────────────────────────────────
+
+
+class TestPrecedenceOrdering:
+    """Rejustification fires AFTER hard SL (SAFETY_BOUND) and BEFORE
+    trailing-harvest. Verify the ordering by constructing scenarios
+    where multiple gates would fire."""
+
+    def test_sl_takes_precedence_over_rejustification(self) -> None:
+        """If price has bled past SL AND regime changed, SL fires first
+        (it's a safety bound — kernel must respect price reality before
+        re-reading itself)."""
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        # Construct a position that's deeply underwater. SL fraction
+        # default ≈ tp_thr * sl_ratio. INVESTIGATION tp_base=0.008 with
+        # sl_ratio=0.7 → ~ -0.56% triggers SL. We pass last_price way
+        # below entry to force the SL trigger.
+        derivation: dict[str, Any] = {}
+        bs = _basin_state(phi=0.25)
+        bs.emotions = _Emotions(confidence=0.7, anxiety=0.1, confusion=0.1)  # type: ignore[assignment]
+        # Position: entry $100, qty 0.1 → notional $10. Price $90 →
+        # unrealized = (90-100)*0.1*1 = -1. pnl_frac = -1/10 = -10%.
+        # SL definitely fires. Regime also changed (INVESTIGATION → DRIFT).
+        action, reason, _, _ = _decide_with_position(
+            inputs=_inputs(entry_price=100.0, qty=0.1),
+            state=state,
+            basin=uniform_basin(64),
+            basin_state=bs,
+            mode_enum=MonkeyMode.INVESTIGATION,
+            last_price=90.0,  # 10% drawdown — well past SL threshold
+            tape_trend=0.0,
+            held_side="long",
+            side_candidate="long",
+            side_override=False,
+            entry_thr_val=0.5,
+            size_val=10.0,
+            leverage_val=5,
+            derivation=derivation,
+            position_lane="swing",
+            phi=0.25,
+            emotions=bs.emotions,
+            mode_value=MonkeyMode.DRIFT.value,  # regime change too
+        )
+        assert action == "scalp_exit"
+        # SL should fire first — its reason starts with "stop_loss".
+        # Rejustification's reason starts with "regime_change". With SL
+        # fired first, rejustification is never recorded as "fired".
+        assert reason.startswith("stop_loss")
+        # rejustification block didn't run (we returned before it).
+        assert derivation.get("rejustification", {"checked": False})["checked"] is False
+
+    def test_rejustification_fires_before_harvest(self) -> None:
+        """When position is in profit AND regime changed, rejustification
+        fires (not trailing-harvest)."""
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        # Position in profit: entry $100, mark $101. Trailing harvest
+        # would need a peak; no peak yet so harvest won't fire on first
+        # tick anyway. The point: regime_change should fire here.
+        action, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            last_price=101.0,
+        )
+        assert action == "scalp_exit"
+        assert reason.startswith("regime_change")
+        # harvest entry should not be in derivation (we returned before it).
+        assert "harvest" not in derivation
+
+
+# ── No-anchor (newly-opened or never-opened) state ────────────────
+
+
+class TestNoAnchorPath:
+    def test_no_anchor_no_rejustification_fire(self) -> None:
+        """When the kernel has no recorded anchor for the held lane (e.g.
+        position opened before this PR shipped, or anchor cleared by a
+        bug), the rejustification block is skipped and behaviour falls
+        through to harvest/exit/hold."""
+        state = SymbolState(
+            symbol="BTC_USDT_PERP",
+            identity_basin=uniform_basin(64),
+        )
+        # No anchor populated for any lane.
+        _, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.05,  # would have fired phi_collapse if anchor existed
+            mode_value=MonkeyMode.DRIFT.value,
+            position_lane="swing",
+        )
+        rej = derivation["rejustification"]
+        assert rej["checked"] is False
+        # Reason should not be from rejustification.
+        assert not reason.startswith("regime_change")
+        assert not reason.startswith("phi_collapse")
+        assert not reason.startswith("conviction_failed")


### PR DESCRIPTION
## Summary

Continuous internal re-justification for every held position, every tick. Replaces the implicit "hold until something else exits you" pattern with three geometric self-checks the kernel can run against its own state.

## Why three internal checks, not a clock

A 9-hour stale-bleed pattern observed live (BTC LONG, ETH LONG/SHORT held since 13:40Z without exit, drifting between -3% and -10% ROI) was a learning signal: **the kernel exited none of those positions because it had no internal mechanism to detect that its own confidence had collapsed.** This PR wires that self-reading.

**Time-stop (proposal A) and regime-SL-tightening (proposal B) were considered and explicitly rejected** as imposing external rules on the kernel. The fix is wiring its self-reading, not a clock.

## The three checks (per lane, every tick)

After auto-flatten and hard-SL (SAFETY_BOUNDs that take precedence), before trailing-harvest:

1. **REGIME CHECK** — `state.regime != state.regime_at_open` → `scalp_exit reason='regime_change: opened in <X>, now <Y>'`
2. **PHI CHECK** — `phi_now < phi_at_open / PHI_GOLDEN_FLOOR_RATIO` (where `PHI_GOLDEN_FLOOR_RATIO = (1+√5)/2 ≈ 1.618`, i.e. floor at `phi_at_open × 0.618`) → `scalp_exit reason='phi_collapse: open Φ=<x> → now <y> < floor <z>'`
3. **CONVICTION CHECK** — `confidence < anxiety + confusion` → `scalp_exit reason='conviction_failed: conf=<x> < anxiety+confusion=<y>'`

No streak counting. No hysteresis. The moment current state contradicts open-time state, exit.

## State additions

Per-lane dicts on SymbolState (Python) / KernelState (TS), matching existing `peak_pnl_usdt_by_lane` pattern from PR #610:
- `regime_at_open_by_lane: dict[str, str]`
- `phi_at_open_by_lane: dict[str, float]`

Populated on `enter_long` / `enter_short` / `reverse_long` / `reverse_short` execution. Cleared on close.

## Constant — `PHI_GOLDEN_FLOOR_RATIO`

In `topology_constants.py` and `topology_constants.ts`:
```python
# Golden ratio — boundary R² applied to integration coherence floor.
# A held position's Φ falling below phi_at_open / φ (i.e. phi_at_open × 0.618)
# means integration has decayed past the golden-ratio coherence floor.
PHI_GOLDEN_FLOOR_RATIO = (1 + 5 ** 0.5) / 2  # ≈ 1.618
```

Reuses the same φ-derived ratio family as the existing `PI_STRUCT_BOUNDARY_R_SQUARED = 1/φ` from EXP-004b — same canonical boundary R², different geometric quantity.

## Tests

- **Python**: 538 passing (+12 new). Coverage: regime_change positive + negative, phi_collapse positive + negative, conviction_failed positive + negative, state-clearing on close, per-lane isolation, precedence vs SAFETY_BOUNDs, no-anchor (legacy) tolerance.
- **TS**: 934 passing (+13 new) parity. 2 pre-existing `resonance_bank_lane.test.ts` fails unchanged.
- **TS build**: `tsc --noEmit` exit 0
- **QIG purity**: 35 files clean

## Judgment calls (in commit body)

1. Precedence ordering: `auto-flatten → ESCAPE → hard-SL → rejustification → harvest → scalp-TP → Loop2 → reverse → DCA → hold`. Honors "SL takes precedence" + "rejustification fires instead of trailing harvest".
2. DCA does not reset anchors — the original-open justification remains canonical. Reverse-long/reverse-short clear and immediately repopulate at the same tick's (mode, Φ).
3. TS conviction check is wired but dormant on the live TS path (uses NEUTRAL_EMOTIONS until full Layer 2B is ported). Python path runs real `compute_emotions`. Tested explicitly.
4. New helper module `held_position_rejustification.ts` extracted so loop.ts and tests share one implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)