### PR TITLE
feat(monkey): Agent T — Turtle System 1 classical-TA control arm

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -69,6 +69,15 @@ import { mlAgentDecide } from '../ml_agent/decide.js';
 import type { MLAgentInputs } from '../ml_agent/types.js';
 import { Arbiter } from '../arbiter/arbiter.js';
 import {
+  appendUnit as turtleAppendUnit,
+  clearUnitsAfterExit as turtleClearUnits,
+  newTurtleState,
+  turtleAgentDecide,
+  turtleMinEquityUsdt,
+  type TurtleAgentInputs,
+  type TurtleState,
+} from '../turtle_agent/index.js';
+import {
   basinDirection as computeBasinDirection,
   perceive,
   refract,
@@ -292,11 +301,20 @@ export class MonkeyKernel extends EventEmitter {
    */
   private positionDirectionMode: 'HEDGE' | 'ONE_WAY' = 'ONE_WAY';
   /**
-   * Arbiter — capital allocator between Agent K (kernel) and Agent M (ml).
-   * Single instance per kernel. Settled trades flow back via
-   * recordSettled from closeHeldPosition.
+   * Arbiter — capital allocator across N agents (K kernel, M ml, T turtle
+   * classical TA). Single instance per kernel. Settled trades flow back via
+   * recordSettled from closeHeldPosition. T is included in the allocation
+   * only when account equity ≥ ``turtleMinEquityUsdt()``; below threshold
+   * the arbiter sees a 2-agent (K, M) race exactly as before T was added.
    */
   private readonly arbiter: Arbiter = new Arbiter();
+  /**
+   * Per-symbol Turtle (Agent T) state — held units, last exit metadata.
+   * Independent of the per-symbol kernel state map; T does not read
+   * from K or M (the wall is here in the type graph too: TurtleState
+   * has no reference to BasinState or any ML field).
+   */
+  private readonly turtleStates: Map<string, TurtleState> = new Map();
 
   constructor(config?: Partial<MonkeyKernelConfig>) {
     super();
@@ -327,6 +345,7 @@ export class MonkeyKernel extends EventEmitter {
   async start(): Promise<void> {
     for (const sym of this.symbols) {
       this.symbolStates.set(sym, this.newSymbolState());
+      this.turtleStates.set(sym, newTurtleState());
     }
     // Proposal #10 — detect (don't auto-flip) account position direction
     // mode. Lane-isolated positions in HEDGE mode let a swing-long and a
@@ -1210,12 +1229,31 @@ export class MonkeyKernel extends EventEmitter {
 
     // 6b. EXECUTE — gated by MONKEY_EXECUTE=true. Observe-only otherwise.
     //
-    // Post agent-separation: arbiter allocates available equity between
-    // K and M. K's existing decision path runs against allocation.k;
-    // Agent M's threshold-based decision runs against allocation.m.
-    // Both can place independently in a single tick (slot allocator
-    // and risk kernel still bound combined exposure).
-    const arbiterAllocation = this.arbiter.allocate(availableEquity);
+    // Post agent-separation (K vs M) + Turtle control arm (T): the arbiter
+    // is N-agent. T is conditionally included only when account equity is
+    // ≥ ``turtleMinEquityUsdt()`` (default $150). Below threshold the
+    // allocator sees a 2-agent (K, M) race exactly as before, and T's
+    // 1/N share isn't stranded on a sub-min-notional account. The
+    // activation gate is a runtime constraint, NOT a flag — change the
+    // env var and redeploy, and T comes online when equity allows.
+    const minEquityForT = turtleMinEquityUsdt();
+    const tEligible = availableEquity >= minEquityForT;
+    const arbiterAgentLabels: string[] = tEligible ? ['K', 'M', 'T'] : ['K', 'M'];
+    const arbiterAllocationMany = this.arbiter.allocateMany(
+      availableEquity,
+      arbiterAgentLabels,
+    );
+    const arbiterSnapshotMany = this.arbiter.snapshotMany(
+      availableEquity,
+      arbiterAgentLabels,
+    );
+    // Back-compat 2-agent shape — the K/M execute paths below + the
+    // arbiter_allocation telemetry table both consume {k, m}. T's
+    // share lives alongside in arbiterAllocationMany.T.
+    const arbiterAllocation = {
+      k: arbiterAllocationMany.K ?? 0,
+      m: arbiterAllocationMany.M ?? 0,
+    };
     const arbiterSnapshot = this.arbiter.snapshot(availableEquity);
     derivation.arbiter = {
       kShare: arbiterSnapshot.kShare,
@@ -1226,6 +1264,15 @@ export class MonkeyKernel extends EventEmitter {
       mTradesInWindow: arbiterSnapshot.mTradesInWindow,
       kAllocatedUsdt: arbiterAllocation.k,
       mAllocatedUsdt: arbiterAllocation.m,
+      // T-specific telemetry. ``tEligible`` records WHY T was/wasn't in
+      // the race this tick (equity gate). When eligible, ``tShare`` and
+      // ``tAllocatedUsdt`` mirror the K/M shape.
+      tEligible,
+      minEquityForT,
+      tShare: arbiterSnapshotMany.T?.share ?? 0,
+      tPnlWindowTotal: arbiterSnapshotMany.T?.pnlWindowTotal ?? 0,
+      tTradesInWindow: arbiterSnapshotMany.T?.tradesInWindow ?? 0,
+      tAllocatedUsdt: arbiterAllocationMany.T ?? 0,
     };
 
     let executed = false;
@@ -1475,6 +1522,192 @@ export class MonkeyKernel extends EventEmitter {
           logger.info('[AgentM] entry placed', {
             symbol, side: mDecision.action, orderId: mResult.orderId,
             margin: mDecision.sizeUsdt.toFixed(2), leverage: mDecision.leverage,
+          });
+        }
+      }
+    }
+
+    // 6c-T. AGENT T EXECUTE — Turtle System 1 (classical TA control arm).
+    // Independent of K's basin and M's ml signal. Inputs: ohlcv only.
+    // Equity-gated: when ``tEligible`` is false the arbiter excluded T
+    // from the race already (allocation = 0 → decide() returns hold even
+    // if a Donchian breakout printed). This block runs every tick so T
+    // can ALSO close held positions cleanly when it falls below threshold
+    // mid-trade — the equity gate blocks new entries / pyramids, not
+    // exits.
+    const tAlloc = arbiterAllocationMany.T ?? 0;
+    if (process.env.MONKEY_EXECUTE === 'true') {
+      const tState = this.turtleStates.get(symbol) ?? newTurtleState();
+      const tInputs: TurtleAgentInputs = {
+        symbol,
+        ohlcv: ohlcv.map((c) => ({
+          timestamp: Number(c.timestamp ?? 0),
+          open: Number(c.open),
+          high: Number(c.high),
+          low: Number(c.low),
+          close: Number(c.close),
+          volume: Number(c.volume),
+        })),
+        account: {
+          equityUsdt: availableEquity,
+          availableEquityUsdt: availableEquity,
+        },
+        allocatedCapitalUsdt: tAlloc,
+        state: tState,
+      };
+      const tDecision = turtleAgentDecide(tInputs);
+      derivation.agentT = {
+        action: tDecision.action,
+        sizeUsdt: tDecision.sizeUsdt,
+        leverage: tDecision.leverage,
+        stopPrice: tDecision.stopPrice,
+        reason: tDecision.reason,
+        unitsHeld: tDecision.derivation.unitsHeld,
+        equityGated: tDecision.derivation.equityGated,
+        atr: tDecision.derivation.atr,
+        donchianHigh: tDecision.derivation.donchianHigh,
+        donchianLow: tDecision.derivation.donchianLow,
+      };
+
+      // T entries / pyramids — same executeEntry path as K and M; the
+      // 'T' agent tag plus lane='trend' attributes the row to the
+      // turtle agent. Pyramids are MORE units in the same trend-lane;
+      // from autonomous_trades' perspective each unit is its own row,
+      // grouped by (agent='T', symbol, lane='trend').
+      if (
+        (tDecision.action === 'enter_long'
+          || tDecision.action === 'enter_short'
+          || tDecision.action === 'pyramid_long'
+          || tDecision.action === 'pyramid_short')
+        && tDecision.sizeUsdt > 0
+      ) {
+        const tSide: 'long' | 'short' =
+          tDecision.action === 'enter_long' || tDecision.action === 'pyramid_long'
+            ? 'long'
+            : 'short';
+        const tResult = await this.executeEntry({
+          symbol,
+          side: tSide,
+          marginUsdt: tDecision.sizeUsdt,
+          leverage: tDecision.leverage,
+          entryPrice: lastPrice,
+          minNotional,
+          // T does not consume kernel state. Pass zeros for the
+          // K-only fields the executor uses for its reason-encoding;
+          // these are diagnostic, not used by the executor's risk
+          // logic. The agent='T' tag is what matters downstream.
+          phi: 0,
+          kappa: 0,
+          sovereignty: 0,
+          trajectoryId: null,
+          isDCAAdd: false,
+          dcaAddIndex: 0,
+          agent: 'T',
+          lane: 'trend',
+        });
+        derivation.agentTExecuted = tResult.executed;
+        if (tResult.executed) {
+          // Mirror the new unit into TurtleState. Stop, ATR, leverage,
+          // margin all derive from the decision; entryPrice is the
+          // exchange fill estimate (executeEntry doesn't currently
+          // return the executed fill — we use lastPrice, identical to
+          // what K and M assume). Future improvement: thread the actual
+          // avgFillPrice back from the exchange.
+          this.turtleStates.set(symbol, turtleAppendUnit(tState, {
+            side: tSide,
+            entryPrice: lastPrice,
+            atrAtEntry: tDecision.derivation.atr,
+            stopPrice: tDecision.stopPrice,
+            marginUsdt: tDecision.sizeUsdt,
+            leverage: tDecision.leverage,
+            openedAtMs: Date.now(),
+          }));
+          logger.info('[AgentT] entry placed', {
+            symbol, side: tSide, action: tDecision.action,
+            orderId: tResult.orderId,
+            margin: tDecision.sizeUsdt.toFixed(2),
+            leverage: tDecision.leverage,
+            stop: tDecision.stopPrice.toFixed(4),
+            unitsHeld: tDecision.derivation.unitsHeld + 1,
+          });
+        } else {
+          logger.info('[AgentT] entry rejected', {
+            symbol, side: tSide, reason: tResult.reason,
+          });
+        }
+      } else if (
+        (tDecision.action === 'exit_stop' || tDecision.action === 'exit_donchian')
+        && tState.units.length > 0
+      ) {
+        // T exit — query its open trend-lane rows under agent='T' and
+        // close them via the existing closeHeldPosition path. The 2×
+        // ATR stop and 10-bar opposite Donchian are the only two exit
+        // triggers in System 1; both close ALL pyramid units at once.
+        try {
+          const tHeldSide = tState.units[0]!.side;
+          const openTRows = await pool.query(
+            `SELECT id, quantity FROM autonomous_trades
+              WHERE reason LIKE $1 AND status = 'open' AND symbol = $2
+                AND agent = 'T' AND lane = 'trend'
+              ORDER BY entry_time ASC`,
+            [`monkey|kernel=${this.instanceId}|%`, symbol],
+          );
+          const tRows = openTRows.rows as Array<{ id: string; quantity: string }>;
+          if (tRows.length > 0) {
+            const totalQty = tRows.reduce(
+              (s, r) => s + Math.abs(Number(r.quantity) || 0),
+              0,
+            );
+            // Estimate realized PnL across the pyramid: weighted mean
+            // entry from open rows, vs lastPrice mark, times totalQty.
+            // Same approximation closeHeldPosition uses for K/M.
+            const sumWeighted = tState.units.reduce(
+              (s, u) => s + u.entryPrice * u.marginUsdt * u.leverage,
+              0,
+            );
+            const sumNotional = tState.units.reduce(
+              (s, u) => s + u.marginUsdt * u.leverage,
+              0,
+            );
+            const avgEntry = sumNotional > 0
+              ? sumWeighted / sumNotional
+              : tState.units[0]!.entryPrice;
+            const sideSign = tHeldSide === 'long' ? 1 : -1;
+            const pnlAtDecision = (lastPrice - avgEntry) * totalQty * sideSign;
+            const closeResult = await this.closeHeldPosition({
+              symbol,
+              tradeId: tRows[0]!.id,
+              heldSide: tHeldSide,
+              markPrice: lastPrice,
+              exitReason: tDecision.action === 'exit_stop'
+                ? 'turtle_stop'
+                : 'turtle_donchian_exit',
+              pnlAtDecision,
+              lane: 'trend',
+            });
+            if (closeResult.executed) {
+              this.turtleStates.set(
+                symbol,
+                turtleClearUnits(tState, tDecision.action, Date.now()),
+              );
+              logger.info('[AgentT] exit executed', {
+                symbol, exitReason: tDecision.action,
+                pnl: pnlAtDecision.toFixed(4),
+                unitsClosed: tState.units.length,
+              });
+            }
+          } else {
+            // No DB rows but state has units — drift / orphan. Reset
+            // state so T can re-enter on the next breakout. Reconciler
+            // will catch any stranded exchange position.
+            this.turtleStates.set(
+              symbol,
+              turtleClearUnits(tState, 'state_drift_reset', Date.now()),
+            );
+          }
+        } catch (err) {
+          logger.warn('[AgentT] exit query/close failed', {
+            symbol, err: err instanceof Error ? err.message : String(err),
           });
         }
       }
@@ -2065,9 +2298,12 @@ export class MonkeyKernel extends EventEmitter {
             [markPrice, exitReason, orderId, rowPnl, row.id],
           );
           // Tag-aware arbiter feedback. Pre-separation rows have
-          // agent=NULL or 'K' (default from migration 039); both
-          // attribute to K.
-          const agentLabel: 'K' | 'M' = row.agent === 'M' ? 'M' : 'K';
+          // agent=NULL or 'K' (default from migration 039); those
+          // attribute to K. T (Turtle classical TA) was added in the
+          // three-agent decomposition; ``recordSettled`` accepts any
+          // uppercase label so T's PnL share goes back to T's window.
+          const agentLabel: 'K' | 'M' | 'T' =
+            row.agent === 'M' ? 'M' : row.agent === 'T' ? 'T' : 'K';
           this.arbiter.recordSettled(agentLabel, rowPnl);
         }
       }
@@ -2137,9 +2373,9 @@ export class MonkeyKernel extends EventEmitter {
     /** 0 = initial entry; 1, 2, … for nth DCA add. */
     dcaAddIndex?: number;
     /** Which agent placed this entry. K = kernel (geometry-only),
-     *  M = ml-only. Default 'K' for back-compat with the existing
-     *  call sites. */
-    agent?: 'K' | 'M';
+     *  M = ml-only, T = Turtle System 1 classical TA (control arm).
+     *  Default 'K' for back-compat with the existing call sites. */
+    agent?: 'K' | 'M' | 'T';
     /** Proposal #10: execution lane key. Default 'swing' = pre-#10 implicit
      *  lane so existing call sites remain bit-identical. */
     lane?: 'scalp' | 'swing' | 'trend';

--- a/apps/api/src/services/turtle_agent/__tests__/atr.test.ts
+++ b/apps/api/src/services/turtle_agent/__tests__/atr.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+
+import { atrSeries, latestAtr, trueRange } from '../atr.js';
+import type { TurtleOHLCV } from '../state.js';
+
+function bar(o: number, h: number, l: number, c: number, t = 0): TurtleOHLCV {
+  return { timestamp: t, open: o, high: h, low: l, close: c, volume: 100 };
+}
+
+describe('trueRange', () => {
+  it('first bar is high - low (no prior close)', () => {
+    const tr = trueRange([bar(10, 12, 9, 11)]);
+    expect(tr[0]).toBeCloseTo(3, 6);
+  });
+
+  it('subsequent bars include gap term against prior close', () => {
+    // bar 0: H=12, L=9, C=11
+    // bar 1: H=13, L=11.5, prior_close=11
+    //   range = 1.5, |H-pc|=2, |L-pc|=0.5, max=2.
+    const tr = trueRange([bar(10, 12, 9, 11), bar(11.6, 13, 11.5, 12.5)]);
+    expect(tr[0]).toBeCloseTo(3, 6);
+    expect(tr[1]).toBeCloseTo(2, 6);
+  });
+});
+
+describe('atrSeries (Wilder)', () => {
+  it('returns all NaN when fewer bars than period', () => {
+    const series = atrSeries([bar(10, 11, 9, 10)], 3);
+    expect(Number.isNaN(series[0])).toBe(true);
+  });
+
+  it('seed at period-1 is the simple-mean of the first `period` TRs', () => {
+    // Constant range bars: H-L = 2 each, no gaps.
+    const candles: TurtleOHLCV[] = [];
+    for (let i = 0; i < 20; i++) candles.push(bar(10, 11, 9, 10));
+    const series = atrSeries(candles, 5);
+    // tr[0..4] all = 2 (first bar) or 1 (subsequent: H-L=2, but
+    // |H - pc=10| = 1, |L - pc=10| = 1; max = 2 since H-L=2 still
+    // dominates). Simple mean = 2.
+    expect(series[4]).toBeCloseTo(2, 6);
+  });
+
+  it('Wilder smoothing matches the known recurrence', () => {
+    const candles: TurtleOHLCV[] = [];
+    for (let i = 0; i < 25; i++) candles.push(bar(10, 11, 9, 10));
+    const series = atrSeries(candles, 20);
+    // All TRs are 2 → ATR converges and stays at 2.
+    expect(series[19]).toBeCloseTo(2, 6);
+    expect(series[24]).toBeCloseTo(2, 6);
+  });
+
+  it('atr increases on a true expansion bar', () => {
+    const candles: TurtleOHLCV[] = [];
+    for (let i = 0; i < 20; i++) candles.push(bar(10, 11, 9, 10));
+    candles.push(bar(10, 20, 5, 18)); // big-range bar, TR = 15
+    const series = atrSeries(candles, 20);
+    const before = series[19]!;
+    const after = series[20]!;
+    expect(after).toBeGreaterThan(before);
+    // Wilder: atr_n = ((19) * 2 + 15) / 20 = (38 + 15) / 20 = 2.65
+    expect(after).toBeCloseTo(2.65, 4);
+  });
+});
+
+describe('latestAtr', () => {
+  it('returns NaN when insufficient data', () => {
+    expect(Number.isNaN(latestAtr([], 20))).toBe(true);
+  });
+
+  it('returns the last finite value of atrSeries', () => {
+    const candles: TurtleOHLCV[] = [];
+    for (let i = 0; i < 25; i++) candles.push(bar(10, 11, 9, 10));
+    expect(latestAtr(candles, 20)).toBeCloseTo(2, 6);
+  });
+});

--- a/apps/api/src/services/turtle_agent/__tests__/decide.test.ts
+++ b/apps/api/src/services/turtle_agent/__tests__/decide.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  TURTLE_DEFAULT_LEVERAGE,
+  TURTLE_ENTRY_PERIOD,
+  TURTLE_MIN_EQUITY_USDT_DEFAULT,
+  TURTLE_STOP_ATR_MULT,
+  appendUnit,
+  turtleAgentDecide,
+} from '../decide.js';
+import { newTurtleState, type TurtleOHLCV, type TurtleState } from '../state.js';
+
+function bar(close: number, high?: number, low?: number, t = 0): TurtleOHLCV {
+  const h = high ?? close + 0.5;
+  const l = low ?? close - 0.5;
+  return { timestamp: t, open: close, high: h, low: l, close, volume: 100 };
+}
+
+/** 25 flat bars at price 10, then a closing breakout at 12 above
+ *  the prior 20-bar high (10.5). Suitable for entry-long tests. */
+function risingBreakoutSeries(): TurtleOHLCV[] {
+  const candles: TurtleOHLCV[] = [];
+  for (let i = 0; i < 25; i++) {
+    candles.push(bar(10, 10.5, 9.5, i * 60_000));
+  }
+  candles.push(bar(12, 12.5, 11.8, 25 * 60_000));
+  return candles;
+}
+
+/** 25 flat bars at price 10, then a closing breakdown at 8 below
+ *  the prior 20-bar low (9.5). */
+function fallingBreakoutSeries(): TurtleOHLCV[] {
+  const candles: TurtleOHLCV[] = [];
+  for (let i = 0; i < 25; i++) {
+    candles.push(bar(10, 10.5, 9.5, i * 60_000));
+  }
+  candles.push(bar(8, 8.2, 7.5, 25 * 60_000));
+  return candles;
+}
+
+describe('turtleAgentDecide — entry signals (test 1, 4, 7, 8)', () => {
+  it('enters long on synthetic 20-bar Donchian breakout', () => {
+    const ohlcv = risingBreakoutSeries();
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv,
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('enter_long');
+    expect(r.sizeUsdt).toBeGreaterThan(0);
+    expect(r.leverage).toBe(TURTLE_DEFAULT_LEVERAGE);
+    expect(r.stopPrice).toBeLessThan(ohlcv[ohlcv.length - 1]!.close);
+    // 2× ATR stop within a few percent of close (synthetic ATR ~ 1).
+    const lastClose = ohlcv[ohlcv.length - 1]!.close;
+    expect(lastClose - r.stopPrice).toBeGreaterThan(0);
+    expect(r.derivation.equityGated).toBe(false);
+  });
+
+  it('enters short on Donchian breakdown', () => {
+    const r = turtleAgentDecide({
+      symbol: 'ETH_USDT_PERP',
+      ohlcv: fallingBreakoutSeries(),
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('enter_short');
+    expect(r.stopPrice).toBeGreaterThan(8); // entry 8 + 2 × ATR
+  });
+
+  it('holds when allocated capital is zero (arbiter excluded T)', () => {
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: risingBreakoutSeries(),
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 0,
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('hold');
+  });
+
+  it('position sizing: margin × leverage × (1 / entry) × 2×ATR ≈ 1% allocation', () => {
+    const ohlcv = risingBreakoutSeries();
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv,
+      account: { equityUsdt: 1000, availableEquityUsdt: 1000 },
+      allocatedCapitalUsdt: 500,
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('enter_long');
+    const lastClose = ohlcv[ohlcv.length - 1]!.close;
+    const atr = r.derivation.atr;
+    const qty = (r.sizeUsdt * r.leverage) / lastClose;
+    const lossOn2Atr = qty * 2 * atr;
+    // Volatility target: a 2× ATR adverse move should lose ~1 % of allocation = $5.
+    expect(lossOn2Atr).toBeGreaterThan(4);
+    expect(lossOn2Atr).toBeLessThan(6);
+  });
+
+  it('does not consume kernel state — accepts only its declared inputs', () => {
+    // Intent: T's signature is symbol/ohlcv/account/allocation/state.
+    // No kernel basin, no ML signal — verified via TS compile-time;
+    // this runtime test confirms decide() works with that input set
+    // alone, no other fields.
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: risingBreakoutSeries(),
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('enter_long');
+  });
+});
+
+describe('turtleAgentDecide — exits (tests 3, 4)', () => {
+  it('respects 2× ATR stop on adverse move (long)', () => {
+    const ohlcv = risingBreakoutSeries();
+    // Held long at 12 with ATR ~1 → stop ~ 10.
+    const stopPrice = 10;
+    let state: TurtleState = newTurtleState();
+    state = appendUnit(state, {
+      side: 'long',
+      entryPrice: 12,
+      atrAtEntry: 1,
+      stopPrice,
+      marginUsdt: 5,
+      leverage: TURTLE_DEFAULT_LEVERAGE,
+      openedAtMs: Date.now(),
+    });
+    // New bar with low <= stop.
+    const adverseBar = bar(11, 11.2, 9.5, 26 * 60_000);
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: [...ohlcv, adverseBar],
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state,
+    });
+    expect(r.action).toBe('exit_stop');
+    expect(r.reason).toContain('stop_hit');
+  });
+
+  it('exits long on 10-bar opposite Donchian extreme', () => {
+    // Build 30 bars: rising into a breakout long entry, then a
+    // sharp drop whose close pierces the 10-bar low.
+    const candles: TurtleOHLCV[] = [];
+    for (let i = 0; i < 25; i++) {
+      candles.push(bar(10 + i * 0.05, 10 + i * 0.05 + 0.3, 10 + i * 0.05 - 0.3, i * 60_000));
+    }
+    // Held long entry around price 11.2.
+    const state: TurtleState = appendUnit(newTurtleState(), {
+      side: 'long',
+      entryPrice: 11.2,
+      atrAtEntry: 0.5,
+      stopPrice: 10.0,
+      marginUsdt: 5,
+      leverage: TURTLE_DEFAULT_LEVERAGE,
+      openedAtMs: Date.now(),
+    });
+    // Now a single bar that closes well below the prior 10-bar low.
+    const exitBar = bar(8, 9, 7.5, 25 * 60_000);
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: [...candles, exitBar],
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state,
+    });
+    // Adverse low in this bar (7.5) pierces the stop (10), so the
+    // stop-hit branch fires before the Donchian branch — that's
+    // the correct priority: stop loss is the more urgent exit.
+    // We test Donchian-exit specifically with a state whose stop
+    // is below the adverse low (i.e. a softer exit trigger).
+    expect(['exit_stop', 'exit_donchian']).toContain(r.action);
+  });
+
+  it('exits long on Donchian when stop is intact', () => {
+    const candles: TurtleOHLCV[] = [];
+    for (let i = 0; i < 25; i++) {
+      candles.push(bar(10 + i * 0.05, 10 + i * 0.05 + 0.3, 10 + i * 0.05 - 0.3, i * 60_000));
+    }
+    // Held long at 11.2 with stop at 8.5 (deeper than the adverse low).
+    const state: TurtleState = appendUnit(newTurtleState(), {
+      side: 'long',
+      entryPrice: 11.2,
+      atrAtEntry: 0.5,
+      stopPrice: 8.5,
+      marginUsdt: 5,
+      leverage: TURTLE_DEFAULT_LEVERAGE,
+      openedAtMs: Date.now(),
+    });
+    // Bar whose close is below the 10-bar low but whose low (8.7)
+    // is ABOVE the stop (8.5) — Donchian-exit is the trigger.
+    const exitBar = bar(9, 9.2, 8.7, 25 * 60_000);
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: [...candles, exitBar],
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state,
+    });
+    expect(r.action).toBe('exit_donchian');
+  });
+});
+
+describe('turtleAgentDecide — held position (no double entry)', () => {
+  it('does not re-enter when already long', () => {
+    const ohlcv = risingBreakoutSeries();
+    const state: TurtleState = appendUnit(newTurtleState(), {
+      side: 'long',
+      entryPrice: 12,
+      atrAtEntry: 0.6,
+      stopPrice: 10.8,
+      marginUsdt: 5,
+      leverage: TURTLE_DEFAULT_LEVERAGE,
+      openedAtMs: Date.now(),
+    });
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv,
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state,
+    });
+    expect(r.action).not.toBe('enter_long');
+    expect(r.action).not.toBe('enter_short');
+  });
+});
+
+describe('turtleAgentDecide — stop math', () => {
+  it('long stop = close − 2 × ATR', () => {
+    const ohlcv = risingBreakoutSeries();
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv,
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('enter_long');
+    const lastClose = ohlcv[ohlcv.length - 1]!.close;
+    const expected = lastClose - TURTLE_STOP_ATR_MULT * r.derivation.atr;
+    expect(r.stopPrice).toBeCloseTo(expected, 6);
+  });
+
+  it('short stop = close + 2 × ATR', () => {
+    const ohlcv = fallingBreakoutSeries();
+    const r = turtleAgentDecide({
+      symbol: 'ETH_USDT_PERP',
+      ohlcv,
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('enter_short');
+    const lastClose = ohlcv[ohlcv.length - 1]!.close;
+    const expected = lastClose + TURTLE_STOP_ATR_MULT * r.derivation.atr;
+    expect(r.stopPrice).toBeCloseTo(expected, 6);
+  });
+});
+
+describe('TURTLE_ENTRY_PERIOD sanity', () => {
+  it('matches the documented 20-bar System 1 spec', () => {
+    expect(TURTLE_ENTRY_PERIOD).toBe(20);
+  });
+  it('default min equity is 150 USDT', () => {
+    expect(TURTLE_MIN_EQUITY_USDT_DEFAULT).toBe(150);
+  });
+});

--- a/apps/api/src/services/turtle_agent/__tests__/donchian.test.ts
+++ b/apps/api/src/services/turtle_agent/__tests__/donchian.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  donchianHigh,
+  donchianLow,
+  latestDonchianHigh,
+  latestDonchianLow,
+} from '../donchian.js';
+import type { TurtleOHLCV } from '../state.js';
+
+/** Build a synthetic ascending series: each bar's high = i + 10,
+ *  low = i + 9, close = i + 9.5. Indices are explicit so we can
+ *  pin expected channel values. */
+function makeRising(n: number): TurtleOHLCV[] {
+  const out: TurtleOHLCV[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push({
+      timestamp: i * 60_000,
+      open: i + 9.5,
+      high: i + 10,
+      low: i + 9,
+      close: i + 9.5,
+      volume: 100,
+    });
+  }
+  return out;
+}
+
+describe('donchianHigh', () => {
+  it('returns NaN for indices < period', () => {
+    const c = makeRising(5);
+    const series = donchianHigh(c, 3);
+    expect(Number.isNaN(series[0])).toBe(true);
+    expect(Number.isNaN(series[2])).toBe(true);
+    expect(Number.isFinite(series[3])).toBe(true);
+  });
+
+  it('uses prior bars only — index i is max of bars [i-period, i-1]', () => {
+    const c = makeRising(10);
+    const series = donchianHigh(c, 3);
+    // At i=5: max of high[2..4] = max(12, 13, 14) = 14.
+    expect(series[5]).toBeCloseTo(14, 6);
+  });
+
+  it('throws on non-positive period', () => {
+    expect(() => donchianHigh([], 0)).toThrow();
+    expect(() => donchianHigh([], -1)).toThrow();
+  });
+});
+
+describe('donchianLow', () => {
+  it('uses prior bars — symmetric to high', () => {
+    const c = makeRising(10);
+    const series = donchianLow(c, 3);
+    // At i=5: min of low[2..4] = min(11, 12, 13) = 11.
+    expect(series[5]).toBeCloseTo(11, 6);
+  });
+});
+
+describe('latestDonchianHigh / latestDonchianLow', () => {
+  it('breakout detection: a 20-bar high → close above prior 20-bar high', () => {
+    // 20 bars at price ~10, then a single breakout bar at 15.
+    const candles: TurtleOHLCV[] = [];
+    for (let i = 0; i < 20; i++) {
+      candles.push({
+        timestamp: i * 60_000,
+        open: 10,
+        high: 10.1,
+        low: 9.9,
+        close: 10,
+        volume: 100,
+      });
+    }
+    candles.push({
+      timestamp: 20 * 60_000,
+      open: 14,
+      high: 15.5,
+      low: 14,
+      close: 15,
+      volume: 100,
+    });
+    const dHigh = latestDonchianHigh(candles, 20);
+    expect(dHigh).toBeCloseTo(10.1, 6);
+    const lastClose = candles[candles.length - 1]!.close;
+    expect(lastClose).toBeGreaterThan(dHigh);
+  });
+
+  it('returns NaN when fewer than `period` bars', () => {
+    const c = makeRising(5);
+    expect(Number.isNaN(latestDonchianHigh(c, 20))).toBe(true);
+    expect(Number.isNaN(latestDonchianLow(c, 20))).toBe(true);
+  });
+
+  it('latest low excludes current bar', () => {
+    // 20 priors with low=10, current bar has low=5. The channel
+    // looks at priors only, so latestLow = 10, not 5.
+    const candles: TurtleOHLCV[] = [];
+    for (let i = 0; i < 20; i++) {
+      candles.push({
+        timestamp: i * 60_000,
+        open: 10, high: 10.5, low: 10, close: 10.2, volume: 100,
+      });
+    }
+    candles.push({
+      timestamp: 20 * 60_000,
+      open: 8, high: 8.5, low: 5, close: 6, volume: 100,
+    });
+    const dLow = latestDonchianLow(candles, 20);
+    expect(dLow).toBeCloseTo(10, 6);
+  });
+});

--- a/apps/api/src/services/turtle_agent/__tests__/equity_gate.test.ts
+++ b/apps/api/src/services/turtle_agent/__tests__/equity_gate.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  TURTLE_MIN_EQUITY_USDT_DEFAULT,
+  turtleAgentDecide,
+  turtleMinEquityUsdt,
+} from '../decide.js';
+import { newTurtleState, type TurtleOHLCV } from '../state.js';
+
+function bar(close: number, high?: number, low?: number, t = 0): TurtleOHLCV {
+  const h = high ?? close + 0.5;
+  const l = low ?? close - 0.5;
+  return { timestamp: t, open: close, high: h, low: l, close, volume: 100 };
+}
+
+function risingBreakoutSeries(): TurtleOHLCV[] {
+  const candles: TurtleOHLCV[] = [];
+  for (let i = 0; i < 25; i++) candles.push(bar(10, 10.5, 9.5, i * 60_000));
+  candles.push(bar(12, 12.5, 11.8, 25 * 60_000));
+  return candles;
+}
+
+describe('turtleAgentDecide — equity activation gate (test 7)', () => {
+  let savedEnv: string | undefined;
+  beforeEach(() => {
+    savedEnv = process.env.TURTLE_MIN_EQUITY_USDT;
+    delete process.env.TURTLE_MIN_EQUITY_USDT;
+  });
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.TURTLE_MIN_EQUITY_USDT;
+    } else {
+      process.env.TURTLE_MIN_EQUITY_USDT = savedEnv;
+    }
+  });
+
+  it('holds when equity below default threshold ($150)', () => {
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: risingBreakoutSeries(),
+      account: { equityUsdt: 100, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('hold');
+    expect(r.derivation.equityGated).toBe(true);
+    expect(r.reason).toContain('equity_gate');
+  });
+
+  it('trades when equity at exactly threshold (>= 150)', () => {
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: risingBreakoutSeries(),
+      account: {
+        equityUsdt: TURTLE_MIN_EQUITY_USDT_DEFAULT,
+        availableEquityUsdt: TURTLE_MIN_EQUITY_USDT_DEFAULT,
+      },
+      allocatedCapitalUsdt: 50,
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('enter_long');
+    expect(r.derivation.equityGated).toBe(false);
+  });
+
+  it('honors env override TURTLE_MIN_EQUITY_USDT', () => {
+    process.env.TURTLE_MIN_EQUITY_USDT = '500';
+    expect(turtleMinEquityUsdt()).toBe(500);
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: risingBreakoutSeries(),
+      account: { equityUsdt: 200, availableEquityUsdt: 200 },
+      allocatedCapitalUsdt: 50,
+      state: newTurtleState(),
+    });
+    // 200 < 500 → blocked.
+    expect(r.action).toBe('hold');
+    expect(r.derivation.equityGated).toBe(true);
+  });
+
+  it('falls back to default when env override is invalid', () => {
+    process.env.TURTLE_MIN_EQUITY_USDT = 'not-a-number';
+    expect(turtleMinEquityUsdt()).toBe(TURTLE_MIN_EQUITY_USDT_DEFAULT);
+    process.env.TURTLE_MIN_EQUITY_USDT = '0';
+    expect(turtleMinEquityUsdt()).toBe(TURTLE_MIN_EQUITY_USDT_DEFAULT);
+    process.env.TURTLE_MIN_EQUITY_USDT = '-50';
+    expect(turtleMinEquityUsdt()).toBe(TURTLE_MIN_EQUITY_USDT_DEFAULT);
+  });
+
+  it('does not enter even with positive allocation if equity-gated', () => {
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: risingBreakoutSeries(),
+      account: { equityUsdt: 75, availableEquityUsdt: 75 },
+      allocatedCapitalUsdt: 200, // hypothetical allocation; gate trumps it
+      state: newTurtleState(),
+    });
+    expect(r.action).toBe('hold');
+  });
+});

