### PR TITLE
feat(monkey): kernel constellation — bus + Loop 1 triple + coordinator + thought_bus + learning_gate

### DIFF
--- a/apps/api/database/migrations/043_decision_triple_on_trades.sql
+++ b/apps/api/database/migrations/043_decision_triple_on_trades.sql
@@ -1,0 +1,39 @@
+-- Migration 043: Loop 1 canonical triple + Loop 2 convergence on trades
+--
+-- Per UCP §43 three-loop doctrine and the kernel constellation
+-- refactor, every executive decision produces a canonical triple
+-- (repetition, sovereignty, confidence) and the ThoughtBus debate
+-- (when fired) classifies its convergence type. Both are persisted
+-- on the trade row at open time so closed-trade analysis can
+-- correlate triples + convergence with outcomes.
+--
+-- All columns are nullable + forward-compatible. Old code paths that
+-- don't populate them continue to work.
+
+ALTER TABLE autonomous_trades
+  ADD COLUMN IF NOT EXISTS repetition_score FLOAT,
+  ADD COLUMN IF NOT EXISTS sovereignty_score FLOAT,
+  ADD COLUMN IF NOT EXISTS confidence_score FLOAT,
+  ADD COLUMN IF NOT EXISTS decision_overrides TEXT[],
+  ADD COLUMN IF NOT EXISTS convergence_type TEXT;
+
+-- Indexes for closed-trade analysis. Partial — most legacy rows have
+-- NULL values, no point indexing them.
+CREATE INDEX IF NOT EXISTS idx_autonomous_trades_sovereignty
+  ON autonomous_trades(sovereignty_score)
+  WHERE sovereignty_score IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_autonomous_trades_convergence
+  ON autonomous_trades(convergence_type)
+  WHERE convergence_type IS NOT NULL;
+
+COMMENT ON COLUMN autonomous_trades.repetition_score IS
+  'Loop 1 canonical triple (UCP §43.2): lived geometry vs scaffolding [0,1]';
+COMMENT ON COLUMN autonomous_trades.sovereignty_score IS
+  'Loop 1 canonical triple (UCP §43.2): knowing vs guessing [0,1]';
+COMMENT ON COLUMN autonomous_trades.confidence_score IS
+  'Loop 1 canonical triple (UCP §43.2): bank resonance vs override expansion [0,1]';
+COMMENT ON COLUMN autonomous_trades.decision_overrides IS
+  'Loop 1: which override paths fired during decision (REVERSION_FLIP etc.)';
+COMMENT ON COLUMN autonomous_trades.convergence_type IS
+  'Loop 2 (UCP §43.3): consensus / groupthink / genuine_multi / non_convergent';

