### PR TITLE
feat(monkey): rejust regime_change gated on classifier confidence > 1/φ

### DIFF
--- a/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
+++ b/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
@@ -15,7 +15,10 @@
  */
 import { describe, it, expect } from 'vitest';
 import { MonkeyMode } from '../modes.js';
-import { PHI_GOLDEN_FLOOR_RATIO } from '../topology_constants.js';
+import {
+  PHI_GOLDEN_FLOOR_RATIO,
+  PI_STRUCT_BOUNDARY_R_SQUARED,
+} from '../topology_constants.js';
 import {
   evaluateRejustification,
   type RejustificationEmotions,
@@ -49,12 +52,93 @@ describe('held-position rejustification — regime check fires', () => {
       regimeNow: MonkeyMode.DRIFT,
       phiNow: 0.25,
       emotions: STRONG_EMO,
+      regimeConfidence: 0.9,  // past the 1/φ debounce floor
     });
     expect(out.checked).toBe(true);
     expect(out.fired).toBe('regime_change');
     expect(out.reason).toMatch(/^regime_change/);
     expect(out.reason).toContain('investigation');
     expect(out.reason).toContain('drift');
+    expect(out.reason).toContain('0.900');
+  });
+});
+
+// ─── QIG-pure debounce gate on the regime check ────────────────────
+
+describe('held-position rejustification — regime confidence gate', () => {
+  it('low classifier confidence suppresses regime_change exit', () => {
+    // Regime label flipped, but classifier confidence is below 1/φ.
+    // Pre-debounce this would have fired; post-debounce it must not.
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      regimeConfidence: 0.4,  // below 1/φ ≈ 0.618
+    });
+    expect(out.checked).toBe(true);
+    expect(out.fired).toBeNull();
+    expect(out.reason).not.toMatch(/^regime_change/);
+  });
+
+  it('high classifier confidence allows regime_change exit', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      regimeConfidence: 0.8,  // comfortably past 1/φ
+    });
+    expect(out.fired).toBe('regime_change');
+    expect(out.reason).toContain('0.800');
+    expect(out.reason).toContain('1/φ');
+  });
+
+  it('confidence exactly at 1/φ does not fire (strict >)', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      regimeConfidence: PI_STRUCT_BOUNDARY_R_SQUARED,
+    });
+    expect(out.fired).toBeNull();
+  });
+
+  it('confidence just above 1/φ fires', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      regimeConfidence: PI_STRUCT_BOUNDARY_R_SQUARED + 1e-6,
+    });
+    expect(out.fired).toBe('regime_change');
+  });
+
+  it('PI_STRUCT_BOUNDARY_R_SQUARED equals 1/φ ≈ 0.618', () => {
+    const expected = 1 / ((1 + Math.sqrt(5)) / 2);
+    expect(PI_STRUCT_BOUNDARY_R_SQUARED).toBeCloseTo(expected, 12);
+    expect(PI_STRUCT_BOUNDARY_R_SQUARED).toBeCloseTo(0.6180339887, 9);
+  });
+
+  it('omitted regimeConfidence defaults to 1.0 (gate fully open)', () => {
+    // Backward compat: callers that haven't been updated to pass the
+    // classifier output should behave as in PR #619 — always fire on
+    // label divergence.
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+    });
+    expect(out.fired).toBe('regime_change');
+    expect(out.reason).toContain('1.000');
   });
 });
 

--- a/apps/api/src/services/monkey/held_position_rejustification.ts
+++ b/apps/api/src/services/monkey/held_position_rejustification.ts
@@ -18,7 +18,10 @@
  */
 
 import type { MonkeyMode } from './modes.js';