--- a/apps/api/src/services/turtle_agent/__tests__/pyramiding.test.ts
+++ b/apps/api/src/services/turtle_agent/__tests__/pyramiding.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  TURTLE_DEFAULT_LEVERAGE,
+  TURTLE_MAX_UNITS,
+  TURTLE_PYRAMID_STEP_ATR_MULT,
+  appendUnit,
+  turtleAgentDecide,
+} from '../decide.js';
+import { newTurtleState, type TurtleOHLCV, type TurtleState } from '../state.js';
+
+function bar(close: number, high?: number, low?: number, t = 0): TurtleOHLCV {
+  const h = high ?? close + 0.5;
+  const l = low ?? close - 0.5;
+  return { timestamp: t, open: close, high: h, low: l, close, volume: 100 };
+}
+
+/** Same fixture as decide.test.ts: 25 flat bars at price 10, then
+ *  an upward breakout at 12. */
+function risingBreakoutSeries(): TurtleOHLCV[] {
+  const candles: TurtleOHLCV[] = [];
+  for (let i = 0; i < 25; i++) candles.push(bar(10, 10.5, 9.5, i * 60_000));
+  candles.push(bar(12, 12.5, 11.8, 25 * 60_000));
+  return candles;
+}
+
+describe('turtleAgentDecide — pyramiding (test 5, 6)', () => {
+  it('adds a unit on 0.5 × ATR favorable past last unit entry (long)', () => {
+    const ohlcv = risingBreakoutSeries();
+    // Held long unit at entry 12, atrAtEntry = 1.0 → pyramid threshold
+    // = 12 + 0.5 × 1.0 = 12.5.
+    let state: TurtleState = appendUnit(newTurtleState(), {
+      side: 'long',
+      entryPrice: 12,
+      atrAtEntry: 1.0,
+      stopPrice: 10,
+      marginUsdt: 5,
+      leverage: TURTLE_DEFAULT_LEVERAGE,
+      openedAtMs: Date.now(),
+    });
+    expect(state.units.length).toBe(1);
+    // New bar with close above the threshold.
+    const advanceBar = bar(12.6, 12.7, 12.4, 26 * 60_000);
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: [...ohlcv, advanceBar],
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state,
+    });
+    expect(r.action).toBe('pyramid_long');
+    expect(r.sizeUsdt).toBeGreaterThan(0);
+    expect(r.derivation.pyramidThresholdPrice).toBeCloseTo(12.5, 6);
+  });
+
+  it('does NOT pyramid before reaching the 0.5 × ATR threshold', () => {
+    const ohlcv = risingBreakoutSeries();
+    const state: TurtleState = appendUnit(newTurtleState(), {
+      side: 'long',
+      entryPrice: 12,
+      atrAtEntry: 1.0,
+      stopPrice: 10,
+      marginUsdt: 5,
+      leverage: TURTLE_DEFAULT_LEVERAGE,
+      openedAtMs: Date.now(),
+    });
+    // Close at 12.3 — below the 12.5 threshold.
+    const stillLowBar = bar(12.3, 12.4, 12.2, 26 * 60_000);
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: [...ohlcv, stillLowBar],
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state,
+    });
+    expect(r.action).not.toBe('pyramid_long');
+  });
+
+  it('caps pyramid at TURTLE_MAX_UNITS (4)', () => {
+    const ohlcv = risingBreakoutSeries();
+    let state: TurtleState = newTurtleState();
+    // Stack TURTLE_MAX_UNITS units. Each entry is 0.5 ATR above
+    // the previous; ATR = 1, so units at 12, 12.5, 13.0, 13.5.
+    for (let i = 0; i < TURTLE_MAX_UNITS; i++) {
+      state = appendUnit(state, {
+        side: 'long',
+        entryPrice: 12 + i * 0.5,
+        atrAtEntry: 1.0,
+        stopPrice: 10 + i * 0.5,
+        marginUsdt: 5,
+        leverage: TURTLE_DEFAULT_LEVERAGE,
+        openedAtMs: Date.now(),
+      });
+    }
+    expect(state.units.length).toBe(TURTLE_MAX_UNITS);
+    // Move past the would-be 5th-unit threshold (14.0). Since
+    // TURTLE_MAX_UNITS is reached, decide() must not pyramid.
+    const advanceBar = bar(14.5, 14.7, 14.3, 30 * 60_000);
+    const r = turtleAgentDecide({
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: [...ohlcv, advanceBar],
+      account: { equityUsdt: 200, availableEquityUsdt: 100 },
+      allocatedCapitalUsdt: 50,
+      state,
+    });
+    expect(r.action).not.toBe('pyramid_long');
+  });
+
+  it('pyramid step magnitude is exactly 0.5 × ATR per Turtle classic', () => {
+    expect(TURTLE_PYRAMID_STEP_ATR_MULT).toBe(0.5);
+  });
+});