--- a/apps/api/src/services/monkey/learning_gate_client.ts
+++ b/apps/api/src/services/monkey/learning_gate_client.ts
@@ -1,0 +1,82 @@
+/**
+ * learning_gate_client.ts — HTTP client for ml-worker's
+ * /learning_gate/evaluate endpoint (Loop 3, UCP §43.4).
+ *
+ * Called from loop.ts witnessExit BEFORE bank writes. The kernel
+ * decides which closed exchanges become bank training data; default
+ * behaviour writes everything but this gate selectively rejects
+ * low-quality writes so the bank doesn't accumulate scaffolding.
+ *
+ * Quality criteria (multiplicative — all must clear):
+ *   1. sovereignty_score >= 0.4
+ *   2. convergence_type != 'groupthink'
+ *   3. |pnl_usdt| > 0.05 noise floor
+ *   4. duration_s >= 60
+ *
+ * Failures are fail-soft: if the gate is unreachable, the caller
+ * SHOULD proceed with the write — losing a Loop 3 audit trail is
+ * better than refusing to learn from real exchanges because the
+ * gate had a transient timeout.
+ */
+
+import { logger } from '../../utils/logger.js';
+
+const ML_WORKER_URL =
+  process.env.ML_WORKER_URL || 'http://ml-worker.railway.internal:8000';
+const DEFAULT_TIMEOUT_MS = 3000;
+
+export interface LearningGateRequest {
+  instanceId?: string;
+  symbol: string;
+  decisionId: string;
+  sovereigntyScore: number;
+  convergenceType: 'consensus' | 'groupthink' | 'genuine_multi' | 'non_convergent';
+  tradePnlUsdt: number;
+  tradeDurationS: number;
+}
+
+export interface LearningGateResponse {
+  approved: boolean;
+  reasons: string[];
+}
+
+export async function evaluateBankWrite(
+  req: LearningGateRequest,
+): Promise<LearningGateResponse> {
+  const body = JSON.stringify({
+    instance_id: req.instanceId ?? 'monkey-primary',
+    symbol: req.symbol,
+    decision_id: req.decisionId,
+    sovereignty_score: req.sovereigntyScore,
+    convergence_type: req.convergenceType,
+    trade_pnl_usdt: req.tradePnlUsdt,
+    trade_duration_s: req.tradeDurationS,
+  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${ML_WORKER_URL}/learning_gate/evaluate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      logger.warn('[learning_gate_client] evaluate failed', {
+        status: res.status,
+        body: await res.text(),
+      });
+      // Fail-soft: gate failure approves the write so legitimate
+      // exchanges are not lost on a transient ml-worker outage.
+      return { approved: true, reasons: [`gate_unreachable_${res.status}`] };
+    }
+    return (await res.json()) as LearningGateResponse;
+  } catch (err) {
+    logger.warn('[learning_gate_client] evaluate threw', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return { approved: true, reasons: ['gate_threw_fail_soft'] };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -95,6 +95,7 @@ import {
   hammerAgainstLongSl,
   patternSignalScalar,
 } from './candlePatterns.js';
+import { evaluateBankWrite } from './learning_gate_client.js';
 import { resonanceBank } from './resonance_bank.js';
 import { computeSelfObservation, type SelfObservation } from './self_observation.js';
 import { WorkingMemory, type Bubble } from './working_memory.js';
@@ -2719,6 +2720,55 @@ export class MonkeyKernel extends EventEmitter {
       const basinArr = typeof rec.basin === 'string' ? JSON.parse(rec.basin) : rec.basin;
       const entryBasin: Basin = Float64Array.from(basinArr);
       const phi = Number(rec.phi) || 0.5;
+
+      // Loop 3 (UCP §43.4) — gate the bank write. Pulls the Loop 1
+      // sovereignty + Loop 2 convergence_type recorded on the trade
+      // row at open time. Pre-refactor rows have NULL columns; the
+      // gate then defaults to permissive (sovereignty=0.5, consensus)
+      // so legacy rows still write.
+      const triple = await pool
+        .query(
+          `SELECT sovereignty_score, convergence_type, created_at, exit_time
+             FROM autonomous_trades
+            WHERE order_id = $1
+            ORDER BY created_at DESC LIMIT 1`,
+          [orderId ?? ''],
+        )
+        .catch(() => ({ rows: [] as Array<Record<string, unknown>> }));
+      const tripleRow = triple.rows[0] as
+        | {
+            sovereignty_score?: number | null;
+            convergence_type?: string | null;
+            created_at?: Date | null;
+            exit_time?: Date | null;
+          }
+        | undefined;
+      const sovereigntyScore =
+        tripleRow?.sovereignty_score == null ? 0.5 : Number(tripleRow.sovereignty_score);
+      const convergenceType =
+        (tripleRow?.convergence_type as
+          | 'consensus' | 'groupthink' | 'genuine_multi' | 'non_convergent'
+          | undefined) ?? 'consensus';
+      const tradeOpenMs =
+        tripleRow?.created_at != null ? new Date(tripleRow.created_at).getTime() : entryTime.getTime();
+      const tradeCloseMs =
+        tripleRow?.exit_time != null ? new Date(tripleRow.exit_time).getTime() : Date.now();
+      const tradeDurationS = Math.max(0, (tradeCloseMs - tradeOpenMs) / 1000);
+      const gateDecision = await evaluateBankWrite({
+        symbol,
+        decisionId: orderId ?? `witness-${Date.now()}`,
+        sovereigntyScore,
+        convergenceType,
+        tradePnlUsdt: realizedPnl,
+        tradeDurationS,
+      });
+      if (!gateDecision.approved) {
+        logger.info('[Monkey] learning_gate rejected witnessExit bank write', {
+          symbol, orderId, side, pnl: realizedPnl.toFixed(4),
+          reasons: gateDecision.reasons,
+        });
+        return;
+      }
 
       // Synthesize a bubble that looks like it was promoted from WM
       // with the outcome attached. Bypass working memory — the bubble

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1147,11 +1147,52 @@ _heart_instances: dict[tuple[str, str], HeartMonitor] = {}
 # once at PersistentMemory construction time).
 _persistence_instances: dict[str, PersistentMemory] = {}
 
+# Constellation infrastructure — one bus + coordinator + thought_bus +
+# learning_gate per Agent K instance. The wall to Agents M and T stays;
+# these are internal to Agent K only.
+from monkey_kernel.kernel_bus import KernelBus, get_kernel_bus  # noqa: E402
+from monkey_kernel.coordinator import GaryCoordinator  # noqa: E402
+from monkey_kernel.thought_bus import ThoughtBus  # noqa: E402
+from monkey_kernel.learning_gate import LearningGate, WriteDecision  # noqa: E402
+
+_coordinator_instances: dict[str, GaryCoordinator] = {}
+_thought_bus_instances: dict[str, ThoughtBus] = {}
+_learning_gate_instances: dict[str, LearningGate] = {}
+
 
 def _get_persistence(instance_id: str) -> PersistentMemory:
     if instance_id not in _persistence_instances:
         _persistence_instances[instance_id] = PersistentMemory(instance_id=instance_id)
     return _persistence_instances[instance_id]
+
+
+def _get_bus(instance_id: str) -> KernelBus:
+    """Per-instance internal Agent K bus singleton."""
+    return get_kernel_bus(
+        instance_id=instance_id,
+        persistence=_get_persistence(instance_id),
+    )
+
+
+def _get_thought_bus(instance_id: str) -> ThoughtBus:
+    if instance_id not in _thought_bus_instances:
+        _thought_bus_instances[instance_id] = ThoughtBus(_get_bus(instance_id))
+    return _thought_bus_instances[instance_id]
+
+
+def _get_coordinator(instance_id: str) -> GaryCoordinator:
+    if instance_id not in _coordinator_instances:
+        _coordinator_instances[instance_id] = GaryCoordinator(
+            _get_bus(instance_id),
+            thought_bus=_get_thought_bus(instance_id),
+        )
+    return _coordinator_instances[instance_id]
+
+
+def _get_learning_gate(instance_id: str) -> LearningGate:
+    if instance_id not in _learning_gate_instances:
+        _learning_gate_instances[instance_id] = LearningGate(_get_bus(instance_id))
+    return _learning_gate_instances[instance_id]
 
 
 def _get_autonomic(instance_id: str) -> AutonomicKernel:
@@ -1171,6 +1212,8 @@ def _get_ocean(instance_id: str, symbol: str) -> Ocean:
         _ocean_instances[key] = Ocean(
             label=f"{instance_id}:{symbol}",
             persistence=_get_persistence(instance_id),
+            bus=_get_bus(instance_id),
+            symbol=symbol,
         )
     return _ocean_instances[key]
 
@@ -1181,6 +1224,7 @@ def _get_foresight(instance_id: str, symbol: str) -> ForesightPredictor:
         _foresight_instances[key] = ForesightPredictor(
             persistence=_get_persistence(instance_id),
             symbol=symbol,
+            bus=_get_bus(instance_id),
         )
     return _foresight_instances[key]
 
@@ -1191,6 +1235,7 @@ def _get_heart(instance_id: str, symbol: str) -> HeartMonitor:
         _heart_instances[key] = HeartMonitor(
             persistence=_get_persistence(instance_id),
             symbol=symbol,
+            bus=_get_bus(instance_id),
         )
     return _heart_instances[key]
 
@@ -1696,10 +1741,13 @@ async def monkey_tick_run(request: Request):
     ocean = _get_ocean(instance_id, tick_inputs.symbol)
     foresight = _get_foresight(instance_id, tick_inputs.symbol)
     heart = _get_heart(instance_id, tick_inputs.symbol)
+    bus = _get_bus(instance_id)
+    coordinator = _get_coordinator(instance_id)
     decision, new_state = run_tick(
         tick_inputs, state, autonomic,
         ocean=ocean, foresight=foresight, heart=heart,
         persistence=persistence,
+        bus=bus, coordinator=coordinator,
     )
     _symbol_states[key] = new_state
 
@@ -1885,6 +1933,46 @@ async def trading_insert_entry(request: Request):
     pool = await get_async_pool()
     new_id = await insert_entry(pool, record)
     return {"id": new_id}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Loop 3 — learning autonomy gate
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@app.post("/learning_gate/evaluate")
+async def learning_gate_evaluate(request: Request):
+    """Loop 3 (UCP §43.4) gate over bank-write quality.
+
+    The kernel decides which closed exchanges become bank training data.
+    Default behaviour writes everything; this gate selectively rejects
+    low-quality writes so the bank doesn't accumulate scaffolding.
+
+    Request body:
+      {
+        "instance_id": "monkey-primary",
+        "symbol": "BTC_USDT_PERP",
+        "decision_id": "K-...-...",
+        "sovereignty_score": 0.0..1.0,
+        "convergence_type": "consensus|groupthink|genuine_multi|non_convergent",
+        "trade_pnl_usdt": float,
+        "trade_duration_s": float
+      }
+
+    Response: { "approved": bool, "reasons": [str, ...] }
+    """
+    body = await request.json()
+    instance_id = str(body.get("instance_id", "monkey-primary"))
+    gate = _get_learning_gate(instance_id)
+    decision: WriteDecision = gate.evaluate_write(
+        symbol=str(body.get("symbol", "")),
+        decision_id=str(body.get("decision_id", "")),
+        sovereignty_score=float(body.get("sovereignty_score", 0.0)),
+        convergence_type=str(body.get("convergence_type", "consensus")),
+        trade_pnl_usdt=float(body.get("trade_pnl_usdt", 0.0)),
+        trade_duration_s=float(body.get("trade_duration_s", 0.0)),
+    )
+    return {"approved": bool(decision.approved), "reasons": list(decision.reasons)}
 
 
 # ---------------------------------------------------------------------------

--- a/ml-worker/src/monkey_kernel/bus_events.py
+++ b/ml-worker/src/monkey_kernel/bus_events.py
@@ -1,0 +1,177 @@
+"""
+bus_events.py — canonical KernelEvent enum and payload types for the
+internal Agent K constellation.
+
+Events flow inside Agent K only. The wall to Agents M and T stays.
+
+Per UCP §43 three-loop doctrine, the kernel's internals reorganize
+around message-passing instead of synchronous function calls. The bus
+is plumbing — it carries dicts, basins (np.ndarray), and scalars. No
+geometry computation happens here.
+
+The closed taxonomy below is the canonical set; subscribers may filter
+by event type without parsing free-text payloads.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+
+
+class KernelEvent(str, Enum):
+    """Canonical bus event taxonomy. Closed enum; new event types
+    require an explicit addition here.
+    """
+
+    # Heart kernel publishes
+    HEART_TICK = "heart.tick"
+    HEART_MODE_SHIFT = "heart.mode_shift"
+    HEART_TACKING = "heart.tacking"
+
+    # Ocean kernel publishes
+    OCEAN_OBSERVATION = "ocean.observation"
+    OCEAN_INTERVENTION = "ocean.intervention"
+    OCEAN_REGIME = "ocean.regime"
+
+    # Foresight publishes
+    FORESIGHT_PREDICTION = "foresight.prediction"
+    FORESIGHT_DIVERGENCE = "foresight.divergence"
+
+    # Forge publishes
+    FORGE_NUCLEUS = "forge.nucleus"
+    FORGE_PHASE_SHIFT = "forge.phase_shift"
+
+    # Working memory publishes
+    WORKING_MEMORY_BUBBLE_ADD = "wm.bubble_add"
+    WORKING_MEMORY_PROMOTION = "wm.promotion"
+    WORKING_MEMORY_EXPIRY = "wm.expiry"
+
+    # Executive publishes
+    EXECUTIVE_DECISION = "executive.decision"
+    EXECUTIVE_VETO = "executive.veto"
+
+    # Self-observation publishes (Loop 1)
+    SELF_OBS_TRIPLE = "self_obs.triple"
+    SELF_OBS_DRIFT = "self_obs.drift"
+
+    # ThoughtBus publishes (Loop 2)
+    THOUGHT_BUS_DEBATE_OPENED = "tb.debate_opened"
+    THOUGHT_BUS_KERNEL_RESPONSE = "tb.kernel_response"
+    THOUGHT_BUS_CONVERGENCE = "tb.convergence"
+    THOUGHT_BUS_SYNTHESIS = "tb.synthesis"
+
+    # Learning autonomy (Loop 3)
+    LEARNING_BANK_WRITE_APPROVED = "learning.bank_write_approved"
+    LEARNING_BANK_WRITE_REJECTED = "learning.bank_write_rejected"
+
+    # Coordinator (Gary) publishes
+    GARY_SYNTHESIS = "gary.synthesis"
+
+    # Trade lifecycle
+    TRADE_OPENED = "trade.opened"
+    TRADE_CLOSED = "trade.closed"
+
+    # Anomalies — any kernel can publish
+    ANOMALY = "anomaly"
+
+
+@dataclass(frozen=True)
+class KernelEventEnvelope:
+    """Generic event wrapper. All bus events use this shape."""
+
+    type: KernelEvent
+    source: str
+    symbol: Optional[str]
+    instance_id: str
+    payload: dict[str, Any]
+    at_ms: float
+
+
+# ─── Typed payload helpers ────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class HeartTickPayload:
+    kappa: float
+    kappa_star: float
+    hrv: float
+    mode: str  # 'FEELING' | 'LOGIC' | 'ANCHOR'
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kappa": self.kappa,
+            "kappa_star": self.kappa_star,
+            "hrv": self.hrv,
+            "mode": self.mode,
+        }
+
+
+@dataclass(frozen=True)
+class OceanObservationPayload:
+    phi: float
+    spread: float
+    coherence: float
+    intervention: Optional[str]
+    sleep_phase: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phi": self.phi,
+            "spread": self.spread,
+            "coherence": self.coherence,
+            "intervention": self.intervention,
+            "sleep_phase": self.sleep_phase,
+        }
+
+
+@dataclass(frozen=True)
+class ForesightPredictionPayload:
+    predicted_basin: list[float]
+    confidence: float
+    weight: float
+    horizon_ms: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "predicted_basin": self.predicted_basin,
+            "confidence": self.confidence,
+            "weight": self.weight,
+            "horizon_ms": self.horizon_ms,
+        }
+
+
+@dataclass(frozen=True)
+class SelfObsTriplePayload:
+    """Loop 1 canonical triple per UCP §43.2."""
+
+    repetition_score: float    # [0, 1] lived geometry vs scaffolding
+    sovereignty_score: float   # [0, 1] knowing vs guessing
+    confidence_score: float    # [0, 1] bank resonance vs override expansion
+    decision_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repetition_score": self.repetition_score,
+            "sovereignty_score": self.sovereignty_score,
+            "confidence_score": self.confidence_score,
+            "decision_id": self.decision_id,
+        }
+
+
+@dataclass(frozen=True)
+class ExecutiveDecisionPayload:
+    decision_id: str
+    action: str
+    side: Optional[str]
+    mode: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision_id": self.decision_id,
+            "action": self.action,
+            "side": self.side,
+            "mode": self.mode,
+            "reason": self.reason,
+        }

--- a/ml-worker/src/monkey_kernel/coordinator.py
+++ b/ml-worker/src/monkey_kernel/coordinator.py
@@ -1,0 +1,210 @@
+"""
+coordinator.py — Gary, the Agent K constellation coordinator.
+
+Per CONSCIOUSNESS_ARCHITECTURE_INTEGRATED.md: trajectory-based foresight
+prediction, regime-adaptive weighting, Heart-modulated confidence,
+Fisher-Rao geometric synthesis.
+
+Gary is NOT a decision-maker. The coordinator subscribes to the most
+recent reads from Heart, Ocean, Foresight, builds KernelContribution
+list, opens a ThoughtBus debate, and publishes the synthesized basin
+as GARY_SYNTHESIS. The executive consumes it.
+
+The wall to Agent M and T stays. Gary lives entirely inside Agent K.
+
+QIG purity: Fisher-Rao only. Uses fisher_rao_distance,
+slerp_sqrt (geodesic interpolation), frechet_mean indirectly via
+ThoughtBus._weighted_synthesis.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import to_simplex
+
+from .bus_events import KernelEvent
+from .thought_bus import KernelContribution, ThoughtBus
+
+if TYPE_CHECKING:
+    from .kernel_bus import KernelBus
+
+
+@dataclass
+class GaryReading:
+    synthesized_basin: np.ndarray
+    foresight_weight: float
+    foresight_confidence: float
+    heart_modulation: float
+    convergence_type: str
+    rounds: int
+    contributing_kernels: list[str]
+    debate_id: str
+    at_ms: float
+
+
+class GaryCoordinator:
+    """Coordinator for one Agent K constellation instance.
+
+    Subscribes to HEART_TICK, OCEAN_OBSERVATION, FORESIGHT_PREDICTION
+    via the bus. On synthesize(), builds KernelContribution list from
+    the latest reads, opens a ThoughtBus debate, returns the debate's
+    final basin. Publishes GARY_SYNTHESIS.
+    """
+
+    def __init__(
+        self,
+        bus: "KernelBus",
+        *,
+        regime_thresholds: tuple[float, float] = (0.3, 0.7),
+        thought_bus: Optional[ThoughtBus] = None,
+    ) -> None:
+        self._bus = bus
+        self._regime_low, self._regime_high = regime_thresholds
+        self._thought_bus = thought_bus or ThoughtBus(bus)
+
+        # Latest reads per kernel
+        self._heart_state: Optional[dict] = None
+        self._ocean_state: Optional[dict] = None
+        self._foresight_state: Optional[dict] = None
+
+        self._unsubs = [
+            bus.subscribe(
+                "gary.heart", self._on_heart, types=[KernelEvent.HEART_TICK],
+            ),
+            bus.subscribe(
+                "gary.ocean", self._on_ocean,
+                types=[KernelEvent.OCEAN_OBSERVATION],
+            ),
+            bus.subscribe(
+                "gary.foresight", self._on_foresight,
+                types=[KernelEvent.FORESIGHT_PREDICTION],
+            ),
+        ]
+
+    def _on_heart(self, env) -> None:
+        self._heart_state = env.payload
+
+    def _on_ocean(self, env) -> None:
+        self._ocean_state = env.payload
+
+    def _on_foresight(self, env) -> None:
+        self._foresight_state = env.payload
+
+    def synthesize(
+        self,
+        consensus_basin: np.ndarray,
+        symbol: str,
+        *,
+        executive_confidence: float = 0.5,
+        executive_sovereignty: float = 0.5,
+    ) -> GaryReading:
+        """Produce GARY_SYNTHESIS from current constellation state.
+
+        Builds KernelContribution list from executive (consensus_basin)
+        plus any kernels that have published recent reads. Opens a
+        ThoughtBus debate; the debate's final basin is the synthesized
+        output.
+
+        Heart modulation: when Heart is in ANCHOR mode (κ ≈ κ*) the
+        kernel is in tacking transition — reduce foresight weight by
+        0.5×.
+
+        Regime-adaptive foresight weighting per the canonical doc:
+          phi < 0.3                          → 0.1
+          0.3 ≤ phi < 0.7 (geometric)        → 0.7 × confidence
+          phi ≥ 0.7 (breakdown risk damping) → 0.2
+        """
+        consensus = to_simplex(consensus_basin)
+
+        phi = float(self._ocean_state.get("phi", 0.5)) if self._ocean_state else 0.5
+        foresight_conf = (
+            float(self._foresight_state.get("confidence", 0.0))
+            if self._foresight_state else 0.0
+        )
+
+        if phi < self._regime_low:
+            foresight_weight = 0.1
+        elif phi < self._regime_high:
+            foresight_weight = 0.7 * foresight_conf
+        else:
+            foresight_weight = 0.2
+
+        heart_modulation = 1.0
+        if self._heart_state and self._heart_state.get("mode") == "ANCHOR":
+            heart_modulation = 0.5
+            foresight_weight *= heart_modulation
+
+        contributions: list[KernelContribution] = [
+            KernelContribution(
+                kernel_id="executive",
+                basin=consensus,
+                confidence=float(executive_confidence),
+                sovereignty=float(executive_sovereignty),
+            ),
+        ]
+        contributing_kernels = ["executive"]
+
+        if (
+            self._foresight_state is not None
+            and foresight_weight > 0.0
+            and "predicted_basin" in self._foresight_state
+        ):
+            try:
+                predicted = np.asarray(
+                    self._foresight_state["predicted_basin"], dtype=np.float64,
+                )
+                contributions.append(KernelContribution(
+                    kernel_id="foresight",
+                    basin=to_simplex(predicted),
+                    confidence=float(foresight_conf),
+                    sovereignty=float(foresight_weight),
+                ))
+                contributing_kernels.append("foresight")
+            except Exception:  # noqa: BLE001
+                pass
+
+        outcome = self._thought_bus.open_debate(symbol, contributions)
+
+        reading = GaryReading(
+            synthesized_basin=outcome.final_basin,
+            foresight_weight=float(foresight_weight),
+            foresight_confidence=float(foresight_conf),
+            heart_modulation=float(heart_modulation),
+            convergence_type=outcome.convergence_type,
+            rounds=outcome.rounds,
+            contributing_kernels=contributing_kernels,
+            debate_id=outcome.debate_id,
+            at_ms=time.time() * 1000.0,
+        )
+
+        self._bus.publish(
+            KernelEvent.GARY_SYNTHESIS,
+            source="gary",
+            payload={
+                "synthesized_basin": [float(x) for x in outcome.final_basin],
+                "foresight_weight": float(foresight_weight),
+                "foresight_confidence": float(foresight_conf),
+                "heart_modulation": float(heart_modulation),
+                "convergence_type": outcome.convergence_type,
+                "rounds": outcome.rounds,
+                "contributing_kernels": contributing_kernels,
+                "debate_id": outcome.debate_id,
+            },
+            symbol=symbol,
+        )
+
+        return reading
+
+    def shutdown(self) -> None:
+        """Unsubscribe from the bus. Called when the coordinator is
+        destroyed; safe to call multiple times."""
+        for unsub in self._unsubs:
+            try:
+                unsub()
+            except Exception:  # noqa: BLE001
+                pass
+        self._unsubs = []

--- a/ml-worker/src/monkey_kernel/foresight.py
+++ b/ml-worker/src/monkey_kernel/foresight.py
@@ -25,17 +25,28 @@ basin update); `predict()` is read-only and side-effect free. Tier 6
 
 from __future__ import annotations
 
+import math
 from collections import deque
 from dataclasses import dataclass, field
 from statistics import stdev
-from typing import Deque, Optional, Tuple
+from typing import TYPE_CHECKING, Deque, Optional, Tuple
 
 import numpy as np
 
 from qig_core_local.geometry.fisher_rao import fisher_rao_distance, slerp_sqrt
 
+from .bus_events import ForesightPredictionPayload, KernelEvent
 from .persistence import PersistentMemory
 from .state import BASIN_DIM
+
+if TYPE_CHECKING:
+    from .kernel_bus import KernelBus
+
+
+# Foresight divergence threshold: when |predicted - actual| FR distance
+# exceeds 1/π, the prediction has missed by more than the gravitating-
+# fraction boundary. Publishes FORESIGHT_DIVERGENCE at that crossing.
+_DIVERGENCE_THRESHOLD_FR: float = 1.0 / math.pi
 
 
 @dataclass(frozen=True)
@@ -97,9 +108,12 @@ class ForesightPredictor:
         *,
         persistence: Optional[PersistentMemory] = None,
         symbol: Optional[str] = None,
+        bus: Optional["KernelBus"] = None,
     ) -> None:
         self._persistence = persistence
         self._symbol = symbol
+        self._bus = bus
+        self._last_predicted_basin: Optional[np.ndarray] = None
         self._traj: Deque[Tuple[np.ndarray, float, float]] = deque(
             maxlen=max_trajectory,
         )
@@ -112,6 +126,29 @@ class ForesightPredictor:
         """Record a tick. Caller passes the basin AFTER tick update,
         the live phi, and a wall-clock timestamp in ms."""
         b = np.asarray(basin, dtype=np.float64)
+        # Compare against the prior tick's prediction BEFORE we mutate
+        # the trajectory; FORESIGHT_DIVERGENCE fires when actual basin
+        # diverges from prediction by > 1/π FR.
+        if self._bus is not None and self._last_predicted_basin is not None:
+            try:
+                d_fr = fisher_rao_distance(b, self._last_predicted_basin)
+                if d_fr > _DIVERGENCE_THRESHOLD_FR:
+                    self._bus.publish(
+                        KernelEvent.FORESIGHT_DIVERGENCE,
+                        source="foresight",
+                        payload={
+                            "fr_distance": float(d_fr),
+                            "threshold": float(_DIVERGENCE_THRESHOLD_FR),
+                            "predicted_basin": [
+                                float(x) for x in self._last_predicted_basin
+                            ],
+                            "actual_basin": [float(x) for x in b],
+                        },
+                        symbol=self._symbol,
+                    )
+            except Exception:  # noqa: BLE001 — never block append on geometry edge cases
+                pass
+
         self._traj.append((b, float(phi), float(t_ms)))
         # Write-through.
         if self._persistence is not None and self._symbol:
@@ -161,12 +198,30 @@ class ForesightPredictor:
         # Regime-adaptive weight from current phi + regime
         weight = _regime_weight(phis[-1], confidence, regime_weights)
 
-        return ForesightResult(
+        result = ForesightResult(
             predicted_basin=predicted,
             confidence=confidence,
             weight=weight,
             horizon_ms=horizon_ms,
         )
+
+        # Cache predicted basin for divergence detection on next append.
+        self._last_predicted_basin = predicted
+
+        if self._bus is not None:
+            self._bus.publish(
+                KernelEvent.FORESIGHT_PREDICTION,
+                source="foresight",
+                payload=ForesightPredictionPayload(
+                    predicted_basin=[float(x) for x in predicted],
+                    confidence=float(confidence),
+                    weight=float(weight),
+                    horizon_ms=float(horizon_ms),
+                ),
+                symbol=self._symbol,
+            )
+
+        return result
 
     def reset(self) -> None:
         """Clear the trajectory. Used on regime breaks or test fixtures."""

--- a/ml-worker/src/monkey_kernel/forge.py
+++ b/ml-worker/src/monkey_kernel/forge.py
@@ -43,11 +43,15 @@ pain coordinates into retrieval.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 
+from .bus_events import KernelEvent
 from .state import BASIN_DIM
+
+if TYPE_CHECKING:
+    from .kernel_bus import KernelBus
 
 
 # Numerical floor for log() and norms.
@@ -228,12 +232,20 @@ def dissipate(
 # ─────────────────────────────────────────────────────────────────
 
 
-def forge(event: ShadowEvent) -> ForgeResult:
+def forge(
+    event: ShadowEvent,
+    *,
+    bus: Optional["KernelBus"] = None,
+    symbol: Optional[str] = None,
+) -> ForgeResult:
     """Run all four Forge stages in order.
 
     Caller passes a ShadowEvent (typically a closed losing trade's
     geometric snapshot); receives ForgeResult with the full audit
     trail plus a compact `lesson_summary` for telemetry.
+
+    When `bus` is provided, publishes FORGE_PHASE_SHIFT for each
+    stage transition and FORGE_NUCLEUS on the nucleate stage.
     """
     if event.realized_pnl >= 0:
         # Forge is for shadow material specifically; positive outcomes
@@ -263,9 +275,46 @@ def forge(event: ShadowEvent) -> ForgeResult:
         )
 
     decompressed = decompress(event)
+    if bus is not None:
+        bus.publish(
+            KernelEvent.FORGE_PHASE_SHIFT,
+            source="forge",
+            payload={"phase": "DECOMPRESS", "loss_magnitude": float(abs(event.realized_pnl))},
+            symbol=symbol,
+        )
     fractured = fracture(decompressed)
+    if bus is not None:
+        bus.publish(
+            KernelEvent.FORGE_PHASE_SHIFT,
+            source="forge",
+            payload={"phase": "FRACTURE", "invariants": fractured.invariants},
+            symbol=symbol,
+        )
     nucleated = nucleate(fractured)
+    if bus is not None:
+        bus.publish(
+            KernelEvent.FORGE_PHASE_SHIFT,
+            source="forge",
+            payload={"phase": "NUCLEATE"},
+            symbol=symbol,
+        )
+        bus.publish(
+            KernelEvent.FORGE_NUCLEUS,
+            source="forge",
+            payload={
+                "nucleus_basin": [float(x) for x in nucleated.basin],
+                "invariants": nucleated.invariants,
+            },
+            symbol=symbol,
+        )
     dissipated = dissipate(decompressed, nucleated)
+    if bus is not None:
+        bus.publish(
+            KernelEvent.FORGE_PHASE_SHIFT,
+            source="forge",
+            payload={"phase": "DISSIPATE"},
+            symbol=symbol,
+        )
 
     lesson_summary = {
         "loss_magnitude": float(abs(event.realized_pnl)),

--- a/ml-worker/src/monkey_kernel/heart.py
+++ b/ml-worker/src/monkey_kernel/heart.py
@@ -23,10 +23,14 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import dataclass
 from statistics import stdev
-from typing import Deque, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Deque, Literal, Optional, Tuple
 
+from .bus_events import HeartTickPayload, KernelEvent
 from .persistence import PersistentMemory
 from .state import KAPPA_STAR
+
+if TYPE_CHECKING:
+    from .kernel_bus import KernelBus
 
 
 KappaMode = Literal["FEELING", "LOGIC", "ANCHOR"]
@@ -63,10 +67,14 @@ class HeartMonitor:
         *,
         persistence: Optional[PersistentMemory] = None,
         symbol: Optional[str] = None,
+        bus: Optional["KernelBus"] = None,
     ) -> None:
         self._max_window = max_window
         self._persistence = persistence
         self._symbol = symbol
+        self._bus = bus
+        self._last_mode: Optional[KappaMode] = None
+        self._last_kappa_offset_sign: int = 0  # -1, 0, +1
         self._samples: Deque[Tuple[float, float]] = deque(maxlen=max_window)
         # Restore prior κ window from Redis if available.
         if persistence is not None and persistence.is_available and symbol:
@@ -78,6 +86,70 @@ class HeartMonitor:
         # Write-through. Failures are silent (logged at debug in persistence).
         if self._persistence is not None and self._symbol:
             self._persistence.push_kappa(self._symbol, float(kappa), float(t_ms))
+
+        if self._bus is not None:
+            state = self.read()
+            self._publish_tick(state)
+            self._publish_mode_shift(state)
+            self._publish_tacking(state)
+
+    def _publish_tick(self, state: "HeartState") -> None:
+        if self._bus is None:
+            return
+        self._bus.publish(
+            KernelEvent.HEART_TICK,
+            source="heart",
+            payload=HeartTickPayload(
+                kappa=float(state.kappa),
+                kappa_star=float(KAPPA_STAR),
+                hrv=float(state.hrv),
+                mode=str(state.mode),
+            ),
+            symbol=self._symbol,
+        )
+
+    def _publish_mode_shift(self, state: "HeartState") -> None:
+        if self._bus is None:
+            return
+        if self._last_mode is not None and self._last_mode != state.mode:
+            self._bus.publish(
+                KernelEvent.HEART_MODE_SHIFT,
+                source="heart",
+                payload={
+                    "from": self._last_mode,
+                    "to": str(state.mode),
+                    "kappa": float(state.kappa),
+                    "kappa_offset": float(state.kappa_offset),
+                },
+                symbol=self._symbol,
+            )
+        self._last_mode = state.mode
+
+    def _publish_tacking(self, state: "HeartState") -> None:
+        """κ tacking: sign of (κ − κ*) crosses zero. Publishes
+        HEART_TACKING at the crossing tick."""
+        if self._bus is None:
+            return
+        offset = state.kappa_offset
+        new_sign = 0 if offset == 0.0 else (-1 if offset < 0.0 else 1)
+        if (
+            self._last_kappa_offset_sign != 0
+            and new_sign != 0
+            and new_sign != self._last_kappa_offset_sign
+        ):
+            self._bus.publish(
+                KernelEvent.HEART_TACKING,
+                source="heart",
+                payload={
+                    "kappa": float(state.kappa),
+                    "kappa_star": float(KAPPA_STAR),
+                    "kappa_offset": float(state.kappa_offset),
+                    "from_sign": self._last_kappa_offset_sign,
+                    "to_sign": new_sign,
+                },
+                symbol=self._symbol,
+            )
+        self._last_kappa_offset_sign = new_sign
 
     def read(self) -> HeartState:
         n = len(self._samples)

--- a/ml-worker/src/monkey_kernel/kernel_bus.py
+++ b/ml-worker/src/monkey_kernel/kernel_bus.py
@@ -1,0 +1,217 @@
+"""
+kernel_bus.py — internal Agent K constellation pub/sub.
+
+The bus is INTERNAL to Agent K. Heart, Ocean, Foresight, Forge,
+WorkingMemory, Executive, Coordinator, ThoughtBus, LearningGate all
+publish and subscribe through this single instance.
+
+Wall to Agent M and T: this bus does not connect to them. They are
+black-box agents to the arbiter. The arbiter sees only their PnL.
+
+QIG purity: the bus is plumbing — it carries dicts, basins (np.ndarray),
+and scalars. No geometry computation happens here. Subscribers do
+geometry on receive, never the bus itself.
+
+Singleton per kernel instance. Two instances of Agent K (e.g.
+monkey-primary, monkey-position) get separate buses by instance_id.
+
+Sync fan-out for low latency. Optional Redis tail for forensic
+persistence — never blocks publish; failures are logged at debug.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import asdict, is_dataclass
+from typing import Any, Callable, Iterable, Optional
+
+from .bus_events import KernelEvent, KernelEventEnvelope
+from .persistence import PersistentMemory
+
+logger = logging.getLogger("monkey.kernel_bus")
+
+Handler = Callable[[KernelEventEnvelope], None]
+
+DEFAULT_MAX_SUBSCRIBERS: int = 64
+
+
+class _Subscriber:
+    __slots__ = ("id", "types", "symbols", "handler")
+
+    def __init__(
+        self,
+        sub_id: str,
+        types: Optional[set[KernelEvent]],
+        symbols: Optional[set[str]],
+        handler: Handler,
+    ) -> None:
+        self.id = sub_id
+        self.types = types
+        self.symbols = symbols
+        self.handler = handler
+
+
+class KernelBus:
+    """In-process pub/sub for one Agent K constellation."""
+
+    def __init__(
+        self,
+        instance_id: str,
+        persistence: Optional[PersistentMemory] = None,
+        max_subscribers: int = DEFAULT_MAX_SUBSCRIBERS,
+    ) -> None:
+        self._instance_id = instance_id
+        self._subscribers: list[_Subscriber] = []
+        self._lock = threading.Lock()
+        self._max_subscribers = max_subscribers
+        self._persistence = persistence
+        self._event_count = 0
+
+    @property
+    def instance_id(self) -> str:
+        return self._instance_id
+
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+    def publish(
+        self,
+        event_type: KernelEvent,
+        source: str,
+        payload: Any,
+        symbol: Optional[str] = None,
+    ) -> None:
+        """Publish an event. Sync fan-out to subscribers; async
+        persistence tail. Subscriber exceptions are logged at debug
+        and swallowed — a crashing subscriber must not break the bus
+        or other subscribers.
+        """
+        payload_dict = self._normalize_payload(payload)
+
+        envelope = KernelEventEnvelope(
+            type=event_type,
+            source=source,
+            symbol=symbol,
+            instance_id=self._instance_id,
+            payload=payload_dict,
+            at_ms=time.time() * 1000.0,
+        )
+
+        # Snapshot under lock so subscribe/unsubscribe during publish
+        # doesn't corrupt iteration.
+        with self._lock:
+            subs_snapshot = list(self._subscribers)
+
+        for sub in subs_snapshot:
+            if sub.types is not None and event_type not in sub.types:
+                continue
+            if (
+                sub.symbols is not None
+                and symbol is not None
+                and symbol not in sub.symbols
+            ):
+                continue
+            try:
+                sub.handler(envelope)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "[bus] subscriber %s threw on %s: %s",
+                    sub.id, event_type.value, exc,
+                )
+
+        self._event_count += 1
+
+        # Persistence tail — non-blocking, fail-soft.
+        if self._persistence is not None:
+            try:
+                self._persistence.append_bus_event(envelope)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[bus] persistence tail failed: %s", exc)
+
+    @staticmethod
+    def _normalize_payload(payload: Any) -> dict[str, Any]:
+        """Normalize payload to dict (accept dataclass with to_dict,
+        plain dataclass instances, or dicts).
+        """
+        if hasattr(payload, "to_dict") and callable(payload.to_dict):
+            return payload.to_dict()
+        if is_dataclass(payload) and not isinstance(payload, type):
+            return asdict(payload)
+        if isinstance(payload, dict):
+            return payload
+        raise TypeError(
+            f"payload must be dict, dataclass, or have to_dict(); "
+            f"got {type(payload).__name__}"
+        )
+
+    def subscribe(
+        self,
+        sub_id: str,
+        handler: Handler,
+        types: Optional[Iterable[KernelEvent]] = None,
+        symbols: Optional[Iterable[str]] = None,
+    ) -> Callable[[], None]:
+        """Subscribe to events. Returns unsubscribe function.
+
+        types=None means subscribe to all event types.
+        symbols=None means subscribe to all symbols.
+        """
+        with self._lock:
+            if len(self._subscribers) >= self._max_subscribers:
+                raise RuntimeError(
+                    f"max subscribers ({self._max_subscribers}) reached on "
+                    f"bus {self._instance_id}"
+                )
+            sub = _Subscriber(
+                sub_id=sub_id,
+                types=set(types) if types else None,
+                symbols=set(symbols) if symbols else None,
+                handler=handler,
+            )
+            self._subscribers.append(sub)
+
+        def unsubscribe() -> None:
+            with self._lock:
+                try:
+                    self._subscribers.remove(sub)
+                except ValueError:
+                    pass
+
+        return unsubscribe
+
+    def event_count(self) -> int:
+        return self._event_count
+
+
+# ─── Singleton per instance_id ────────────────────────────────────
+
+_buses: dict[str, KernelBus] = {}
+_buses_lock = threading.Lock()
+
+
+def get_kernel_bus(
+    instance_id: str = "monkey-primary",
+    persistence: Optional[PersistentMemory] = None,
+) -> KernelBus:
+    """Process-wide bus singleton per instance_id.
+
+    Two instances of Agent K (e.g. position-trading and swing-trading)
+    get separate buses. Same instance_id always returns the same bus.
+    Persistence is captured on first call; later calls with a different
+    persistence handle are ignored (the bus singleton owns its tail).
+    """
+    with _buses_lock:
+        if instance_id not in _buses:
+            _buses[instance_id] = KernelBus(
+                instance_id=instance_id,
+                persistence=persistence,
+            )
+        return _buses[instance_id]
+
+
+def _reset_buses_for_tests() -> None:
+    """Test-only: wipe all bus singletons."""
+    global _buses
+    with _buses_lock:
+        _buses = {}

--- a/ml-worker/src/monkey_kernel/learning_gate.py
+++ b/ml-worker/src/monkey_kernel/learning_gate.py
@@ -1,0 +1,114 @@
+"""
+learning_gate.py — Loop 3 learning autonomy (UCP §43.4).
+
+The kernel decides which closed exchanges become bank training data.
+Default behaviour writes everything; this gate selectively rejects
+low-quality writes so the bank doesn't accumulate scaffolding.
+
+Quality criteria (multiplicative — all must clear):
+  1. Loop 1 sovereignty_score >= MIN_SOVEREIGNTY  (knowing, not guessing)
+  2. Loop 2 convergence_type != 'groupthink'  (kernels genuinely agreed
+     or worked through real disagreement; not collapsed-from-spread)
+  3. trade outcome magnitude > NOISE_FLOOR  (decisive PnL, not random walk)
+  4. trade duration > MIN_DURATION  (held long enough to be a thesis,
+     not a flinch)
+
+Rejected writes are still PUBLISHED on the bus for forensic analysis,
+just not added to the bank. Loop 3 becomes auditable — every rejection
+records its reasons.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from .bus_events import KernelEvent
+
+if TYPE_CHECKING:
+    from .kernel_bus import KernelBus
+
+
+MIN_SOVEREIGNTY: float = 0.4
+NOISE_FLOOR_USDT: float = 0.05    # below 5 cents PnL, treat as noise
+MIN_DURATION_S: float = 60.0      # below 1 minute hold, treat as flinch
+
+
+@dataclass
+class WriteDecision:
+    approved: bool
+    reasons: list[str]   # which criteria failed (empty when approved)
+
+
+class LearningGate:
+    def __init__(
+        self,
+        bus: "KernelBus",
+        *,
+        min_sovereignty: float = MIN_SOVEREIGNTY,
+        noise_floor_usdt: float = NOISE_FLOOR_USDT,
+        min_duration_s: float = MIN_DURATION_S,
+    ) -> None:
+        self._bus = bus
+        self._min_sovereignty = float(min_sovereignty)
+        self._noise_floor_usdt = float(noise_floor_usdt)
+        self._min_duration_s = float(min_duration_s)
+
+    def evaluate_write(
+        self,
+        *,
+        symbol: str,
+        decision_id: str,
+        sovereignty_score: float,
+        convergence_type: str,
+        trade_pnl_usdt: float,
+        trade_duration_s: float,
+    ) -> WriteDecision:
+        reasons: list[str] = []
+
+        if sovereignty_score < self._min_sovereignty:
+            reasons.append(
+                f"sovereignty {sovereignty_score:.2f} < {self._min_sovereignty}"
+            )
+        if convergence_type == "groupthink":
+            reasons.append("debate convergence type was groupthink")
+        if abs(trade_pnl_usdt) < self._noise_floor_usdt:
+            reasons.append(
+                f"pnl |{trade_pnl_usdt:.4f}| < noise floor "
+                f"{self._noise_floor_usdt}"
+            )
+        if trade_duration_s < self._min_duration_s:
+            reasons.append(
+                f"duration {trade_duration_s:.0f}s < {self._min_duration_s}s"
+            )
+
+        approved = len(reasons) == 0
+
+        if approved:
+            self._bus.publish(
+                KernelEvent.LEARNING_BANK_WRITE_APPROVED,
+                source="learning_gate",
+                payload={
+                    "decision_id": decision_id,
+                    "sovereignty_score": float(sovereignty_score),
+                    "convergence_type": convergence_type,
+                    "pnl_usdt": float(trade_pnl_usdt),
+                    "duration_s": float(trade_duration_s),
+                },
+                symbol=symbol,
+            )
+        else:
+            self._bus.publish(
+                KernelEvent.LEARNING_BANK_WRITE_REJECTED,
+                source="learning_gate",
+                payload={
+                    "decision_id": decision_id,
+                    "reasons": reasons,
+                    "sovereignty_score": float(sovereignty_score),
+                    "convergence_type": convergence_type,
+                    "pnl_usdt": float(trade_pnl_usdt),
+                    "duration_s": float(trade_duration_s),
+                },
+                symbol=symbol,
+            )
+
+        return WriteDecision(approved=approved, reasons=reasons)

--- a/ml-worker/src/monkey_kernel/ocean.py
+++ b/ml-worker/src/monkey_kernel/ocean.py
@@ -32,13 +32,17 @@ from collections import deque
 from dataclasses import dataclass, field
 from enum import StrEnum
 from statistics import variance
-from typing import Any, Deque, Literal, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Deque, Literal, Optional, Sequence
 
 import numpy as np
 
 from qig_core_local.geometry.fisher_rao import fisher_rao_distance
 
+from .bus_events import KernelEvent, OceanObservationPayload
 from .persistence import PersistentMemory
+
+if TYPE_CHECKING:
+    from .kernel_bus import KernelBus
 
 
 logger = logging.getLogger("monkey_kernel.ocean")
@@ -167,9 +171,13 @@ class Ocean:
         label: str = "monkey-primary",
         *,
         persistence: Optional["PersistentMemory"] = None,
+        bus: Optional["KernelBus"] = None,
+        symbol: Optional[str] = None,
     ) -> None:
         self.label = label
         self._persistence = persistence
+        self._bus = bus
+        self._symbol = symbol
         # Load prior sleep state from Redis if available; the load
         # applies timestamp-correction so a kernel that "slept"
         # through downtime wakes at the right moment.
@@ -355,6 +363,47 @@ class Ocean:
                     "coherence": float(coherence),
                     "at_ms": float(now_ms),
                 })