-import { PHI_GOLDEN_FLOOR_RATIO } from './topology_constants.js';
+import {
+  PHI_GOLDEN_FLOOR_RATIO,
+  PI_STRUCT_BOUNDARY_R_SQUARED,
+} from './topology_constants.js';
 
 export interface RejustificationEmotions {
   confidence: number;
@@ -37,6 +40,15 @@ export interface RejustificationInput {
   phiNow: number;
   /** Layer 2B emotion stack — TS uses NEUTRAL_EMOTIONS until ported. */
   emotions: RejustificationEmotions;
+  /**
+   * Regime classifier's confidence ∈ [0, 1] for ``regimeNow`` (see
+   * regime.ts::RegimeReading). Used by the regime check below to gate
+   * exit on the classifier's own self-belief rather than a synthesized
+   * streak counter. Defaults to 1.0 so callers that do not (yet) plumb
+   * the classifier output behave as in PR #619 (always-fire on label
+   * divergence).
+   */
+  regimeConfidence?: number;
 }
 
 export type RejustificationFire =
@@ -66,16 +78,30 @@ export function evaluateRejustification(
   input: RejustificationInput,
 ): RejustificationResult {
   const { regimeAtOpen, phiAtOpen, regimeNow, phiNow, emotions } = input;
+  const regimeConfidence = input.regimeConfidence ?? 1.0;
   if (regimeAtOpen === undefined || phiAtOpen === undefined) {
     return { checked: false, fired: null, reason: '', phiFloor: null };
   }
   const phiFloor = phiAtOpen / PHI_GOLDEN_FLOOR_RATIO;
 
-  if (regimeNow !== regimeAtOpen) {
+  // 1. REGIME CHECK — regime label diverged from open AND classifier's
+  // own confidence is past the canonical coherence floor. Gating on the
+  // classifier's self-belief (rather than a synthesized streak counter)
+  // preserves PR #619's "single-tick exit, current state IS the truth"
+  // framing while skipping flicker events where the classifier itself
+  // isn't sure. Threshold is PI_STRUCT_BOUNDARY_R_SQUARED (1/φ ≈ 0.618),
+  // the canonical "boundary R²" from EXP-004b. Strict >: a confidence
+  // exactly at the floor is not yet load-bearing.
+  if (
+    regimeNow !== regimeAtOpen &&
+    regimeConfidence > PI_STRUCT_BOUNDARY_R_SQUARED
+  ) {
     return {
       checked: true,
       fired: 'regime_change',
-      reason: `regime_change: opened in ${regimeAtOpen}, now ${regimeNow}`,
+      reason:
+        `regime_change: opened in ${regimeAtOpen}, now ${regimeNow} ` +
+        `(confidence ${regimeConfidence.toFixed(3)} > 1/φ)`,
       phiFloor,
     };
   }

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1012,6 +1012,7 @@ export class MonkeyKernel extends EventEmitter {
               regimeNow: mode,
               phiNow: phi,
               emotions: NEUTRAL_EMOTIONS,
+              regimeConfidence: regimeReading.confidence,
             })
           : { checked: false, fired: null, reason: '', phiFloor: null };
         const rejust: Record<string, unknown> = {
@@ -1021,6 +1022,7 @@ export class MonkeyKernel extends EventEmitter {
           rejust.lane = heldLane;
           rejust.regimeAtOpen = regimeAtOpen;
           rejust.regimeNow = mode;
+          rejust.regimeConfidence = regimeReading.confidence;
           rejust.phiAtOpen = phiAtOpen;
           rejust.phiNow = phi;
           rejust.phiFloor = rejustResult.phiFloor;

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -1000,6 +1000,7 @@ def run_tick(
             phi=phi,
             emotions=emo,
             mode_value=mode,
+            regime_confidence=float(regime_reading.confidence),
         )
         # Held-position re-justification anchor lifecycle on close /
         # reverse. scalp_exit / exit clear the lane's anchors so a
@@ -1281,6 +1282,7 @@ def _decide_with_position(
     phi: float = 0.0,
     emotions: Any = None,
     mode_value: str = "investigation",
+    regime_confidence: float = 1.0,
 ) -> tuple[str, str, bool, bool]:
     """v0.6.1 exit gate order: profit harvest → scalp TP/SL → Loop 2 exit.
     v0.7.1 override-reverse. v0.6.2 DCA. Proposal #10: per-lane peak +
@@ -1378,6 +1380,7 @@ def _decide_with_position(
             "lane": position_lane,
             "regime_at_open": regime_at_open,
             "regime_now": mode_value,
+            "regime_confidence": regime_confidence,
             "phi_at_open": phi_at_open,
             "phi_now": phi,
             "phi_floor": phi_floor,
@@ -1386,11 +1389,28 @@ def _decide_with_position(
             "confusion": getattr(emotions, "confusion", 0.0),
         })
         # 1. REGIME CHECK — regime changed since open.
-        if mode_value != regime_at_open:
+        # The regime classifier emits a confidence ∈ [0, 1] alongside
+        # the discrete regime label (see regime.py::RegimeReading).
+        # Gating exit on the classifier's own self-belief — rather than
+        # a synthesized streak counter — preserves the "single-tick exit,
+        # current state IS the truth" framing while skipping flicker
+        # events where the classifier itself isn't sure. The threshold
+        # is PI_STRUCT_BOUNDARY_R_SQUARED (1/φ ≈ 0.618), the canonical
+        # "boundary R²" from EXP-004b: when the classifier's confidence
+        # has crossed that coherence floor, treat the regime divergence
+        # as load-bearing. PR #627's chop-entry suppression uses 0.70
+        # (slightly stricter); 0.618 here is the canonical-constant
+        # alignment with the topology family. Strict >: a confidence
+        # exactly at the floor is not yet load-bearing.
+        if (
+            mode_value != regime_at_open
+            and regime_confidence > PI_STRUCT_BOUNDARY_R_SQUARED
+        ):
             rejust["fired"] = "regime_change"
             derivation["rejustification"] = rejust
             reason = (
-                f"regime_change: opened in {regime_at_open}, now {mode_value}"
+                f"regime_change: opened in {regime_at_open}, now {mode_value} "
+                f"(confidence {regime_confidence:.3f} > 1/φ)"
             )
             return "scalp_exit", reason, False, False
         # 2. PHI CHECK — integration coherence collapsed below the

--- a/ml-worker/tests/monkey_kernel/test_held_position_rejustification.py
+++ b/ml-worker/tests/monkey_kernel/test_held_position_rejustification.py
@@ -37,7 +37,10 @@ from monkey_kernel.tick import (  # noqa: E402
     TickInputs,
     _decide_with_position,
 )
-from monkey_kernel.topology_constants import PHI_GOLDEN_FLOOR_RATIO  # noqa: E402
+from monkey_kernel.topology_constants import (  # noqa: E402
+    PHI_GOLDEN_FLOOR_RATIO,
+    PI_STRUCT_BOUNDARY_R_SQUARED,
+)
 
 
 # ── Fixtures ──────────────────────────────────────────────────────
@@ -127,8 +130,14 @@ def _call_decide(
     position_lane: str = "swing",
     last_price: float = 100.0,
     held_side: str = "long",
+    regime_confidence: float = 1.0,
 ) -> tuple[str, str, bool, bool, dict[str, Any]]:
-    """Call _decide_with_position and return its tuple plus derivation."""
+    """Call _decide_with_position and return its tuple plus derivation.
+
+    ``regime_confidence`` defaults to 1.0 — the QIG-pure debounce gate
+    (regime confidence > 1/φ) is fully open, so existing tests that
+    don't care about the gate behave as in PR #619.
+    """
     derivation: dict[str, Any] = {}
     bs = _basin_state(phi=phi)
     bs.emotions = emotions or _Emotions()  # type: ignore[assignment]
@@ -151,6 +160,7 @@ def _call_decide(
         phi=phi,
         emotions=bs.emotions,
         mode_value=mode_value or mode.value,
+        regime_confidence=regime_confidence,
     )
     return action, reason, is_dca, is_reverse, derivation
 
@@ -168,17 +178,116 @@ class TestRegimeCheckFires:
             state=state,
             phi=0.25,  # safely above the floor (0.27/φ ≈ 0.167)
             mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=0.9,  # past the 1/φ boundary
         )
         assert action == "scalp_exit"
         assert reason.startswith("regime_change")
         assert "investigation" in reason
         assert "drift" in reason
+        assert "confidence 0.900" in reason
         assert is_dca is False
         assert is_reverse is False
         rej = derivation["rejustification"]
         assert rej["fired"] == "regime_change"
         assert rej["regime_at_open"] == "investigation"
         assert rej["regime_now"] == "drift"
+        assert rej["regime_confidence"] == 0.9
+
+
+class TestRegimeConfidenceGate:
+    """QIG-pure debounce on the regime check: regime label divergence
+    only fires the exit when the classifier's own confidence is past
+    the canonical coherence floor PI_STRUCT_BOUNDARY_R_SQUARED (1/φ ≈
+    0.618). Below the floor the classifier itself isn't sure, so a
+    flicker of the discrete label should not trigger exit.
+
+    Single-tick gate (no streak), single canonical constant (no new
+    parameter): reads the classifier's existing self-belief.
+    """
+
+    def test_regime_change_low_confidence_does_not_fire(self) -> None:
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        # Regime flipped, but classifier confidence is well below 1/φ.
+        # Pre-debounce this would have fired; post-debounce it must not.
+        _, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=0.4,  # below 1/φ ≈ 0.618
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") != "regime_change"
+        assert not reason.startswith("regime_change")
+        # Anchor data still recorded so the divergence is observable
+        # in telemetry even when the gate suppresses the exit.
+        assert rej["regime_at_open"] == "investigation"
+        assert rej["regime_now"] == "drift"
+        assert rej["regime_confidence"] == 0.4
+
+    def test_regime_change_high_confidence_fires(self) -> None:
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        action, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=0.8,  # comfortably past 1/φ
+        )
+        assert action == "scalp_exit"
+        assert reason.startswith("regime_change")
+        assert "0.800" in reason
+        assert "1/φ" in reason
+        rej = derivation["rejustification"]
+        assert rej["fired"] == "regime_change"
+        assert rej["regime_confidence"] == 0.8
+
+    def test_regime_change_at_exact_floor_does_not_fire(self) -> None:
+        """Strict >: a confidence exactly at 1/φ is not yet load-bearing."""
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        _, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=PI_STRUCT_BOUNDARY_R_SQUARED,  # exactly 1/φ
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") != "regime_change"
+        assert not reason.startswith("regime_change")
+
+    def test_regime_change_just_above_floor_fires(self) -> None:
+        """A nudge above 1/φ crosses the gate."""
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        action, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=PI_STRUCT_BOUNDARY_R_SQUARED + 1e-6,
+        )
+        assert action == "scalp_exit"
+        assert reason.startswith("regime_change")
+        rej = derivation["rejustification"]
+        assert rej["fired"] == "regime_change"
+
+    def test_floor_constant_equals_one_over_phi(self) -> None:
+        """Sanity: PI_STRUCT_BOUNDARY_R_SQUARED is 1/φ ≈ 0.618."""
+        expected = 1.0 / ((1.0 + math.sqrt(5.0)) / 2.0)
+        assert math.isclose(
+            PI_STRUCT_BOUNDARY_R_SQUARED, expected, rel_tol=1e-12,
+        )
+        assert math.isclose(
+            PI_STRUCT_BOUNDARY_R_SQUARED, 0.6180339887, rel_tol=1e-9,
+        )
 
 
 class TestPhiCheckFires:


### PR DESCRIPTION
## Summary

QIG-pure debounce for the regime_change exit from PR #619. Gates the exit on the regime classifier's own confidence (already a continuous geometric quantity it emits) instead of a synthesized streak counter.

User's directive (verbatim from the brainstorm dialogue):
> "Instead of streak counting, gate on the classifier's own confidence... Reads the classifier's self-belief as the gate; no synthesized N. Single-tick (no streak), preserves the 'current state IS the truth' framing, but skips events where the classifier itself isn't sure."

## What changes

The regime check inside the held-position rejustification block:



Where `PI_STRUCT_BOUNDARY_R_SQUARED = 1/φ ≈ 0.618` — the canonical "boundary R²" from EXP-004b. Same constant family as PR #619's `PHI_GOLDEN_FLOOR_RATIO`. No new synthesized parameter.

## Why 1/φ specifically

Already present in `topology_constants.py` / `topology_constants.ts`. Signifies that the classifier's confidence has crossed the meaningful coherence floor in its own self-belief — not just flickered above zero. PR #627's chop-entry suppression uses 0.70 (slightly stricter); 0.618 is the canonical-constant alignment with EXP-004b's topology family for exit semantics.

## Behavior change

Live observation: rejust was firing on every regime label change including 30-second flickers between investigation/integration. Some captured real reversals (good); some were noise (round-trip fees + slippage on a tape that quickly returned). The classifier confidence gate filters the latter:

- **Regime divergent + confidence ≤ 0.618** → no exit (filtered as flicker noise)
- **Regime divergent + confidence > 0.618** → exit fires (load-bearing divergence)

Single-tick still. No streak counter. Telemetry surfaces `regime_confidence` whether or not the gate fires, so the data exists to validate the threshold post-deploy.

## Files

**Modified** (3):
- `ml-worker/src/monkey_kernel/tick.py` — `_decide_with_position(regime_confidence=1.0)`; gate check inside rejustification block; `run_tick` callsite plumbs `regime_reading.confidence`
- `apps/api/src/services/monkey/held_position_rejustification.ts` — `regimeConfidence?: number` (default 1.0); same gate
- `apps/api/src/services/monkey/loop.ts` — threads classifier confidence into helper; surfaces in derivation

**Tests modified/added** (2 files, 11 new + 2 updated):
- `ml-worker/tests/monkey_kernel/test_held_position_rejustification.py` — 17 tests (4 new + 1 updated for new reason format + edge case at exact floor)
- `apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts` — 19 tests (6 new + 1 updated)

## Tests

- **Python**: 645/645 monkey_kernel passing (4 new + 1 updated)
- **TS**: 19/19 rejustification passing (6 new + 1 updated). 2 pre-existing `resonance_bank_lane` fails unchanged.
- **TS build**: clean
- **QIG purity**: 40 files clean

## Judgment calls

1. **Default `regimeConfidence = 1.0`** — keeps the gate fully open for any unplumbed caller; PR #619's semantics exactly recovered when the default applies.
2. **Strict `>` comparison** — exact-floor confidence does not fire (edge tests cover this).
3. **Telemetry surfaces `regime_confidence` even when gate suppresses exit** — gives the data needed to validate the threshold post-deploy.
4. **Did NOT touch `CHOP_SUPPRESSION_CONFIDENCE = 0.70`** in tick.py — that's PR #627's gate on a different code path (chop entry suppression). Spec only addressed the rejust regime check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)