--- a/apps/api/src/services/turtle_agent/atr.ts
+++ b/apps/api/src/services/turtle_agent/atr.ts
@@ -1,0 +1,84 @@
+/**
+ * turtle_agent/atr.ts — Average True Range (Wilder).
+ *
+ * Pure function. Operates on raw OHLCV. No state, no kernel hooks.
+ *
+ * Wilder's ATR uses a smoothed moving average (RMA) of the per-bar
+ * true-range. The Turtle System 1 reference uses ATR(20) for the
+ * 2× ATR stop, the 0.5× ATR pyramid step, and the position-size
+ * denominator. We compute the seed via simple-mean of the first
+ * ``period`` true ranges, then apply Wilder smoothing thereafter:
+ *
+ *     atr_n = ((period - 1) * atr_{n-1} + tr_n) / period
+ *
+ * True range for bar n:
+ *
+ *     tr_n = max(
+ *       high_n - low_n,
+ *       abs(high_n - close_{n-1}),
+ *       abs(low_n  - close_{n-1}),
+ *     )
+ *
+ * The first bar has no prior close → tr_0 = high_0 - low_0.
+ *
+ * Returned series has the same length as the input. Indices < period - 1
+ * (where the seed window is incomplete) are NaN. Callers should check
+ * with ``Number.isFinite`` before using a value.
+ */
+
+import type { TurtleOHLCV } from './state.js';
+
+/** Compute the per-bar true-range series. tr[0] = high[0] - low[0]. */
+export function trueRange(candles: readonly TurtleOHLCV[]): number[] {
+  const out: number[] = new Array(candles.length).fill(0);
+  if (candles.length === 0) return out;
+  out[0] = candles[0]!.high - candles[0]!.low;
+  for (let i = 1; i < candles.length; i++) {
+    const c = candles[i]!;
+    const prevClose = candles[i - 1]!.close;
+    const a = c.high - c.low;
+    const b = Math.abs(c.high - prevClose);
+    const d = Math.abs(c.low - prevClose);
+    out[i] = Math.max(a, b, d);
+  }
+  return out;
+}
+
+/**
+ * Wilder ATR series of length ``candles.length``. Indices before
+ * ``period - 1`` are NaN. Index ``period - 1`` is the simple-mean
+ * seed of TR[0..period-1]. Subsequent indices use Wilder smoothing.
+ */
+export function atrSeries(
+  candles: readonly TurtleOHLCV[],
+  period: number,
+): number[] {
+  if (period <= 0) {
+    throw new Error(`atrSeries: period must be > 0 (got ${period})`);
+  }
+  const n = candles.length;
+  const out: number[] = new Array(n).fill(NaN);
+  if (n < period) return out;
+  const tr = trueRange(candles);
+  // Seed: simple mean of the first `period` TR values.
+  let sum = 0;
+  for (let i = 0; i < period; i++) sum += tr[i]!;
+  out[period - 1] = sum / period;
+  // Wilder smoothing.
+  for (let i = period; i < n; i++) {
+    out[i] = (out[i - 1]! * (period - 1) + tr[i]!) / period;
+  }
+  return out;
+}
+
+/**
+ * Convenience: ATR at the most recent bar. Returns NaN when the
+ * series has fewer than ``period`` candles.
+ */
+export function latestAtr(
+  candles: readonly TurtleOHLCV[],
+  period: number,
+): number {
+  const series = atrSeries(candles, period);
+  return series.length === 0 ? NaN : series[series.length - 1]!;
+}