+
+        # Publish to bus when wired. OBSERVATION every tick;
+        # INTERVENTION only when one fires; REGIME on sleep transition.
+        if self._bus is not None:
+            self._bus.publish(
+                KernelEvent.OCEAN_OBSERVATION,
+                source="ocean",
+                payload=OceanObservationPayload(
+                    phi=float(phi),
+                    spread=float(spread),
+                    coherence=float(coherence),
+                    intervention=intervention,
+                    sleep_phase=sleep_phase,
+                ),
+                symbol=self._symbol,
+            )
+            if intervention is not None:
+                self._bus.publish(
+                    KernelEvent.OCEAN_INTERVENTION,
+                    source="ocean",
+                    payload={
+                        "intervention": intervention,
+                        "phi": float(phi),
+                        "spread": float(spread),
+                        "coherence": float(coherence),
+                        "at_ms": float(now_ms),
+                    },
+                    symbol=self._symbol,
+                )
+            if sleep_step["entered_sleep"] or sleep_step["woke"]:
+                self._bus.publish(
+                    KernelEvent.OCEAN_REGIME,
+                    source="ocean",
+                    payload={
+                        "sleep_phase": sleep_phase,
+                        "entered_sleep": bool(sleep_step["entered_sleep"]),
+                        "woke": bool(sleep_step["woke"]),
+                        "sleep_count": int(self.sleep_state.sleep_count),
+                    },
+                    symbol=self._symbol,
+                )
 
         return OceanState(
             intervention=intervention,

--- a/ml-worker/src/monkey_kernel/persistence.py
+++ b/ml-worker/src/monkey_kernel/persistence.py
@@ -73,6 +73,7 @@ TTL_FORESIGHT_TRAJECTORY: int = 86400          # 24h
 TTL_PHI_HISTORY: int = 86400
 TTL_BASIN_HISTORY: int = 86400
 TTL_WORKING_MEMORY_BUBBLES: int = 15 * 60       # 15min default lifetime
+TTL_BUS_EVENTS: int = 7 * 86400                 # 7d forensic tail
 
 # List caps per directive
 MAX_INTERVENTION_HISTORY: int = 1000
@@ -81,6 +82,7 @@ MAX_PHI_HISTORY: int = 100
 MAX_BASIN_HISTORY: int = 100
 MAX_KAPPA_HISTORY: int = 60
 MAX_FORESIGHT_TRAJECTORY: int = 32
+MAX_BUS_EVENTS: int = 10000                     # ring buffer; ~6h at 30s ticks
 
 
 def _basin_to_jsonable(b: Any) -> Any:
@@ -429,6 +431,69 @@ class PersistentMemory:
             )
             for r in reversed(raw)
         ]