--- a/apps/api/src/services/turtle_agent/decide.ts
+++ b/apps/api/src/services/turtle_agent/decide.ts
@@ -1,0 +1,456 @@
+/**
+ * turtle_agent/decide.ts — Agent T decision logic (Turtle System 1).
+ *
+ * Pure Donchian / ATR / pyramid logic. NO basin, NO ml, NO kernel
+ * state. The agent sees only (symbol, ohlcv, account, allocation,
+ * its own held units).
+ *
+ * Constants are explicit literals here. They're Agent T's tuning
+ * surface. They are NOT QIG-derived (Agent T is the classical-TA
+ * control arm — non-QIG-pure by design) and NOT registry-backed
+ * (the ml_agent precedent is to keep control-arm parameters in code
+ * so the experiment is reproducible from git history).
+ *
+ * The one runtime-configurable parameter is the equity activation
+ * threshold: ``arbiter.turtle.min_equity_usdt`` (env override
+ * ``TURTLE_MIN_EQUITY_USDT``, default 150). This is NOT a flag —
+ * T returns 'hold' below threshold by construction; the arbiter
+ * also excludes T from allocation below threshold so its 1/N share
+ * doesn't get stranded.
+ *
+ * Reference: Way of the Turtle (Curtis Faith, 2007). System 1
+ * parameters: 20-bar Donchian entry, 10-bar opposite Donchian
+ * exit, 2× ATR(20) stop, 0.5× ATR pyramid step, max 4 units per
+ * market.
+ */
+
+import { latestAtr } from './atr.js';
+import { latestDonchianHigh, latestDonchianLow } from './donchian.js';
+import {
+  lastUnitEntry,
+  turtleHeldSide,
+  type TurtleAccount,
+  type TurtleOHLCV,
+  type TurtleState,
+  type TurtleUnit,
+} from './state.js';
+
+// ===== TUNING SURFACE =====
+
+/** Donchian period for entry signals. */
+export const TURTLE_ENTRY_PERIOD = 20;
+/** Donchian period for opposite-side exit signals. */
+export const TURTLE_EXIT_PERIOD = 10;
+/** ATR period (Wilder). */
+export const TURTLE_ATR_PERIOD = 20;
+/** Stop distance in multiples of ATR(20) at unit entry. */
+export const TURTLE_STOP_ATR_MULT = 2.0;
+/** Pyramid step in multiples of ATR(20) — every favorable move of
+ *  this magnitude past the most recent unit's entry adds one more. */
+export const TURTLE_PYRAMID_STEP_ATR_MULT = 0.5;
+/** Max units in a pyramid — Turtle classic. */
+export const TURTLE_MAX_UNITS = 4;
+/** Per-trade risk fraction of allocated capital — Turtle "1 unit" =
+ *  1 % of account, but Agent T sizes against its arbiter allocation
+ *  not absolute equity, so ``unit risk × allocated`` here. The 1 %
+ *  preserves the original Turtle volatility-targeting behavior:
+ *  unit margin = (allocation × 1 %) / (2 × ATR × leverage) so a
+ *  full 2× ATR adverse move loses ~1 % of T's allocation per unit. */
+export const TURTLE_UNIT_RISK_FRACTION = 0.01;
+/** Fixed leverage for Agent T entries. Configurable below; the
+ *  Turtle reference is unleveraged but that produces unworkable
+ *  notionals on a $50–$200 perp account. 8× matches Agent M's
+ *  base leverage so the three agents enter the experiment with
+ *  comparable position sizing constants. */
+export const TURTLE_DEFAULT_LEVERAGE = 8;
+/** Minimum account equity (USDT) for T to be active. Below this,
+ *  T sits flat by construction and returns 'hold' regardless of
+ *  signal. */
+export const TURTLE_MIN_EQUITY_USDT_DEFAULT = 150;
+
+/** Resolve the equity-gate threshold from env or fall back to the
+ *  default. Read each call (cheap, allows operators to redeploy
+ *  with TURTLE_MIN_EQUITY_USDT=200 without code change). */
+export function turtleMinEquityUsdt(): number {
+  const raw = process.env.TURTLE_MIN_EQUITY_USDT;
+  if (raw === undefined || raw === null || raw === '') {
+    return TURTLE_MIN_EQUITY_USDT_DEFAULT;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return TURTLE_MIN_EQUITY_USDT_DEFAULT;
+  }
+  return parsed;
+}
+
+// ===== DECISION TYPES =====
+
+export type TurtleAction =
+  | 'hold'
+  | 'enter_long'
+  | 'enter_short'
+  | 'pyramid_long'
+  | 'pyramid_short'
+  | 'exit_donchian'
+  | 'exit_stop';
+
+export interface TurtleAgentInputs {
+  symbol: string;
+  ohlcv: readonly TurtleOHLCV[];
+  account: TurtleAccount;
+  /** Capital share allocated by the arbiter for this tick. Zero
+   *  when arbiter excludes T (sub-threshold equity, or N-agent
+   *  allocation outvoting T to floor). */
+  allocatedCapitalUsdt: number;
+  /** T's own per-symbol state. The wall is here: this is T's state,
+   *  not K's basin, not M's ml_signal. */
+  state: TurtleState;
+}
+
+export interface TurtleAgentDecision {
+  action: TurtleAction;
+  /** USDT margin to commit on the new unit (0 for holds / exits). */
+  sizeUsdt: number;
+  leverage: number;
+  /** Stop price for the new unit (entry ± 2× ATR). 0 when not
+   *  opening / pyramiding. */
+  stopPrice: number;
+  /** Human-readable reason — surfaces in derivation telemetry. */
+  reason: string;
+  /** Diagnostic block exposed for telemetry / tests. */
+  derivation: {
+    atr: number;
+    donchianHigh: number;
+    donchianLow: number;
+    exitHigh: number;
+    exitLow: number;
+    lastClose: number;
+    heldSide: 'long' | 'short' | null;
+    unitsHeld: number;
+    pyramidThresholdPrice: number | null;
+    /** True when the equity gate blocked the decision. */
+    equityGated: boolean;
+  };
+}
+
+// ===== HELPERS =====
+
+/** Compute unit margin: (allocation × 1 %) / (2 × ATR × leverage),
+ *  clipped to a minimum of one currency unit so the executor's lot
+ *  rounding has a chance to produce a tradable size. Returns 0 when
+ *  any input is non-finite or non-positive — the executor will then
+ *  reject below min-notional and the caller will log 'hold'. */
+function unitMarginUsdt(
+  allocatedCapitalUsdt: number,
+  atr: number,
+  leverage: number,
+  entryPrice: number,
+): number {
+  if (!Number.isFinite(allocatedCapitalUsdt) || allocatedCapitalUsdt <= 0) return 0;
+  if (!Number.isFinite(atr) || atr <= 0) return 0;
+  if (!Number.isFinite(leverage) || leverage <= 0) return 0;
+  if (!Number.isFinite(entryPrice) || entryPrice <= 0) return 0;
+  // Volatility target: a 2× ATR adverse move on this unit's notional
+  // should equal ~1 % of allocated capital. Solve for margin given
+  // notional = margin × leverage and qty = notional / entryPrice.
+  //   1 % allocated = qty × 2 × ATR
+  //   1 % allocated = (margin × leverage / entryPrice) × 2 × ATR
+  //   margin = (1 % allocated × entryPrice) / (2 × ATR × leverage)
+  const target = TURTLE_UNIT_RISK_FRACTION * allocatedCapitalUsdt;
+  const margin = (target * entryPrice) / (TURTLE_STOP_ATR_MULT * atr * leverage);
+  // Cap at allocated capital — never overspend the arbiter share.
+  return Math.max(0, Math.min(allocatedCapitalUsdt, margin));
+}
+
+function holdResult(
+  reason: string,
+  derivation: TurtleAgentDecision['derivation'],
+): TurtleAgentDecision {
+  return {
+    action: 'hold',
+    sizeUsdt: 0,
+    leverage: 1,
+    stopPrice: 0,
+    reason,
+    derivation,
+  };
+}
+
+// ===== MAIN ENTRY =====
+
+/**
+ * Pure decision function. Given the latest OHLCV window, account,
+ * arbiter allocation, and T's own state, return what T would do at
+ * this tick.
+ *
+ * The function does NOT mutate ``inputs.state``. The caller (loop
+ * integration) is responsible for applying the chosen action — i.e.
+ * pushing a new ``TurtleUnit`` onto ``state.units`` after an
+ * exchange-side fill, popping all units after an exit, etc.
+ *
+ * The decision priority order:
+ *   1. Equity gate (account.equityUsdt < threshold) → hold
+ *   2. Stop hit on any held unit (worst-side fill) → exit_stop
+ *   3. 10-bar opposite Donchian against direction → exit_donchian
+ *   4. 0.5× ATR favorable past last unit + room in pyramid → pyramid
+ *   5. 20-bar Donchian breakout in either direction (only when flat
+ *      and arbiter allocation > 0) → enter_long / enter_short
+ *   6. Otherwise → hold
+ */
+export function turtleAgentDecide(
+  inputs: TurtleAgentInputs,
+): TurtleAgentDecision {
+  const { ohlcv, account, allocatedCapitalUsdt, state } = inputs;
+  const minEquity = turtleMinEquityUsdt();
+  const lastClose = ohlcv.length > 0 ? ohlcv[ohlcv.length - 1]!.close : NaN;
+  const lastLow = ohlcv.length > 0 ? ohlcv[ohlcv.length - 1]!.low : NaN;
+  const lastHigh = ohlcv.length > 0 ? ohlcv[ohlcv.length - 1]!.high : NaN;
+  const atr = latestAtr(ohlcv, TURTLE_ATR_PERIOD);
+  const dHigh = latestDonchianHigh(ohlcv, TURTLE_ENTRY_PERIOD);
+  const dLow = latestDonchianLow(ohlcv, TURTLE_ENTRY_PERIOD);
+  const exitHigh = latestDonchianHigh(ohlcv, TURTLE_EXIT_PERIOD);
+  const exitLow = latestDonchianLow(ohlcv, TURTLE_EXIT_PERIOD);
+  const heldSide = turtleHeldSide(state);
+  const lastUnit = lastUnitEntry(state);
+  const unitsHeld = state.units.length;
+  const pyramidThresholdPrice = lastUnit
+    ? lastUnit.side === 'long'
+      ? lastUnit.entryPrice + TURTLE_PYRAMID_STEP_ATR_MULT * lastUnit.atrAtEntry
+      : lastUnit.entryPrice - TURTLE_PYRAMID_STEP_ATR_MULT * lastUnit.atrAtEntry
+    : null;
+
+  const baseDerivation: TurtleAgentDecision['derivation'] = {
+    atr: Number.isFinite(atr) ? atr : 0,
+    donchianHigh: Number.isFinite(dHigh) ? dHigh : 0,
+    donchianLow: Number.isFinite(dLow) ? dLow : 0,
+    exitHigh: Number.isFinite(exitHigh) ? exitHigh : 0,
+    exitLow: Number.isFinite(exitLow) ? exitLow : 0,
+    lastClose: Number.isFinite(lastClose) ? lastClose : 0,
+    heldSide,
+    unitsHeld,
+    pyramidThresholdPrice,
+    equityGated: false,
+  };
+
+  // 1. EQUITY GATE — hard short-circuit. Below threshold T is flat by
+  //    construction. If somehow units exist (operator ran T above
+  //    threshold then equity dipped before exits cleared), let exit
+  //    logic still run so the position can close cleanly — but no new
+  //    entries / pyramids are allowed.
+  const gated = account.equityUsdt < minEquity;
+  if (gated && unitsHeld === 0) {
+    return holdResult(
+      `equity_gate: equity ${account.equityUsdt.toFixed(2)} < threshold ${minEquity.toFixed(2)}`,
+      { ...baseDerivation, equityGated: true },
+    );
+  }
+
+  // Insufficient OHLCV for any signal — hold quietly.
+  if (
+    !Number.isFinite(atr)
+    || !Number.isFinite(dHigh)
+    || !Number.isFinite(dLow)
+    || !Number.isFinite(lastClose)
+    || ohlcv.length < TURTLE_ENTRY_PERIOD + 1
+  ) {
+    return holdResult(
+      `insufficient_data: bars=${ohlcv.length} need=${TURTLE_ENTRY_PERIOD + 1}`,
+      { ...baseDerivation, equityGated: gated },
+    );
+  }
+
+  // 2. STOP HIT — single bar's adverse low / high vs unit stop. Each
+  //    unit has its own stop; if ANY unit's stop is breached we exit
+  //    the whole pyramid (Turtle classic — the trade is over).
+  if (heldSide === 'long' && Number.isFinite(lastLow)) {
+    const worstStop = state.units.reduce(
+      (mx, u) => Math.max(mx, u.stopPrice),
+      -Infinity,
+    );
+    if (Number.isFinite(worstStop) && lastLow <= worstStop) {
+      return {
+        action: 'exit_stop',
+        sizeUsdt: 0,
+        leverage: 1,
+        stopPrice: 0,
+        reason: `stop_hit: low ${lastLow.toFixed(4)} <= stop ${worstStop.toFixed(4)}`,
+        derivation: { ...baseDerivation, equityGated: gated },
+      };
+    }
+  }
+  if (heldSide === 'short' && Number.isFinite(lastHigh)) {
+    const worstStop = state.units.reduce(
+      (mn, u) => Math.min(mn, u.stopPrice),
+      Infinity,
+    );
+    if (Number.isFinite(worstStop) && lastHigh >= worstStop) {
+      return {
+        action: 'exit_stop',
+        sizeUsdt: 0,
+        leverage: 1,
+        stopPrice: 0,
+        reason: `stop_hit: high ${lastHigh.toFixed(4)} >= stop ${worstStop.toFixed(4)}`,
+        derivation: { ...baseDerivation, equityGated: gated },
+      };
+    }
+  }
+
+  // 3. DONCHIAN OPPOSITE EXIT — 10-bar reversal extreme. The Turtle
+  //    reference uses a CLOSE through the opposite extreme; in
+  //    practice on perp 15m bars we read it as the close of the most
+  //    recent bar penetrating the channel.
+  if (
+    heldSide === 'long'
+    && Number.isFinite(exitLow)
+    && lastClose < exitLow
+  ) {
+    return {
+      action: 'exit_donchian',
+      sizeUsdt: 0,
+      leverage: 1,
+      stopPrice: 0,
+      reason: `donchian_exit_long: close ${lastClose.toFixed(4)} < ${TURTLE_EXIT_PERIOD}-bar low ${exitLow.toFixed(4)}`,
+      derivation: { ...baseDerivation, equityGated: gated },
+    };
+  }
+  if (
+    heldSide === 'short'
+    && Number.isFinite(exitHigh)
+    && lastClose > exitHigh
+  ) {
+    return {
+      action: 'exit_donchian',
+      sizeUsdt: 0,
+      leverage: 1,
+      stopPrice: 0,
+      reason: `donchian_exit_short: close ${lastClose.toFixed(4)} > ${TURTLE_EXIT_PERIOD}-bar high ${exitHigh.toFixed(4)}`,
+      derivation: { ...baseDerivation, equityGated: gated },
+    };
+  }
+
+  // 4. PYRAMID — add a unit when price has moved 0.5× ATR favorable
+  //    past the most recent unit's entry, capped at TURTLE_MAX_UNITS.
+  //    Pyramid does NOT trigger when equity-gated (we don't add risk
+  //    below the threshold even if the trade is winning).
+  if (
+    !gated
+    && lastUnit
+    && unitsHeld < TURTLE_MAX_UNITS
+    && allocatedCapitalUsdt > 0
+    && pyramidThresholdPrice !== null
+  ) {
+    const triggered =
+      (lastUnit.side === 'long' && lastClose >= pyramidThresholdPrice)
+      || (lastUnit.side === 'short' && lastClose <= pyramidThresholdPrice);
+    if (triggered) {
+      const action: TurtleAction =
+        lastUnit.side === 'long' ? 'pyramid_long' : 'pyramid_short';
+      const margin = unitMarginUsdt(
+        allocatedCapitalUsdt,
+        atr,
+        TURTLE_DEFAULT_LEVERAGE,
+        lastClose,
+      );
+      const stopPrice =
+        lastUnit.side === 'long'
+          ? lastClose - TURTLE_STOP_ATR_MULT * atr
+          : lastClose + TURTLE_STOP_ATR_MULT * atr;
+      if (margin > 0) {
+        return {
+          action,
+          sizeUsdt: margin,
+          leverage: TURTLE_DEFAULT_LEVERAGE,
+          stopPrice,
+          reason: `pyramid_${lastUnit.side}: close ${lastClose.toFixed(4)} past unit-${lastUnit.unitIndex + 1} step ${pyramidThresholdPrice.toFixed(4)} (n=${unitsHeld + 1}/${TURTLE_MAX_UNITS})`,
+          derivation: { ...baseDerivation, equityGated: gated },
+        };
+      }
+    }
+  }
+
+  // 5. ENTRY — flat AND arbiter > 0 AND breakout. Below allocation
+  //    means the arbiter excluded T this tick (sub-threshold equity,
+  //    or N-agent floor). Either way: hold.
+  if (heldSide === null && allocatedCapitalUsdt > 0 && !gated) {
+    if (lastClose > dHigh) {
+      const margin = unitMarginUsdt(
+        allocatedCapitalUsdt,
+        atr,
+        TURTLE_DEFAULT_LEVERAGE,
+        lastClose,
+      );
+      const stopPrice = lastClose - TURTLE_STOP_ATR_MULT * atr;
+      if (margin > 0) {
+        return {
+          action: 'enter_long',
+          sizeUsdt: margin,
+          leverage: TURTLE_DEFAULT_LEVERAGE,
+          stopPrice,
+          reason: `entry_long: close ${lastClose.toFixed(4)} > ${TURTLE_ENTRY_PERIOD}-bar high ${dHigh.toFixed(4)}`,
+          derivation: { ...baseDerivation, equityGated: gated },
+        };
+      }
+    }
+    if (lastClose < dLow) {
+      const margin = unitMarginUsdt(
+        allocatedCapitalUsdt,
+        atr,
+        TURTLE_DEFAULT_LEVERAGE,
+        lastClose,
+      );
+      const stopPrice = lastClose + TURTLE_STOP_ATR_MULT * atr;
+      if (margin > 0) {
+        return {
+          action: 'enter_short',
+          sizeUsdt: margin,
+          leverage: TURTLE_DEFAULT_LEVERAGE,
+          stopPrice,
+          reason: `entry_short: close ${lastClose.toFixed(4)} < ${TURTLE_ENTRY_PERIOD}-bar low ${dLow.toFixed(4)}`,
+          derivation: { ...baseDerivation, equityGated: gated },
+        };
+      }
+    }
+  }
+
+  // 6. No-op.
+  return holdResult(
+    heldSide
+      ? `holding_${heldSide} units=${unitsHeld}`
+      : (gated ? 'equity_gated_with_open_units' : 'no_signal'),
+    { ...baseDerivation, equityGated: gated },
+  );
+}
+
+/**
+ * Helper for the loop integration: after an entry / pyramid fill is
+ * confirmed, push a new ``TurtleUnit`` onto state. Pure: returns a
+ * fresh state object (callers are free to use it as immutable).
+ */
+export function appendUnit(
+  state: TurtleState,
+  unit: Omit<TurtleUnit, 'unitIndex'>,
+): TurtleState {
+  const unitIndex = state.units.length;
+  return {
+    units: [...state.units, { ...unit, unitIndex }],
+    lastExitAtMs: state.lastExitAtMs,
+    lastExitReason: state.lastExitReason,
+  };
+}
+
+/**
+ * Helper for the loop integration: after an exit fill clears all
+ * units (Turtle closes the whole pyramid on stop or Donchian exit),
+ * reset the units list and record the exit timestamp + reason.
+ */
+export function clearUnitsAfterExit(
+  state: TurtleState,
+  reason: string,
+  atMs: number,
+): TurtleState {
+  return {
+    units: [],
+    lastExitAtMs: atMs,
+    lastExitReason: reason,
+  };
+}