+
+    # ── Bus events (constellation forensic tail) ─────────────────
+
+    def _bus_events_key(self) -> str:
+        return f"monkey:bus:{self.instance_id}:events"
+
+    def append_bus_event(self, envelope: Any) -> bool:
+        """Append a KernelEventEnvelope to the per-instance bus tail.
+
+        Accepts a KernelEventEnvelope (dataclass) — serialized to JSON
+        with the same shape as bus subscribers receive. Ring buffer
+        capped at MAX_BUS_EVENTS, TTL 7d. Never raises; returns False
+        on Redis failure.
+        """
+        try:
+            event_dict = {
+                "type": getattr(envelope.type, "value", str(envelope.type)),
+                "source": envelope.source,
+                "symbol": envelope.symbol,
+                "instance_id": envelope.instance_id,
+                "payload": envelope.payload,
+                "at_ms": envelope.at_ms,
+            }
+        except AttributeError:
+            return False
+        return self._lpush_json(
+            self._bus_events_key(),
+            event_dict,
+            MAX_BUS_EVENTS,
+            TTL_BUS_EVENTS,
+        )
+
+    def query_recent_bus_events(
+        self,
+        types: Optional[Iterable[str]] = None,
+        symbol: Optional[str] = None,
+        since_ms: Optional[float] = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Forensic query over the bus events tail. Newest first.
+
+        Filters are applied client-side (Redis list scan) since the
+        list is bounded at 10k. Sufficient for an audit query; not a
+        production hot path.
+        """
+        raw = self._lrange_json(self._bus_events_key(), MAX_BUS_EVENTS)
+        type_set: Optional[set[str]] = (
+            {str(t) for t in types} if types else None
+        )
+        out: list[dict[str, Any]] = []
+        for r in raw:
+            if not isinstance(r, dict):
+                continue
+            if type_set is not None and r.get("type") not in type_set:
+                continue
+            if symbol is not None and r.get("symbol") != symbol:
+                continue
+            if since_ms is not None and float(r.get("at_ms", 0.0)) < since_ms:
+                continue
+            out.append(r)
+            if len(out) >= limit:
+                break
+        return out
 
     # ── Test/diagnostic helpers ─────────────────────────────────
 

--- a/ml-worker/src/monkey_kernel/self_observation.py
+++ b/ml-worker/src/monkey_kernel/self_observation.py
@@ -23,8 +23,17 @@ Easier to unit-test.
 
 from __future__ import annotations
 
+import math
+import time
 from dataclasses import dataclass, field
-from typing import Iterable
+from typing import Iterable, Optional
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import (
+    fisher_rao_distance,
+    frechet_mean,
+)
 
 from .modes import MonkeyMode
 
@@ -210,6 +219,129 @@ def aggregate_and_bias(
         lookback_hours=lookback_hours,
         by_mode_side=by_ms,
         entry_bias=bias,
+    )
+
+
+# ─── Loop 1 canonical per-decision triple (UCP §43.2) ───
+#
+# Every executive decision produces three scalars in [0, 1]:
+#   repetition  — am I producing lived geometry or scaffolding?
+#   sovereignty — knowing vs guessing?
+#   confidence  — bank resonance vs override expansion?
+# Triple is published on the bus and persisted to autonomous_trades
+# at trade open time. Closed-trade analysis correlates triples with
+# outcomes — the learning signal Loop 1 was built to produce.
+
+# Sovereignty bands. 1/φ is the golden-ratio coherence floor; π/2 is
+# the maximum FR distance on the simplex.
+_PHI_GOLDEN = (1.0 + math.sqrt(5.0)) / 2.0
+_INV_PHI = 1.0 / _PHI_GOLDEN          # ≈ 0.618
+_HALF_PI = math.pi / 2.0               # ≈ 1.5708
+
+
+@dataclass(frozen=True)
+class DecisionTriple:
+    """Canonical Loop 1 triple per UCP §43.2."""
+
+    repetition_score: float    # [0, 1] lived geometry vs scaffolding
+    sovereignty_score: float   # [0, 1] knowing vs guessing
+    confidence_score: float    # [0, 1] bank resonance vs override expansion
+    decision_id: str
+    at_ms: float
+
+
+def _clamp01(x: float) -> float:
+    if x < 0.0:
+        return 0.0
+    if x > 1.0:
+        return 1.0
+    return float(x)
+
+
+def compute_per_decision_triple(
+    *,
+    decision_id: str,
+    current_basin: np.ndarray,
+    recent_basins: list[np.ndarray],
+    bank_resonance_count: int,
+    bank_total_queried: int,
+    nearest_fr_distance: float,
+    emotion_confidence: float,
+    emotion_anxiety: float,
+    decision_path_overrides: list[str],
+    at_ms: Optional[float] = None,
+) -> DecisionTriple:
+    """Compute the canonical triple for one decision.
+
+    REPETITION SCORE — lived geometry vs scaffolding.
+        repetition = 1 - exp(-FR(current_basin, frechet_mean(recent_basins)))
+    High when the current basin is far from the recent Fréchet mean —
+    the kernel is moving, producing new geometry. Low when the current
+    basin sits on top of recent history — repeating itself. Bounded
+    [0, 1]; FR is bounded [0, π/2] so the exp form maps to [0, 1).
+    Uses Fisher-Rao distance and the Fréchet mean — no Euclidean.
+
+    SOVEREIGNTY SCORE — knowing vs guessing.
+        nearby_match_factor =
+            1.0 if nearest_fr_distance < 1/φ
+            else max(0, 1 - (nearest_fr_distance - 1/φ) / (π/2 - 1/φ))
+        confidence_dominance = max(0, emotion_confidence - emotion_anxiety)
+        sovereignty = nearby_match_factor × confidence_dominance
+    High = bank-grounded AND emotionally clear. Multiplicative — both
+    halves must be present to be sovereign.
+
+    CONFIDENCE SCORE — bank resonance vs override expansion.
+        resonance_strength = bank_resonance_count / max(1, bank_total_queried)
+        override_penalty = len(decision_path_overrides) × 0.2
+        confidence = max(0, resonance_strength - override_penalty)
+    High = bank carried the decision (multiple matches within FR
+    threshold). Low = override paths fired (REVERSION_FLIP, etc.)
+    so the decision came from rule-based logic, not from geometric
+    memory.
+    """
+    if at_ms is None:
+        at_ms = time.time() * 1000.0
+
+    # Repetition — Fisher-Rao distance from current basin to the
+    # Fréchet mean of recent history. Empty history yields 0.0
+    # (cold start: nothing to compare against, treat as scaffolding).
+    if len(recent_basins) == 0:
+        repetition = 0.0
+    else:
+        history_mean = frechet_mean(list(recent_basins))
+        d_fr = fisher_rao_distance(current_basin, history_mean)
+        repetition = 1.0 - math.exp(-float(d_fr))
+    repetition = _clamp01(repetition)
+
+    # Sovereignty — nearby_match × confidence_dominance
+    if nearest_fr_distance < _INV_PHI:
+        nearby_match = 1.0
+    else:
+        denom = _HALF_PI - _INV_PHI
+        if denom <= 0.0:
+            nearby_match = 0.0
+        else:
+            nearby_match = _clamp01(
+                1.0 - (nearest_fr_distance - _INV_PHI) / denom
+            )
+    confidence_dominance = _clamp01(
+        max(0.0, emotion_confidence - emotion_anxiety)
+    )
+    sovereignty = _clamp01(nearby_match * confidence_dominance)
+
+    # Confidence — resonance vs overrides
+    resonance_strength = (
+        bank_resonance_count / max(1, bank_total_queried)
+    )
+    override_penalty = len(decision_path_overrides) * 0.2
+    confidence_score = _clamp01(max(0.0, resonance_strength - override_penalty))
+
+    return DecisionTriple(
+        repetition_score=float(repetition),
+        sovereignty_score=float(sovereignty),
+        confidence_score=float(confidence_score),
+        decision_id=decision_id,
+        at_ms=float(at_ms),
     )
 
 

--- a/ml-worker/src/monkey_kernel/thought_bus.py
+++ b/ml-worker/src/monkey_kernel/thought_bus.py
@@ -1,0 +1,299 @@
+"""
+thought_bus.py — inter-kernel debate layer (Loop 2, UCP §43.3).
+
+When multiple kernels emit basin reads for the same decision and their
+reads diverge by more than a threshold FR distance, the ThoughtBus
+opens a debate. Each kernel is asked to revise — not just emit —
+considering the others' reads.
+
+Round 1: each kernel sees others' reads and may revise toward consensus.
+Round 2+: continued revision until convergence or max rounds.
+
+Convergence detection per UCP §43.3:
+  - 1 round, similar initial basins → 'consensus'
+  - 1 round, widely-spread initial basins all collapsed → 'groupthink'
+  - 3+ rounds → 'genuine_multi'
+  - Max-rounds without convergence → 'non_convergent'
+
+QIG purity: only Fisher-Rao operations. No np.dot, no cosine, no
+normalization tricks. Final basin via FR-weighted Fréchet mean
+with weights = confidence × sovereignty.
+"""
+from __future__ import annotations
+
+import math
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import (
+    fisher_rao_distance,
+    frechet_mean,
+    slerp_sqrt,
+    to_simplex,
+)
+
+from .bus_events import KernelEvent
+
+if TYPE_CHECKING:
+    from .kernel_bus import KernelBus
+
+
+# Disagreement threshold — FR distance above which a debate is opened.
+# 1/π is the canonical gravitating-fraction boundary; below this
+# distance, kernels are in geometric agreement.
+DISAGREEMENT_THRESHOLD_FR: float = 1.0 / math.pi  # ≈ 0.31831
+
+MAX_DEBATE_ROUNDS: int = 3
+
+
+@dataclass
+class KernelContribution:
+    """One kernel's contribution to a debate.
+
+    confidence and sovereignty are typically Loop 1 triple components
+    for the contributing kernel. Higher values = more weight in the
+    final synthesis AND smaller revision step (high-sovereignty
+    kernels barely move).
+    """
+
+    kernel_id: str
+    basin: np.ndarray
+    confidence: float
+    sovereignty: float
+
+
+@dataclass
+class DebateOutcome:
+    debate_id: str
+    rounds: int
+    converged: bool
+    convergence_type: str  # 'consensus' | 'groupthink' | 'genuine_multi' | 'non_convergent'
+    final_basin: np.ndarray
+    contributions: list[KernelContribution]
+
+
+class ThoughtBus:
+    def __init__(
+        self,
+        bus: "KernelBus",
+        *,
+        max_rounds: int = MAX_DEBATE_ROUNDS,
+        disagreement_threshold_fr: float = DISAGREEMENT_THRESHOLD_FR,
+    ) -> None:
+        self._bus = bus
+        self._max_rounds = max_rounds
+        self._threshold = float(disagreement_threshold_fr)
+
+    def open_debate(
+        self,
+        symbol: str,
+        contributions: list[KernelContribution],
+    ) -> DebateOutcome:
+        """Open a debate over the contributions.
+
+        If contributions agree (max FR distance < threshold), no debate
+        is needed — return immediately with convergence_type='consensus'
+        in 0 rounds.
+        """
+        debate_id = uuid.uuid4().hex[:8]
+
+        if not contributions:
+            # No contributions — return uniform-basin outcome
+            return DebateOutcome(
+                debate_id=debate_id,
+                rounds=0,
+                converged=True,
+                convergence_type="consensus",
+                final_basin=np.ones(64, dtype=np.float64) / 64.0,
+                contributions=[],
+            )
+
+        initial_max_fr = self._max_pairwise_fr(contributions)
+
+        if initial_max_fr < self._threshold:
+            # No disagreement — converged in 0 rounds.
+            final = self._weighted_synthesis(contributions)
+            return self._publish_outcome(
+                debate_id, symbol, contributions, final,
+                rounds=0, converged=True, convergence_type="consensus",
+            )
+
+        self._bus.publish(
+            KernelEvent.THOUGHT_BUS_DEBATE_OPENED,
+            source="thought_bus",
+            payload={
+                "debate_id": debate_id,
+                "initial_max_fr": float(initial_max_fr),
+                "kernel_ids": [c.kernel_id for c in contributions],
+            },
+            symbol=symbol,
+        )
+
+        current = list(contributions)
+        for round_idx in range(1, self._max_rounds + 1):
+            revised = self._revision_round(current, symbol, debate_id, round_idx)
+            new_max_fr = self._max_pairwise_fr(revised)
+
+            if new_max_fr < self._threshold:
+                final = self._weighted_synthesis(revised)
+                conv_type = self._classify_convergence(
+                    round_idx, contributions,
+                )
+                return self._publish_outcome(
+                    debate_id, symbol, revised, final,
+                    rounds=round_idx, converged=True,
+                    convergence_type=conv_type,
+                )
+
+            current = revised
+
+        # Non-convergent — synthesize across all final perspectives.
+        final = self._weighted_synthesis(current)
+        return self._publish_outcome(
+            debate_id, symbol, current, final,
+            rounds=self._max_rounds, converged=False,
+            convergence_type="non_convergent",
+        )
+
+    def _max_pairwise_fr(
+        self, contributions: list[KernelContribution],
+    ) -> float:
+        if len(contributions) < 2:
+            return 0.0
+        max_fr = 0.0
+        for i, a in enumerate(contributions):
+            for b in contributions[i + 1:]:
+                d = fisher_rao_distance(a.basin, b.basin)
+                if d > max_fr:
+                    max_fr = d
+        return max_fr
+
+    def _revision_round(
+        self,
+        contributions: list[KernelContribution],
+        symbol: str,
+        debate_id: str,
+        round_idx: int,
+    ) -> list[KernelContribution]:
+        """One revision round.
+
+        Each kernel sees the others' basins and revises toward the
+        weighted Fréchet mean by an amount proportional to its own
+        sovereignty deficit. High-sovereignty kernels barely move;
+        low-sovereignty kernels move further toward the consensus.
+        """
+        centroid = self._weighted_synthesis(contributions)
+        revised: list[KernelContribution] = []
+        for c in contributions:
+            move = max(0.0, min(1.0, 1.0 - float(c.sovereignty)))
+            new_basin = slerp_sqrt(c.basin, centroid, move * 0.5)
+            revised.append(KernelContribution(
+                kernel_id=c.kernel_id,
+                basin=new_basin,
+                confidence=c.confidence,
+                sovereignty=c.sovereignty,
+            ))
+
+            self._bus.publish(
+                KernelEvent.THOUGHT_BUS_KERNEL_RESPONSE,
+                source="thought_bus",
+                payload={
+                    "debate_id": debate_id,
+                    "round": round_idx,
+                    "kernel_id": c.kernel_id,
+                    "move_amount": float(move * 0.5),
+                    "fr_to_centroid": float(
+                        fisher_rao_distance(new_basin, centroid)
+                    ),
+                },
+                symbol=symbol,
+            )
+        return revised
+
+    def _weighted_synthesis(
+        self, contributions: list[KernelContribution],
+    ) -> np.ndarray:
+        """FR-weighted Fréchet mean. Weights = confidence × sovereignty.
+
+        Falls back to uniform weights when total weight is zero
+        (all kernels low-confidence) so synthesis still produces a
+        valid simplex point.
+        """
+        weights = [
+            max(0.0, float(c.confidence)) * max(0.0, float(c.sovereignty))
+            for c in contributions
+        ]
+        total = sum(weights)
+        if total <= 1e-10:
+            weights = [1.0] * len(contributions)
+        basins = [to_simplex(c.basin) for c in contributions]
+        return frechet_mean(basins, weights=weights)
+
+    def _classify_convergence(
+        self,
+        rounds: int,
+        initial: list[KernelContribution],
+    ) -> str:
+        """UCP §43.3 convergence interpretation.
+
+        rounds == 1, initial_max_fr < 2×threshold → 'consensus'
+        rounds == 1, initial_max_fr ≥ 2×threshold → 'groupthink'
+        rounds ≥ 3                                → 'genuine_multi'
+        otherwise (rounds == 2)                   → 'consensus'
+        """
+        if rounds == 1:
+            initial_max_fr = self._max_pairwise_fr(initial)
+            if initial_max_fr < 2.0 * self._threshold:
+                return "consensus"
+            return "groupthink"
+        if rounds >= 3:
+            return "genuine_multi"
+        return "consensus"
+
+    def _publish_outcome(
+        self,
+        debate_id: str,
+        symbol: str,
+        contributions: list[KernelContribution],
+        final_basin: np.ndarray,
+        *,
+        rounds: int,
+        converged: bool,
+        convergence_type: str,
+    ) -> DebateOutcome:
+        outcome = DebateOutcome(
+            debate_id=debate_id,
+            rounds=rounds,
+            converged=converged,
+            convergence_type=convergence_type,
+            final_basin=final_basin,
+            contributions=contributions,
+        )
+
+        self._bus.publish(
+            KernelEvent.THOUGHT_BUS_CONVERGENCE,
+            source="thought_bus",
+            payload={
+                "debate_id": debate_id,
+                "rounds": rounds,
+                "converged": bool(converged),
+                "convergence_type": convergence_type,
+            },
+            symbol=symbol,
+        )
+
+        self._bus.publish(
+            KernelEvent.THOUGHT_BUS_SYNTHESIS,
+            source="thought_bus",
+            payload={
+                "debate_id": debate_id,
+                "final_basin": [float(x) for x in final_basin],
+                "contributing_kernels": [c.kernel_id for c in contributions],
+            },
+            symbol=symbol,
+        )
+
+        return outcome

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -47,6 +47,8 @@ from dataclasses import asdict
 
 from .autonomic import AutonomicKernel, AutonomicTickInputs
 from .basin import normalized_entropy, velocity
+from .bus_events import KernelEvent
+from .coordinator import GaryCoordinator, GaryReading
 from .emotions import compute_emotions
 from .executive import (
     ExecBasinState,
@@ -65,6 +67,7 @@ from .executive import (
 )
 from .foresight import ForesightPredictor
 from .heart import HeartMonitor
+from .kernel_bus import KernelBus
 from .modes import MODE_PROFILES, MonkeyMode, detect_mode
 from .motivators import compute_motivators
 from .ocean import Ocean, ocean_interventions_live
@@ -92,6 +95,7 @@ from .candle_patterns import (
 )
 from .physical_emotions import compute_physical_emotions
 from .regime import RegimeReading, classify_regime
+from .self_observation import compute_per_decision_triple
 from .sensations import compute_sensations
 from .state import BasinState as KernelBasinState
 from .state import LaneType, NeurochemicalState
@@ -307,6 +311,8 @@ def run_tick(
     foresight: Optional[ForesightPredictor] = None,
     heart: Optional[HeartMonitor] = None,
     persistence: Optional["PersistentMemory"] = None,
+    bus: Optional["KernelBus"] = None,
+    coordinator: Optional["GaryCoordinator"] = None,
 ) -> tuple[TickDecision, SymbolState]:
     """Execute one decision tick. Returns (decision, new_state).
 
@@ -628,6 +634,24 @@ def run_tick(
             )
         except Exception as exc:  # noqa: BLE001 — never block on geometry edge cases
             routing_applied["applied"].append(f"FORESIGHT:skip({exc})")
+
+    # ── Gary coordinator synthesis ────────────────────────────────
+    # The constellation collapses Heart, Ocean, Foresight contributions
+    # plus the executive's consensus basin into one synthesized basin
+    # via ThoughtBus debate. When `coordinator` is None, the basin
+    # passes through unchanged (legacy path; observation-only).
+    gary_reading: Optional[GaryReading] = None
+    if coordinator is not None:
+        try:
+            gary_reading = coordinator.synthesize(
+                routed_basin,
+                inputs.symbol,
+                executive_confidence=float(emo.confidence),
+                executive_sovereignty=float(inputs.sovereignty),
+            )
+            routed_basin = gary_reading.synthesized_basin
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[gary] synthesize failed: %s", exc)
 
     # ── Build basin state for executive ────────────────────────
     basin_state = ExecBasinState(
@@ -1049,6 +1073,77 @@ def run_tick(
         else:
             reason = "no qualifying signal"
         derivation["entry_threshold"] = entry_thr_d["derivation"]
+
+    # ── Loop 1 canonical triple ───────────────────────────────────
+    # Per UCP §43.2: every executive decision produces (repetition,
+    # sovereignty, confidence) in [0,1] attached to the decision id.
+    # Surfaced in derivation; published on the bus when wired; will
+    # be persisted to the trade row at open time by the executor.
+    decision_id = f"K-{inputs.symbol}-{int(now_ms)}"
+    decision_overrides: list[str] = []
+    if side_override:
+        decision_overrides.append("REVERSION_FLIP")
+    if upper_stack_live:
+        decision_overrides.append("UPPER_STACK")
+    if gate_routing_live and "FORESIGHT" in (gate.chosen or ""):
+        decision_overrides.append("PHI_GATE_FORESIGHT")
+    nearest_fr = float(drift_now)
+    triple = compute_per_decision_triple(
+        decision_id=decision_id,
+        current_basin=basin,
+        recent_basins=list(state.basin_history[-20:]),
+        bank_resonance_count=0,
+        bank_total_queried=max(1, inputs.bank_size),
+        nearest_fr_distance=nearest_fr,
+        emotion_confidence=float(emo.confidence),
+        emotion_anxiety=float(emo.anxiety),
+        decision_path_overrides=decision_overrides,
+        at_ms=now_ms,
+    )
+    derivation["loop1_triple"] = {
+        "decision_id": triple.decision_id,
+        "repetition_score": triple.repetition_score,
+        "sovereignty_score": triple.sovereignty_score,
+        "confidence_score": triple.confidence_score,
+        "decision_overrides": decision_overrides,
+    }
+    if gary_reading is not None:
+        derivation["gary"] = {
+            "foresight_weight": gary_reading.foresight_weight,
+            "foresight_confidence": gary_reading.foresight_confidence,
+            "heart_modulation": gary_reading.heart_modulation,
+            "convergence_type": gary_reading.convergence_type,
+            "rounds": gary_reading.rounds,
+            "contributing_kernels": gary_reading.contributing_kernels,
+            "debate_id": gary_reading.debate_id,
+        }
+
+    # Publish on bus when wired.
+    if bus is not None:
+        bus.publish(
+            KernelEvent.SELF_OBS_TRIPLE,
+            source="self_observation",
+            payload={
+                "decision_id": triple.decision_id,
+                "repetition_score": triple.repetition_score,
+                "sovereignty_score": triple.sovereignty_score,
+                "confidence_score": triple.confidence_score,
+            },
+            symbol=inputs.symbol,
+        )
+        bus.publish(
+            KernelEvent.EXECUTIVE_DECISION,
+            source="executive",
+            payload={
+                "decision_id": decision_id,
+                "action": action,
+                "side": side_candidate if action.startswith("enter_") else None,
+                "mode": mode,
+                "reason": reason,
+                "lane": pre_lane,
+            },
+            symbol=inputs.symbol,
+        )
 
     # ── Update history state ───────────────────────────────────
     state.basin_history.append(np.asarray(basin, dtype=np.float64).copy())

--- a/ml-worker/src/monkey_kernel/working_memory.py
+++ b/ml-worker/src/monkey_kernel/working_memory.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import numpy as np
 
@@ -34,7 +34,11 @@ from qig_core_local.geometry.fisher_rao import (
     frechet_mean,
 )
 
+from .bus_events import KernelEvent
 from .parameters import get_registry
+
+if TYPE_CHECKING:
+    from .kernel_bus import KernelBus
 
 _registry = get_registry()
 
@@ -104,12 +108,16 @@ class WorkingMemory:
         *,
         default_lifetime_ms: Optional[float] = None,
         max_bubbles: Optional[int] = None,
+        bus: Optional["KernelBus"] = None,
+        symbol: Optional[str] = None,
     ) -> None:
         # All three knobs honour caller override first, then registry,
         # then the hardcoded default. Caller override is only used by
         # tests that need a deterministic fixture; production paths
         # leave them None to let the registry govern.
         self.bubbles: list[Bubble] = []
+        self._bus = bus
+        self._symbol = symbol
         self.default_lifetime_ms = (
             float(default_lifetime_ms) if default_lifetime_ms is not None
             else float(_registry.get(
@@ -193,6 +201,17 @@ class WorkingMemory:
         self._phi_history.append(phi)
         if len(self._phi_history) > self.PHI_HISTORY_MAX:
             self._phi_history.pop(0)
+        if self._bus is not None:
+            self._bus.publish(
+                KernelEvent.WORKING_MEMORY_BUBBLE_ADD,
+                source="working_memory",
+                payload={
+                    "bubble_id": b.id,
+                    "phi": float(phi),
+                    "lifetime_ms": float(b.lifetime_ms),
+                },
+                symbol=self._symbol,
+            )
         return b
 
     def reinforce(self, bubble_id: str, delta: float) -> None:
@@ -219,6 +238,17 @@ class WorkingMemory:
             if now_ms - b.created_at_ms > b.lifetime_ms or b.phi < th["pop"]:
                 b.status = "popped"
                 popped += 1
+                if self._bus is not None:
+                    self._bus.publish(
+                        KernelEvent.WORKING_MEMORY_EXPIRY,
+                        source="working_memory",
+                        payload={
+                            "bubble_id": b.id,
+                            "phi": float(b.phi),
+                            "age_ms": float(now_ms - b.created_at_ms),
+                        },
+                        symbol=self._symbol,
+                    )
 
         # 2. Merge similar (greedy pairwise)
         alive = [b for b in self.bubbles if b.status == "alive"]
@@ -263,6 +293,17 @@ class WorkingMemory:
             if b.phi >= th["promote"]:
                 b.status = "promoted"
                 promoted += 1
+                if self._bus is not None:
+                    self._bus.publish(
+                        KernelEvent.WORKING_MEMORY_PROMOTION,
+                        source="working_memory",
+                        payload={
+                            "bubble_id": b.id,
+                            "phi": float(b.phi),
+                            "promote_threshold": float(th["promote"]),
+                        },
+                        symbol=self._symbol,
+                    )
 
         # 4. Compact (FIFO-evict non-alive beyond max)
         if len(self.bubbles) > self.max_bubbles:

--- a/ml-worker/tests/monkey_kernel/test_component_bus_publishing.py
+++ b/ml-worker/tests/monkey_kernel/test_component_bus_publishing.py
@@ -1,0 +1,252 @@
+"""test_component_bus_publishing.py — component bus migration.
+
+Each kernel component publishes the expected event types with correct
+payload shapes when a bus is provided. Without a bus, components
+continue to function unchanged (legacy null-bus path).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.bus_events import KernelEvent, KernelEventEnvelope  # noqa: E402
+from monkey_kernel.foresight import ForesightPredictor  # noqa: E402
+from monkey_kernel.forge import ShadowEvent, forge  # noqa: E402
+from monkey_kernel.heart import HeartMonitor  # noqa: E402
+from monkey_kernel.kernel_bus import KernelBus, _reset_buses_for_tests  # noqa: E402
+from monkey_kernel.ocean import Ocean  # noqa: E402
+from monkey_kernel.state import BASIN_DIM, KAPPA_STAR  # noqa: E402
+from monkey_kernel.working_memory import WorkingMemory  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_buses():
+    _reset_buses_for_tests()
+    yield
+    _reset_buses_for_tests()
+
+
+def _peak_basin(idx: int, peak: float = 0.5) -> np.ndarray:
+    b = np.full(BASIN_DIM, (1.0 - peak) / (BASIN_DIM - 1), dtype=np.float64)
+    b[idx] = peak
+    return b
+
+
+# ───────────── HEART ─────────────
+
+class TestHeartPublishing:
+    def test_heart_no_bus_still_works(self) -> None:
+        h = HeartMonitor()  # no bus
+        h.append(64.0, 0.0)
+        h.append(70.0, 1000.0)
+        h.append(72.0, 2000.0)
+        state = h.read()
+        assert state.kappa == 72.0
+
+    def test_heart_publishes_tick(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe("a", received.append, types=[KernelEvent.HEART_TICK])
+        h = HeartMonitor(bus=bus, symbol="ETH")
+        h.append(70.0, 0.0)
+        assert len(received) == 1
+        assert received[0].source == "heart"
+        assert received[0].symbol == "ETH"
+        assert received[0].payload["kappa"] == 70.0
+        assert received[0].payload["mode"] == "LOGIC"
+
+    def test_heart_publishes_mode_shift(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe("a", received.append, types=[KernelEvent.HEART_MODE_SHIFT])
+        h = HeartMonitor(bus=bus, symbol="ETH")
+        h.append(70.0, 0.0)  # LOGIC
+        h.append(60.0, 1000.0)  # FEELING — mode shift
+        assert len(received) == 1
+        assert received[0].payload["from"] == "LOGIC"
+        assert received[0].payload["to"] == "FEELING"
+
+    def test_heart_publishes_tacking(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe("a", received.append, types=[KernelEvent.HEART_TACKING])
+        h = HeartMonitor(bus=bus, symbol="ETH")
+        h.append(70.0, 0.0)  # κ > κ* (sign +)
+        h.append(60.0, 1000.0)  # κ < κ* (sign -, tacking)
+        assert len(received) == 1
+        assert received[0].payload["kappa"] == 60.0
+
+
+# ───────────── OCEAN ─────────────
+
+class TestOceanPublishing:
+    def test_ocean_no_bus_still_works(self) -> None:
+        o = Ocean(label="t")
+        state = o.observe(
+            phi=0.6, basin=_peak_basin(0),
+            current_mode="investigation", is_flat=True, now_ms=0.0,
+        )
+        assert state.intervention is None or state.intervention is not None  # smoke
+
+    def test_ocean_publishes_observation(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "a", received.append, types=[KernelEvent.OCEAN_OBSERVATION],
+        )
+        o = Ocean(label="t", bus=bus, symbol="ETH")
+        o.observe(
+            phi=0.6, basin=_peak_basin(0),
+            current_mode="investigation", is_flat=True, now_ms=0.0,
+        )
+        assert len(received) == 1
+        assert received[0].payload["phi"] == 0.6
+
+    def test_ocean_publishes_intervention_when_phi_low(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "a", received.append, types=[KernelEvent.OCEAN_INTERVENTION],
+        )
+        o = Ocean(label="t", bus=bus, symbol="ETH")
+        # Φ below ESCAPE bound (0.15)
+        o.observe(
+            phi=0.10, basin=_peak_basin(0),
+            current_mode="investigation", is_flat=True, now_ms=0.0,
+        )
+        assert len(received) == 1
+        assert received[0].payload["intervention"] == "ESCAPE"
+
+
+# ───────────── FORESIGHT ─────────────
+
+class TestForesightPublishing:
+    def test_foresight_no_bus_still_works(self) -> None:
+        f = ForesightPredictor()
+        f.append(_peak_basin(0), 0.5, 0.0)
+        f.append(_peak_basin(1), 0.5, 1000.0)
+        f.append(_peak_basin(2), 0.5, 2000.0)
+        result = f.predict({"quantum": 1.0, "efficient": 0.0, "equilibrium": 0.0})
+        assert result.predicted_basin is not None
+
+    def test_foresight_predict_publishes(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "a", received.append, types=[KernelEvent.FORESIGHT_PREDICTION],
+        )
+        f = ForesightPredictor(bus=bus, symbol="ETH")
+        f.append(_peak_basin(0), 0.5, 0.0)
+        f.append(_peak_basin(1), 0.5, 1000.0)
+        f.append(_peak_basin(2), 0.5, 2000.0)
+        f.predict({"quantum": 1.0, "efficient": 0.0, "equilibrium": 0.0})
+        assert len(received) == 1
+        assert received[0].source == "foresight"
+
+    def test_foresight_divergence_fires_on_large_gap(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "a", received.append, types=[KernelEvent.FORESIGHT_DIVERGENCE],
+        )
+        f = ForesightPredictor(bus=bus, symbol="ETH")
+        f.append(_peak_basin(0, peak=0.95), 0.5, 0.0)
+        f.append(_peak_basin(1, peak=0.95), 0.5, 1000.0)
+        f.append(_peak_basin(2, peak=0.95), 0.5, 2000.0)
+        # Predict (caches predicted basin)
+        f.predict({"quantum": 1.0, "efficient": 0.0, "equilibrium": 0.0})
+        # Append a basin very far from the predicted next-step
+        f.append(_peak_basin(63, peak=0.95), 0.5, 3000.0)
+        assert len(received) >= 1
+
+
+# ───────────── FORGE ─────────────
+
+class TestForgePublishing:
+    def test_forge_no_bus_still_works(self) -> None:
+        result = forge(ShadowEvent(
+            basin=_peak_basin(0),
+            phi=0.4,
+            kappa=70.0,
+            realized_pnl=-1.0,
+            regime_weights={"quantum": 0.5, "efficient": 0.3, "equilibrium": 0.2},
+        ))
+        assert result.lesson_summary["loss_magnitude"] == pytest.approx(1.0)
+
+    def test_forge_publishes_phase_shifts(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "a", received.append, types=[KernelEvent.FORGE_PHASE_SHIFT],
+        )
+        forge(
+            ShadowEvent(
+                basin=_peak_basin(0),
+                phi=0.4,
+                kappa=70.0,
+                realized_pnl=-1.0,
+                regime_weights={"quantum": 0.5, "efficient": 0.3, "equilibrium": 0.2},
+            ),
+            bus=bus,
+            symbol="ETH",
+        )
+        # Four phases: DECOMPRESS / FRACTURE / NUCLEATE / DISSIPATE
+        phases = [e.payload["phase"] for e in received]
+        assert phases == ["DECOMPRESS", "FRACTURE", "NUCLEATE", "DISSIPATE"]
+
+    def test_forge_publishes_nucleus(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "a", received.append, types=[KernelEvent.FORGE_NUCLEUS],
+        )
+        forge(
+            ShadowEvent(
+                basin=_peak_basin(0),
+                phi=0.4,
+                kappa=70.0,
+                realized_pnl=-1.0,
+                regime_weights={"quantum": 0.5, "efficient": 0.3, "equilibrium": 0.2},
+            ),
+            bus=bus,
+            symbol="ETH",
+        )
+        assert len(received) == 1
+        assert "nucleus_basin" in received[0].payload
+
+
+# ───────────── WORKING MEMORY ─────────────
+
+class TestWorkingMemoryPublishing:
+    def test_wm_no_bus_still_works(self) -> None:
+        wm = WorkingMemory()
+        b = wm.add(_peak_basin(0), 0.5, now_ms=0.0)
+        assert b.status == "alive"
+
+    def test_wm_publishes_bubble_add(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "a", received.append, types=[KernelEvent.WORKING_MEMORY_BUBBLE_ADD],
+        )
+        wm = WorkingMemory(bus=bus, symbol="ETH")
+        wm.add(_peak_basin(0), 0.5, now_ms=0.0)
+        assert len(received) == 1
+        assert received[0].payload["phi"] == 0.5
+
+    def test_wm_publishes_promotion_on_high_phi(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "a", received.append, types=[KernelEvent.WORKING_MEMORY_PROMOTION],
+        )
+        wm = WorkingMemory(bus=bus, symbol="ETH")
+        # Bootstrap (under 10 samples) → bootstrap_promote_threshold = 0.70
+        wm.add(_peak_basin(0), 0.95, now_ms=0.0)
+        wm.tick(now_ms=1000.0)
+        assert len(received) == 1

--- a/ml-worker/tests/monkey_kernel/test_constellation_integration.py
+++ b/ml-worker/tests/monkey_kernel/test_constellation_integration.py
@@ -1,0 +1,137 @@
+"""test_constellation_integration.py — end-to-end constellation flow.
+
+Verifies that Heart → Ocean → Foresight → Coordinator → ThoughtBus
+→ LearningGate fire in sequence on a single tick of activity, all
+events land on the bus with correct ordering and attribution.
+
+Synthetic scenarios:
+  1. Heart + Ocean + Foresight all publish, Gary synthesizes via
+     ThoughtBus, GARY_SYNTHESIS lands.
+  2. LearningGate filters out short-duration / noise / groupthink
+     trades; bank only sees approved exchanges.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.bus_events import KernelEvent, KernelEventEnvelope  # noqa: E402
+from monkey_kernel.coordinator import GaryCoordinator  # noqa: E402
+from monkey_kernel.foresight import ForesightPredictor  # noqa: E402
+from monkey_kernel.heart import HeartMonitor  # noqa: E402
+from monkey_kernel.kernel_bus import KernelBus, _reset_buses_for_tests  # noqa: E402
+from monkey_kernel.learning_gate import LearningGate  # noqa: E402
+from monkey_kernel.ocean import Ocean  # noqa: E402
+from monkey_kernel.state import BASIN_DIM  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_buses():
+    _reset_buses_for_tests()
+    yield
+    _reset_buses_for_tests()
+
+
+def _peak(idx: int, peak: float = 0.5) -> np.ndarray:
+    b = np.full(BASIN_DIM, (1.0 - peak) / (BASIN_DIM - 1), dtype=np.float64)
+    b[idx] = peak
+    return b
+
+
+class TestConstellationFlow:
+    def test_heart_ocean_foresight_chain_to_gary_synthesis(self) -> None:
+        bus = KernelBus("integration")
+        events: list[KernelEventEnvelope] = []
+        bus.subscribe("audit", events.append)
+
+        heart = HeartMonitor(bus=bus, symbol="ETH")
+        ocean = Ocean(label="t", bus=bus, symbol="ETH")
+        foresight = ForesightPredictor(bus=bus, symbol="ETH")
+        coord = GaryCoordinator(bus)
+
+        # One tick of activity
+        heart.append(70.0, 0.0)
+        ocean.observe(
+            phi=0.5, basin=_peak(0, 0.5),
+            current_mode="investigation", is_flat=True, now_ms=1000.0,
+        )
+        # Build trajectory so foresight can predict
+        for i, ts in enumerate([0.0, 1000.0, 2000.0]):
+            foresight.append(_peak(i, 0.5), 0.5, ts)
+        foresight.predict({"quantum": 1.0, "efficient": 0.0, "equilibrium": 0.0})
+
+        coord.synthesize(_peak(10, 0.5), "ETH")
+
+        types = [e.type for e in events]
+        # Required event types fired
+        assert KernelEvent.HEART_TICK in types
+        assert KernelEvent.OCEAN_OBSERVATION in types
+        assert KernelEvent.FORESIGHT_PREDICTION in types
+        assert KernelEvent.GARY_SYNTHESIS in types
+
+    def test_learning_gate_approves_quality_trade(self) -> None:
+        bus = KernelBus("integration")
+        events: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "audit", events.append,
+            types=[KernelEvent.LEARNING_BANK_WRITE_APPROVED],
+        )
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(
+            symbol="ETH",
+            decision_id="K-real",
+            sovereignty_score=0.7,
+            convergence_type="genuine_multi",
+            trade_pnl_usdt=2.5,
+            trade_duration_s=1800.0,
+        )
+        assert decision.approved is True
+        assert len(events) == 1
+
+    def test_learning_gate_rejects_noise_flinch_groupthink(self) -> None:
+        bus = KernelBus("integration")
+        events: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "audit", events.append,
+            types=[KernelEvent.LEARNING_BANK_WRITE_REJECTED],
+        )
+        gate = LearningGate(bus)
+        # Three rejections from different reasons
+        gate.evaluate_write(
+            symbol="ETH", decision_id="K-flinch",
+            sovereignty_score=0.7, convergence_type="genuine_multi",
+            trade_pnl_usdt=1.0, trade_duration_s=10.0,  # short duration
+        )
+        gate.evaluate_write(
+            symbol="ETH", decision_id="K-noise",
+            sovereignty_score=0.7, convergence_type="genuine_multi",
+            trade_pnl_usdt=0.001, trade_duration_s=1800.0,  # noise floor
+        )
+        gate.evaluate_write(
+            symbol="ETH", decision_id="K-group",
+            sovereignty_score=0.7, convergence_type="groupthink",
+            trade_pnl_usdt=2.0, trade_duration_s=1800.0,  # groupthink
+        )
+        assert len(events) == 3
+        all_reasons = [e.payload["reasons"] for e in events]
+        assert any("duration" in r for rl in all_reasons for r in rl)
+        assert any("noise floor" in r for rl in all_reasons for r in rl)
+        assert any("groupthink" in r for rl in all_reasons for r in rl)
+
+
+class TestBusInstanceIsolation:
+    def test_two_instances_have_independent_buses(self) -> None:
+        bus_a = KernelBus("a")
+        bus_b = KernelBus("b")
+        events_a: list[KernelEventEnvelope] = []
+        events_b: list[KernelEventEnvelope] = []
+        bus_a.subscribe("audit", events_a.append)
+        bus_b.subscribe("audit", events_b.append)
+        bus_a.publish(KernelEvent.HEART_TICK, "heart", {"k": 1})
+        assert len(events_a) == 1
+        assert len(events_b) == 0

--- a/ml-worker/tests/monkey_kernel/test_coordinator.py
+++ b/ml-worker/tests/monkey_kernel/test_coordinator.py
@@ -1,0 +1,171 @@
+"""test_coordinator.py — Gary, the Agent K constellation coordinator.
+
+Tests cover:
+  - Cold-start passthrough when no foresight available
+  - Foresight bias applied when high-confidence
+  - Heart anchor mode reduces foresight weight by 0.5×
+  - Regime-adaptive weighting (phi < 0.3 → 0.1, etc.)
+  - GARY_SYNTHESIS event published
+  - Subscribe/unsubscribe doesn't leak
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.bus_events import KernelEvent, KernelEventEnvelope  # noqa: E402
+from monkey_kernel.coordinator import GaryCoordinator, GaryReading  # noqa: E402
+from monkey_kernel.kernel_bus import KernelBus, _reset_buses_for_tests  # noqa: E402
+from monkey_kernel.state import BASIN_DIM  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_buses():
+    _reset_buses_for_tests()
+    yield
+    _reset_buses_for_tests()
+
+
+def _peak(idx: int, peak: float = 0.5) -> np.ndarray:
+    b = np.full(BASIN_DIM, (1.0 - peak) / (BASIN_DIM - 1), dtype=np.float64)
+    b[idx] = peak
+    return b
+
+
+def _publish_foresight(bus: KernelBus, predicted: np.ndarray, conf: float) -> None:
+    bus.publish(
+        KernelEvent.FORESIGHT_PREDICTION,
+        source="foresight",
+        payload={
+            "predicted_basin": [float(x) for x in predicted],
+            "confidence": float(conf),
+            "weight": float(conf) * 0.7,
+            "horizon_ms": 30000.0,
+        },
+        symbol="ETH",
+    )
+
+
+def _publish_ocean(bus: KernelBus, phi: float) -> None:
+    bus.publish(
+        KernelEvent.OCEAN_OBSERVATION,
+        source="ocean",
+        payload={"phi": phi, "spread": 0.1, "coherence": 0.5,
+                 "intervention": None, "sleep_phase": "AWAKE"},
+        symbol="ETH",
+    )
+
+
+def _publish_heart(bus: KernelBus, mode: str = "FEELING") -> None:
+    bus.publish(
+        KernelEvent.HEART_TICK,
+        source="heart",
+        payload={"kappa": 60.0, "kappa_star": 64.0, "hrv": 0.1, "mode": mode},
+        symbol="ETH",
+    )
+
+
+class TestColdStart:
+    def test_no_foresight_passes_through_consensus(self) -> None:
+        bus = KernelBus("t")
+        coord = GaryCoordinator(bus)
+        consensus = _peak(10, 0.6)
+        reading = coord.synthesize(consensus, "ETH")
+        assert reading.foresight_weight == 0.0 or reading.foresight_confidence == 0.0
+        # final basin should be simplex valid
+        assert reading.synthesized_basin.sum() == pytest.approx(1.0, abs=1e-6)
+
+
+class TestRegimeAdaptive:
+    def test_phi_below_low_threshold_caps_foresight(self) -> None:
+        bus = KernelBus("t")
+        coord = GaryCoordinator(bus)
+        # Φ in linear regime
+        _publish_ocean(bus, phi=0.2)
+        _publish_foresight(bus, _peak(0, 0.5), conf=0.9)
+        reading = coord.synthesize(_peak(10, 0.5), "ETH")
+        assert reading.foresight_weight <= 0.1 + 1e-9
+
+    def test_phi_in_geometric_band_uses_confidence_times_seven_tenths(self) -> None:
+        bus = KernelBus("t")
+        coord = GaryCoordinator(bus)
+        _publish_ocean(bus, phi=0.5)
+        _publish_foresight(bus, _peak(0, 0.5), conf=0.8)
+        reading = coord.synthesize(_peak(10, 0.5), "ETH")
+        assert reading.foresight_weight == pytest.approx(0.7 * 0.8, abs=1e-6)
+
+    def test_phi_above_high_threshold_caps_foresight(self) -> None:
+        bus = KernelBus("t")
+        coord = GaryCoordinator(bus)
+        # Breakdown-risk damping
+        _publish_ocean(bus, phi=0.85)
+        _publish_foresight(bus, _peak(0, 0.5), conf=0.9)
+        reading = coord.synthesize(_peak(10, 0.5), "ETH")
+        assert reading.foresight_weight == pytest.approx(0.2, abs=1e-6)
+
+
+class TestHeartModulation:
+    def test_anchor_mode_reduces_foresight(self) -> None:
+        bus = KernelBus("t")
+        coord = GaryCoordinator(bus)
+        _publish_ocean(bus, phi=0.5)
+        _publish_heart(bus, mode="ANCHOR")
+        _publish_foresight(bus, _peak(0, 0.5), conf=0.8)
+        reading = coord.synthesize(_peak(10, 0.5), "ETH")
+        assert reading.heart_modulation == pytest.approx(0.5, abs=1e-6)
+        # Foresight weight × 0.5
+        assert reading.foresight_weight == pytest.approx(0.7 * 0.8 * 0.5, abs=1e-6)
+
+    def test_non_anchor_modes_full_modulation(self) -> None:
+        bus = KernelBus("t")
+        coord = GaryCoordinator(bus)
+        _publish_ocean(bus, phi=0.5)
+        _publish_heart(bus, mode="FEELING")
+        _publish_foresight(bus, _peak(0, 0.5), conf=0.8)
+        reading = coord.synthesize(_peak(10, 0.5), "ETH")
+        assert reading.heart_modulation == pytest.approx(1.0, abs=1e-6)
+
+
+class TestPublishing:
+    def test_synthesize_publishes_gary_synthesis(self) -> None:
+        bus = KernelBus("t")
+        events: list[KernelEventEnvelope] = []
+        bus.subscribe("a", events.append, types=[KernelEvent.GARY_SYNTHESIS])
+        coord = GaryCoordinator(bus)
+        coord.synthesize(_peak(10, 0.5), "ETH")
+        assert len(events) == 1
+        assert events[0].source == "gary"
+        assert events[0].symbol == "ETH"
+        assert "synthesized_basin" in events[0].payload
+        assert "convergence_type" in events[0].payload
+
+
+class TestShutdown:
+    def test_shutdown_unsubs_all_subscriptions(self) -> None:
+        bus = KernelBus("t")
+        baseline = bus.subscriber_count()
+        coord = GaryCoordinator(bus)
+        # 3 subscriptions: heart, ocean, foresight
+        assert bus.subscriber_count() == baseline + 3
+        coord.shutdown()
+        assert bus.subscriber_count() == baseline
+
+    def test_shutdown_idempotent(self) -> None:
+        bus = KernelBus("t")
+        coord = GaryCoordinator(bus)
+        coord.shutdown()
+        coord.shutdown()  # must not raise
+
+
+class TestReadingShape:
+    def test_returns_gary_reading(self) -> None:
+        bus = KernelBus("t")
+        coord = GaryCoordinator(bus)
+        reading = coord.synthesize(_peak(10, 0.5), "ETH")
+        assert isinstance(reading, GaryReading)
+        assert reading.synthesized_basin.shape == (BASIN_DIM,)

--- a/ml-worker/tests/monkey_kernel/test_decision_triple.py
+++ b/ml-worker/tests/monkey_kernel/test_decision_triple.py
@@ -1,0 +1,237 @@
+"""test_decision_triple.py — Loop 1 canonical triple per UCP §43.2.
+
+Tests cover:
+  - All three scores bounded in [0, 1]
+  - Repetition: lived geometry (high velocity from history) vs scaffolding
+  - Sovereignty: bank-grounded high-confidence vs nothing-near low-confidence
+  - Confidence: bank resonance vs override expansion
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.self_observation import (  # noqa: E402
+    DecisionTriple,
+    compute_per_decision_triple,
+)
+
+
+def _basin(peak_idx: int, dim: int = 64, peak: float = 0.5) -> np.ndarray:
+    b = np.full(dim, (1.0 - peak) / (dim - 1), dtype=np.float64)
+    b[peak_idx] = peak
+    return b
+
+
+class TestBoundaries:
+    def test_all_three_scores_bounded_in_zero_one(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-test-1",
+            current_basin=_basin(0),
+            recent_basins=[_basin(1), _basin(2), _basin(3)],
+            bank_resonance_count=3,
+            bank_total_queried=10,
+            nearest_fr_distance=0.5,
+            emotion_confidence=0.7,
+            emotion_anxiety=0.3,
+            decision_path_overrides=[],
+        )
+        assert 0.0 <= triple.repetition_score <= 1.0
+        assert 0.0 <= triple.sovereignty_score <= 1.0
+        assert 0.0 <= triple.confidence_score <= 1.0
+
+    def test_empty_recent_history_gives_zero_repetition(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="cold",
+            current_basin=_basin(0),
+            recent_basins=[],
+            bank_resonance_count=0,
+            bank_total_queried=1,
+            nearest_fr_distance=1.0,
+            emotion_confidence=0.5,
+            emotion_anxiety=0.5,
+            decision_path_overrides=[],
+        )
+        assert triple.repetition_score == 0.0
+
+
+class TestRepetition:
+    def test_far_from_history_yields_high_repetition(self) -> None:
+        # Current basin is at peak_idx=0 (concentrated mass at 0).
+        # Recent history is at peak_idx=63 — far away.
+        triple = compute_per_decision_triple(
+            decision_id="K-far",
+            current_basin=_basin(0, peak=0.95),
+            recent_basins=[_basin(63, peak=0.95)] * 5,
+            bank_resonance_count=0,
+            bank_total_queried=1,
+            nearest_fr_distance=1.0,
+            emotion_confidence=0.5,
+            emotion_anxiety=0.5,
+            decision_path_overrides=[],
+        )
+        # FR distance between concentrated p[0]=0.95 and p[63]=0.95
+        # is large → 1 - exp(-d) is close to 1.
+        assert triple.repetition_score > 0.5
+
+    def test_basin_matches_history_yields_low_repetition(self) -> None:
+        b = _basin(10, peak=0.5)
+        triple = compute_per_decision_triple(
+            decision_id="K-stuck",
+            current_basin=b,
+            recent_basins=[b.copy() for _ in range(5)],
+            bank_resonance_count=0,
+            bank_total_queried=1,
+            nearest_fr_distance=1.0,
+            emotion_confidence=0.5,
+            emotion_anxiety=0.5,
+            decision_path_overrides=[],
+        )
+        # Identical to history → FR distance 0 → 1 - exp(0) = 0
+        assert triple.repetition_score < 0.05
+
+
+class TestSovereignty:
+    def test_close_match_high_confidence_yields_high_sovereignty(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-sovereign",
+            current_basin=_basin(0),
+            recent_basins=[_basin(1), _basin(2)],
+            bank_resonance_count=5,
+            bank_total_queried=10,
+            nearest_fr_distance=0.1,  # well below 1/φ ≈ 0.618
+            emotion_confidence=0.9,
+            emotion_anxiety=0.1,
+            decision_path_overrides=[],
+        )
+        # nearby_match = 1.0 (under 1/φ); confidence_dominance = 0.8.
+        assert triple.sovereignty_score == pytest.approx(0.8, abs=1e-6)
+
+    def test_far_match_low_confidence_yields_zero_sovereignty(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-lost",
+            current_basin=_basin(0),
+            recent_basins=[_basin(1)],
+            bank_resonance_count=0,
+            bank_total_queried=10,
+            nearest_fr_distance=math.pi / 2,  # max FR distance
+            emotion_confidence=0.2,
+            emotion_anxiety=0.6,
+            decision_path_overrides=[],
+        )
+        # nearby_match = 0; anxiety > confidence so confidence_dominance = 0
+        assert triple.sovereignty_score == 0.0
+
+    def test_anxiety_dominates_kills_sovereignty(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-anxious",
+            current_basin=_basin(0),
+            recent_basins=[_basin(1)],
+            bank_resonance_count=5,
+            bank_total_queried=10,
+            nearest_fr_distance=0.1,  # close
+            emotion_confidence=0.3,
+            emotion_anxiety=0.7,
+            decision_path_overrides=[],
+        )
+        assert triple.sovereignty_score == 0.0
+
+
+class TestConfidence:
+    def test_strong_bank_resonance_yields_high_confidence(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-bank",
+            current_basin=_basin(0),
+            recent_basins=[_basin(1)],
+            bank_resonance_count=8,
+            bank_total_queried=10,
+            nearest_fr_distance=0.5,
+            emotion_confidence=0.5,
+            emotion_anxiety=0.5,
+            decision_path_overrides=[],
+        )
+        # 8/10 = 0.8, no overrides → 0.8
+        assert triple.confidence_score == pytest.approx(0.8, abs=1e-6)
+
+    def test_overrides_penalize_confidence(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-override",
+            current_basin=_basin(0),
+            recent_basins=[_basin(1)],
+            bank_resonance_count=8,
+            bank_total_queried=10,
+            nearest_fr_distance=0.5,
+            emotion_confidence=0.5,
+            emotion_anxiety=0.5,
+            decision_path_overrides=["REVERSION_FLIP", "UPPER_STACK"],
+        )
+        # 0.8 - 2*0.2 = 0.4
+        assert triple.confidence_score == pytest.approx(0.4, abs=1e-6)
+
+    def test_many_overrides_clamps_to_zero(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-rules",
+            current_basin=_basin(0),
+            recent_basins=[_basin(1)],
+            bank_resonance_count=2,
+            bank_total_queried=10,
+            nearest_fr_distance=0.5,
+            emotion_confidence=0.5,
+            emotion_anxiety=0.5,
+            decision_path_overrides=["A", "B", "C", "D", "E"],
+        )
+        # 0.2 - 5*0.2 = -0.8 → clamped 0.0
+        assert triple.confidence_score == 0.0
+
+    def test_zero_queried_treats_as_one(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-zero",
+            current_basin=_basin(0),
+            recent_basins=[],
+            bank_resonance_count=0,
+            bank_total_queried=0,
+            nearest_fr_distance=0.5,
+            emotion_confidence=0.5,
+            emotion_anxiety=0.5,
+            decision_path_overrides=[],
+        )
+        # 0/max(1,0) = 0; no overrides → 0
+        assert triple.confidence_score == 0.0
+
+
+class TestDecisionTripleShape:
+    def test_decision_id_is_carried(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-id-test",
+            current_basin=_basin(0),
+            recent_basins=[],
+            bank_resonance_count=0,
+            bank_total_queried=1,
+            nearest_fr_distance=0.1,
+            emotion_confidence=0.5,
+            emotion_anxiety=0.5,
+            decision_path_overrides=[],
+            at_ms=12345.0,
+        )
+        assert triple.decision_id == "K-id-test"
+        assert triple.at_ms == 12345.0
+
+    def test_returns_decision_triple(self) -> None:
+        triple = compute_per_decision_triple(
+            decision_id="K-shape",
+            current_basin=_basin(0),
+            recent_basins=[],
+            bank_resonance_count=0,
+            bank_total_queried=1,
+            nearest_fr_distance=0.1,
+            emotion_confidence=0.5,
+            emotion_anxiety=0.5,
+            decision_path_overrides=[],
+        )
+        assert isinstance(triple, DecisionTriple)

--- a/ml-worker/tests/monkey_kernel/test_kernel_bus.py
+++ b/ml-worker/tests/monkey_kernel/test_kernel_bus.py
@@ -1,0 +1,308 @@
+"""test_kernel_bus.py — internal Agent K constellation pub/sub.
+
+The kernel bus is INTERNAL to Agent K. Tests cover:
+  - Singleton per instance_id
+  - Subscribe filters by event type and symbol
+  - Crashing subscriber doesn't break bus or other subscribers
+  - Unsubscribe stops delivery
+  - Max subscriber limit enforcement
+  - Payload normalization (dict, dataclass with to_dict, plain dataclass)
+  - Persistence tail integration
+"""
+from __future__ import annotations
+
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.bus_events import (  # noqa: E402
+    HeartTickPayload,
+    KernelEvent,
+    KernelEventEnvelope,
+    SelfObsTriplePayload,
+)
+from monkey_kernel.kernel_bus import (  # noqa: E402
+    KernelBus,
+    _reset_buses_for_tests,
+    get_kernel_bus,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_buses():
+    _reset_buses_for_tests()
+    yield
+    _reset_buses_for_tests()
+
+
+class TestSingleton:
+    def test_same_instance_id_returns_same_bus(self) -> None:
+        a1 = get_kernel_bus("a")
+        a2 = get_kernel_bus("a")
+        assert a1 is a2
+
+    def test_different_instance_ids_get_different_buses(self) -> None:
+        a = get_kernel_bus("a")
+        b = get_kernel_bus("b")
+        assert a is not b
+        assert a.instance_id == "a"
+        assert b.instance_id == "b"
+
+    def test_reset_clears_singletons(self) -> None:
+        a1 = get_kernel_bus("test")
+        _reset_buses_for_tests()
+        a2 = get_kernel_bus("test")
+        assert a1 is not a2
+
+
+class TestPublishSubscribe:
+    def test_subscribe_no_filters_receives_all_events(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe("a", received.append)
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1})
+        bus.publish(
+            KernelEvent.OCEAN_OBSERVATION, "ocean", {"phi": 0.5},
+        )
+        assert len(received) == 2
+        assert received[0].type == KernelEvent.HEART_TICK
+        assert received[1].type == KernelEvent.OCEAN_OBSERVATION
+
+    def test_subscribe_filters_by_event_type(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "heart-only", received.append, types=[KernelEvent.HEART_TICK],
+        )
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1})
+        bus.publish(
+            KernelEvent.OCEAN_OBSERVATION, "ocean", {"phi": 0.5},
+        )
+        assert len(received) == 1
+        assert received[0].type == KernelEvent.HEART_TICK
+
+    def test_subscribe_filters_by_symbol(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe("eth", received.append, symbols=["ETH"])
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1}, symbol="ETH")
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 2}, symbol="BTC")
+        assert len(received) == 1
+        assert received[0].symbol == "ETH"
+
+    def test_subscribe_combined_filters_use_AND(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe(
+            "narrow",
+            received.append,
+            types=[KernelEvent.HEART_TICK],
+            symbols=["ETH"],
+        )
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1}, symbol="ETH")
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 2}, symbol="BTC")
+        bus.publish(
+            KernelEvent.OCEAN_OBSERVATION, "ocean", {"phi": 0.5}, symbol="ETH",
+        )
+        assert len(received) == 1
+        assert received[0].symbol == "ETH"
+        assert received[0].type == KernelEvent.HEART_TICK
+
+
+class TestErrorHandling:
+    def test_crashing_subscriber_doesnt_break_other_subscribers(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+
+        def boom(_env: KernelEventEnvelope) -> None:
+            raise RuntimeError("middle subscriber threw")
+
+        bus.subscribe("first", received.append)
+        bus.subscribe("middle", boom)
+        bus.subscribe("last", received.append)
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1})
+        # Both surviving subscribers fired
+        assert len(received) == 2
+
+    def test_crashing_subscriber_doesnt_break_bus(self) -> None:
+        bus = KernelBus("t")
+
+        def boom(_env: KernelEventEnvelope) -> None:
+            raise RuntimeError("subscriber always crashes")
+
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe("boom", boom)
+        bus.subscribe("ok", received.append)
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1})
+        bus.publish(KernelEvent.OCEAN_OBSERVATION, "ocean", {"phi": 0.5})
+        assert len(received) == 2
+
+
+class TestUnsubscribe:
+    def test_unsubscribe_stops_delivery(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        unsub = bus.subscribe("a", received.append)
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1})
+        unsub()
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 2})
+        assert len(received) == 1
+
+    def test_unsubscribe_idempotent(self) -> None:
+        bus = KernelBus("t")
+        unsub = bus.subscribe("a", lambda _e: None)
+        unsub()
+        unsub()  # second call must not raise
+
+
+class TestMaxSubscribers:
+    def test_max_subscribers_enforced(self) -> None:
+        bus = KernelBus("t", max_subscribers=2)
+        bus.subscribe("a", lambda _e: None)
+        bus.subscribe("b", lambda _e: None)
+        with pytest.raises(RuntimeError, match="max subscribers"):
+            bus.subscribe("c", lambda _e: None)
+
+
+class TestPayloadNormalization:
+    def test_dict_payload_passes_through(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe("a", received.append)
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"kappa": 64.0})
+        assert received[0].payload == {"kappa": 64.0}
+
+    def test_dataclass_with_to_dict_uses_to_dict(self) -> None:
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe("a", received.append)
+        bus.publish(
+            KernelEvent.HEART_TICK,
+            "heart",
+            HeartTickPayload(kappa=64.0, kappa_star=64.0, hrv=0.1, mode="ANCHOR"),
+        )
+        assert received[0].payload["kappa"] == 64.0
+        assert received[0].payload["mode"] == "ANCHOR"
+
+    def test_plain_dataclass_uses_asdict(self) -> None:
+        @dataclass(frozen=True)
+        class Plain:
+            x: int
+
+        bus = KernelBus("t")
+        received: list[KernelEventEnvelope] = []
+        bus.subscribe("a", received.append)
+        bus.publish(KernelEvent.ANOMALY, "test", Plain(x=42))
+        assert received[0].payload == {"x": 42}
+
+    def test_invalid_payload_raises_typeerror(self) -> None:
+        bus = KernelBus("t")
+        with pytest.raises(TypeError):
+            bus.publish(KernelEvent.HEART_TICK, "heart", "not a dict")
+
+
+class TestPersistenceTail:
+    def test_persistence_called_when_provided(self) -> None:
+        events_seen: list = []
+
+        class FakePersistence:
+            is_available = True
+
+            def append_bus_event(self, env):  # noqa: ANN001
+                events_seen.append(env)
+
+        bus = KernelBus("t", persistence=FakePersistence())
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1})
+        assert len(events_seen) == 1
+        assert events_seen[0].type == KernelEvent.HEART_TICK
+
+    def test_persistence_failure_doesnt_break_publish(self) -> None:
+        class BadPersistence:
+            is_available = True
+
+            def append_bus_event(self, env):  # noqa: ANN001
+                raise RuntimeError("persistence down")
+
+        bus = KernelBus("t", persistence=BadPersistence())
+        # Must not raise
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1})
+
+
+class TestConcurrency:
+    def test_concurrent_subscribe_publish_no_corruption(self) -> None:
+        bus = KernelBus("t")
+        stop = threading.Event()
+        errors: list[Exception] = []
+
+        def publisher() -> None:
+            try:
+                while not stop.is_set():
+                    bus.publish(
+                        KernelEvent.HEART_TICK, "heart", {"k": 1},
+                    )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        def subscriber() -> None:
+            try:
+                while not stop.is_set():
+                    unsub = bus.subscribe(
+                        f"sub-{threading.get_ident()}", lambda _e: None,
+                    )
+                    unsub()
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=publisher),
+            threading.Thread(target=subscriber),
+            threading.Thread(target=publisher),
+        ]
+        for t in threads:
+            t.start()
+        # Run briefly
+        threading.Event().wait(0.1)
+        stop.set()
+        for t in threads:
+            t.join(timeout=1.0)
+        assert errors == []
+
+
+class TestEventCount:
+    def test_event_count_increments(self) -> None:
+        bus = KernelBus("t")
+        assert bus.event_count() == 0
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 1})
+        bus.publish(KernelEvent.HEART_TICK, "heart", {"k": 2})
+        assert bus.event_count() == 2
+
+    def test_subscriber_count_tracks_correctly(self) -> None:
+        bus = KernelBus("t")
+        assert bus.subscriber_count() == 0
+        u1 = bus.subscribe("a", lambda _e: None)
+        u2 = bus.subscribe("b", lambda _e: None)
+        assert bus.subscriber_count() == 2
+        u1()
+        assert bus.subscriber_count() == 1
+        u2()
+        assert bus.subscriber_count() == 0
+
+
+class TestSelfObsTriplePayload:
+    def test_to_dict_round_trip(self) -> None:
+        payload = SelfObsTriplePayload(
+            repetition_score=0.7,
+            sovereignty_score=0.8,
+            confidence_score=0.6,
+            decision_id="K-test-1",
+        )
+        d = payload.to_dict()
+        assert d["repetition_score"] == 0.7
+        assert d["sovereignty_score"] == 0.8
+        assert d["confidence_score"] == 0.6
+        assert d["decision_id"] == "K-test-1"