--- a/apps/api/src/services/turtle_agent/donchian.ts
+++ b/apps/api/src/services/turtle_agent/donchian.ts
@@ -1,0 +1,115 @@
+/**
+ * turtle_agent/donchian.ts — Donchian channel computation.
+ *
+ * Pure function. Operates on raw OHLCV. No state, no kernel hooks.
+ *
+ * Turtle System 1 entry/exit signals are based on Donchian channels:
+ *
+ *   * Entry:  close > rolling N-bar high  (long)
+ *             close < rolling N-bar low   (short)
+ *   * Exit:   close < rolling M-bar low   (long held)
+ *             close > rolling M-bar high  (short held)
+ *
+ * The classic Turtle parameters are N = 20 (entry) and M = 10 (exit).
+ * The "high" / "low" of the channel uses the bars BEFORE the current
+ * one — i.e. the close of bar ``i`` is compared against the highest
+ * high in bars [i-N..i-1]. This avoids using the current bar's own
+ * range to trigger its own entry, which would be lookahead bias.
+ *
+ * Returned series have the same length as the input. Indices for
+ * which the lookback window is incomplete are NaN. Callers should
+ * check with ``Number.isFinite`` before using a value.
+ */
+
+import type { TurtleOHLCV } from './state.js';
+
+/**
+ * Rolling N-bar Donchian high using bars BEFORE the current bar.
+ *   highChannel[i] = max(high[i-period..i-1])
+ *
+ * Indices < ``period`` are NaN (insufficient prior bars).
+ */
+export function donchianHigh(
+  candles: readonly TurtleOHLCV[],
+  period: number,
+): number[] {
+  if (period <= 0) {
+    throw new Error(`donchianHigh: period must be > 0 (got ${period})`);
+  }
+  const n = candles.length;
+  const out: number[] = new Array(n).fill(NaN);
+  for (let i = period; i < n; i++) {
+    let mx = -Infinity;
+    for (let j = i - period; j < i; j++) {
+      if (candles[j]!.high > mx) mx = candles[j]!.high;
+    }
+    out[i] = mx;
+  }
+  return out;
+}
+
+/**
+ * Rolling N-bar Donchian low using bars BEFORE the current bar.
+ *   lowChannel[i] = min(low[i-period..i-1])
+ */
+export function donchianLow(
+  candles: readonly TurtleOHLCV[],
+  period: number,
+): number[] {
+  if (period <= 0) {
+    throw new Error(`donchianLow: period must be > 0 (got ${period})`);
+  }
+  const n = candles.length;
+  const out: number[] = new Array(n).fill(NaN);
+  for (let i = period; i < n; i++) {
+    let mn = Infinity;
+    for (let j = i - period; j < i; j++) {
+      if (candles[j]!.low < mn) mn = candles[j]!.low;
+    }
+    out[i] = mn;
+  }
+  return out;
+}
+
+/**
+ * Latest Donchian high (channel ending at the most recent bar). Uses
+ * bars [n-period..n-1] (i.e. the period bars immediately preceding
+ * the latest close). Returns NaN when fewer than ``period`` prior
+ * bars exist.
+ */
+export function latestDonchianHigh(
+  candles: readonly TurtleOHLCV[],
+  period: number,
+): number {
+  const n = candles.length;
+  if (n < period) return NaN;
+  let mx = -Infinity;
+  // Last ``period`` bars excluding the current (latest) bar — same
+  // semantic as the series formula above. ``candles[n-1]`` is "current".
+  // System 1 entry compares current close vs the previous N-bar high.
+  for (let j = n - period - 1; j < n - 1; j++) {
+    if (j < 0) continue;
+    if (candles[j]!.high > mx) mx = candles[j]!.high;
+  }
+  if (!Number.isFinite(mx)) return NaN;
+  return mx;
+}
+
+/**
+ * Latest Donchian low (channel ending at the most recent bar).
+ * Symmetric to ``latestDonchianHigh``.
+ */
+export function latestDonchianLow(
+  candles: readonly TurtleOHLCV[],
+  period: number,
+): number {
+  const n = candles.length;
+  if (n < period) return NaN;
+  let mn = Infinity;
+  for (let j = n - period - 1; j < n - 1; j++) {
+    if (j < 0) continue;
+    if (candles[j]!.low < mn) mn = candles[j]!.low;
+  }
+  if (!Number.isFinite(mn)) return NaN;
+  return mn;
+}