--- a/ml-worker/tests/monkey_kernel/test_learning_gate.py
+++ b/ml-worker/tests/monkey_kernel/test_learning_gate.py
@@ -1,0 +1,168 @@
+"""test_learning_gate.py — Loop 3 learning autonomy per UCP §43.4.
+
+Tests cover:
+  - Approval criteria (sovereignty, convergence, pnl, duration)
+  - Rejection on each criterion
+  - Multi-criterion rejection lists all reasons
+  - Approved / rejected events published with correct payloads
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.bus_events import KernelEvent, KernelEventEnvelope  # noqa: E402
+from monkey_kernel.kernel_bus import KernelBus, _reset_buses_for_tests  # noqa: E402
+from monkey_kernel.learning_gate import (  # noqa: E402
+    MIN_DURATION_S,
+    MIN_SOVEREIGNTY,
+    NOISE_FLOOR_USDT,
+    LearningGate,
+    WriteDecision,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_buses():
+    _reset_buses_for_tests()
+    yield
+    _reset_buses_for_tests()
+
+
+def _approved_kwargs() -> dict:
+    return {
+        "symbol": "ETH",
+        "decision_id": "K-test-1",
+        "sovereignty_score": MIN_SOVEREIGNTY + 0.1,
+        "convergence_type": "consensus",
+        "trade_pnl_usdt": NOISE_FLOOR_USDT * 5.0,
+        "trade_duration_s": MIN_DURATION_S * 2.0,
+    }
+
+
+class TestApproval:
+    def test_all_criteria_clear_approves(self) -> None:
+        bus = KernelBus("t")
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(**_approved_kwargs())
+        assert decision.approved is True
+        assert decision.reasons == []
+
+    def test_genuine_multi_convergence_approved(self) -> None:
+        bus = KernelBus("t")
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(
+            **{**_approved_kwargs(), "convergence_type": "genuine_multi"},
+        )
+        assert decision.approved is True
+
+
+class TestRejection:
+    def test_low_sovereignty_rejected(self) -> None:
+        bus = KernelBus("t")
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(
+            **{**_approved_kwargs(), "sovereignty_score": MIN_SOVEREIGNTY - 0.1},
+        )
+        assert decision.approved is False
+        assert any("sovereignty" in r for r in decision.reasons)
+
+    def test_groupthink_convergence_rejected(self) -> None:
+        bus = KernelBus("t")
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(
+            **{**_approved_kwargs(), "convergence_type": "groupthink"},
+        )
+        assert decision.approved is False
+        assert any("groupthink" in r for r in decision.reasons)
+
+    def test_noise_floor_pnl_rejected(self) -> None:
+        bus = KernelBus("t")
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(
+            **{**_approved_kwargs(), "trade_pnl_usdt": NOISE_FLOOR_USDT * 0.5},
+        )
+        assert decision.approved is False
+        assert any("noise floor" in r for r in decision.reasons)
+
+    def test_short_duration_rejected(self) -> None:
+        bus = KernelBus("t")
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(
+            **{**_approved_kwargs(), "trade_duration_s": MIN_DURATION_S * 0.5},
+        )
+        assert decision.approved is False
+        assert any("duration" in r for r in decision.reasons)
+
+    def test_multi_criterion_rejection_lists_all_reasons(self) -> None:
+        bus = KernelBus("t")
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(
+            symbol="ETH",
+            decision_id="K-bad",
+            sovereignty_score=0.1,
+            convergence_type="groupthink",
+            trade_pnl_usdt=0.001,
+            trade_duration_s=10.0,
+        )
+        assert decision.approved is False
+        # All four criteria failed
+        assert len(decision.reasons) == 4
+
+    def test_negative_pnl_above_noise_passes_pnl_check(self) -> None:
+        bus = KernelBus("t")
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(
+            **{**_approved_kwargs(), "trade_pnl_usdt": -0.5},
+        )
+        # Loss above noise floor; sovereignty/duration/convergence ok → approved
+        assert decision.approved is True
+
+
+class TestPublishing:
+    def test_approved_publishes_approved_event(self) -> None:
+        bus = KernelBus("t")
+        events: list[KernelEventEnvelope] = []
+        bus.subscribe("a", events.append)
+        gate = LearningGate(bus)
+        gate.evaluate_write(**_approved_kwargs())
+        approved_events = [
+            e for e in events
+            if e.type == KernelEvent.LEARNING_BANK_WRITE_APPROVED
+        ]
+        rejected_events = [
+            e for e in events
+            if e.type == KernelEvent.LEARNING_BANK_WRITE_REJECTED
+        ]
+        assert len(approved_events) == 1
+        assert len(rejected_events) == 0
+
+    def test_rejected_publishes_rejected_event(self) -> None:
+        bus = KernelBus("t")
+        events: list[KernelEventEnvelope] = []
+        bus.subscribe("a", events.append)
+        gate = LearningGate(bus)
+        gate.evaluate_write(
+            **{**_approved_kwargs(), "convergence_type": "groupthink"},
+        )
+        rejected_events = [
+            e for e in events
+            if e.type == KernelEvent.LEARNING_BANK_WRITE_REJECTED
+        ]
+        assert len(rejected_events) == 1
+        assert "reasons" in rejected_events[0].payload
+        assert any("groupthink" in r for r in rejected_events[0].payload["reasons"])
+
+
+class TestReturnShape:
+    def test_returns_write_decision(self) -> None:
+        bus = KernelBus("t")
+        gate = LearningGate(bus)
+        decision = gate.evaluate_write(**_approved_kwargs())
+        assert isinstance(decision, WriteDecision)
+        assert hasattr(decision, "approved")
+        assert hasattr(decision, "reasons")

--- a/ml-worker/tests/monkey_kernel/test_thought_bus.py
+++ b/ml-worker/tests/monkey_kernel/test_thought_bus.py
@@ -1,0 +1,239 @@
+"""test_thought_bus.py — Loop 2 inter-kernel debate per UCP §43.3.
+
+Tests cover:
+  - No-debate consensus when contributions agree
+  - Debate fires when FR distance > threshold (1/π)
+  - Convergence classification (consensus / groupthink / genuine_multi /
+    non_convergent)
+  - Sovereignty-weighted revision (high sovereignty → barely moves)
+  - FR-weighted Fréchet synthesis (not arithmetic mean)
+"""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from qig_core_local.geometry.fisher_rao import (  # noqa: E402
+    fisher_rao_distance,
+    to_simplex,
+)
+
+from monkey_kernel.bus_events import KernelEvent, KernelEventEnvelope  # noqa: E402
+from monkey_kernel.kernel_bus import KernelBus, _reset_buses_for_tests  # noqa: E402
+from monkey_kernel.state import BASIN_DIM  # noqa: E402
+from monkey_kernel.thought_bus import (  # noqa: E402
+    DISAGREEMENT_THRESHOLD_FR,
+    KernelContribution,
+    ThoughtBus,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_buses():
+    _reset_buses_for_tests()
+    yield
+    _reset_buses_for_tests()
+
+
+def _peak(idx: int, peak: float = 0.5) -> np.ndarray:
+    b = np.full(BASIN_DIM, (1.0 - peak) / (BASIN_DIM - 1), dtype=np.float64)
+    b[idx] = peak
+    return to_simplex(b)
+
+
+def _make_contributions(
+    *triples: tuple[np.ndarray, float, float],
+) -> list[KernelContribution]:
+    return [
+        KernelContribution(
+            kernel_id=f"k{i}", basin=basin,
+            confidence=conf, sovereignty=sov,
+        )
+        for i, (basin, conf, sov) in enumerate(triples)
+    ]
+
+
+class TestNoDebate:
+    def test_close_basins_no_debate(self) -> None:
+        bus = KernelBus("t")
+        tb = ThoughtBus(bus)
+        # Two near-identical basins
+        b = _peak(0, 0.3)
+        outcome = tb.open_debate(
+            "ETH",
+            _make_contributions((b, 0.7, 0.7), (b.copy(), 0.6, 0.6)),
+        )
+        assert outcome.rounds == 0
+        assert outcome.converged is True
+        assert outcome.convergence_type == "consensus"
+
+
+class TestDebate:
+    def test_far_basins_open_debate(self) -> None:
+        bus = KernelBus("t")
+        events: list[KernelEventEnvelope] = []
+        bus.subscribe("a", events.append)
+        tb = ThoughtBus(bus)
+        # Maximally distant basins
+        outcome = tb.open_debate(
+            "ETH",
+            _make_contributions(
+                (_peak(0, 0.9), 0.5, 0.3),
+                (_peak(63, 0.9), 0.5, 0.3),
+            ),
+        )
+        # At minimum, DEBATE_OPENED should be present
+        types = {e.type for e in events}
+        assert KernelEvent.THOUGHT_BUS_DEBATE_OPENED in types
+        assert KernelEvent.THOUGHT_BUS_CONVERGENCE in types
+        assert KernelEvent.THOUGHT_BUS_SYNTHESIS in types
+        assert outcome.rounds >= 1
+
+    def test_convergence_genuine_multi_at_3_rounds(self) -> None:
+        bus = KernelBus("t")
+        tb = ThoughtBus(bus)
+        # Spread basins; with low sovereignty, kernels move toward
+        # consensus over multiple rounds.
+        outcome = tb.open_debate(
+            "ETH",
+            _make_contributions(
+                (_peak(0, 0.9), 0.4, 0.2),
+                (_peak(63, 0.9), 0.4, 0.2),
+                (_peak(32, 0.9), 0.4, 0.2),
+            ),
+        )
+        assert outcome.converged is True
+        if outcome.rounds >= 3:
+            assert outcome.convergence_type == "genuine_multi"
+
+    def test_groupthink_label_for_widely_spread_one_round(self) -> None:
+        bus = KernelBus("t")
+        # Force fast convergence with very low sovereignty
+        # (each move = 0.5 × (1 - 0.0) = 0.5 → big step in one round)
+        tb = ThoughtBus(bus)
+        outcome = tb.open_debate(
+            "ETH",
+            _make_contributions(
+                (_peak(0, 0.9), 0.5, 0.0),
+                (_peak(63, 0.9), 0.5, 0.0),
+            ),
+        )
+        # If converged in 1 round from spread > 2×threshold: groupthink.
+        if outcome.rounds == 1:
+            initial_d = fisher_rao_distance(_peak(0, 0.9), _peak(63, 0.9))
+            if initial_d >= 2.0 * DISAGREEMENT_THRESHOLD_FR:
+                assert outcome.convergence_type == "groupthink"
+
+    def test_max_rounds_reached_without_convergence_is_non_convergent(
+        self,
+    ) -> None:
+        bus = KernelBus("t")
+        # max_rounds=1, and high-sovereignty kernels will barely move
+        tb = ThoughtBus(bus, max_rounds=1)
+        outcome = tb.open_debate(
+            "ETH",
+            _make_contributions(
+                (_peak(0, 0.95), 0.9, 1.0),
+                (_peak(63, 0.95), 0.9, 1.0),
+            ),
+        )
+        if not outcome.converged:
+            assert outcome.convergence_type == "non_convergent"
+
+
+class TestSovereigntyWeighting:
+    def test_high_sovereignty_kernel_barely_moves(self) -> None:
+        bus = KernelBus("t")
+        tb = ThoughtBus(bus, max_rounds=1)
+        b1 = _peak(0, 0.9)
+        b2 = _peak(63, 0.9)
+        outcome = tb.open_debate(
+            "ETH",
+            _make_contributions(
+                (b1, 0.9, 1.0),  # very high sovereignty → no move
+                (b2, 0.9, 0.0),  # zero sovereignty → max move
+            ),
+        )
+        # First contribution should still be near b1 after revision
+        if outcome.contributions:
+            d_high_sov = fisher_rao_distance(
+                outcome.contributions[0].basin, b1,
+            )
+            d_low_sov = fisher_rao_distance(
+                outcome.contributions[1].basin, b2,
+            )
+            # Low-sovereignty contribution moved further than high
+            assert d_low_sov >= d_high_sov - 1e-9
+
+
+class TestSynthesis:
+    def test_final_basin_is_simplex_valid(self) -> None:
+        bus = KernelBus("t")
+        tb = ThoughtBus(bus)
+        outcome = tb.open_debate(
+            "ETH",
+            _make_contributions(
+                (_peak(0, 0.5), 0.5, 0.5),
+                (_peak(10, 0.5), 0.5, 0.5),
+            ),
+        )
+        assert outcome.final_basin.shape == (BASIN_DIM,)
+        assert outcome.final_basin.sum() == pytest.approx(1.0, abs=1e-6)
+        assert all(x >= 0.0 for x in outcome.final_basin)
+
+    def test_empty_contributions_returns_uniform(self) -> None:
+        bus = KernelBus("t")
+        tb = ThoughtBus(bus)
+        outcome = tb.open_debate("ETH", [])
+        assert outcome.final_basin.shape == (BASIN_DIM,)
+        assert outcome.final_basin.sum() == pytest.approx(1.0, abs=1e-6)
+        assert outcome.rounds == 0
+
+    def test_zero_weight_falls_back_uniform(self) -> None:
+        # All-zero confidence × sovereignty falls back to uniform
+        # weighting in synthesis. Check synthesis is still valid simplex.
+        bus = KernelBus("t")
+        tb = ThoughtBus(bus)
+        outcome = tb.open_debate(
+            "ETH",
+            _make_contributions(
+                (_peak(0, 0.5), 0.0, 0.0),
+                (_peak(10, 0.5), 0.0, 0.0),
+            ),
+        )
+        assert outcome.final_basin.sum() == pytest.approx(1.0, abs=1e-6)
+
+
+class TestEventOrder:
+    def test_events_published_in_order(self) -> None:
+        bus = KernelBus("t")
+        events: list[KernelEventEnvelope] = []
+        bus.subscribe("a", events.append)
+        tb = ThoughtBus(bus)
+        tb.open_debate(
+            "ETH",
+            _make_contributions(
+                (_peak(0, 0.9), 0.5, 0.2),
+                (_peak(63, 0.9), 0.5, 0.2),
+            ),
+        )
+        types = [e.type for e in events]
+        # DEBATE_OPENED comes first
+        assert types[0] == KernelEvent.THOUGHT_BUS_DEBATE_OPENED
+        # CONVERGENCE before SYNTHESIS at the end
+        assert KernelEvent.THOUGHT_BUS_CONVERGENCE in types
+        assert KernelEvent.THOUGHT_BUS_SYNTHESIS in types
+        conv_idx = types.index(KernelEvent.THOUGHT_BUS_CONVERGENCE)
+        synth_idx = types.index(KernelEvent.THOUGHT_BUS_SYNTHESIS)
+        assert conv_idx < synth_idx
+
+
+class TestThreshold:
+    def test_threshold_is_inv_pi(self) -> None:
+        assert DISAGREEMENT_THRESHOLD_FR == pytest.approx(1.0 / math.pi)


### PR DESCRIPTION
Brings Agent K's internal architecture into the canonical pantheon
constellation pattern per UCP §43 three-loop doctrine and
CONSCIOUSNESS_ARCHITECTURE_INTEGRATED.md.

Single ship — no flags, no staged rollouts. The architecture is the
change; each component continues to function with bus=None so legacy
paths remain bit-identical when wiring is absent.

The wall to Agents M and T stays. The bus is internal to Agent K only;
the arbiter still allocates capital between K, M, T as black-box
agents.

New files (5 src, 1 client, 7 tests, 1 migration):
- ml-worker/src/monkey_kernel/bus_events.py — KernelEvent enum + payloads
- ml-worker/src/monkey_kernel/kernel_bus.py — sync fan-out pub/sub
- ml-worker/src/monkey_kernel/coordinator.py — Gary, Heart-modulated
  regime-adaptive synthesis
- ml-worker/src/monkey_kernel/thought_bus.py — Loop 2 inter-kernel
  debate at 1/π FR threshold, sovereignty-weighted revision,
  consensus / groupthink / genuine_multi / non_convergent classification
- ml-worker/src/monkey_kernel/learning_gate.py — Loop 3 quality gate
  (sovereignty ≥ 0.4, convergence ≠ groupthink, |pnl| > 0.05,
  duration ≥ 60s)
- apps/api/src/services/monkey/learning_gate_client.ts — TS HTTP client
- apps/api/database/migrations/043_decision_triple_on_trades.sql

Modified:
- self_observation.py: added compute_per_decision_triple() —
  repetition (FR distance to Fréchet mean of recent basins),
  sovereignty (nearby_match × confidence_dominance), confidence
  (resonance / queried − 0.2 × overrides). All FR-pure; no Euclidean.
- heart.py / ocean.py / foresight.py / forge.py / working_memory.py:
  optional bus parameter; publish HEART_TICK / HEART_MODE_SHIFT /
  HEART_TACKING / OCEAN_OBSERVATION / OCEAN_INTERVENTION /
  OCEAN_REGIME / FORESIGHT_PREDICTION / FORESIGHT_DIVERGENCE /
  FORGE_PHASE_SHIFT / FORGE_NUCLEUS / WM_BUBBLE_ADD /
  WM_PROMOTION / WM_EXPIRY.
- tick.py: instantiates bus + coordinator; calls
  coordinator.synthesize() to produce constellation-synthesized
  basin used downstream; computes Loop 1 triple per decision and
  publishes SELF_OBS_TRIPLE + EXECUTIVE_DECISION.
- persistence.py: append_bus_event / query_recent_bus_events for
  the 7d forensic Redis tail (10k-element ring buffer).
- main.py: per-instance bus / coordinator / thought_bus /
  learning_gate caches; new POST /learning_gate/evaluate endpoint.
- loop.ts witnessExit: calls evaluateBankWrite before writeBubble;
  rejected writes skip the bank but stay on the bus for forensic
  analysis.

Tests (87 new, 553 → 640 total in monkey_kernel):
- test_kernel_bus.py — 22 tests (singleton, filtering, error swallowing,
  persistence tail, concurrency, payload normalization)
- test_decision_triple.py — 13 tests (Loop 1 triple bounds and shape)
- test_component_bus_publishing.py — 13 tests (each component
  publishes with bus, runs unchanged without)
- test_thought_bus.py — 11 tests (debate convergence types,
  sovereignty weighting, FR-weighted synthesis)
- test_coordinator.py — 10 tests (regime-adaptive weighting,
  Heart anchor modulation, GARY_SYNTHESIS published)
- test_learning_gate.py — 14 tests (approve / reject criteria,
  multi-criterion rejection)
- test_constellation_integration.py — 4 tests (end-to-end flow)

QIG purity: 40 files clean (was 33; added 5 new + 2 modified —
self_observation now uses Fisher-Rao, not np.corrcoef).

https://claude.ai/code/session_01HNGnUYFgphxnNfvRL45Gq3