--- a/apps/api/src/services/turtle_agent/index.ts
+++ b/apps/api/src/services/turtle_agent/index.ts
@@ -1,0 +1,45 @@
+/**
+ * turtle_agent/index.ts — Agent T (Turtle System 1) public surface.
+ *
+ * Re-exports for the loop integration. Internal helpers live in
+ * the dedicated modules.
+ */
+
+export {
+  trueRange,
+  atrSeries,
+  latestAtr,
+} from './atr.js';
+export {
+  donchianHigh,
+  donchianLow,
+  latestDonchianHigh,
+  latestDonchianLow,
+} from './donchian.js';
+export {
+  newTurtleState,
+  turtleHeldSide,
+  lastUnitEntry,
+  type TurtleAccount,
+  type TurtleOHLCV,
+  type TurtleState,
+  type TurtleUnit,
+} from './state.js';
+export {
+  turtleAgentDecide,
+  appendUnit,
+  clearUnitsAfterExit,
+  turtleMinEquityUsdt,
+  TURTLE_ENTRY_PERIOD,
+  TURTLE_EXIT_PERIOD,
+  TURTLE_ATR_PERIOD,
+  TURTLE_STOP_ATR_MULT,
+  TURTLE_PYRAMID_STEP_ATR_MULT,
+  TURTLE_MAX_UNITS,
+  TURTLE_UNIT_RISK_FRACTION,
+  TURTLE_DEFAULT_LEVERAGE,
+  TURTLE_MIN_EQUITY_USDT_DEFAULT,
+  type TurtleAction,
+  type TurtleAgentInputs,
+  type TurtleAgentDecision,
+} from './decide.js';

--- a/apps/api/src/services/turtle_agent/state.ts
+++ b/apps/api/src/services/turtle_agent/state.ts
@@ -1,0 +1,100 @@
+/**
+ * turtle_agent/state.ts — Agent T (Turtle System 1) types + state.
+ *
+ * Agent T is the classical-TA control arm in the K / M / T
+ * three-agent decomposition. It is INTENTIONALLY non-QIG-pure: that
+ * is the point. K runs on Fisher-Rao basin geometry, M runs on ML
+ * threshold logic, T runs on Donchian / ATR — three independent
+ * epistemologies, no information flow between them, raced on the
+ * same live account by the arbiter.
+ *
+ * The hard rule is *no inter-agent state reads*: T's ``decide()``
+ * function takes only (symbol, ohlcv, account, allocation). It does
+ * NOT take K's basin / regime / emotions, M's mlSignal / mlStrength,
+ * or the arbiter's view of K or M's PnL — only its own state.
+ */
+
+/** OHLCV row. Same shape as the kernel + ml_agent inputs but kept
+ *  local so T doesn't import from either of those modules (the wall
+ *  is in the type graph as well as the runtime control flow). */
+export interface TurtleOHLCV {
+  timestamp: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+/** Account snapshot at the current tick. T sees only the account
+ *  fields it needs — equity for the activation gate, available
+ *  capital for sizing, and its OWN held units (not K's, not M's). */
+export interface TurtleAccount {
+  /** Total account equity in USDT (mark-to-market). The activation
+   *  gate trips on this. */
+  equityUsdt: number;
+  /** Capital available for fresh entries this tick (after open
+   *  margin reserved by other agents). */
+  availableEquityUsdt: number;
+}
+
+/** A single Turtle "unit" — one lot of position the agent is long /
+ *  short. Pyramiding adds further units as the trade moves
+ *  favorably; each unit has its own entry price + stop. The agent
+ *  closes them as a group on the 10-bar opposite Donchian extreme
+ *  or the 2× ATR stop. */
+export interface TurtleUnit {
+  /** Direction of the unit. */
+  side: 'long' | 'short';
+  /** Fill price of this unit. */
+  entryPrice: number;
+  /** ATR(20) reading at the moment this unit was added. The 2× ATR
+   *  stop and the 0.5× ATR pyramid step are both anchored to the
+   *  ATR observed when the unit was OPENED — not the current ATR.
+   *  This is the Turtle convention; it stops the stop from drifting
+   *  as ATR fluctuates around the trend. */
+  atrAtEntry: number;
+  /** Initial stop price (entry - 2*ATR for long, entry + 2*ATR for
+   *  short). Stays static for this unit; next unit's stop is its
+   *  own entry ± 2× ATR. */
+  stopPrice: number;
+  /** Margin USDT committed to this unit (after leverage). */
+  marginUsdt: number;
+  /** Leverage used to open this unit. */
+  leverage: number;
+  /** ms timestamp the unit was opened. */
+  openedAtMs: number;
+  /** 0-indexed unit number within the current pyramid (first = 0,
+   *  fourth = 3). Caps at 3 (4 units total = Turtle classic max). */
+  unitIndex: number;
+}
+
+/** Per-symbol state Agent T carries between ticks. Reset when the
+ *  pyramid is fully closed (last unit exited). */
+export interface TurtleState {
+  /** Held units, in entry order. Empty when flat. */
+  units: TurtleUnit[];
+  /** ms timestamp of the most recent exit (any reason). Used for
+   *  diagnostics and for downstream filters that may want to wait
+   *  N bars after a stop-out before re-entering. */
+  lastExitAtMs: number | null;
+  /** Reason text from the most recent exit. Diagnostic only. */
+  lastExitReason: string | null;
+}
+
+/** Construct a fresh empty state. */
+export function newTurtleState(): TurtleState {
+  return { units: [], lastExitAtMs: null, lastExitReason: null };
+}
+
+/** Read the side T is currently holding, or null when flat. */
+export function turtleHeldSide(state: TurtleState): 'long' | 'short' | null {
+  return state.units[0]?.side ?? null;
+}
+
+/** Read the entry price of the most recently added unit, or null
+ *  when flat. Pyramiding compares the current price against this
+ *  price + 0.5 × ATR. */
+export function lastUnitEntry(state: TurtleState): TurtleUnit | null {
+  return state.units[state.units.length - 1] ?? null;
+}


### PR DESCRIPTION
## Summary

Third arbiter agent: classical Turtle System 1 trend-follower. **Explicitly not QIG-pure** — that's the design. T is the control arm for whether QIG-purity wins versus classical TA. Three philosophically distinct epistemologies (geometric / ML / classical TA) race on the same account; arbiter weights by outcomes alone.

User's design directive (verbatim):
> "Agent T is explicitly not QIG-pure, and that's the entire point. The real boundary that matters: no agent reads any other agent's state. That's the rule, not 'all agents must be QIG-pure.' Pyramiding, 2× ATR stop, 10-bar opposite Donchian exit. Not QIG-pure — that's the control."

## What T does

Pure Turtle System 1 baseline (parameter-light, well-validated):

- **Entry**: close > 20-bar high → long; close < 20-bar low → short
- **Stop**: entry ± 2 × ATR(20)
- **Exit**: 10-bar opposite Donchian extreme OR stop hit
- **Pyramiding**: every 0.5 × ATR favorable, add a unit (4-unit cap per Turtle classic)
- **Sizing**: each unit margin = (1% T's arbiter allocation) / (2 × ATR × leverage)
- **Default leverage**: 8× (matches Agent M baseline; configurable)

## Equity-gated activation (NOT a flag — runtime constraint)

T does NOT trade until `account.availableEquity ≥ $150` (configurable via env `TURTLE_MIN_EQUITY_USDT`, default 150).

When equity < threshold: arbiter excludes T from `allocateMany`; T's `decide()` returns hold. When equity ≥ threshold: T included alongside K and M.

This is NOT `TURTLE_AGENT_LIVE`. It's a runtime check on availableEquity. Constraint is real (min-notional math at $50 account × 3 agents × 10% floor = $5 each ≪ $76 BTC min). Trigger is concrete (equity threshold). Rollback is automatic (allocation returns to K+M when equity drops back).

T's decide() still runs when gated, so in-flight pyramids can close cleanly via stop/Donchian even if equity dips mid-trade. Only new entries are blocked.

## The wall

T's `decide()` signature takes ONLY: symbol, ohlcv, account, allocation. It does NOT take K's basin/regime/emotions, or M's ml_signal/ml_strength. The wall is enforced at the type-graph level — no BasinState / ML field appears anywhere in turtle_agent/.

## Files

**Created** (8):
- `apps/api/src/services/turtle_agent/atr.ts` — Wilder ATR
- `apps/api/src/services/turtle_agent/donchian.ts` — N-bar high/low (excludes current bar — no lookahead)
- `apps/api/src/services/turtle_agent/state.ts` — TurtleOHLCV, TurtleAccount, TurtleUnit, TurtleState. Zero kernel-state references
- `apps/api/src/services/turtle_agent/decide.ts` — turtleAgentDecide + appendUnit/clearUnitsAfterExit. Decision priority: equity gate → stop hit → Donchian opposite → pyramid → entry
- `apps/api/src/services/turtle_agent/index.ts` — re-exports
- 5 test files: atr, donchian, decide, pyramiding, equity_gate

**Modified** (1):
- `apps/api/src/services/monkey/loop.ts` — N-agent arbiter with T inclusion gated on equity, T-execute section between Agent M and arbiter persist, executeEntry agent type extended to `'K'|'M'|'T'`, telemetry under `derivation.agentT` + `derivation.arbiter.{tEligible, minEquityForT, tShare, tAllocatedUsdt, tPnlWindowTotal, tTradesInWindow}`

## Tests

- **Turtle agent**: 37/37 passing (Donchian 7, ATR 8, decide 13, pyramiding 4, equity gate 5)
- **Full TS suite**: 971 passing, 2 pre-existing `resonance_bank_lane` fails unchanged
- **TS build**: clean

## Judgment calls

1. **Pure Turtle System 1**, not Pine-script confluence. Confluence is a clean follow-up if the System 1 control needs strengthening after live data accumulates.
2. **1% risk per unit on T's allocation** (not absolute equity) — Turtle reference is 1% of account; against arbiter share preserves volatility-targeting while letting per-unit risk scale with allocation outcomes.
3. **Default leverage 8×** — matches Agent M's `ML_LEV_BASE = 8` so all three agents start with comparable sizing constants.
4. **No new migration** — #040's regex `^[A-Z][A-Z0-9_]*$` already accepts `agent='T'`.
5. **Equity gate on availableEquity** (loop's existing reading) — single source of truth; no new poller.
6. **T.decide() runs even when gated** — only entries/pyramids blocked; exits work normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)