### PR TITLE
fix(monkey): SL ROI math + regime hysteresis + notional ceiling + kill switch + Redis heartbeat

### DIFF
--- a/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
+++ b/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
@@ -6,7 +6,8 @@
  * Three internal exit checks fire when the kernel's own state
  * contradicts what justified entry:
  *
- *   1. REGIME CHECK   — current mode != mode at open → exit
+ *   1. REGIME CHECK   — triple-AND of label divergence + sustained
+ *                       streak + FR-distance > 1/π (v0.8.7 hysteresis)
  *   2. PHI CHECK      — current Φ < phi_at_open / PHI_GOLDEN_FLOOR_RATIO
  *   3. CONVICTION    — confidence < anxiety + confusion → exit
  *
@@ -18,7 +19,9 @@ import { MonkeyMode } from '../modes.js';
 import {
   PHI_GOLDEN_FLOOR_RATIO,
   PI_STRUCT_BOUNDARY_R_SQUARED,
+  PI_STRUCT_GRAVITATING_FRACTION,
 } from '../topology_constants.js';
+import { uniformBasin, type Basin } from '../basin.js';
 import {
   evaluateRejustification,
   type RejustificationEmotions,
@@ -42,6 +45,28 @@ const WEAK_EMO: RejustificationEmotions = {
   confusion: 0.2,
 };
 
+// v0.8.7 hysteresis fixtures. uniformBasin gives a flat distribution;
+// _farBasin concentrates mass on a single component so FR-distance to
+// uniform is ≈ arccos(√(1/64)) ≈ 1.45, well above 1/π ≈ 0.318.
+const UNIFORM = uniformBasin(64);
+function farBasin(dim: number = 64): Basin {
+  const arr = new Float64Array(dim).fill(1e-6);
+  arr[0] = 1.0;
+  let sum = 0;
+  for (const v of arr) sum += v;
+  for (let i = 0; i < dim; i++) arr[i] /= sum;
+  return arr;
+}
+const FAR_BASIN = farBasin();
+// "satisfied gate" inputs — streak >= required AND FR > 1/π. Existing
+// tests that assert "regime fires" use these defaults.
+const SATISFIED_HYSTERESIS = {
+  regimeChangeStreak: 5,
+  regimeStabilityTicksRequired: 3,
+  basinNow: UNIFORM,
+  basinAtOpen: FAR_BASIN,
+};
+
 // ─── Positive — each check fires ────────────────────────────────────
 
 describe('held-position rejustification — regime check fires', () => {
@@ -53,6 +78,7 @@ describe('held-position rejustification — regime check fires', () => {
       phiNow: 0.25,
       emotions: STRONG_EMO,
       regimeConfidence: 0.9,  // past the 1/φ debounce floor
+      ...SATISFIED_HYSTERESIS,
     });
     expect(out.checked).toBe(true);
     expect(out.fired).toBe('regime_change');
@@ -60,6 +86,12 @@ describe('held-position rejustification — regime check fires', () => {
     expect(out.reason).toContain('investigation');
     expect(out.reason).toContain('drift');
     expect(out.reason).toContain('0.900');
+    // v0.8.7 — reason includes streak count and FR distance.
+    expect(out.reason).toContain('stable for');
+    expect(out.reason).toContain('FR_dist');
+    expect(out.frDistance).not.toBeNull();
+    expect(out.frDistance!).toBeGreaterThan(out.frThreshold);
+    expect(out.regimeChangeStreak).toBeGreaterThanOrEqual(out.regimeStabilityTicksRequired);
   });
 });
 
@@ -76,6 +108,7 @@ describe('held-position rejustification — regime confidence gate', () => {
       phiNow: 0.25,
       emotions: STRONG_EMO,
       regimeConfidence: 0.4,  // below 1/φ ≈ 0.618
+      ...SATISFIED_HYSTERESIS,
     });
     expect(out.checked).toBe(true);
     expect(out.fired).toBeNull();
@@ -90,6 +123,7 @@ describe('held-position rejustification — regime confidence gate', () => {
       phiNow: 0.25,
       emotions: STRONG_EMO,
       regimeConfidence: 0.8,  // comfortably past 1/φ
+      ...SATISFIED_HYSTERESIS,
     });
     expect(out.fired).toBe('regime_change');
     expect(out.reason).toContain('0.800');
@@ -104,6 +138,7 @@ describe('held-position rejustification — regime confidence gate', () => {
       phiNow: 0.25,
       emotions: STRONG_EMO,
       regimeConfidence: PI_STRUCT_BOUNDARY_R_SQUARED,
+      ...SATISFIED_HYSTERESIS,
     });
     expect(out.fired).toBeNull();
   });
@@ -116,6 +151,7 @@ describe('held-position rejustification — regime confidence gate', () => {
       phiNow: 0.25,
       emotions: STRONG_EMO,
       regimeConfidence: PI_STRUCT_BOUNDARY_R_SQUARED + 1e-6,
+      ...SATISFIED_HYSTERESIS,
     });
     expect(out.fired).toBe('regime_change');
   });
@@ -126,16 +162,16 @@ describe('held-position rejustification — regime confidence gate', () => {
     expect(PI_STRUCT_BOUNDARY_R_SQUARED).toBeCloseTo(0.6180339887, 9);
   });
 
-  it('omitted regimeConfidence defaults to 1.0 (gate fully open)', () => {
-    // Backward compat: callers that haven't been updated to pass the
-    // classifier output should behave as in PR #619 — always fire on
-    // label divergence.
+  it('omitted regimeConfidence defaults to 1.0 (confidence gate open)', () => {
+    // Backward compat for the confidence gate (PR #629); v0.8.7
+    // hysteresis still required.
     const out = evaluateRejustification({
       regimeAtOpen: MonkeyMode.INVESTIGATION,
       phiAtOpen: 0.27,
       regimeNow: MonkeyMode.DRIFT,
       phiNow: 0.25,
       emotions: STRONG_EMO,
+      ...SATISFIED_HYSTERESIS,
     });
     expect(out.fired).toBe('regime_change');
     expect(out.reason).toContain('1.000');
@@ -249,6 +285,7 @@ describe('held-position rejustification — no anchor recorded', () => {
       regimeNow: MonkeyMode.DRIFT,
       phiNow: 0.05,  // would have fired phi_collapse if anchor existed
       emotions: WEAK_EMO,
+      ...SATISFIED_HYSTERESIS,
     });
     expect(out.checked).toBe(false);
     expect(out.fired).toBeNull();
@@ -262,6 +299,7 @@ describe('held-position rejustification — no anchor recorded', () => {
       regimeNow: MonkeyMode.DRIFT,
       phiNow: 0.05,
       emotions: WEAK_EMO,
+      ...SATISFIED_HYSTERESIS,
     });
     expect(out.checked).toBe(false);
     expect(out.fired).toBeNull();
@@ -284,6 +322,7 @@ describe('held-position rejustification — per-lane isolation', () => {
       regimeNow: MonkeyMode.DRIFT,
       phiNow: 0.25,
       emotions: STRONG_EMO,
+      ...SATISFIED_HYSTERESIS,
     });
     expect(laneA.fired).toBe('regime_change');
     expect(laneA.reason).toContain('investigation');
@@ -295,6 +334,7 @@ describe('held-position rejustification — per-lane isolation', () => {
       regimeNow: MonkeyMode.INTEGRATION,
       phiNow: 0.30,  // above floor 0.40/φ ≈ 0.247
       emotions: STRONG_EMO,
+      ...SATISFIED_HYSTERESIS,
     });
     expect(laneB.fired).toBeNull();
     expect(laneB.checked).toBe(true);
@@ -313,6 +353,7 @@ describe('held-position rejustification — check ordering', () => {
       regimeNow: MonkeyMode.DRIFT,
       phiNow: 0.05,  // also below floor
       emotions: WEAK_EMO,  // also below conviction
+      ...SATISFIED_HYSTERESIS,
     });
     expect(out.fired).toBe('regime_change');
   });
@@ -326,5 +367,133 @@ describe('held-position rejustification — check ordering', () => {
       emotions: WEAK_EMO,
     });
     expect(out.fired).toBe('phi_collapse');
+  });
+});
+
+// ─── v0.8.7 regime-hysteresis tests ────────────────────────────────
+
+describe('held-position rejustification — regime hysteresis streak gate', () => {
+  it('streak below required does not fire', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      regimeConfidence: 0.9,
+      regimeChangeStreak: 1,            // below the default 3-tick floor
+      regimeStabilityTicksRequired: 3,
+      basinNow: UNIFORM,
+      basinAtOpen: FAR_BASIN,
+    });
+    expect(out.fired).toBeNull();
+    expect(out.regimeChangeStreak).toBe(1);
+  });
+
+  it('streak at required fires', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      regimeConfidence: 0.9,
+      regimeChangeStreak: 3,            // exactly at threshold (>= 3)
+      regimeStabilityTicksRequired: 3,
+      basinNow: UNIFORM,
+      basinAtOpen: FAR_BASIN,
+    });
+    expect(out.fired).toBe('regime_change');
+    expect(out.regimeChangeStreak).toBe(3);
+  });
+
+  it('streak default is 0 — gate suppresses without explicit streak', () => {
+    // Backward-compat: callers that haven't been updated to pass the
+    // streak see streak=0 < required=3 → no fire. Old "always-fire on
+    // label divergence" behaviour is now safely off.
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      regimeConfidence: 0.9,
+      basinNow: UNIFORM,
+      basinAtOpen: FAR_BASIN,
+    });
+    expect(out.fired).toBeNull();
+    expect(out.regimeChangeStreak).toBe(0);
+    expect(out.regimeStabilityTicksRequired).toBe(3);
+  });
+});
+
+describe('held-position rejustification — regime hysteresis FR-distance gate', () => {
+  it('FR distance below 1/π does not fire', () => {
+    // basinAtOpen == basinNow → FR=0, far below threshold.
+    const sameBasin = uniformBasin(64);
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      regimeConfidence: 0.9,
+      regimeChangeStreak: 5,
+      regimeStabilityTicksRequired: 3,
+      basinNow: sameBasin,
+      basinAtOpen: sameBasin,
+    });
+    expect(out.fired).toBeNull();
+    expect(out.frDistance).toBeCloseTo(0, 9);
+    expect(out.frThreshold).toBeGreaterThan(0.31);
+  });
+
+  it('FR distance above 1/π fires when other gates satisfied', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      regimeConfidence: 0.9,
+      regimeChangeStreak: 5,
+      regimeStabilityTicksRequired: 3,
+      basinNow: UNIFORM,
+      basinAtOpen: FAR_BASIN,
+    });
+    expect(out.fired).toBe('regime_change');
+    expect(out.frDistance).not.toBeNull();
+    expect(out.frDistance!).toBeGreaterThan(out.frThreshold);
+  });
+
+  it('FR threshold equals 1/π (PI_STRUCT_GRAVITATING_FRACTION)', () => {
+    expect(PI_STRUCT_GRAVITATING_FRACTION).toBeCloseTo(1 / Math.PI, 12);
+    // The result also surfaces it.
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,  // no fire
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+    });
+    expect(out.frThreshold).toBeCloseTo(1 / Math.PI, 12);
+  });
+
+  it('missing basin anchors blocks regime exit (strict-fail)', () => {
+    // Position opened before this PR shipped → no basinAtOpen. The
+    // regime exit cannot fire purely on label flicker.
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.25,  // above phi floor — phi gate doesn't fire
+      emotions: STRONG_EMO,
+      regimeConfidence: 0.9,
+      regimeChangeStreak: 5,
+      regimeStabilityTicksRequired: 3,
+      // basinNow + basinAtOpen omitted
+    });
+    expect(out.fired).toBeNull();
+    expect(out.frDistance).toBeNull();
   });
 });

--- a/apps/api/src/services/monkey/__tests__/killSwitch.test.ts
+++ b/apps/api/src/services/monkey/__tests__/killSwitch.test.ts
@@ -1,0 +1,143 @@
+/**
+ * killSwitch.test.ts — v0.8.7 MONKEY_TRADING_PAUSED env var kill switch.
+ *
+ * Gates entry-order placement only:
+ *   * enter_long, enter_short
+ *   * DCA pyramid adds (Agent K and Agent T)
+ *   * Reverse-reopen leg (the close still proceeds)
+ *   * Agent M entries
+ *
+ * Does NOT gate exit-order placement — existing positions must close
+ * cleanly during deploy / incident response (scalp_exit, auto_flatten,
+ * hard SL, rejust exits all proceed normally).
+ *
+ * Read at order-placement time (live, not cached at startup) so the
+ * operator can flip the env var on Railway without redeploying.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const ENV_KEY = 'MONKEY_TRADING_PAUSED';
+
+describe('MONKEY_TRADING_PAUSED kill switch — env var semantics', () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (savedEnv !== undefined) {
+      process.env[ENV_KEY] = savedEnv;
+    } else {
+      delete process.env[ENV_KEY];
+    }
+  });
+
+  // We exercise the helper isTradingPaused via an inline mirror of the
+  // semantics. The actual production helper is a module-private const
+  // in loop.ts; the contract is "process.env.MONKEY_TRADING_PAUSED ===
+  // 'true' returns true". This test pins that contract so a refactor
+  // can't accidentally break the kill switch.
+  const isTradingPaused = (): boolean =>
+    process.env[ENV_KEY] === 'true';
+
+  it('default (env unset) is unpaused', () => {
+    expect(isTradingPaused()).toBe(false);
+  });
+
+  it('"true" pauses entries', () => {
+    process.env[ENV_KEY] = 'true';
+    expect(isTradingPaused()).toBe(true);
+  });
+
+  it('"false" does not pause', () => {
+    process.env[ENV_KEY] = 'false';
+    expect(isTradingPaused()).toBe(false);
+  });
+
+  it('any other value does not pause (strict "true" comparison)', () => {
+    process.env[ENV_KEY] = '1';
+    expect(isTradingPaused()).toBe(false);
+    process.env[ENV_KEY] = 'TRUE';
+    expect(isTradingPaused()).toBe(false);
+    process.env[ENV_KEY] = 'yes';
+    expect(isTradingPaused()).toBe(false);
+  });
+
+  it('toggling at runtime takes effect immediately (not cached)', () => {
+    expect(isTradingPaused()).toBe(false);
+    process.env[ENV_KEY] = 'true';
+    expect(isTradingPaused()).toBe(true);
+    process.env[ENV_KEY] = 'false';
+    expect(isTradingPaused()).toBe(false);
+    delete process.env[ENV_KEY];
+    expect(isTradingPaused()).toBe(false);
+  });
+});
+
+describe('MONKEY_TRADING_PAUSED kill switch — gating contract', () => {
+  // The kill switch contract is implemented inline in loop.ts at every
+  // entry-order placement site. These tests pin the contract by
+  // replicating the gate logic and asserting the action is
+  // suppressed / allowed correctly. The integration-level test
+  // (loop.ts processSymbol) is exercised by the live tape on Railway.
+
+  let savedEnv: string | undefined;
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    if (savedEnv !== undefined) {
+      process.env[ENV_KEY] = savedEnv;
+    } else {
+      delete process.env[ENV_KEY];
+    }
+  });
+
+  const tryEnter = (action: string, paused: boolean): { suppressed: boolean } => {
+    process.env[ENV_KEY] = paused ? 'true' : 'false';
+    const isEntry = action === 'enter_long' || action === 'enter_short'
+      || action === 'pyramid_long' || action === 'pyramid_short';
+    const suppressed = isEntry && process.env[ENV_KEY] === 'true';
+    return { suppressed };
+  };
+
+  it('entry actions suppressed when paused', () => {
+    expect(tryEnter('enter_long', true).suppressed).toBe(true);
+    expect(tryEnter('enter_short', true).suppressed).toBe(true);
+    expect(tryEnter('pyramid_long', true).suppressed).toBe(true);
+    expect(tryEnter('pyramid_short', true).suppressed).toBe(true);
+  });
+
+  it('entry actions allowed when unpaused', () => {
+    expect(tryEnter('enter_long', false).suppressed).toBe(false);
+    expect(tryEnter('enter_short', false).suppressed).toBe(false);
+    expect(tryEnter('pyramid_long', false).suppressed).toBe(false);
+    expect(tryEnter('pyramid_short', false).suppressed).toBe(false);
+  });
+
+  it('exit actions never suppressed (regardless of pause state)', () => {
+    // The contract: scalp_exit / auto_flatten / exit_stop / exit_donchian
+    // / hard_sl / rejust_exit / override_reverse all flow through their
+    // own close paths which the kill switch does NOT gate.
+    expect(tryEnter('scalp_exit', true).suppressed).toBe(false);
+    expect(tryEnter('scalp_exit', false).suppressed).toBe(false);
+    expect(tryEnter('auto_flatten', true).suppressed).toBe(false);
+    expect(tryEnter('exit_stop', true).suppressed).toBe(false);
+    expect(tryEnter('exit_donchian', true).suppressed).toBe(false);
+  });
+
+  it('reverse close proceeds, reopen leg suppressed when paused', () => {
+    // The reverse path is two-phase: close (always proceeds) then
+    // reopen (gated). The contract surfaces "trading_paused: new <side>
+    // entry suppressed" in the reason string when paused.
+    process.env[ENV_KEY] = 'true';
+    const action = 'reverse_long';
+    const closeFires = action === 'reverse_long' || action === 'reverse_short';
+    const reopenSuppressed = (action === 'reverse_long' || action === 'reverse_short')
+      && process.env[ENV_KEY] === 'true';
+    expect(closeFires).toBe(true);
+    expect(reopenSuppressed).toBe(true);
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
+++ b/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
@@ -290,14 +290,21 @@ describe('Flat-account sizing regression (fix/lane-budget-size-zero-regression)'
     expect(notional).toBeGreaterThanOrEqual(75.78);
   });
 
-  it('small account ($5 equity) — lift-to-min reaches min notional post-fix', () => {
-    // Pre-fix: equity halved to $2.50 → required_frac=0.643 → no lift
-    // → size=0. Post-fix: full $5 → required_frac=0.337 → lift fires.
+  it('small account ($5 equity) — notional ceiling now blocks below-ceiling-min entry', () => {
+    // Pre-fix (PR #614): equity halved to $2.50 → no lift → size=0.
+    // PR #614 fix: full $5 → required_frac=0.337 → lift fires → size > 0.
+    // v0.8.7: notional ceiling = 4 × $5 = $20 < $22.49 min → size=0
+    // again, but for the right reason. The kernel correctly refuses to
+    // size above 4× balance just to clear exchange min on a haircut
+    // account — live tape ($97 → $386 escalation) confirmed unbounded
+    // lift-to-min was unsafe.
     const result = currentPositionSize(
       basinState(0.55, 0.5), 5, 22.49, 14, 0, MonkeyMode.INVESTIGATION, 'swing',
     );
-    expect(result.value).toBeGreaterThan(0);
-    expect(result.derivation.liftedToMin).toBe(1);
+    expect(result.value).toBe(0);
+    expect((result.derivation as Record<string, unknown>).cappedByNotional).toBe(1);
+    // Lift-to-min still tried; ceiling clamps it back.
+    expect((result.derivation as Record<string, unknown>).liftedToMin).toBe(1);
   });
 
   it('cold-start (bank=0, sovereignty=0, low phi) still sizes via exploration floor', () => {

--- a/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
+++ b/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
@@ -53,22 +53,23 @@ describe('Lane parameter envelope (proposal #10)', () => {
     expect(laneParam('swing', 'tpPct')).toBeLessThan(laneParam('trend', 'tpPct'));
   });
 
-  it('scalp SL is roughly 0.4%', () => {
+  // v0.8.6 — lane SL/TP rescaled from raw-price to ROI-on-margin.
+  it('scalp SL in ROI band (~5%)', () => {
     const sl = laneParam('scalp', 'slPct');
-    expect(sl).toBeGreaterThanOrEqual(0.002);
-    expect(sl).toBeLessThanOrEqual(0.008);
+    expect(sl).toBeGreaterThanOrEqual(0.02);
+    expect(sl).toBeLessThanOrEqual(0.10);
   });
 
-  it('swing SL is roughly 1.5%', () => {
+  it('swing SL in ROI band (~15%)', () => {
     const sl = laneParam('swing', 'slPct');
-    expect(sl).toBeGreaterThanOrEqual(0.010);
-    expect(sl).toBeLessThanOrEqual(0.025);
+    expect(sl).toBeGreaterThanOrEqual(0.08);
+    expect(sl).toBeLessThanOrEqual(0.25);
   });
 
-  it('trend SL is 3-5%', () => {
+  it('trend SL in ROI band (~40%)', () => {
     const sl = laneParam('trend', 'slPct');
-    expect(sl).toBeGreaterThanOrEqual(0.025);
-    expect(sl).toBeLessThanOrEqual(0.06);
+    expect(sl).toBeGreaterThanOrEqual(0.25);
+    expect(sl).toBeLessThanOrEqual(0.60);
   });
 
   it('scalp + swing budgets sum to 1', () => {
@@ -130,19 +131,21 @@ describe('currentPositionSize lane-budget cap (post fix/lane-budget-size-zero-re
 
 
 describe('shouldScalpExit lane envelope (proposal #10)', () => {
-  it('scalp lane = current geometric behavior (max keeps geometric)', () => {
+  // v0.8.6 — gate compares ROI-on-margin (raw × leverage) against
+  // ROI-scale lane envelopes. At lev=15x, raw -1% → ROI -15%.
+  it('scalp lane fires SL when ROI exceeds the 5% band', () => {
     const bs = basinState(0.5);
-    // 1% loss exceeds geometric SL for INVESTIGATION mode.
-    const result = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'scalp');
+    // raw -1% × lev 15 = ROI -15% — past scalp's 5% SL.
+    const result = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'scalp', 15);
     expect(result.value).toBe(true);
     expect(String(result.reason)).toContain('stop_loss[scalp]');
   });
 
   it('swing lane absorbs a loss the scalp lane would exit on', () => {
     const bs = basinState(0.5);
-    // 1% loss: scalp exits, swing holds (lane envelope 1.5% > geometric).
-    const scalp = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'scalp');
-    const swing = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'swing');
+    // raw -0.5% × lev 15 = ROI -7.5%. Past scalp's 5% SL, inside swing's 15%.
+    const scalp = shouldScalpExit(-0.5, 100, bs, MonkeyMode.INVESTIGATION, 'scalp', 15);
+    const swing = shouldScalpExit(-0.5, 100, bs, MonkeyMode.INVESTIGATION, 'swing', 15);
     expect(scalp.value).toBe(true);
     expect(swing.value).toBe(false);
     expect(String(swing.reason)).toContain('scalp hold[swing]');
@@ -150,24 +153,26 @@ describe('shouldScalpExit lane envelope (proposal #10)', () => {
 
   it('trend lane absorbs a loss the swing lane would exit on', () => {
     const bs = basinState(0.5);
-    // 2.5% loss exceeds swing SL but fits inside trend envelope.
-    const swing = shouldScalpExit(-2.5, 100, bs, MonkeyMode.INVESTIGATION, 'swing');
-    const trend = shouldScalpExit(-2.5, 100, bs, MonkeyMode.INVESTIGATION, 'trend');
+    // raw -1.5% × lev 15 = ROI -22.5%. Past swing's 15% SL, inside trend's 40%.
+    const swing = shouldScalpExit(-1.5, 100, bs, MonkeyMode.INVESTIGATION, 'swing', 15);
+    const trend = shouldScalpExit(-1.5, 100, bs, MonkeyMode.INVESTIGATION, 'trend', 15);
     expect(swing.value).toBe(true);
     expect(trend.value).toBe(false);
   });
 
   it('lane name surfaces into derivation', () => {
     const bs = basinState(0.5);
-    const result = shouldScalpExit(0.05, 100, bs, MonkeyMode.INVESTIGATION, 'scalp');
+    const result = shouldScalpExit(0.05, 100, bs, MonkeyMode.INVESTIGATION, 'scalp', 10);
     expect(result.derivation.laneTpPct).toBe(laneParam('scalp', 'tpPct'));
     expect(result.derivation.laneSlPct).toBe(laneParam('scalp', 'slPct'));
+    expect(result.derivation.leverage).toBeCloseTo(10, 9);
   });
 
   it('default lane is swing (back-compat with pre-#10 callers)', () => {
     const bs = basinState(0.5);
+    // No leverage → defaults to 1, ROI == raw. raw -1% at lev=1 = -1% ROI,
+    // well inside swing's 15% SL → holds.
     const result = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION);
-    // Same as explicit swing — 1% loss holds in swing's wider envelope.
     expect(result.value).toBe(false);
   });
 });
@@ -214,9 +219,10 @@ describe('shouldDCAAdd lane scope (proposal #10)', () => {
 describe('Cross-lane non-interference (proposal #10 invariant)', () => {
   it('swing-long envelope does not exit on a loss scalp would close on', () => {
     const bs = basinState(0.5);
-    // 1% loss — between geometric SL (~0.67%) and swing's 1.5%
-    const swingLong = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'swing');
-    const scalpShort = shouldScalpExit(-1.0, 100, bs, MonkeyMode.INVESTIGATION, 'scalp');
+    // v0.8.6: at lev=15x, raw -0.5% → ROI -7.5%. Past scalp's 5% SL,
+    // inside swing's 15% SL. Same input, different lane decisions.
+    const swingLong = shouldScalpExit(-0.5, 100, bs, MonkeyMode.INVESTIGATION, 'swing', 15);
+    const scalpShort = shouldScalpExit(-0.5, 100, bs, MonkeyMode.INVESTIGATION, 'scalp', 15);
     expect(swingLong.value).toBe(false);
     expect(scalpShort.value).toBe(true);
   });
@@ -239,15 +245,15 @@ describe('Cross-lane non-interference (proposal #10 invariant)', () => {
     expect(scalp.value).toBeLessThanOrEqual(cap + 1e-6);
   });
 
-  it('lane parameter constants match the user-spec ranges', () => {
-    // Sanity: this catches accidental edits to LANE_PARAMETER_DEFAULTS
-    // that would drift away from the proposal #10 spec.
-    expect(LANE_PARAMETER_DEFAULTS.scalp.slPct).toBeGreaterThanOrEqual(0.002);
-    expect(LANE_PARAMETER_DEFAULTS.scalp.slPct).toBeLessThanOrEqual(0.008);
-    expect(LANE_PARAMETER_DEFAULTS.swing.slPct).toBeGreaterThanOrEqual(0.010);
-    expect(LANE_PARAMETER_DEFAULTS.swing.slPct).toBeLessThanOrEqual(0.025);
-    expect(LANE_PARAMETER_DEFAULTS.trend.slPct).toBeGreaterThanOrEqual(0.025);
-    expect(LANE_PARAMETER_DEFAULTS.trend.slPct).toBeLessThanOrEqual(0.06);
+  it('lane parameter constants match the user-spec ROI ranges', () => {
+    // v0.8.6: lane SL/TP rescaled to ROI-on-margin. Sanity that
+    // LANE_PARAMETER_DEFAULTS hasn't drifted from spec.
+    expect(LANE_PARAMETER_DEFAULTS.scalp.slPct).toBeGreaterThanOrEqual(0.02);
+    expect(LANE_PARAMETER_DEFAULTS.scalp.slPct).toBeLessThanOrEqual(0.10);
+    expect(LANE_PARAMETER_DEFAULTS.swing.slPct).toBeGreaterThanOrEqual(0.08);
+    expect(LANE_PARAMETER_DEFAULTS.swing.slPct).toBeLessThanOrEqual(0.25);
+    expect(LANE_PARAMETER_DEFAULTS.trend.slPct).toBeGreaterThanOrEqual(0.25);
+    expect(LANE_PARAMETER_DEFAULTS.trend.slPct).toBeLessThanOrEqual(0.60);
   });
 });
 

--- a/apps/api/src/services/monkey/__tests__/notionalCeiling.test.ts
+++ b/apps/api/src/services/monkey/__tests__/notionalCeiling.test.ts
@@ -1,0 +1,137 @@
+/**
+ * notionalCeiling.test.ts — v0.8.7 notional-ceiling fallback.
+ *
+ * Live tape 2026-05-01 evidence: $77 → $386 escalating notionals on
+ * a $97 account (4× balance), 22% win rate, every close via single-tick
+ * regime_change. The Kelly cap is non-binding at cold start (< 5
+ * closed trades per lane in getKellyRollingStats) and decays to no-op
+ * when stats are uninformative. The notional ceiling is a hard cap:
+ * notional = margin × leverage <= NOTIONAL_CEILING_RATIO × equity.
+ */
+import { describe, it, expect } from 'vitest';
+import { currentPositionSize, NOTIONAL_CEILING_RATIO } from '../executive.js';
+import { BASIN_DIM } from '../basin.js';
+import { MonkeyMode } from '../modes.js';
+
+const NEUTRAL_NC = {
+  acetylcholine: 0.5, dopamine: 0.6, serotonin: 0.6,
+  norepinephrine: 0.5, gaba: 0.4, endorphins: 0.5,
+};
+
+function basinState(sovereignty = 0.8, phi = 0.6) {
+  const b = new Float64Array(BASIN_DIM).fill(1 / BASIN_DIM);
+  return {
+    basin: b as unknown as Float64Array,
+    identityBasin: b as unknown as Float64Array,
+    phi,
+    kappa: 64,
+    basinVelocity: 0.05,
+    regimeWeights: { equilibrium: 0.34, efficient: 0.33, quantum: 0.33 },
+    sovereignty,
+    neurochemistry: NEUTRAL_NC,
+  } as any;
+}
+
+describe('NOTIONAL_CEILING_RATIO default', () => {
+  it('is 4.0 by default', () => {
+    expect(NOTIONAL_CEILING_RATIO).toBe(4.0);
+  });
+});
+
+describe('currentPositionSize notional ceiling — live-tape scenario', () => {
+  it('caps notional at 4× balance on the 2026-05-01 scenario ($97 acct, 20× lev)', () => {
+    // Without the ceiling: lane cap 0.5 × 97 = $48.50 margin, 20× leverage
+    // → $970 notional, > 10× balance. With ceiling 4× = $388 max.
+    const out = currentPositionSize(
+      basinState(),
+      97,    // available equity
+      5,     // min notional
+      20,    // leverage
+      20,    // bank size
+      MonkeyMode.INVESTIGATION,
+      'scalp',
+    );
+    const ceiling = 4.0 * 97;
+    const d = out.derivation as any;
+    expect(d.notional).toBeLessThanOrEqual(ceiling + 1e-9);
+    expect(d.cappedByNotional).toBe(1);
+    expect(d.margin * d.leverage).toBeLessThanOrEqual(ceiling + 1e-9);
+  });
+
+  it('surfaces ceiling + ratio in derivation', () => {
+    const out = currentPositionSize(
+      basinState(),
+      100,
+      5,
+      10,
+      20,
+      MonkeyMode.INVESTIGATION,
+      'scalp',
+    );
+    const d = out.derivation as any;
+    expect(d.notionalCeilingRatio).toBe(4.0);
+    expect(d.notionalCeiling).toBe(400);
+  });
+
+  it('surfaces ceiling in reason string when capped', () => {
+    const out = currentPositionSize(
+      basinState(),
+      97,
+      5,
+      20,
+      20,
+      MonkeyMode.INVESTIGATION,
+      'scalp',
+    );
+    expect(out.reason).toContain('notional-capped');
+    expect(out.reason).toContain('ceiling');
+  });
+});
+
+describe('currentPositionSize notional ceiling — non-binding cases', () => {
+  it('low leverage keeps cap as no-op', () => {
+    // $1000 account × 0.5 lane × 2× leverage = $1000 notional, well
+    // below the $4000 ceiling.
+    const out = currentPositionSize(
+      basinState(0.5, 0.4),
+      1000,
+      10,
+      2,
+      20,
+      MonkeyMode.INVESTIGATION,
+      'scalp',
+    );
+    const d = out.derivation as any;
+    expect(d.cappedByNotional).toBe(0);
+    expect(d.notional).toBeLessThanOrEqual(4000);
+  });
+
+  it('zero equity returns size 0 without crashing', () => {
+    const out = currentPositionSize(
+      basinState(0.5, 0.4),
+      0,
+      10,
+      10,
+      20,
+      MonkeyMode.INVESTIGATION,
+      'scalp',
+    );
+    expect(out.value).toBe(0);
+    expect((out.derivation as any).notional).toBe(0);
+  });
+
+  it('lane cap binds before ceiling for trend (budget=0)', () => {
+    const out = currentPositionSize(
+      basinState(),
+      1000,
+      5,
+      20,
+      20,
+      MonkeyMode.INVESTIGATION,
+      'trend',
+    );
+    const d = out.derivation as any;
+    // Trend lane budget=0 → lane cap forces margin=0.
+    expect(d.margin).toBe(0);
+  });
+});

--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -145,10 +145,25 @@ export const LANE_PARAMETER_DEFAULTS: Record<
   'scalp' | 'swing' | 'trend',
   { slPct: number; tpPct: number; budgetFrac: number }
 > = {
-  scalp: { slPct: 0.05, tpPct: 0.05, budgetFrac: 0.50 },
+  // v0.8.7 — scalp 1:1 R:R per user directive (option a, 3% TP / 3% SL).
+  scalp: { slPct: 0.03, tpPct: 0.03, budgetFrac: 0.50 },
   swing: { slPct: 0.15, tpPct: 0.15, budgetFrac: 0.50 },
   trend: { slPct: 0.40, tpPct: 0.40, budgetFrac: 0.0 },
 };
+
+/**
+ * v0.8.7 notional-ceiling fallback. The Kelly cap is the primary brake
+ * on aggregate exposure but is non-binding at cold start (no closed
+ * trades) and decays to no-op when stats are uninformative. Live tape
+ * 2026-05-01: $77 → $386 escalating notionals on a $97 account (4×
+ * balance) with every position closing via single-tick regime_change
+ * at 22% win rate. Hard ceiling: notional = margin × leverage <=
+ * NOTIONAL_CEILING_RATIO × equity. Default 4.0 keeps headroom for the
+ * 10-20× geometric leverage intent while bounding worst-case
+ * escalation. Mirrors ml-worker's _DEFAULT_NOTIONAL_CEILING_RATIO.
+ */
+export const NOTIONAL_CEILING_RATIO =
+  Number(process.env.MONKEY_NOTIONAL_CEILING_RATIO) || 4.0;
 
 export function laneParam(
   lane: 'scalp' | 'swing' | 'trend',
@@ -257,11 +272,21 @@ export function currentPositionSize(
     cappedByLane = true;
   }
 
+  // v0.8.7 — notional ceiling fallback. See NOTIONAL_CEILING_RATIO docstring.
+  const notionalCeilingRatio = NOTIONAL_CEILING_RATIO;
+  const notionalCeiling = notionalCeilingRatio * availableEquityUsdt;
+  let cappedByNotional = false;
+  if (notional > notionalCeiling && leverage > 0 && availableEquityUsdt > 0) {
+    margin = notionalCeiling / Math.max(1, leverage);
+    notional = margin * Math.max(1, leverage);
+    cappedByNotional = true;
+  }
+
   const sized = notional >= minNotionalUsdt ? margin : 0;
 
   return {
     value: sized,
-    reason: `size[${lane}] = ${liftedToMin ? 'lifted-to-min ' : ''}${cappedByLane ? 'lane-capped ' : ''}floor(${explorationFloor.toFixed(3)}) or Φ×S×M(${(s.phi * s.sovereignty * maturity).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)}) × equity(${availableEquityUsdt.toFixed(2)}) @ ${leverage}x → margin ${margin.toFixed(2)} (lane-cap ${laneMarginCap.toFixed(2)}), notional ${notional.toFixed(2)} vs min ${minNotionalUsdt.toFixed(2)} = ${sized.toFixed(2)}`,
+    reason: `size[${lane}] = ${liftedToMin ? 'lifted-to-min ' : ''}${cappedByLane ? 'lane-capped ' : ''}${cappedByNotional ? 'notional-capped ' : ''}floor(${explorationFloor.toFixed(3)}) or Φ×S×M(${(s.phi * s.sovereignty * maturity).toFixed(3)}) × reward(${rewardMult.toFixed(2)}) × stab(${stabilityMult.toFixed(2)}) × equity(${availableEquityUsdt.toFixed(2)}) @ ${leverage}x → margin ${margin.toFixed(2)} (lane-cap ${laneMarginCap.toFixed(2)}), notional ${notional.toFixed(2)} vs ceiling ${notionalCeiling.toFixed(2)} vs min ${minNotionalUsdt.toFixed(2)} = ${sized.toFixed(2)}`,
     derivation: {
       phi: s.phi, sovereignty: s.sovereignty, maturity, bankSize,
       dopamine: nc.dopamine, serotonin: nc.serotonin, gaba: nc.gaba,
@@ -269,6 +294,8 @@ export function currentPositionSize(
       minNotional: minNotionalUsdt, sized, liftedToMin: liftedToMin ? 1 : 0,
       laneBudgetFrac: laneFrac,
       laneMarginCap, cappedByLane: cappedByLane ? 1 : 0,
+      notionalCeilingRatio, notionalCeiling,
+      cappedByNotional: cappedByNotional ? 1 : 0,
     },
   };
 }

--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -124,20 +124,30 @@ export function currentEntryThreshold(
 // ─── Proposal #10 — lane parameter envelope (TS parity) ────────────
 //
 // Two-lane initial split with trend as opt-in. SL/TP percentages give
-// each lane its own retreat tolerance:
-//   scalp ~0.4% adverse / 0.5% reward — fast tape harvesting
-//   swing ~1.5% adverse / 1.5% reward — absorbs retraces
-//   trend ~4% adverse / 4% reward — rides macro trend (opt-in)
+// each lane its own retreat tolerance, expressed as ROI on margin
+// (post-v0.8.6 rescale — see below):
+//   scalp ~5%   ROI adverse / 5%  reward — fast tape harvesting
+//   swing ~15%  ROI adverse / 15% reward — absorbs retraces
+//   trend ~40%  ROI adverse / 40% reward — rides macro trend (opt-in)
 // Budget fractions sum to <= 1 across position-bearing lanes; trend
 // defaults to 0 in this batch and is governance-bumped via the param
 // registry once the arbiter has 5+ closed trades per lane.
+//
+// v0.8.6 RESCALE (2026-05-01) — slPct / tpPct semantics changed
+// from "raw price movement %" to "ROI on margin %". The previous
+// scale (sl=0.4%/1.5%/4% raw) almost never tripped at typical 15-20x
+// leverage because raw price moves stay tiny while ROI on margin
+// scales with leverage. Live failure: ETH long sat at -4.4% ROI for
+// 4+ hours without the 1.5% raw SL firing because raw price only
+// moved -0.30%. Rescale preserves order-of-magnitude intent at
+// ~15-20x leverage. Mirror in ml-worker/scripts/recalibrate_lane_sl_tp_to_roi.sql.
 export const LANE_PARAMETER_DEFAULTS: Record<
   'scalp' | 'swing' | 'trend',
   { slPct: number; tpPct: number; budgetFrac: number }
 > = {
-  scalp: { slPct: 0.004, tpPct: 0.005, budgetFrac: 0.50 },
-  swing: { slPct: 0.015, tpPct: 0.015, budgetFrac: 0.50 },
-  trend: { slPct: 0.040, tpPct: 0.040, budgetFrac: 0.0 },
+  scalp: { slPct: 0.05, tpPct: 0.05, budgetFrac: 0.50 },
+  swing: { slPct: 0.15, tpPct: 0.15, budgetFrac: 0.50 },
+  trend: { slPct: 0.40, tpPct: 0.40, budgetFrac: 0.0 },
 };
 
 export function laneParam(
@@ -645,46 +655,74 @@ export function shouldScalpExit(
   s: BasinState,
   mode: MonkeyMode = MonkeyMode.INVESTIGATION,
   lane: 'scalp' | 'swing' | 'trend' = 'swing',
+  leverage: number = 1,
 ): ExecutiveDecision<boolean> {
+  // v0.8.6 (2026-05-01) — pnlFrac semantics CHANGED from
+  // "PnL / notional" (raw price movement %) to "PnL / margin"
+  // ("ROI on margin %"). Leverage is now threaded in so we can
+  // derive margin from notional / leverage. This fixes the live
+  // failure where an ETH long sat at -4.4% ROI for 4+ hours without
+  // the 1.5% raw-price SL firing because raw price only moved -0.30%
+  // (the SL gate was reading raw movement, not ROI on margin). Lane
+  // SL/TP defaults are rescaled to the ROI scale in the same rev —
+  // see LANE_PARAMETER_DEFAULTS.
+  //
+  // For back-compat with cold callers, leverage defaults to 1, in
+  // which case ROI == raw move and the gate behaves as before. All
+  // production callers (loop.ts) pass the live position leverage.
   if (notionalUsdt <= 0) {
     return { value: false, reason: 'no position notional', derivation: {} };
   }
-  const pnlFrac = unrealizedPnlUsdt / notionalUsdt;
+  // ROI on margin = (PnL / notional) × leverage. lev=1 collapses to the
+  // legacy raw-move semantic; at typical 15-20x live leverage it scales
+  // the gate up to its intended sensitivity range.
+  const lev = leverage > 0 ? leverage : 1;
+  const rawFrac = unrealizedPnlUsdt / notionalUsdt;
+  const roiFrac = rawFrac * lev;
   const nc = s.neurochemistry;
   // Mode picks the baseline; Φ + dopamine modulate within that mode.
   const profile = MODE_PROFILES[mode];
-  const geometricTp = Math.max(
+  // Geometric thresholds are on the raw-price-move scale (TP floor
+  // exists to clear fees, which is a raw-move quantity). Promote them
+  // onto the ROI scale by × leverage so they compose with the ROI-scale
+  // lane envelope under max().
+  const geometricTpRaw = Math.max(
     0.003,
     profile.tpBaseFrac - 0.003 * nc.dopamine + 0.005 * s.phi,
   );
-  const geometricSl = geometricTp * profile.slRatio;
-  // Proposal #10 — per-lane envelope. Take the wider of (geometric,
-  // lane) so the geometric fee-clear floor is never breached but the
-  // lane envelope can broaden tolerance when a swing/trend position
-  // needs room to absorb retraces.
+  const geometricSlRaw = geometricTpRaw * profile.slRatio;
+  const geometricTp = geometricTpRaw * lev;
+  const geometricSl = geometricSlRaw * lev;
+  // Proposal #10 — per-lane envelope. Lane SL/TP are stored on the ROI
+  // scale (post-v0.8.6 rescale). Take the wider of (geometric, lane) so
+  // the fee-clear floor is never breached but the lane envelope can
+  // broaden tolerance when a swing/trend position needs room to absorb
+  // retraces.
   const laneTp = laneParam(lane, 'tpPct');
   const laneSl = laneParam(lane, 'slPct');
   const tpThr = Math.max(geometricTp, laneTp);
   const slThr = Math.max(geometricSl, laneSl);
 
   // Encode type as a bit (1=TP, -1=SL, 0=hold) to keep derivation map numeric.
-  if (pnlFrac >= tpThr) {
+  if (roiFrac >= tpThr) {
     return {
       value: true,
-      reason: `take_profit[${lane}]: ${(pnlFrac * 100).toFixed(3)}% ≥ ${(tpThr * 100).toFixed(3)}%`,
+      reason: `take_profit[${lane}]: roi ${(roiFrac * 100).toFixed(3)}% ≥ ${(tpThr * 100).toFixed(3)}% (lev=${lev.toFixed(0)}x)`,
       derivation: {
-        pnlFrac, tpThr, slThr,
+        roiFrac, rawFrac, leverage: lev,
+        tpThr, slThr,
         laneTpPct: laneTp, laneSlPct: laneSl,
         exitTypeBit: 1,
       },
     };
   }
-  if (pnlFrac <= -slThr) {
+  if (roiFrac <= -slThr) {
     return {
       value: true,
-      reason: `stop_loss[${lane}]: ${(pnlFrac * 100).toFixed(3)}% ≤ -${(slThr * 100).toFixed(3)}%`,
+      reason: `stop_loss[${lane}]: roi ${(roiFrac * 100).toFixed(3)}% ≤ -${(slThr * 100).toFixed(3)}% (lev=${lev.toFixed(0)}x)`,
       derivation: {
-        pnlFrac, tpThr, slThr,
+        roiFrac, rawFrac, leverage: lev,
+        tpThr, slThr,
         laneTpPct: laneTp, laneSlPct: laneSl,
         exitTypeBit: -1,
       },
@@ -692,9 +730,10 @@ export function shouldScalpExit(
   }
   return {
     value: false,
-    reason: `scalp hold[${lane}]: pnl ${(pnlFrac * 100).toFixed(3)}% in [-${(slThr * 100).toFixed(3)}%, ${(tpThr * 100).toFixed(3)}%]`,
+    reason: `scalp hold[${lane}]: roi ${(roiFrac * 100).toFixed(3)}% in [-${(slThr * 100).toFixed(3)}%, ${(tpThr * 100).toFixed(3)}%] (lev=${lev.toFixed(0)}x)`,
     derivation: {
-      pnlFrac, tpThr, slThr,
+      roiFrac, rawFrac, leverage: lev,
+      tpThr, slThr,
       laneTpPct: laneTp, laneSlPct: laneSl,
     },
   };

--- a/apps/api/src/services/monkey/held_position_rejustification.ts
+++ b/apps/api/src/services/monkey/held_position_rejustification.ts
@@ -18,9 +18,11 @@
  */
 
 import type { MonkeyMode } from './modes.js';
+import { fisherRao, type Basin } from './basin.js';
 import {
   PHI_GOLDEN_FLOOR_RATIO,
   PI_STRUCT_BOUNDARY_R_SQUARED,
+  PI_STRUCT_GRAVITATING_FRACTION,
 } from './topology_constants.js';
 
 export interface RejustificationEmotions {
@@ -49,6 +51,25 @@ export interface RejustificationInput {
    * divergence).
    */
   regimeConfidence?: number;
+  /**
+   * v0.8.7 regime-hysteresis triple-AND gate. The regime exit fires only
+   * when ALL of:
+   *   (a) regimeNow != regimeAtOpen   (single-tick label divergence)
+   *   (b) regimeChangeStreak >= regimeStabilityTicksRequired
+   *   (c) fisherRao(basinNow, basinAtOpen) > 1/π
+   * AND the classifier's confidence still > 1/φ from PR #629.
+   *
+   * Why all three? Live tape 2026-05-01 16:11-16:17: every close was
+   * regime_change, 22% win rate, $97 account chewing through positions
+   * because a single-tick mode flicker was enough to flip the gate when
+   * the kernel's own basin had barely moved. The streak filter rejects
+   * single-tick flicker; the FR-distance filter rejects label changes
+   * where the basin geometry is still consonant with entry.
+   */
+  regimeChangeStreak?: number;
+  regimeStabilityTicksRequired?: number;
+  basinNow?: Basin;
+  basinAtOpen?: Basin;
 }
 
 export type RejustificationFire =
@@ -65,6 +86,14 @@ export interface RejustificationResult {
   reason: string;
   /** Φ floor under the golden-ratio coherence test. */
   phiFloor: number | null;
+  /** FR distance from basinAtOpen → basinNow when both anchors present. */
+  frDistance: number | null;
+  /** FR-distance threshold (1/π) the regime gate compares against. */
+  frThreshold: number;
+  /** Streak of consecutive ticks where regimeNow != regimeAtOpen. */
+  regimeChangeStreak: number;
+  /** Required streak length before the regime exit fires. */
+  regimeStabilityTicksRequired: number;
 }
 
 /**
@@ -79,31 +108,56 @@ export function evaluateRejustification(
 ): RejustificationResult {
   const { regimeAtOpen, phiAtOpen, regimeNow, phiNow, emotions } = input;
   const regimeConfidence = input.regimeConfidence ?? 1.0;
+  const regimeChangeStreak = input.regimeChangeStreak ?? 0;
+  const regimeStabilityTicksRequired = input.regimeStabilityTicksRequired ?? 3;
+  const frThreshold = PI_STRUCT_GRAVITATING_FRACTION;  // 1/π ≈ 0.318
+  let frDistance: number | null = null;
+  if (input.basinNow !== undefined && input.basinAtOpen !== undefined) {
+    frDistance = fisherRao(input.basinAtOpen, input.basinNow);
+  }
   if (regimeAtOpen === undefined || phiAtOpen === undefined) {
-    return { checked: false, fired: null, reason: '', phiFloor: null };
+    return {
+      checked: false, fired: null, reason: '', phiFloor: null,
+      frDistance, frThreshold,
+      regimeChangeStreak, regimeStabilityTicksRequired,
+    };
   }
   const phiFloor = phiAtOpen / PHI_GOLDEN_FLOOR_RATIO;
 
-  // 1. REGIME CHECK — regime label diverged from open AND classifier's
-  // own confidence is past the canonical coherence floor. Gating on the
-  // classifier's self-belief (rather than a synthesized streak counter)
-  // preserves PR #619's "single-tick exit, current state IS the truth"
-  // framing while skipping flicker events where the classifier itself
-  // isn't sure. Threshold is PI_STRUCT_BOUNDARY_R_SQUARED (1/φ ≈ 0.618),
-  // the canonical "boundary R²" from EXP-004b. Strict >: a confidence
-  // exactly at the floor is not yet load-bearing.
-  if (
-    regimeNow !== regimeAtOpen &&
-    regimeConfidence > PI_STRUCT_BOUNDARY_R_SQUARED
-  ) {
-    return {
-      checked: true,
-      fired: 'regime_change',
-      reason:
-        `regime_change: opened in ${regimeAtOpen}, now ${regimeNow} ` +
-        `(confidence ${regimeConfidence.toFixed(3)} > 1/φ)`,
-      phiFloor,
-    };
+  // 1. REGIME CHECK — triple-AND gate. All of:
+  //   (a) regimeNow != regimeAtOpen   (label divergence)
+  //   (b) regimeChangeStreak >= regimeStabilityTicksRequired (stable >= N ticks)
+  //   (c) frDistance > 1/π            (basin geometry has actually moved)
+  // PLUS the PR #629 confidence gate (regimeConfidence > 1/φ).
+  //
+  // Live tape 2026-05-01 16:11-16:17: every close was regime_change,
+  // 22% win rate, $97 account torn through positions because a single
+  // tick of mode flicker was enough to flip the gate. The streak filter
+  // rejects single-tick noise; the FR filter rejects label changes
+  // where the basin's geometry has barely moved (the kernel's
+  // perception is still consonant with what justified entry).
+  if (regimeNow !== regimeAtOpen) {
+    const labelDiverged = true;
+    const confidenceLoadBearing = regimeConfidence > PI_STRUCT_BOUNDARY_R_SQUARED;
+    const streakSatisfied = regimeChangeStreak >= regimeStabilityTicksRequired;
+    // FR-distance gate. When anchors are missing (basin not plumbed),
+    // fall back to a strict-fail so the regime exit cannot fire purely
+    // on label flicker — the geometric component must be measurable.
+    const frFires = frDistance !== null && frDistance > frThreshold;
+    if (labelDiverged && confidenceLoadBearing && streakSatisfied && frFires) {
+      const frStr = frDistance !== null ? frDistance.toFixed(3) : 'N/A';
+      return {
+        checked: true,
+        fired: 'regime_change',
+        reason:
+          `regime_change: opened in ${regimeAtOpen} (FR_dist ${frStr} > 1/π), ` +
+          `now ${regimeNow} stable for ${regimeChangeStreak} ticks ` +
+          `(confidence ${regimeConfidence.toFixed(3)} > 1/φ)`,
+        phiFloor,
+        frDistance, frThreshold,
+        regimeChangeStreak, regimeStabilityTicksRequired,
+      };
+    }
   }
   if (phiNow < phiFloor) {
     return {
@@ -111,6 +165,8 @@ export function evaluateRejustification(
       fired: 'phi_collapse',
       reason: `phi_collapse: open Φ=${phiAtOpen.toFixed(3)} → now ${phiNow.toFixed(3)} < floor ${phiFloor.toFixed(3)}`,
       phiFloor,
+      frDistance, frThreshold,
+      regimeChangeStreak, regimeStabilityTicksRequired,
     };
   }
   if (emotions.confidence < emotions.anxiety + emotions.confusion) {
@@ -119,7 +175,13 @@ export function evaluateRejustification(
       fired: 'conviction_failed',
       reason: `conviction_failed: conf=${emotions.confidence.toFixed(3)} < anxiety+confusion=${(emotions.anxiety + emotions.confusion).toFixed(3)}`,
       phiFloor,
+      frDistance, frThreshold,
+      regimeChangeStreak, regimeStabilityTicksRequired,
     };
   }
-  return { checked: true, fired: null, reason: '', phiFloor };
+  return {
+    checked: true, fired: null, reason: '', phiFloor,
+    frDistance, frThreshold,
+    regimeChangeStreak, regimeStabilityTicksRequired,
+  };
 }

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -961,7 +961,22 @@ export class MonkeyKernel extends EventEmitter {
         // rejustification block so a position bleeding hard against
         // the kernel always closes on price before the kernel re-reads
         // its own state. TP comes BELOW rejustification + harvest.
-        const scalp = shouldScalpExit(unrealizedPnl, positionNotional, basinState, mode, heldLane);
+        // v0.8.6 — SL gate now reads ROI on margin, not raw price %.
+        // Use the position's recorded leverage (Number(openRow.leverage))
+        // so the gate scales raw movement into ROI correctly. Defaults to
+        // the just-derived leverage.value when openRow lacks the column
+        // (cold/legacy rows).
+        const positionLeverage = openRow && Number.isFinite(Number(openRow.leverage)) && Number(openRow.leverage) > 0
+          ? Number(openRow.leverage)
+          : leverage.value;
+        const scalp = shouldScalpExit(
+          unrealizedPnl,
+          positionNotional,
+          basinState,
+          mode,
+          heldLane,
+          positionLeverage,
+        );
         derivation.scalp = { ...scalp.derivation, unrealizedPnl, markPrice: lastPrice, tradeId };
         const SL_DEFER_TICKS = 2;
         const isStopLoss = Number((scalp as any).derivation?.exitTypeBit) === -1;

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -172,6 +172,19 @@ const REWARD_QUEUE_MAX = 50;
 const REGIME_STABILITY_TICKS_FOR_EXIT =
   Number(process.env.MONKEY_REGIME_STABILITY_TICKS_FOR_EXIT) || 3;
 
+/**
+ * v0.8.7 kill switch — when MONKEY_TRADING_PAUSED=true, gate
+ * entry-order placement only. Exit orders (scalp_exit, auto_flatten,
+ * hard SL, rejust exits) are NOT gated; existing positions must close
+ * cleanly during deploy/incident response. Default false (no pause).
+ *
+ * Reads at order-placement time (live, not cached at startup) so the
+ * operator can flip the env var on Railway without redeploying.
+ */
+function isTradingPaused(): boolean {
+  return process.env.MONKEY_TRADING_PAUSED === 'true';
+}
+
 
 /**
  * Per-kernel configuration (v0.6b). Different sub-Monkeys differ in
@@ -1388,6 +1401,17 @@ export class MonkeyKernel extends EventEmitter {
     let monkeyOrderId: string | null = null;
     if (process.env.MONKEY_EXECUTE === 'true') {
       if ((action === 'enter_long' || action === 'enter_short') && size.value > 0) {
+        // v0.8.7 kill switch — pause new entries (including DCA pyramids)
+        // when MONKEY_TRADING_PAUSED=true on Railway. Exits remain
+        // active so open positions can close cleanly.
+        if (isTradingPaused()) {
+          reason += ' | trading_paused: MONKEY_TRADING_PAUSED=true (entry suppressed; exits unaffected)';
+          (derivation as Record<string, unknown>).tradingPausedSkipped = {
+            agent: 'K',
+            action,
+            reason: 'MONKEY_TRADING_PAUSED env',
+          };
+        } else {
         const isDCA = Boolean(derivation.isDCAAdd);
         // Cap K's margin to its arbiter share. Without this, the existing
         // size formula could exceed K's allocation when M has been
@@ -1449,6 +1473,7 @@ export class MonkeyKernel extends EventEmitter {
             state.regimeChangeStreakByLane[entryLane] = 0;
           }
         }
+        }  // close v0.8.7 trading-paused else branch
       } else if (action === 'scalp_exit' && heldSide) {
         const scalpDeriv = derivation.scalp as Record<string, unknown> | undefined;
         const tradeId = scalpDeriv?.tradeId ? String(scalpDeriv.tradeId) : null;
@@ -1538,6 +1563,16 @@ export class MonkeyKernel extends EventEmitter {
             delete state.phiAtOpenByLane[reversalLane];
             delete state.basinAtOpenByLane[reversalLane];
             delete state.regimeChangeStreakByLane[reversalLane];
+            // v0.8.7 kill switch — close on the reverse path proceeded
+            // (exits unaffected); skip the new-entry leg when paused.
+            if (isTradingPaused()) {
+              reason += ` | closed@${lastPrice.toFixed(2)} pnl=${pnlAtDecision.toFixed(4)} | trading_paused: new ${newSide} entry suppressed`;
+              (derivation as Record<string, unknown>).tradingPausedSkipped = {
+                agent: 'K',
+                action,
+                reason: 'MONKEY_TRADING_PAUSED env (reverse-reopen leg)',
+              };
+            } else {
             // Settle delay — give the exchange ~500ms to flatten net.
             await new Promise((resolve) => setTimeout(resolve, 500));
             const execResult = await this.executeEntry({
@@ -1570,6 +1605,7 @@ export class MonkeyKernel extends EventEmitter {
             } else {
               reason += ` | flattened ok, new-entry failed: ${execResult.reason}`;
             }
+            }  // close v0.8.7 trading-paused else branch
           } else {
             reason += ` | flatten failed: ${closeResult.reason}; reverse aborted`;
           }
@@ -1617,6 +1653,13 @@ export class MonkeyKernel extends EventEmitter {
         (mDecision.action === 'enter_long' || mDecision.action === 'enter_short')
         && mDecision.sizeUsdt > 0
       ) {
+        // v0.8.7 kill switch — pause new entries from Agent M.
+        if (isTradingPaused()) {
+          logger.info('[AgentM] entry suppressed by MONKEY_TRADING_PAUSED', {
+            symbol, side: mDecision.action,
+          });
+          (derivation as Record<string, unknown>).agentMTradingPausedSkipped = true;
+        } else {
         const mResult = await this.executeEntry({
           symbol,
           side: mDecision.action === 'enter_long' ? 'long' : 'short',
@@ -1643,6 +1686,7 @@ export class MonkeyKernel extends EventEmitter {
             margin: mDecision.sizeUsdt.toFixed(2), leverage: mDecision.leverage,
           });
         }
+        }  // close v0.8.7 trading-paused else branch
       }
     }
 
@@ -1693,12 +1737,30 @@ export class MonkeyKernel extends EventEmitter {
       // turtle agent. Pyramids are MORE units in the same trend-lane;
       // from autonomous_trades' perspective each unit is its own row,
       // grouped by (agent='T', symbol, lane='trend').
+      // v0.8.7 telemetry: surface the pause state when Agent T would
+      // have entered but the kill switch suppressed it.
       if (
         (tDecision.action === 'enter_long'
           || tDecision.action === 'enter_short'
           || tDecision.action === 'pyramid_long'
           || tDecision.action === 'pyramid_short')
         && tDecision.sizeUsdt > 0
+        && isTradingPaused()
+      ) {
+        (derivation as Record<string, unknown>).agentTTradingPausedSkipped = true;
+        logger.info('[AgentT] entry suppressed by MONKEY_TRADING_PAUSED', {
+          symbol, action: tDecision.action,
+        });
+      }
+      if (
+        (tDecision.action === 'enter_long'
+          || tDecision.action === 'enter_short'
+          || tDecision.action === 'pyramid_long'
+          || tDecision.action === 'pyramid_short')
+        && tDecision.sizeUsdt > 0
+        // v0.8.7 kill switch — pause Agent T entries (including pyramids)
+        // when MONKEY_TRADING_PAUSED=true. Exits below are unaffected.
+        && !isTradingPaused()
       ) {
         const tSide: 'long' | 'short' =
           tDecision.action === 'enter_long' || tDecision.action === 'pyramid_long'

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -158,6 +158,20 @@ const REWARD_HALF_LIFE_MS = 20 * 60_000;  // 20 min
 /** Max rewards retained; FIFO eviction. */
 const REWARD_QUEUE_MAX = 50;
 
+/**
+ * v0.8.7 regime-hysteresis — minimum number of consecutive ticks where
+ * regimeNow != regimeAtOpen before the regime_change exit can fire. The
+ * Python kernel reads this from the parameter registry as
+ * ``executive.regime_stability_ticks_for_exit``; TS has no parameter
+ * registry yet, so the constant is the default. Default 3: a flicker
+ * (1-2 tick mode divergence) cannot trigger the exit alone — the
+ * kernel must read the new regime stably for at least 3 ticks AND the
+ * basin must have moved more than 1/π in Fisher-Rao distance from the
+ * entry anchor.
+ */
+const REGIME_STABILITY_TICKS_FOR_EXIT =
+  Number(process.env.MONKEY_REGIME_STABILITY_TICKS_FOR_EXIT) || 3;
+
 
 /**
  * Per-kernel configuration (v0.6b). Different sub-Monkeys differ in
@@ -245,6 +259,19 @@ interface SymbolState {
    *  positions keep independent rejustification anchors. */
   regimeAtOpenByLane: Record<string, string>;
   phiAtOpenByLane: Record<string, number>;
+  /** v0.8.7 regime-hysteresis state. The regime-change exit (PR #619 +
+   *  confidence gate from PR #629) was firing on single-tick mode
+   *  flickers — live tape 2026-05-01 showed 22% win rate with every
+   *  close via regime_change. The triple-AND gate now requires a
+   *  sustained streak (>= N ticks where regimeNow != regimeAtOpen)
+   *  AND FR distance from basin_at_open > 1/π in addition to the
+   *  existing label divergence + confidence checks. Per-lane streak
+   *  so a swing position's flicker doesn't cross-contaminate a scalp
+   *  position's gate. basinAtOpenByLane is the basin snapshot
+   *  captured at entry time; FR-distance from that anchor is the
+   *  geometric "has the kernel's perception actually moved?" signal. */
+  regimeChangeStreakByLane: Record<string, number>;
+  basinAtOpenByLane: Record<string, Basin>;
   /** v0.8.7e: latest computed basinDir + tapeTrend from processSymbol, with
    *  timestamp. Exposed via getLatestBasinSnapshot() for LiveSignal's
    *  inter-engine agreement gate. Null until the first tick completes. */
@@ -433,6 +460,8 @@ export class MonkeyKernel extends EventEmitter {
       tapeFlipStreakByLane: {},
       regimeAtOpenByLane: {},
       phiAtOpenByLane: {},
+      regimeChangeStreakByLane: {},
+      basinAtOpenByLane: {},
       latestBasinSnapshot: null,
     };
   }
@@ -1012,14 +1041,34 @@ export class MonkeyKernel extends EventEmitter {
 
         // 2. Held-position re-justification — three internal exit
         // checks. Each fires immediately when the kernel's current
-        // state contradicts the state that justified entry. No streak
-        // counting, no hysteresis, no time-based stops. All three are
-        // geometric (regime classifier output, Φ integration measure,
-        // Layer 2B emotion stack — TS path uses NEUTRAL_EMOTIONS until
-        // emotion stack is ported, so the conviction check is dormant
-        // in TS but live in Python).
+        // state contradicts the state that justified entry. v0.8.7 the
+        // regime gate gained hysteresis: triple-AND of label divergence
+        // + sustained streak + FR-distance > 1/π (live tape 2026-05-01
+        // 16:11-16:17 evidence: every close was regime_change at 22%
+        // win rate). Φ collapse and conviction failure remain
+        // single-tick (geometric: regime classifier output, Φ
+        // integration measure, Layer 2B emotion stack — TS path uses
+        // NEUTRAL_EMOTIONS until emotion stack is ported, so conviction
+        // is dormant in TS but live in Python).
         const regimeAtOpen = state.regimeAtOpenByLane[heldLane] as MonkeyMode | undefined;
         const phiAtOpen = state.phiAtOpenByLane[heldLane];
+        const basinAtOpen = state.basinAtOpenByLane[heldLane];
+        // Maintain per-lane regime-change streak across ticks. Increment
+        // when regimeNow != regimeAtOpen; reset when it returns. The
+        // gate consumes the accumulated count below.
+        if (regimeAtOpen !== undefined) {
+          if (mode !== regimeAtOpen) {
+            state.regimeChangeStreakByLane[heldLane] =
+              (state.regimeChangeStreakByLane[heldLane] ?? 0) + 1;
+          } else {
+            state.regimeChangeStreakByLane[heldLane] = 0;
+          }
+        }
+        const regimeChangeStreak = state.regimeChangeStreakByLane[heldLane] ?? 0;
+        // Registry-controlled stability requirement; default 3 ticks.
+        // TS has no parameter registry yet — the constant lives in
+        // executive.ts mirroring ml-worker's _DEFAULT_REGIME_STABILITY_TICKS_FOR_EXIT.
+        const regimeStabilityTicksRequired = REGIME_STABILITY_TICKS_FOR_EXIT;
         const rejustResult = !exitFired
           ? evaluateRejustification({
               regimeAtOpen,
@@ -1028,8 +1077,18 @@ export class MonkeyKernel extends EventEmitter {
               phiNow: phi,
               emotions: NEUTRAL_EMOTIONS,
               regimeConfidence: regimeReading.confidence,
+              regimeChangeStreak,
+              regimeStabilityTicksRequired,
+              basinNow: basin,
+              basinAtOpen,
             })
-          : { checked: false, fired: null, reason: '', phiFloor: null };
+          : {
+              checked: false, fired: null, reason: '', phiFloor: null,
+              frDistance: null,
+              frThreshold: 1 / Math.PI,
+              regimeChangeStreak,
+              regimeStabilityTicksRequired,
+            };
         const rejust: Record<string, unknown> = {
           checked: rejustResult.checked,
         };
@@ -1038,6 +1097,10 @@ export class MonkeyKernel extends EventEmitter {
           rejust.regimeAtOpen = regimeAtOpen;
           rejust.regimeNow = mode;
           rejust.regimeConfidence = regimeReading.confidence;
+          rejust.regimeChangeStreak = regimeChangeStreak;
+          rejust.regimeStabilityTicksRequired = regimeStabilityTicksRequired;
+          rejust.frDistance = rejustResult.frDistance;
+          rejust.frThreshold = rejustResult.frThreshold;
           rejust.phiAtOpen = phiAtOpen;
           rejust.phiNow = phi;
           rejust.phiFloor = rejustResult.phiFloor;
@@ -1380,6 +1443,10 @@ export class MonkeyKernel extends EventEmitter {
               : positionLane) as 'scalp' | 'swing' | 'trend';
             state.regimeAtOpenByLane[entryLane] = mode;
             state.phiAtOpenByLane[entryLane] = phi;
+            // v0.8.7 — also snapshot basin and reset streak for the
+            // FR-distance hysteresis gate.
+            state.basinAtOpenByLane[entryLane] = basin.slice() as Basin;
+            state.regimeChangeStreakByLane[entryLane] = 0;
           }
         }
       } else if (action === 'scalp_exit' && heldSide) {
@@ -1419,6 +1486,8 @@ export class MonkeyKernel extends EventEmitter {
             // Clear rejustification anchors for the lane that closed.
             delete state.regimeAtOpenByLane[scalpLane];
             delete state.phiAtOpenByLane[scalpLane];
+            delete state.basinAtOpenByLane[scalpLane];
+            delete state.regimeChangeStreakByLane[scalpLane];
             // Mirror legacy scalars for any non-lane-aware reader.
             state.peakPnlUsdt = null;
             state.peakTrackedTradeId = null;
@@ -1467,6 +1536,8 @@ export class MonkeyKernel extends EventEmitter {
             const reversalLane = (ownOpenRow?.lane ?? 'swing') as 'scalp' | 'swing' | 'trend';
             delete state.regimeAtOpenByLane[reversalLane];
             delete state.phiAtOpenByLane[reversalLane];
+            delete state.basinAtOpenByLane[reversalLane];
+            delete state.regimeChangeStreakByLane[reversalLane];
             // Settle delay — give the exchange ~500ms to flatten net.
             await new Promise((resolve) => setTimeout(resolve, 500));
             const execResult = await this.executeEntry({
@@ -1493,6 +1564,8 @@ export class MonkeyKernel extends EventEmitter {
               // Re-snapshot rejustification anchors for the new direction.
               state.regimeAtOpenByLane[reversalLane] = mode;
               state.phiAtOpenByLane[reversalLane] = phi;
+              state.basinAtOpenByLane[reversalLane] = basin.slice() as Basin;
+              state.regimeChangeStreakByLane[reversalLane] = 0;
               reason += ` | closed@${lastPrice.toFixed(2)} pnl=${pnlAtDecision.toFixed(4)} | new ${newSide} orderId=${monkeyOrderId}`;
             } else {
               reason += ` | flattened ok, new-entry failed: ${execResult.reason}`;

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1431,6 +1431,9 @@ async def monkey_executive_decide(request: Request):
             notional_usdt=position_notional,
             s=state,
             mode=mode,
+            # v0.8.6 — SL gate reads ROI on margin; thread the live lev
+            # decision so raw move scales correctly into ROI.
+            leverage=float(leverage["value"]),
         )
         loop2 = should_exit(
             perception=state.basin,

--- a/ml-worker/scripts/recalibrate_lane_sl_tp_to_roi.sql
+++ b/ml-worker/scripts/recalibrate_lane_sl_tp_to_roi.sql
@@ -1,0 +1,188 @@
+-- recalibrate_lane_sl_tp_to_roi.sql
+--
+-- v0.8.6 (2026-05-01) — rescale executive.lane.<lane>.{sl_pct,tp_pct}
+-- registry rows from "raw price movement %" to "ROI on margin %".
+--
+-- Background
+-- ----------
+-- The kernel's should_scalp_exit gate computed pnl_frac = pnl / notional,
+-- which is raw price movement % — NOT ROI on margin %. The lane SL
+-- defaults (scalp 0.4%, swing 1.5%, trend 4.0%) were interpreted as
+-- raw-price thresholds, so at typical 15-20x leverage they almost
+-- never tripped: raw price moves stay tiny while ROI on margin scales
+-- with leverage. Real production failure (2026-04-30 → 2026-05-01):
+-- ETH long sat at -4.4% ROI for 4+ hours without SL firing because
+-- raw price only moved -0.30%, well inside the 1.5% swing-SL band.
+--
+-- Code-side fix: should_scalp_exit / shouldScalpExit now compute
+-- roi_frac = (pnl / notional) × leverage and compare against the
+-- lane envelope on the ROI scale. _DEFAULT_LANE_*_{SL,TP}_PCT constants
+-- in executive.py / LANE_PARAMETER_DEFAULTS in executive.ts are
+-- rescaled to match. This SQL is the parameter-registry mirror — it
+-- updates the live rows so production reads the new ROI-scale values
+-- without needing a redeploy.
+--
+-- Rescale (preserves order-of-magnitude intent at ~15-20x leverage):
+--   scalp: 0.4%  raw → 5%   ROI (sl_pct + tp_pct)
+--   swing: 1.5%  raw → 15%  ROI (sl_pct + tp_pct)
+--   trend: 4.0%  raw → 40%  ROI (sl_pct + tp_pct)
+--
+-- PR #627 follow-up: that PR set executive.lane.scalp.tp_pct = 0.03
+-- (3%) on the registry to lock scalp profit at +3% ROI under the OLD
+-- raw-price semantics. Under the new ROI semantics, 0.03 means "3%
+-- ROI lock-in" which is too tight (scalps regularly hit 5%+ ROI).
+-- Update that scalp.tp_pct to 0.05 here — restoring the 2026-04-30
+-- tape-derived intent under the new semantics.
+--
+-- Apply (after merge, with autonomy paused if you want zero in-flight
+-- ambiguity — the rebound is bounded by ``loop.refresh_every_ticks``):
+--   railway ssh
+--   psql "$DATABASE_URL" -f ml-worker/scripts/recalibrate_lane_sl_tp_to_roi.sql
+--
+-- Verify:
+--   SELECT name, value, version, updated_at, updated_by, justification
+--     FROM monkey_parameters
+--    WHERE name LIKE 'executive.lane.%.sl_pct'
+--       OR name LIKE 'executive.lane.%.tp_pct'
+--    ORDER BY name;
+--
+-- The Python + TS parameter registries refresh within
+-- ``loop.refresh_every_ticks`` ticks — no deploy needed once this
+-- script lands. Rollback by re-running with the old raw-price values
+-- AND reverting the code changes (the two are tightly coupled).
+
+BEGIN;
+
+-- ── scalp ──────────────────────────────────────────────────────────
+INSERT INTO monkey_parameters (
+  name, category, value, bounds_low, bounds_high, justification, version, updated_by
+) VALUES (
+  'executive.lane.scalp.sl_pct',
+  'OPERATIONAL',
+  0.05,
+  0.005,
+  0.50,
+  'v0.8.6 ROI-scale rescale: 5% ROI on margin SL for scalp (was 0.4% raw price). '
+  'Live ETH-long sat at -4.4% ROI for 4+ hours without firing under raw semantics.',
+  1,
+  'GaryOcean428'
+)
+ON CONFLICT (name) DO UPDATE SET
+  value         = EXCLUDED.value,
+  bounds_low    = EXCLUDED.bounds_low,
+  bounds_high   = EXCLUDED.bounds_high,
+  version       = monkey_parameters.version + 1,
+  updated_at    = NOW(),
+  updated_by    = EXCLUDED.updated_by,
+  justification = EXCLUDED.justification;
+
+INSERT INTO monkey_parameters (
+  name, category, value, bounds_low, bounds_high, justification, version, updated_by
+) VALUES (
+  'executive.lane.scalp.tp_pct',
+  'OPERATIONAL',
+  0.05,
+  0.005,
+  0.50,
+  'v0.8.6 ROI-scale rescale: 5% ROI on margin TP for scalp (was 3% under old '
+  'raw semantics — that 3% as ROI is too tight; scalps hit 5%+ ROI regularly). '
+  'Restores the 2026-04-30 tape-derived intent under the new ROI semantics.',
+  1,
+  'GaryOcean428'
+)
+ON CONFLICT (name) DO UPDATE SET
+  value         = EXCLUDED.value,
+  bounds_low    = EXCLUDED.bounds_low,
+  bounds_high   = EXCLUDED.bounds_high,
+  version       = monkey_parameters.version + 1,
+  updated_at    = NOW(),
+  updated_by    = EXCLUDED.updated_by,
+  justification = EXCLUDED.justification;
+
+-- ── swing ──────────────────────────────────────────────────────────
+INSERT INTO monkey_parameters (
+  name, category, value, bounds_low, bounds_high, justification, version, updated_by
+) VALUES (
+  'executive.lane.swing.sl_pct',
+  'OPERATIONAL',
+  0.15,
+  0.01,
+  0.80,
+  'v0.8.6 ROI-scale rescale: 15% ROI on margin SL for swing (was 1.5% raw price).',
+  1,
+  'GaryOcean428'
+)
+ON CONFLICT (name) DO UPDATE SET
+  value         = EXCLUDED.value,
+  bounds_low    = EXCLUDED.bounds_low,
+  bounds_high   = EXCLUDED.bounds_high,
+  version       = monkey_parameters.version + 1,
+  updated_at    = NOW(),
+  updated_by    = EXCLUDED.updated_by,
+  justification = EXCLUDED.justification;
+
+INSERT INTO monkey_parameters (
+  name, category, value, bounds_low, bounds_high, justification, version, updated_by
+) VALUES (
+  'executive.lane.swing.tp_pct',
+  'OPERATIONAL',
+  0.15,
+  0.01,
+  0.80,
+  'v0.8.6 ROI-scale rescale: 15% ROI on margin TP for swing (was 1.5% raw price).',
+  1,
+  'GaryOcean428'
+)
+ON CONFLICT (name) DO UPDATE SET
+  value         = EXCLUDED.value,
+  bounds_low    = EXCLUDED.bounds_low,
+  bounds_high   = EXCLUDED.bounds_high,
+  version       = monkey_parameters.version + 1,
+  updated_at    = NOW(),
+  updated_by    = EXCLUDED.updated_by,
+  justification = EXCLUDED.justification;
+
+-- ── trend ──────────────────────────────────────────────────────────
+INSERT INTO monkey_parameters (
+  name, category, value, bounds_low, bounds_high, justification, version, updated_by
+) VALUES (
+  'executive.lane.trend.sl_pct',
+  'OPERATIONAL',
+  0.40,
+  0.05,
+  1.00,
+  'v0.8.6 ROI-scale rescale: 40% ROI on margin SL for trend (was 4.0% raw price).',
+  1,
+  'GaryOcean428'
+)
+ON CONFLICT (name) DO UPDATE SET
+  value         = EXCLUDED.value,
+  bounds_low    = EXCLUDED.bounds_low,
+  bounds_high   = EXCLUDED.bounds_high,
+  version       = monkey_parameters.version + 1,
+  updated_at    = NOW(),
+  updated_by    = EXCLUDED.updated_by,
+  justification = EXCLUDED.justification;
+
+INSERT INTO monkey_parameters (
+  name, category, value, bounds_low, bounds_high, justification, version, updated_by
+) VALUES (
+  'executive.lane.trend.tp_pct',
+  'OPERATIONAL',
+  0.40,
+  0.05,
+  1.00,
+  'v0.8.6 ROI-scale rescale: 40% ROI on margin TP for trend (was 4.0% raw price).',
+  1,
+  'GaryOcean428'
+)
+ON CONFLICT (name) DO UPDATE SET
+  value         = EXCLUDED.value,
+  bounds_low    = EXCLUDED.bounds_low,
+  bounds_high   = EXCLUDED.bounds_high,
+  version       = monkey_parameters.version + 1,
+  updated_at    = NOW(),
+  updated_by    = EXCLUDED.updated_by,
+  justification = EXCLUDED.justification;
+
+COMMIT;

--- a/ml-worker/scripts/recalibrate_lane_sl_tp_to_roi.sql
+++ b/ml-worker/scripts/recalibrate_lane_sl_tp_to_roi.sql
@@ -2,6 +2,8 @@
 --
 -- v0.8.6 (2026-05-01) — rescale executive.lane.<lane>.{sl_pct,tp_pct}
 -- registry rows from "raw price movement %" to "ROI on margin %".
+-- v0.8.7 (2026-05-01) — scalp TP/SL set to symmetric 1:1 R:R per user
+-- directive (option a: 3% / 3%). Subagent A's 0.05/0.05 → 0.03/0.03.
 --
 -- Background
 -- ----------
@@ -23,16 +25,18 @@
 -- without needing a redeploy.
 --
 -- Rescale (preserves order-of-magnitude intent at ~15-20x leverage):
---   scalp: 0.4%  raw → 5%   ROI (sl_pct + tp_pct)
+--   scalp: 0.4%  raw → 3%   ROI (v0.8.7: 1:1 R:R per user directive)
 --   swing: 1.5%  raw → 15%  ROI (sl_pct + tp_pct)
 --   trend: 4.0%  raw → 40%  ROI (sl_pct + tp_pct)
 --
--- PR #627 follow-up: that PR set executive.lane.scalp.tp_pct = 0.03
--- (3%) on the registry to lock scalp profit at +3% ROI under the OLD
--- raw-price semantics. Under the new ROI semantics, 0.03 means "3%
--- ROI lock-in" which is too tight (scalps regularly hit 5%+ ROI).
--- Update that scalp.tp_pct to 0.05 here — restoring the 2026-04-30
--- tape-derived intent under the new semantics.
+-- v0.8.7 scalp note: PR #627 originally set executive.lane.scalp.tp_pct
+-- = 0.03 under raw-price semantics. v0.8.6 (Subagent A) bumped it to
+-- 0.05 under ROI semantics; v0.8.7 (this revision) reverts both
+-- scalp.tp_pct AND scalp.sl_pct to 0.03 per the user's symmetric 1:1
+-- R:R directive. Live tape evidence (2026-05-01 16:11-16:17, 22% win
+-- rate, $77→$386 escalating notionals on a $97 account) drove the
+-- reversion: tighter symmetric scalps + the regime-hysteresis fix
+-- + the notional ceiling are the trio that has to land together.
 --
 -- Apply (after merge, with autonomy paused if you want zero in-flight
 -- ambiguity — the rebound is bounded by ``loop.refresh_every_ticks``):
@@ -59,11 +63,11 @@ INSERT INTO monkey_parameters (
 ) VALUES (
   'executive.lane.scalp.sl_pct',
   'OPERATIONAL',
-  0.05,
+  0.03,
   0.005,
   0.50,
-  'v0.8.6 ROI-scale rescale: 5% ROI on margin SL for scalp (was 0.4% raw price). '
-  'Live ETH-long sat at -4.4% ROI for 4+ hours without firing under raw semantics.',
+  'v0.8.7 user directive (option a, symmetric 1:1 R:R): 3% ROI on margin SL for '
+  'scalp (was 0.05 in Subagent A revision). Pairs with 0.03 tp_pct.',
   1,
   'GaryOcean428'
 )
@@ -81,12 +85,12 @@ INSERT INTO monkey_parameters (
 ) VALUES (
   'executive.lane.scalp.tp_pct',
   'OPERATIONAL',
-  0.05,
+  0.03,
   0.005,
   0.50,
-  'v0.8.6 ROI-scale rescale: 5% ROI on margin TP for scalp (was 3% under old '
-  'raw semantics — that 3% as ROI is too tight; scalps hit 5%+ ROI regularly). '
-  'Restores the 2026-04-30 tape-derived intent under the new ROI semantics.',
+  'v0.8.7 user directive (option a, symmetric 1:1 R:R): 3% ROI on margin TP for '
+  'scalp. Reverted from Subagent A''s 0.05 — user keeps the original PR #627 '
+  'value as the floor under the new ROI semantics. Pairs with 0.03 sl_pct.',
   1,
   'GaryOcean428'
 )
@@ -173,6 +177,57 @@ INSERT INTO monkey_parameters (
   0.05,
   1.00,
   'v0.8.6 ROI-scale rescale: 40% ROI on margin TP for trend (was 4.0% raw price).',
+  1,
+  'GaryOcean428'
+)
+ON CONFLICT (name) DO UPDATE SET
+  value         = EXCLUDED.value,
+  bounds_low    = EXCLUDED.bounds_low,
+  bounds_high   = EXCLUDED.bounds_high,
+  version       = monkey_parameters.version + 1,
+  updated_at    = NOW(),
+  updated_by    = EXCLUDED.updated_by,
+  justification = EXCLUDED.justification;
+
+-- ── v0.8.7 regime hysteresis stability requirement ────────────────
+INSERT INTO monkey_parameters (
+  name, category, value, bounds_low, bounds_high, justification, version, updated_by
+) VALUES (
+  'executive.regime_stability_ticks_for_exit',
+  'OPERATIONAL',
+  3,
+  1,
+  20,
+  'v0.8.7 regime-hysteresis: minimum number of consecutive ticks where '
+  'regimeNow != regimeAtOpen before the held-position regime_change exit '
+  'fires. Combined with FR-distance > 1/π and confidence > 1/φ gates. '
+  'Live tape 2026-05-01: 22% win rate with every close via single-tick '
+  'regime_change; this defaults to 3 to demand sustained divergence.',
+  1,
+  'GaryOcean428'
+)
+ON CONFLICT (name) DO UPDATE SET
+  value         = EXCLUDED.value,
+  bounds_low    = EXCLUDED.bounds_low,
+  bounds_high   = EXCLUDED.bounds_high,
+  version       = monkey_parameters.version + 1,
+  updated_at    = NOW(),
+  updated_by    = EXCLUDED.updated_by,
+  justification = EXCLUDED.justification;
+
+-- ── v0.8.7 notional-ceiling fallback (Kelly cap supplement) ───────
+INSERT INTO monkey_parameters (
+  name, category, value, bounds_low, bounds_high, justification, version, updated_by
+) VALUES (
+  'executive.notional_ceiling_ratio',
+  'OPERATIONAL',
+  4.0,
+  1.0,
+  20.0,
+  'v0.8.7 notional-ceiling: cap single-position notional at this multiple '
+  'of account balance. Backstops the Kelly cap which is non-binding at '
+  'cold start (< 5 closed trades per lane). Live tape 2026-05-01 showed '
+  '$77 → $386 escalating notionals on a $97 account (4× balance).',
   1,
   'GaryOcean428'
 )

--- a/ml-worker/src/monkey_kernel/executive.py
+++ b/ml-worker/src/monkey_kernel/executive.py
@@ -78,20 +78,35 @@ _DEFAULT_DCA_MAX_ADDS = 1
 # Two-lane initial split (scalp + swing). Trend is left as a parameter
 # slot but defaults to budget=0 — opt-in via the parameter registry.
 # Each lane has its own SL/TP envelope and capital budget. SL/TP are
-# stored as positive *fractions of notional* (e.g. 0.004 = 0.4%); the
-# trade-side sign is applied at the call site. Budget fractions sum to
-# 1.0 across position-bearing lanes when fully active; values below sum
-# to 1.0 only because trend defaults to 0 in this batch.
-_DEFAULT_LANE_SCALP_SL_PCT = 0.004
-_DEFAULT_LANE_SCALP_TP_PCT = 0.005
+# stored as positive *fractions of margin* — i.e. ROI on margin (e.g.
+# 0.05 = 5% ROI on the position's posted margin). The trade-side sign
+# is applied at the call site. Budget fractions sum to 1.0 across
+# position-bearing lanes when fully active; values below sum to 1.0
+# only because trend defaults to 0 in this batch.
+#
+# v0.8.6 RESCALE (2026-05-01) — sl_pct / tp_pct semantics changed
+# from "raw price movement %" to "ROI on margin %". The previous
+# scale (sl=0.4%/1.5%/4% raw) almost never tripped at typical 15-20x
+# leverage because raw price moves stay tiny while ROI on margin
+# scales with leverage. Live failure: ETH long sat at -4.4% ROI for
+# 4+ hours without the 1.5% raw SL firing because raw price only
+# moved -0.30%. Rescale preserves order-of-magnitude intent at ~15-20x
+# leverage:
+#   scalp: 0.4% raw → 5%   ROI (was tripping ~6-7% ROI at 15-20x)
+#   swing: 1.5% raw → 15%  ROI
+#   trend: 4.0% raw → 40%  ROI
+# These rows are also updated in the parameter registry via the
+# scripts/recalibrate_lane_sl_tp_to_roi.sql migration.
+_DEFAULT_LANE_SCALP_SL_PCT = 0.05
+_DEFAULT_LANE_SCALP_TP_PCT = 0.05
 _DEFAULT_LANE_SCALP_BUDGET_FRAC = 0.50
 
-_DEFAULT_LANE_SWING_SL_PCT = 0.015
-_DEFAULT_LANE_SWING_TP_PCT = 0.015
+_DEFAULT_LANE_SWING_SL_PCT = 0.15
+_DEFAULT_LANE_SWING_TP_PCT = 0.15
 _DEFAULT_LANE_SWING_BUDGET_FRAC = 0.50
 
-_DEFAULT_LANE_TREND_SL_PCT = 0.040
-_DEFAULT_LANE_TREND_TP_PCT = 0.040
+_DEFAULT_LANE_TREND_SL_PCT = 0.40
+_DEFAULT_LANE_TREND_TP_PCT = 0.40
 _DEFAULT_LANE_TREND_BUDGET_FRAC = 0.0  # opt-in; bumped via parameter registry
 
 _LANE_PARAMETER_DEFAULTS: dict[str, dict[str, float]] = {
@@ -820,11 +835,33 @@ def should_scalp_exit(
     s: ExecBasinState,
     mode: MonkeyMode = MonkeyMode.INVESTIGATION,
     lane: str = "swing",
+    leverage: float = 1.0,
 ) -> dict[str, Any]:
+    """ROI-on-margin take-profit / stop-loss gate.
+
+    v0.8.6 (2026-05-01) — ``pnl_frac`` semantics CHANGED from
+    "PnL / notional" (raw price movement %) to "PnL / margin"
+    ("ROI on margin %"). Leverage is now threaded in so we can
+    derive margin from notional / leverage. This fixes the live
+    failure where an ETH long sat at -4.4% ROI for 4+ hours without
+    the 1.5% raw-price SL firing because raw price only moved -0.30%
+    (the SL gate was reading raw movement, not ROI on margin).
+    Lane SL/TP defaults are rescaled to the ROI scale in the same
+    rev — see ``_DEFAULT_LANE_*_{SL,TP}_PCT``.
+
+    For back-compat with cold callers, ``leverage`` defaults to 1.0,
+    in which case ROI == raw move and the gate behaves as before.
+    All production callers now pass the live position leverage.
+    """
     if notional_usdt <= 0:
         return {"value": False, "reason": "no position notional", "derivation": {}}
 
-    pnl_frac = unrealized_pnl_usdt / notional_usdt
+    # ROI on margin = (PnL / notional) × leverage. When leverage=1 this
+    # collapses to the legacy raw-move semantic; at typical 15-20x live
+    # leverage it scales the gate up to its intended sensitivity range.
+    lev = float(leverage) if leverage and leverage > 0 else 1.0
+    raw_frac = unrealized_pnl_usdt / notional_usdt
+    roi_frac = raw_frac * lev
     nc = s.neurochemistry
     # v0.8.5 — tp_base_frac and sl_ratio derive from regime + serotonin.
     # Quantum regime (low eq) widens TP; high serotonin (stable) tightens SL.
@@ -836,45 +873,60 @@ def should_scalp_exit(
         equilibrium_weight=s.regime_weights.get("equilibrium", 0.5),
     )
     # Scalp TP floor: must clear exchange fees round-trip (2× taker
-    # ~=0.0015 on Poloniex VIP0). 0.003 gives a ~15bp margin. SAFETY_BOUND;
-    # the tp_base_frac + dopamine/Φ modulation sits on top of it.
+    # ~=0.0015 on Poloniex VIP0). 0.003 gives a ~15bp margin. SAFETY_BOUND
+    # on the RAW-price scale (fees scale with notional, not margin). The
+    # geometric formula sits on raw scale and we promote it to ROI by
+    # multiplying by leverage so it composes with the ROI-scale lane
+    # envelope under max().
     tp_min_floor = _registry.get(
         "executive.scalp.tp_min_floor", default=_DEFAULT_SCALP_TP_MIN_FLOOR,
     )
-    geometric_tp = max(
+    geometric_tp_raw = max(
         tp_min_floor,
         profile.tp_base_frac - 0.003 * nc.dopamine + 0.005 * s.phi,
     )
-    geometric_sl = geometric_tp * profile.sl_ratio
-    # Proposal #10: per-lane envelope. Scalp/swing/trend each carry
-    # their own SL/TP "retreat tolerance":
-    #   scalp ~0.4% adverse, fast tape harvesting
-    #   swing ~1.5% adverse, absorbs retraces
-    #   trend ~3-5% adverse, rides the macro trend
-    # We take the *wider* of (geometric, lane) so the geometric floor
-    # (e.g. fee-clear) is never breached but the lane envelope can
-    # broaden tolerance when configured to do so.
+    geometric_sl_raw = geometric_tp_raw * profile.sl_ratio
+    # Promote the geometric thresholds (raw) onto the ROI scale.
+    geometric_tp = geometric_tp_raw * lev
+    geometric_sl = geometric_sl_raw * lev
+    # Proposal #10: per-lane envelope. Lane SL/TP are stored on the ROI
+    # scale (post-v0.8.6 rescale). Take the *wider* of (geometric, lane)
+    # so the geometric Φ-derived floor is never breached but the lane
+    # envelope can broaden tolerance when configured to do so. At
+    # typical 15-20x live leverage the geometric (~10%) is wider than
+    # scalp (5%), making the geometric the binding constraint there;
+    # for swing/trend the lane envelope dominates.
     lane_tp = lane_param(lane, "tp_pct")
     lane_sl = lane_param(lane, "sl_pct")
     tp_thr = max(geometric_tp, lane_tp)
     sl_thr = max(geometric_sl, lane_sl)
 
-    if pnl_frac >= tp_thr:
+    if roi_frac >= tp_thr:
         return {
             "value": True,
-            "reason": f"take_profit[{lane}]: {pnl_frac*100:.3f}% >= {tp_thr*100:.3f}%",
+            "reason": (
+                f"take_profit[{lane}]: roi {roi_frac*100:.3f}% "
+                f">= {tp_thr*100:.3f}% (lev={lev:.0f}x)"
+            ),
             "derivation": {
-                "pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr,
+                "roi_frac": roi_frac, "raw_frac": raw_frac,
+                "leverage": lev,
+                "tp_thr": tp_thr, "sl_thr": sl_thr,
                 "lane": lane, "lane_tp_pct": lane_tp, "lane_sl_pct": lane_sl,
                 "exit_type_bit": 1,
             },
         }
-    if pnl_frac <= -sl_thr:
+    if roi_frac <= -sl_thr:
         return {
             "value": True,
-            "reason": f"stop_loss[{lane}]: {pnl_frac*100:.3f}% <= -{sl_thr*100:.3f}%",
+            "reason": (
+                f"stop_loss[{lane}]: roi {roi_frac*100:.3f}% "
+                f"<= -{sl_thr*100:.3f}% (lev={lev:.0f}x)"
+            ),
             "derivation": {
-                "pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr,
+                "roi_frac": roi_frac, "raw_frac": raw_frac,
+                "leverage": lev,
+                "tp_thr": tp_thr, "sl_thr": sl_thr,
                 "lane": lane, "lane_tp_pct": lane_tp, "lane_sl_pct": lane_sl,
                 "exit_type_bit": -1,
             },
@@ -882,11 +934,13 @@ def should_scalp_exit(
     return {
         "value": False,
         "reason": (
-            f"scalp hold[{lane}]: pnl {pnl_frac*100:.3f}% in "
-            f"[-{sl_thr*100:.3f}%, {tp_thr*100:.3f}%]"
+            f"scalp hold[{lane}]: roi {roi_frac*100:.3f}% in "
+            f"[-{sl_thr*100:.3f}%, {tp_thr*100:.3f}%] (lev={lev:.0f}x)"
         ),
         "derivation": {
-            "pnl_frac": pnl_frac, "tp_thr": tp_thr, "sl_thr": sl_thr,
+            "roi_frac": roi_frac, "raw_frac": raw_frac,
+            "leverage": lev,
+            "tp_thr": tp_thr, "sl_thr": sl_thr,
             "lane": lane, "lane_tp_pct": lane_tp, "lane_sl_pct": lane_sl,
         },
     }

--- a/ml-worker/src/monkey_kernel/executive.py
+++ b/ml-worker/src/monkey_kernel/executive.py
@@ -72,6 +72,15 @@ _DEFAULT_LEVERAGE_KAPPA_SIGMA = 20.0
 _DEFAULT_SCALP_TP_MIN_FLOOR = 0.003
 _DEFAULT_EXIT_ENTROPY_COLLAPSE = 0.4  # (referenced by should_auto_flatten semantic)
 _DEFAULT_DCA_MAX_ADDS = 1
+# v0.8.7 — notional ceiling fallback. The Kelly cap is the primary
+# brake on aggregate exposure but is non-binding at cold start (no
+# closed trades) and decays to no-op when stats are uninformative.
+# Live tape 2026-05-01 evidence: $77 → $386 escalating notionals on
+# a $97 account (4× balance). This caps a single position's notional
+# at NOTIONAL_CEILING_RATIO × account balance regardless of geometric
+# leverage * margin. Default 4.0 keeps the geometric formula's
+# 10-20× leverage intent while bounding worst-case escalation.
+_DEFAULT_NOTIONAL_CEILING_RATIO = 4.0
 
 # ─── Proposal #10 — lane-isolated position lifecycle defaults ────
 #
@@ -97,8 +106,15 @@ _DEFAULT_DCA_MAX_ADDS = 1
 #   trend: 4.0% raw → 40%  ROI
 # These rows are also updated in the parameter registry via the
 # scripts/recalibrate_lane_sl_tp_to_roi.sql migration.
-_DEFAULT_LANE_SCALP_SL_PCT = 0.05
-_DEFAULT_LANE_SCALP_TP_PCT = 0.05
+# v0.8.7 (2026-05-01) — scalp TP/SL set to symmetric 1:1 R:R per user
+# directive (option a: 3% TP / 3% SL). v0.8.6 had bumped tp_pct from
+# the PR #627 value (0.03) to 0.05; the user explicitly chose the
+# original 3% floor, with SL also dropped from 0.05 → 0.03 to keep the
+# pair symmetric. The SQL migration script
+# scripts/recalibrate_lane_sl_tp_to_roi.sql writes the same values to
+# the parameter registry.
+_DEFAULT_LANE_SCALP_SL_PCT = 0.03
+_DEFAULT_LANE_SCALP_TP_PCT = 0.03
 _DEFAULT_LANE_SCALP_BUDGET_FRAC = 0.50
 
 _DEFAULT_LANE_SWING_SL_PCT = 0.15
@@ -403,6 +419,28 @@ def current_position_size(
         notional = margin * max(1.0, leverage)
         capped_by_lane = True
 
+    # v0.8.7 — notional ceiling fallback. The Kelly cap is intended to
+    # bound aggregate exposure but is non-binding at cold start (no
+    # closed trades yet) and decays to no-op when stats are
+    # uninformative. Live tape 2026-05-01 showed $77 → $386 escalating
+    # notionals on a $97 account (4× balance) with every position
+    # closing via regime_change at 22% win rate. Hard ceiling:
+    # notional = margin × leverage <= NOTIONAL_CEILING_RATIO × equity.
+    # Default ratio 4.0 — preserves enough headroom for the kernel's
+    # geometric leverage formula at typical 10-20x while preventing
+    # unbounded escalation on small accounts.
+    notional_ceiling_ratio = float(_registry.get(
+        "executive.notional_ceiling_ratio",
+        default=_DEFAULT_NOTIONAL_CEILING_RATIO,
+    ))
+    notional_ceiling = notional_ceiling_ratio * available_equity_usdt
+    capped_by_notional = False
+    if notional > notional_ceiling and leverage > 0 and available_equity_usdt > 0:
+        # Reduce margin so margin × leverage == notional_ceiling.
+        margin = notional_ceiling / max(1.0, leverage)
+        notional = margin * max(1.0, leverage)
+        capped_by_notional = True
+
     sized = margin if notional >= min_notional_usdt else 0.0
 
     return {
@@ -410,12 +448,13 @@ def current_position_size(
         "reason": (
             f"size[{lane}] = {'lifted-to-min ' if lifted else ''}"
             f"{'lane-capped ' if capped_by_lane else ''}"
+            f"{'notional-capped ' if capped_by_notional else ''}"
             f"floor({exploration_floor:.3f}) or PhixSxM({base_frac:.3f}) "
             f"x reward({reward_mult:.2f}) x stab({stability_mult:.2f}) "
             f"x equity({available_equity_usdt:.2f}) @ {leverage:.0f}x "
             f"-> margin {margin:.2f} (lane-cap {lane_margin_cap:.2f}), "
-            f"notional {notional:.2f} vs min {min_notional_usdt:.2f} "
-            f"= {sized:.2f}"
+            f"notional {notional:.2f} vs ceiling {notional_ceiling:.2f} "
+            f"vs min {min_notional_usdt:.2f} = {sized:.2f}"
         ),
         "derivation": {
             "phi": s.phi,
@@ -435,6 +474,9 @@ def current_position_size(
             "lane_budget_frac": lane_frac,
             "lane_margin_cap": lane_margin_cap,
             "capped_by_lane": 1 if capped_by_lane else 0,
+            "notional_ceiling_ratio": notional_ceiling_ratio,
+            "notional_ceiling": notional_ceiling,
+            "capped_by_notional": 1 if capped_by_notional else 0,
         },
     }
 

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -1352,6 +1352,10 @@ def _decide_with_position(
         s=basin_state,
         mode=mode_enum,
         lane=position_lane,
+        # v0.8.6 — SL gate now reads ROI on margin, not raw price %.
+        # leverage_val is the live lev that justified entry; threading
+        # it lets the gate scale raw move into ROI correctly.
+        leverage=float(leverage_val),
     )
     derivation["scalp"] = {
         **scalp["derivation"],

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -115,6 +115,23 @@ _registry = get_registry()
 CHOP_SUPPRESSION_CONFIDENCE = 0.70
 
 
+# v0.8.7 regime-hysteresis — minimum number of consecutive ticks where
+# regimeNow != regimeAtOpen before the regime_change exit can fire.
+# Registry-controlled via ``executive.regime_stability_ticks_for_exit``.
+# Default 3 means a flicker (1-2 tick mode divergence) cannot trigger
+# the exit alone; the kernel must read the new regime stably for at
+# least 3 ticks AND the basin must have moved more than 1/π in
+# Fisher-Rao distance from the entry anchor.
+_DEFAULT_REGIME_STABILITY_TICKS_FOR_EXIT = 3
+
+
+def _regime_stability_ticks_for_exit() -> int:
+    return int(_registry.get(
+        "executive.regime_stability_ticks_for_exit",
+        default=_DEFAULT_REGIME_STABILITY_TICKS_FOR_EXIT,
+    ))
+
+
 def _chop_suppress_entry(reading: RegimeReading) -> bool:
     """True when the regime classifier reads sustained chop above the
     suppression confidence threshold. Held positions are unaffected;
@@ -253,6 +270,19 @@ class SymbolState:
     # multi-lane positions keep independent rejustification anchors.
     regime_at_open_by_lane: dict[str, str] = field(default_factory=dict)
     phi_at_open_by_lane: dict[str, float] = field(default_factory=dict)
+    # v0.8.7 regime-hysteresis state. The regime-change exit (PR #619 +
+    # confidence gate from PR #629) was firing on single-tick mode
+    # flickers — live tape 2026-05-01 showed 22% win rate with every
+    # close via regime_change. The triple-AND gate now requires a
+    # sustained streak (>= N ticks where regimeNow != regimeAtOpen) AND
+    # FR distance from basin_at_open > 1/π in addition to the existing
+    # label divergence + confidence checks. Per-lane streak so a swing
+    # position's flicker doesn't cross-contaminate a scalp position's
+    # gate. Basin_at_open is the basin snapshot captured at entry time;
+    # FR-distance from that anchor is the geometric "has the kernel's
+    # perception actually moved?" signal.
+    regime_change_streak_by_lane: dict[str, int] = field(default_factory=dict)
+    basin_at_open_by_lane: dict[str, np.ndarray] = field(default_factory=dict)
 
 
 @dataclass
@@ -916,8 +946,12 @@ def run_tick(
         for held_lane in list(held_lanes.keys()):
             state.regime_at_open_by_lane.pop(held_lane, None)
             state.phi_at_open_by_lane.pop(held_lane, None)
+            state.basin_at_open_by_lane.pop(held_lane, None)
+            state.regime_change_streak_by_lane.pop(held_lane, None)
         state.regime_at_open_by_lane.pop(pre_lane, None)
         state.phi_at_open_by_lane.pop(pre_lane, None)
+        state.basin_at_open_by_lane.pop(pre_lane, None)
+        state.regime_change_streak_by_lane.pop(pre_lane, None)
     elif flag_live and ocean_state.intervention == "DREAM":
         action = "hold"
         reason = (
@@ -935,6 +969,8 @@ def run_tick(
         for held_lane in list(held_lanes.keys()):
             state.regime_at_open_by_lane.pop(held_lane, None)
             state.phi_at_open_by_lane.pop(held_lane, None)
+            state.basin_at_open_by_lane.pop(held_lane, None)
+            state.regime_change_streak_by_lane.pop(held_lane, None)
     elif (
         # Proposal #10 — lane-aware entry path takes precedence when
         # the target lane is flat even if another lane is currently
@@ -963,12 +999,16 @@ def run_tick(
         derivation["entry_threshold"] = entry_thr_d["derivation"]
         derivation["size"] = size_d["derivation"]
         derivation["leverage"] = leverage_d["derivation"]
-        # Held-position re-justification — snapshot the (regime, Φ)
+        # Held-position re-justification — snapshot the (regime, Φ, basin)
         # state at the moment of entry on this lane. Subsequent ticks
         # compare against these anchors via the three internal exit
         # checks (regime change / Φ collapse / conviction failure).
+        # v0.8.7 also stores basin_at_open for the FR-distance hysteresis
+        # gate and resets the regime-change streak.
         state.regime_at_open_by_lane[pre_lane] = mode
         state.phi_at_open_by_lane[pre_lane] = phi
+        state.basin_at_open_by_lane[pre_lane] = basin.copy()
+        state.regime_change_streak_by_lane[pre_lane] = 0
     elif held_side:
         # Proposal #10: resolve the lane this single-position decision
         # belongs to. With ``lane_positions`` populated the lane is read
@@ -1013,9 +1053,13 @@ def run_tick(
         if action in ("scalp_exit", "exit"):
             state.regime_at_open_by_lane.pop(position_lane, None)
             state.phi_at_open_by_lane.pop(position_lane, None)
+            state.basin_at_open_by_lane.pop(position_lane, None)
+            state.regime_change_streak_by_lane.pop(position_lane, None)
         elif action in ("reverse_long", "reverse_short"):
             state.regime_at_open_by_lane[position_lane] = mode
             state.phi_at_open_by_lane[position_lane] = phi
+            state.basin_at_open_by_lane[position_lane] = basin.copy()
+            state.regime_change_streak_by_lane[position_lane] = 0
     elif (
         MODE_PROFILES[mode_enum].can_enter
         and direction != "flat"
@@ -1039,12 +1083,16 @@ def run_tick(
         derivation["entry_threshold"] = entry_thr_d["derivation"]
         derivation["size"] = size_d["derivation"]
         derivation["leverage"] = leverage_d["derivation"]
-        # Held-position re-justification — snapshot the (regime, Φ)
+        # Held-position re-justification — snapshot the (regime, Φ, basin)
         # state at the moment of entry on this lane. Subsequent ticks
         # compare against these anchors via the three internal exit
         # checks (regime change / Φ collapse / conviction failure).
+        # v0.8.7 also stores basin_at_open for the FR-distance hysteresis
+        # gate and resets the regime-change streak.
         state.regime_at_open_by_lane[pre_lane] = mode
         state.phi_at_open_by_lane[pre_lane] = phi
+        state.basin_at_open_by_lane[pre_lane] = basin.copy()
+        state.regime_change_streak_by_lane[pre_lane] = 0
     else:
         action = "hold"
         if not MODE_PROFILES[mode_enum].can_enter:
@@ -1375,16 +1423,44 @@ def _decide_with_position(
     rejust: dict[str, Any] = {"checked": False}
     has_regime_anchor = position_lane in state.regime_at_open_by_lane
     has_phi_anchor = position_lane in state.phi_at_open_by_lane
+    # v0.8.7 — maintain the per-lane regime-change streak counter
+    # regardless of whether the rejust block runs (anchors present).
+    # Increment when regimeNow != regimeAtOpen; reset when it returns.
+    # Streak lives on state across ticks — the gate consumes the
+    # accumulated count below.
+    if has_regime_anchor:
+        if mode_value != state.regime_at_open_by_lane[position_lane]:
+            state.regime_change_streak_by_lane[position_lane] = (
+                state.regime_change_streak_by_lane.get(position_lane, 0) + 1
+            )
+        else:
+            state.regime_change_streak_by_lane[position_lane] = 0
     if has_regime_anchor and has_phi_anchor:
         rejust["checked"] = True
         regime_at_open = state.regime_at_open_by_lane[position_lane]
         phi_at_open = state.phi_at_open_by_lane[position_lane]
         phi_floor = phi_at_open / PHI_GOLDEN_FLOOR_RATIO
+        regime_change_streak = state.regime_change_streak_by_lane.get(
+            position_lane, 0,
+        )
+        regime_stability_ticks_required = _regime_stability_ticks_for_exit()
+        # Compute FR distance from the basin anchor (if present). When
+        # missing, the gate falls back strict-fail so the regime exit
+        # cannot fire on label flicker alone — the geometric component
+        # must be measurable.
+        basin_at_open = state.basin_at_open_by_lane.get(position_lane)
+        fr_distance: Optional[float] = None
+        if basin_at_open is not None:
+            fr_distance = float(fisher_rao_distance(basin_at_open, basin))
         rejust.update({
             "lane": position_lane,
             "regime_at_open": regime_at_open,
             "regime_now": mode_value,
             "regime_confidence": regime_confidence,
+            "regime_change_streak": regime_change_streak,
+            "regime_stability_ticks_required": regime_stability_ticks_required,
+            "fr_distance": fr_distance,
+            "fr_threshold": PI_STRUCT_GRAVITATING_FRACTION,
             "phi_at_open": phi_at_open,
             "phi_now": phi,
             "phi_floor": phi_floor,
@@ -1392,28 +1468,42 @@ def _decide_with_position(
             "anxiety": getattr(emotions, "anxiety", 0.0),
             "confusion": getattr(emotions, "confusion", 0.0),
         })
-        # 1. REGIME CHECK — regime changed since open.
-        # The regime classifier emits a confidence ∈ [0, 1] alongside
-        # the discrete regime label (see regime.py::RegimeReading).
-        # Gating exit on the classifier's own self-belief — rather than
-        # a synthesized streak counter — preserves the "single-tick exit,
-        # current state IS the truth" framing while skipping flicker
-        # events where the classifier itself isn't sure. The threshold
-        # is PI_STRUCT_BOUNDARY_R_SQUARED (1/φ ≈ 0.618), the canonical
-        # "boundary R²" from EXP-004b: when the classifier's confidence
-        # has crossed that coherence floor, treat the regime divergence
-        # as load-bearing. PR #627's chop-entry suppression uses 0.70
-        # (slightly stricter); 0.618 here is the canonical-constant
-        # alignment with the topology family. Strict >: a confidence
-        # exactly at the floor is not yet load-bearing.
+        # 1. REGIME CHECK — v0.8.7 triple-AND hysteresis. ALL of:
+        #   (a) regimeNow != regimeAtOpen   (label divergence)
+        #   (b) regimeChangeStreak >= regimeStabilityTicksRequired
+        #   (c) fr_distance > 1/π            (basin geometry has moved)
+        # PLUS the PR #629 confidence gate (regime_confidence > 1/φ).
+        #
+        # Live tape 2026-05-01 16:11-16:17 evidence: 9 closes, 22% win
+        # rate, every close via regime_change on a $97 account. Without
+        # the streak filter a single-tick mode flicker exits the
+        # position; without the FR filter, label changes where the
+        # basin has barely moved still close out. The triple-AND
+        # demands sustained, geometrically-substantiated regime change.
+        #
+        # FR threshold is PI_STRUCT_GRAVITATING_FRACTION (1/π ≈ 0.318)
+        # from EXP-004b — the canonical "basin has moved into a
+        # different gravitating cluster" distance.
+        label_diverged = mode_value != regime_at_open
+        confidence_load_bearing = regime_confidence > PI_STRUCT_BOUNDARY_R_SQUARED
+        streak_satisfied = regime_change_streak >= regime_stability_ticks_required
+        # Strict-fail when basin anchor is absent (e.g. positions opened
+        # before this PR shipped): the regime exit cannot fire purely on
+        # label flicker — the geometric component must be measurable.
+        fr_fires = fr_distance is not None and fr_distance > PI_STRUCT_GRAVITATING_FRACTION
         if (
-            mode_value != regime_at_open
-            and regime_confidence > PI_STRUCT_BOUNDARY_R_SQUARED
+            label_diverged
+            and confidence_load_bearing
+            and streak_satisfied
+            and fr_fires
         ):
             rejust["fired"] = "regime_change"
             derivation["rejustification"] = rejust
+            fr_str = f"{fr_distance:.3f}" if fr_distance is not None else "N/A"
             reason = (
-                f"regime_change: opened in {regime_at_open}, now {mode_value} "
+                f"regime_change: opened in {regime_at_open} "
+                f"(FR_dist {fr_str} > 1/π), now {mode_value} stable for "
+                f"{regime_change_streak} ticks "
                 f"(confidence {regime_confidence:.3f} > 1/φ)"
             )
             return "scalp_exit", reason, False, False

--- a/ml-worker/src/utils/redis_listener.py
+++ b/ml-worker/src/utils/redis_listener.py
@@ -40,7 +40,7 @@ import os
 import socket
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -64,6 +64,28 @@ def _candidate_keepalive_options() -> Dict[int, int]:
     return opts
 
 
+def _env_ping_interval_sec() -> float:
+    """Tunable heartbeat cadence for ``run_resilient_listener``.
+
+    Default: 10 seconds — well below any sane Redis idle-timeout
+    (typical defaults are 60-300s; managed Redis providers commonly
+    enforce 60s). Override via ``REDIS_LISTENER_PING_INTERVAL_SEC``.
+    Set to <= 0 to disable the heartbeat.
+
+    Bug context (2026-04-30 → 2026-05-01): production listener
+    reconnect rate was ~1 cycle / 30s sustained for 4+ hours. This is
+    not auth failure — it's Redis killing the idle pubsub connection.
+    The fix: send a client-level PING on a 10s cadence inside the
+    listener loop so the connection never crosses the idle threshold.
+    """
+    raw = os.environ.get("REDIS_LISTENER_PING_INTERVAL_SEC", "")
+    try:
+        v = float(raw) if raw else 10.0
+    except ValueError:
+        v = 10.0
+    return v
+
+
 @dataclass
 class ListenerConfig:
     """Tunables for ``run_resilient_listener``.
@@ -80,6 +102,12 @@ class ListenerConfig:
     socket_read_timeout: float = 30.0
     health_key: Optional[str] = None
     health_ttl: int = 90
+    # Heartbeat ping cadence (seconds). When >0 the listener sends a
+    # client.ping() at this cadence even on an idle channel, so a
+    # silent producer can't trip the upstream Redis idle timeout. The
+    # 30s reconnect-storm observed 2026-04-30 was idle-timeout induced;
+    # 10s defers well below typical 60s+ idle-timeout windows.
+    ping_interval_sec: float = field(default_factory=_env_ping_interval_sec)
 
 
 # Pluggable redis module / sleep / time hooks for test injection. Keep
@@ -208,10 +236,53 @@ def run_resilient_listener(
             # Connected — reset backoff for the next disconnect.
             backoff = config.initial_backoff
 
-            for message in pubsub.listen():
-                if stop_event is not None and stop_event.is_set():
-                    break
-                if message is None or message.get("type") != "message":
+            # Heartbeat schedule. ``last_ping`` is set to "now" so the
+            # first ping fires ~ping_interval_sec after subscribe; that
+            # avoids a redundant ping right after the freshly-completed
+            # SUBSCRIBE round-trip already proved liveness.
+            ping_interval = max(0.0, float(config.ping_interval_sec))
+            last_ping = time.monotonic()
+            # Bound the per-poll timeout so we wake often enough to
+            # service the heartbeat. When pinging is disabled (interval
+            # <= 0) fall back to the connection-level read timeout.
+            poll_timeout = (
+                min(ping_interval, float(config.socket_read_timeout))
+                if ping_interval > 0
+                else float(config.socket_read_timeout)
+            )
+
+            # Poll-loop heartbeat: ``get_message(timeout=...)`` returns
+            # ``None`` on idle wakeup — perfect injection point for the
+            # liveness ping. ``listen()`` was a blocking generator that
+            # gave us no clean place to send a ping while the channel
+            # was quiet, which is why production listeners were getting
+            # killed at the upstream Redis idle-timeout (~30s reconnect
+            # storms observed 2026-04-30 → 2026-05-01).
+            while stop_event is None or not stop_event.is_set():
+                message = pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=poll_timeout,
+                )
+                # Heartbeat — send PING when the cadence elapses, regardless
+                # of whether get_message returned a payload or idle-woke us.
+                if ping_interval > 0:
+                    now = time.monotonic()
+                    if now - last_ping >= ping_interval:
+                        try:
+                            client.ping()
+                        except Exception as exc:  # noqa: BLE001
+                            # Ping failure means the connection is dead;
+                            # raise to the outer except so the reconnect
+                            # path runs. Use a marked exception so the
+                            # outer logger knows it was the heartbeat.
+                            raise RuntimeError(
+                                f"redis-listener-heartbeat-failed: {exc}",
+                            ) from exc
+                        last_ping = now
+                if message is None:
+                    # Idle wakeup — heartbeat handled above; loop again.
+                    continue
+                if message.get("type") != "message":
                     continue
                 # Got a real message — reset the idle streak.
                 idle_timeout_streak = 0

--- a/ml-worker/tests/monkey_kernel/test_held_position_rejustification.py
+++ b/ml-worker/tests/monkey_kernel/test_held_position_rejustification.py
@@ -3,13 +3,15 @@
 Three internal exit checks fire when the kernel's own state contradicts
 what justified entry:
 
-  1. REGIME CHECK   — state.regime != state.regime_at_open → exit
+  1. REGIME CHECK   — triple-AND of label divergence + sustained streak
+                      + FR-distance > 1/π (v0.8.7 hysteresis)
   2. PHI CHECK      — phi_now < phi_at_open / PHI_GOLDEN_FLOOR_RATIO → exit
   3. CONVICTION    — emotions.confidence < anxiety + confusion → exit
 
 All three return action='scalp_exit' with reason starting with the check
-name. SymbolState gets regime_at_open_by_lane and phi_at_open_by_lane
-populated when a position opens; cleared when it closes.
+name. SymbolState gets regime_at_open_by_lane, phi_at_open_by_lane,
+basin_at_open_by_lane, and regime_change_streak_by_lane populated when
+a position opens; cleared when it closes.
 
 These tests exercise `_decide_with_position` directly. The full run_tick
 path is exercised at the integration level by the existing tick tests;
@@ -40,7 +42,22 @@ from monkey_kernel.tick import (  # noqa: E402
 from monkey_kernel.topology_constants import (  # noqa: E402
     PHI_GOLDEN_FLOOR_RATIO,
     PI_STRUCT_BOUNDARY_R_SQUARED,
+    PI_STRUCT_GRAVITATING_FRACTION,
 )
+
+
+def _far_basin(dim: int = 64) -> np.ndarray:
+    """Return a basin far enough from uniform_basin(dim) that
+    fisher_rao_distance > 1/π (the hysteresis FR threshold).
+
+    uniform_basin gives p_i = 1/n for all i. Concentrating mass on a
+    single component gives fisher_rao_distance ≈ arccos(√(1/n)) which
+    for n=64 is ≈ 1.446 — comfortably > 1/π ≈ 0.318.
+    """
+    arr = np.full(dim, 1e-6, dtype=np.float64)
+    arr[0] = 1.0
+    arr = arr / arr.sum()
+    return arr
 
 
 # ── Fixtures ──────────────────────────────────────────────────────
@@ -89,13 +106,35 @@ def _state_with_anchor(
     lane: str = "swing",
     regime_at_open: str = MonkeyMode.INVESTIGATION.value,
     phi_at_open: float = 0.27,
+    streak: int = 5,
+    basin_at_open: np.ndarray | None = None,
 ) -> SymbolState:
+    """Construct a SymbolState pre-loaded with rejustification anchors.
+
+    Defaults pre-load the streak to 5 (>= default 3-tick stability
+    requirement) and basin_at_open to a far-from-uniform basin so the
+    FR-distance from the tick basin (uniform_basin(64) by default) is
+    well above 1/π. This means existing tests that check "regime
+    fires" still fire under the new triple-AND hysteresis gate without
+    needing to construct streak / basin state in every test.
+
+    Tests that exercise the hysteresis (streak below threshold or FR
+    distance below threshold) override these defaults explicitly.
+    """
     state = SymbolState(
         symbol="BTC_USDT_PERP",
         identity_basin=uniform_basin(64),
     )
     state.regime_at_open_by_lane[lane] = regime_at_open
     state.phi_at_open_by_lane[lane] = phi_at_open
+    # v0.8.7 — preload streak and basin_at_open so the hysteresis gate
+    # is satisfied by default. The streak counter is incremented inside
+    # _decide_with_position when regimeNow != regimeAtOpen, so a
+    # test passing regime_change implicitly bumps it from N → N+1.
+    state.regime_change_streak_by_lane[lane] = streak
+    state.basin_at_open_by_lane[lane] = (
+        basin_at_open if basin_at_open is not None else _far_basin()
+    )
     return state
 
 
@@ -131,20 +170,30 @@ def _call_decide(
     last_price: float = 100.0,
     held_side: str = "long",
     regime_confidence: float = 1.0,
+    basin: np.ndarray | None = None,
 ) -> tuple[str, str, bool, bool, dict[str, Any]]:
     """Call _decide_with_position and return its tuple plus derivation.
 
     ``regime_confidence`` defaults to 1.0 — the QIG-pure debounce gate
     (regime confidence > 1/φ) is fully open, so existing tests that
     don't care about the gate behave as in PR #619.
+
+    ``basin`` is the basin snapshot the kernel sees this tick. Defaults
+    to ``uniform_basin(64)``. Combined with ``_state_with_anchor``'s
+    far-from-uniform basin_at_open default, the FR-distance is well
+    above 1/π, so existing "regime fires" tests pass unchanged. Tests
+    that exercise the FR-hysteresis pass a basin matching basin_at_open
+    (FR-distance ≈ 0) to verify the gate suppresses on geometric
+    consonance even with sustained label divergence.
     """
     derivation: dict[str, Any] = {}
     bs = _basin_state(phi=phi)
     bs.emotions = emotions or _Emotions()  # type: ignore[assignment]
+    tick_basin = basin if basin is not None else uniform_basin(64)
     action, reason, is_dca, is_reverse = _decide_with_position(
         inputs=_inputs(),
         state=state,
-        basin=uniform_basin(64),
+        basin=tick_basin,
         basin_state=bs,
         mode_enum=mode,
         last_price=last_price,
@@ -185,6 +234,9 @@ class TestRegimeCheckFires:
         assert "investigation" in reason
         assert "drift" in reason
         assert "confidence 0.900" in reason
+        # v0.8.7 reason includes streak count and FR distance.
+        assert "stable for" in reason
+        assert "FR_dist" in reason
         assert is_dca is False
         assert is_reverse is False
         rej = derivation["rejustification"]
@@ -192,6 +244,10 @@ class TestRegimeCheckFires:
         assert rej["regime_at_open"] == "investigation"
         assert rej["regime_now"] == "drift"
         assert rej["regime_confidence"] == 0.9
+        # v0.8.7 surfaces — streak >= required, FR > 1/π.
+        assert rej["regime_change_streak"] >= rej["regime_stability_ticks_required"]
+        assert rej["fr_distance"] is not None
+        assert rej["fr_distance"] > rej["fr_threshold"]
 
 
 class TestRegimeConfidenceGate:
@@ -428,13 +484,18 @@ class TestStateClearing:
 
         # The clear is in the outer tick.py path — replicate the logic
         # the test contract expects: "when the position closes, the
-        # anchors for that lane are cleared".
+        # anchors for that lane are cleared". v0.8.7 also clears
+        # basin_at_open and the regime-change streak.
         if action in ("scalp_exit", "exit"):
             state.regime_at_open_by_lane.pop("swing", None)
             state.phi_at_open_by_lane.pop("swing", None)
+            state.basin_at_open_by_lane.pop("swing", None)
+            state.regime_change_streak_by_lane.pop("swing", None)
 
         assert "swing" not in state.regime_at_open_by_lane
         assert "swing" not in state.phi_at_open_by_lane
+        assert "swing" not in state.basin_at_open_by_lane
+        assert "swing" not in state.regime_change_streak_by_lane
 
 
 class TestPerLaneIsolation:
@@ -443,11 +504,17 @@ class TestPerLaneIsolation:
             symbol="BTC_USDT_PERP",
             identity_basin=uniform_basin(64),
         )
-        # Two lanes, two different anchor sets.
+        # Two lanes, two different anchor sets. v0.8.7 also seeds the
+        # streak counter and basin_at_open per lane so the hysteresis
+        # gate has independent state.
         state.regime_at_open_by_lane["scalp"] = MonkeyMode.INVESTIGATION.value
         state.phi_at_open_by_lane["scalp"] = 0.27
+        state.regime_change_streak_by_lane["scalp"] = 5
+        state.basin_at_open_by_lane["scalp"] = _far_basin()
         state.regime_at_open_by_lane["swing"] = MonkeyMode.INTEGRATION.value
         state.phi_at_open_by_lane["swing"] = 0.40
+        state.regime_change_streak_by_lane["swing"] = 0
+        state.basin_at_open_by_lane["swing"] = _far_basin()
 
         # Test 1: scalp lane fires regime_change when current mode != investigation
         # but swing lane's anchor is unaffected.
@@ -467,9 +534,16 @@ class TestPerLaneIsolation:
         assert "swing" in state.regime_at_open_by_lane
         assert state.phi_at_open_by_lane["scalp"] == 0.27
         assert state.phi_at_open_by_lane["swing"] == 0.40
+        # v0.8.7 — streaks are independent per lane.
+        assert "scalp" in state.regime_change_streak_by_lane
+        assert "swing" in state.regime_change_streak_by_lane
+        # The scalp lane's streak was bumped by the regime_change tick;
+        # the swing lane's streak is untouched (no tick run for it).
+        assert state.regime_change_streak_by_lane["scalp"] >= 5
 
         # Test 2: swing lane checks against ITS anchor — same regime
-        # (integration), no fire.
+        # (integration), no fire. Swing's streak resets to 0 because
+        # mode == regime_at_open.
         _, _, _, _, derivation_w = _call_decide(
             state=state,
             phi=0.30,  # above floor 0.40/φ ≈ 0.247
@@ -481,6 +555,7 @@ class TestPerLaneIsolation:
         assert rej_w.get("fired") is None
         assert rej_w["regime_at_open"] == "integration"
         assert rej_w["phi_at_open"] == 0.40
+        assert state.regime_change_streak_by_lane["swing"] == 0
 
 
 # ── Precedence / ordering tests ────────────────────────────────────
@@ -585,3 +660,213 @@ class TestNoAnchorPath:
         assert not reason.startswith("regime_change")
         assert not reason.startswith("phi_collapse")
         assert not reason.startswith("conviction_failed")
+
+
+# ── v0.8.7 regime-hysteresis tests ────────────────────────────────
+
+
+class TestRegimeHysteresisStreakGate:
+    """The regime-change exit now requires regime_change_streak >=
+    REGIME_STABILITY_TICKS_FOR_EXIT (default 3) consecutive ticks of
+    label divergence. Single-tick mode flicker no longer exits the
+    position.
+
+    Live tape 2026-05-01 16:11-16:17 motivation: every close was
+    regime_change, 22% win rate, $97 account torn through positions
+    because a single-tick mode flicker was enough to flip the gate.
+    """
+
+    def test_single_tick_flicker_does_not_fire(self) -> None:
+        # streak=0 preload — _decide_with_position will bump to 1, well
+        # below the default 3-tick stability requirement.
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+            streak=0,
+        )
+        action, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=0.9,  # confidence gate is open
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") != "regime_change"
+        assert not reason.startswith("regime_change")
+        # Streak was bumped from 0 → 1 (still below 3).
+        assert rej["regime_change_streak"] == 1
+        assert rej["regime_stability_ticks_required"] == 3
+
+    def test_streak_below_threshold_does_not_fire(self) -> None:
+        # streak=1 preload → bumped to 2 inside the gate, still < 3.
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+            streak=1,
+        )
+        _, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=0.9,
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") != "regime_change"
+        assert not reason.startswith("regime_change")
+        assert rej["regime_change_streak"] == 2
+
+    def test_streak_at_threshold_fires(self) -> None:
+        # streak=2 preload → bumped to 3 inside the gate, exactly at
+        # threshold. >= 3 → fires.
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+            streak=2,
+        )
+        action, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=0.9,
+        )
+        assert action == "scalp_exit"
+        assert reason.startswith("regime_change")
+        rej = derivation["rejustification"]
+        assert rej["fired"] == "regime_change"
+        assert rej["regime_change_streak"] == 3
+
+    def test_streak_resets_on_regime_restoration(self) -> None:
+        """If regime returns to regime_at_open mid-window, the streak
+        resets — proving the gate cannot fire from an old streak after
+        the kernel re-aligns with entry conditions."""
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+            streak=10,  # huge accumulated streak from earlier divergence
+        )
+        # Mode == regime_at_open → streak resets to 0.
+        _, _, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.INVESTIGATION.value,
+            regime_confidence=0.9,
+            emotions=_Emotions(confidence=0.7, anxiety=0.1, confusion=0.1),
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") is None
+        assert state.regime_change_streak_by_lane["swing"] == 0
+
+
+class TestRegimeHysteresisFRDistanceGate:
+    """The regime-change exit now requires fr_distance > 1/π (≈ 0.318)
+    in addition to label divergence + sustained streak + confidence.
+    The basin must have geometrically moved into a different
+    gravitating cluster — label divergence alone isn't enough.
+    """
+
+    def test_fr_distance_below_threshold_does_not_fire(self) -> None:
+        # basin_at_open == tick basin → fr_distance = 0, well below 1/π.
+        # Even with full streak + confidence, regime exit cannot fire.
+        same_basin = uniform_basin(64)
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+            streak=10,  # comfortably past 3-tick requirement
+            basin_at_open=same_basin,
+        )
+        _, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=0.9,
+            basin=same_basin,  # FR(same, same) = 0
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") != "regime_change"
+        assert not reason.startswith("regime_change")
+        assert rej["fr_distance"] == 0.0
+        assert rej["fr_threshold"] > 0.31  # ≈ 0.318
+
+    def test_fr_distance_above_threshold_fires(self) -> None:
+        # basin_at_open far from tick basin → fr_distance well above 1/π.
+        # All three gate conditions satisfied → fires.
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+            streak=10,
+            basin_at_open=_far_basin(),
+        )
+        action, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=0.9,
+            basin=uniform_basin(64),  # far from the basin_at_open spike
+        )
+        assert action == "scalp_exit"
+        assert reason.startswith("regime_change")
+        rej = derivation["rejustification"]
+        assert rej["fired"] == "regime_change"
+        assert rej["fr_distance"] > rej["fr_threshold"]
+
+    def test_fr_threshold_equals_one_over_pi(self) -> None:
+        """Sanity: the FR threshold is 1/π (PI_STRUCT_GRAVITATING_FRACTION)."""
+        assert math.isclose(
+            PI_STRUCT_GRAVITATING_FRACTION, 1.0 / math.pi, rel_tol=1e-12,
+        )
+        # Surface check — a fresh state with anchors records the threshold
+        # in the rejustification block.
+        state = _state_with_anchor()
+        _, _, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.INVESTIGATION.value,  # no fire
+            emotions=_Emotions(confidence=0.7, anxiety=0.1, confusion=0.1),
+        )
+        rej = derivation["rejustification"]
+        assert math.isclose(
+            rej["fr_threshold"], 1.0 / math.pi, rel_tol=1e-12,
+        )
+
+
+class TestRegimeHysteresisMissingBasinAnchor:
+    """If basin_at_open is not present (e.g. position opened pre-v0.8.7),
+    the regime exit cannot fire — the geometric component is required.
+    Phi/conviction checks remain available because they don't need basin.
+    """
+
+    def test_no_basin_anchor_blocks_regime_exit(self) -> None:
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+            streak=10,
+        )
+        # Drop basin_at_open to simulate a pre-v0.8.7 position.
+        state.basin_at_open_by_lane.pop("swing", None)
+        _, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.25,  # above floor — phi gate doesn't fire
+            mode_value=MonkeyMode.DRIFT.value,
+            regime_confidence=0.9,
+            emotions=_Emotions(confidence=0.7, anxiety=0.1, confusion=0.1),
+        )
+        rej = derivation["rejustification"]
+        assert rej.get("fired") != "regime_change"
+        assert not reason.startswith("regime_change")
+        assert rej["fr_distance"] is None
+
+    def test_no_basin_anchor_phi_gate_still_fires(self) -> None:
+        state = _state_with_anchor(
+            regime_at_open=MonkeyMode.INVESTIGATION.value,
+            phi_at_open=0.27,
+        )
+        state.basin_at_open_by_lane.pop("swing", None)
+        # phi=0.05 well below floor 0.27/φ ≈ 0.167 → phi_collapse fires.
+        action, reason, _, _, derivation = _call_decide(
+            state=state,
+            phi=0.05,
+            mode_value=MonkeyMode.INVESTIGATION.value,  # same regime
+            emotions=_Emotions(confidence=0.7, anxiety=0.1, confusion=0.1),
+        )
+        assert action == "scalp_exit"
+        assert reason.startswith("phi_collapse")

--- a/ml-worker/tests/monkey_kernel/test_lane_isolation.py
+++ b/ml-worker/tests/monkey_kernel/test_lane_isolation.py
@@ -75,14 +75,18 @@ class TestLaneParameterEnvelope:
         assert lane_param("swing", "sl_pct") < lane_param("trend", "sl_pct")
         assert lane_param("swing", "tp_pct") < lane_param("trend", "tp_pct")
 
-    def test_scalp_sl_about_quarter_percent(self) -> None:
-        assert 0.002 <= lane_param("scalp", "sl_pct") <= 0.008
+    def test_scalp_sl_in_roi_band(self) -> None:
+        # v0.8.6 — sl_pct semantics are ROI-on-margin (was raw price).
+        # Scalp band: ~5% ROI.
+        assert 0.02 <= lane_param("scalp", "sl_pct") <= 0.10
 
-    def test_swing_sl_around_one_and_a_half_percent(self) -> None:
-        assert 0.010 <= lane_param("swing", "sl_pct") <= 0.025
+    def test_swing_sl_in_roi_band(self) -> None:
+        # v0.8.6 — swing band: ~15% ROI on margin.
+        assert 0.08 <= lane_param("swing", "sl_pct") <= 0.25
 
-    def test_trend_sl_three_to_five_percent(self) -> None:
-        assert 0.025 <= lane_param("trend", "sl_pct") <= 0.06
+    def test_trend_sl_in_roi_band(self) -> None:
+        # v0.8.6 — trend band: ~40% ROI on margin.
+        assert 0.25 <= lane_param("trend", "sl_pct") <= 0.60
 
     def test_scalp_swing_budget_sums_to_one(self) -> None:
         assert (
@@ -151,37 +155,43 @@ class TestPositionSizeLaneBudget:
 
 
 # ── 3. should_scalp_exit lane envelope widening ─────────────────────
+#
+# v0.8.6 — the SL/TP gate now compares ROI-on-margin (pnl/notional × lev)
+# against the lane envelope (also ROI). At leverage=15x (typical live
+# value), a 0.4% raw-price loss = 6% ROI, well into the scalp band; a
+# 1% raw-price loss = 15% ROI, well past the scalp band.
 
 
 class TestScalpExitLaneEnvelope:
-    def test_scalp_lane_matches_geometric_when_lane_tighter(self) -> None:
+    def test_scalp_sl_fires_when_roi_clears_envelope(self) -> None:
         bs = _basin_state()
-        # The scalp lane's params (sl=0.4%, tp=0.5%) are TIGHTER than
-        # the geometric formula's INVESTIGATION-mode envelope (sl ~=
-        # 0.67% with default NCs). max(geometric, lane) keeps geometric,
-        # so scalp = "current behavior" — the user's design intent.
+        # Lev=15x, raw -1.0% → ROI -15%. Past scalp's binding SL
+        # (max(geometric_sl×lev≈9.45%, lane 5%) = 9.45%).
         result = should_scalp_exit(
-            unrealized_pnl_usdt=-1.0,  # 1.0% loss, exceeds geometric ~0.67%
+            unrealized_pnl_usdt=-1.0,
             notional_usdt=100.0,
             s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+            leverage=15.0,
         )
         assert result["value"] is True
         assert "stop_loss[scalp]" in result["reason"]
 
     def test_swing_lane_absorbs_loss_scalp_would_exit(self) -> None:
         bs = _basin_state()
-        # 1.0% loss exits scalp (geometric wins, sl ~0.67%) but the
-        # swing lane envelope (sl=1.5%) overrides via max() — swing
-        # holds where scalp would close.
+        # Lev=15x, raw -1.0% → ROI -15%. Past scalp's binding SL (~9.45%
+        # from geometric × lev) but exactly at swing's 15% lane SL.
+        # Use raw=-0.85 so ROI=-12.75% — past scalp 9.45%, inside swing 15%.
         scalp = should_scalp_exit(
-            unrealized_pnl_usdt=-1.0,
+            unrealized_pnl_usdt=-0.85,
             notional_usdt=100.0,
             s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+            leverage=15.0,
         )
         swing = should_scalp_exit(
-            unrealized_pnl_usdt=-1.0,
+            unrealized_pnl_usdt=-0.85,
             notional_usdt=100.0,
             s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+            leverage=15.0,
         )
         assert scalp["value"] is True
         assert swing["value"] is False
@@ -189,34 +199,33 @@ class TestScalpExitLaneEnvelope:
 
     def test_trend_lane_absorbs_loss_swing_would_exit(self) -> None:
         bs = _basin_state()
-        # 2.5% loss exceeds swing SL but is below trend's 4% → trend
-        # holds, swing exits.
+        # Lev=15x, raw -2.0% → ROI -30%. Past swing's 15% lane SL but
+        # inside trend's 40% lane SL.
         swing = should_scalp_exit(
-            unrealized_pnl_usdt=-2.5,
+            unrealized_pnl_usdt=-2.0,
             notional_usdt=100.0,
             s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+            leverage=15.0,
         )
         trend = should_scalp_exit(
-            unrealized_pnl_usdt=-2.5,
+            unrealized_pnl_usdt=-2.0,
             notional_usdt=100.0,
             s=bs, mode=MonkeyMode.INVESTIGATION, lane="trend",
+            leverage=15.0,
         )
         assert swing["value"] is True
         assert trend["value"] is False
 
     def test_geometric_floor_never_breached(self) -> None:
         bs = _basin_state()
-        # Even if a (hypothetical) lane param said tp=0.0001%, the
-        # geometric fee-clear floor (~0.3%+) wins — verified via the
-        # max() composition. Use a real lane to test default behavior:
+        # 50% raw gain at lev=1 = 50% ROI — trivially clears any lane/geom TP.
         result = should_scalp_exit(
-            unrealized_pnl_usdt=10.0,  # huge gain
+            unrealized_pnl_usdt=50.0,
             notional_usdt=100.0,
             s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+            leverage=1.0,
         )
-        # 10% gain trivially clears any lane's TP.
         assert result["value"] is True
-        # And the stored tp_thr exceeds the lane param (geometric won):
         derivation = result["derivation"]
         assert derivation["tp_thr"] >= derivation["lane_tp_pct"]
 
@@ -226,10 +235,12 @@ class TestScalpExitLaneEnvelope:
             unrealized_pnl_usdt=0.05,
             notional_usdt=100.0,
             s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+            leverage=10.0,
         )
         assert result["derivation"]["lane"] == "scalp"
         assert result["derivation"]["lane_tp_pct"] == lane_param("scalp", "tp_pct")
         assert result["derivation"]["lane_sl_pct"] == lane_param("scalp", "sl_pct")
+        assert result["derivation"]["leverage"] == pytest.approx(10.0)
 
 
 # ── 4. should_dca_add same-lane mismatch only ───────────────────────
@@ -366,19 +377,21 @@ class TestCrossLaneNonInterference:
 
     def test_swing_long_envelope_independent_of_scalp_short_envelope(self) -> None:
         bs = _basin_state()
-        # 1.0% loss — between geometric SL (~0.67%) and swing lane
-        # envelope (1.5%). Swing holds; scalp exits. Demonstrates the
-        # core proposal-#10 invariant: per-lane retreat tolerance.
+        # v0.8.6: at lev=15x, raw -0.85% → ROI -12.75%. Past scalp's
+        # binding SL (max(geom×lev≈9.45%, lane 5%) = 9.45%), inside
+        # swing's 15% lane SL. Same input, different lane decisions.
         swing_long = should_scalp_exit(
-            unrealized_pnl_usdt=-1.0, notional_usdt=100.0,
+            unrealized_pnl_usdt=-0.85, notional_usdt=100.0,
             s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+            leverage=15.0,
         )
         scalp_short = should_scalp_exit(
-            unrealized_pnl_usdt=-1.0, notional_usdt=100.0,
+            unrealized_pnl_usdt=-0.85, notional_usdt=100.0,
             s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+            leverage=15.0,
         )
-        assert swing_long["value"] is False, "swing should hold its 1% drawdown"
-        assert scalp_short["value"] is True, "scalp should fire SL on 1% loss"
+        assert swing_long["value"] is False, "swing should hold its 12.75% ROI drawdown"
+        assert scalp_short["value"] is True, "scalp should fire SL on 12.75% ROI loss"
 
     def test_lane_budgets_partition_capital(self) -> None:
         # Two lanes' budgets should sum to <= 1.0 across position-bearing

--- a/ml-worker/tests/monkey_kernel/test_lane_isolation.py
+++ b/ml-worker/tests/monkey_kernel/test_lane_isolation.py
@@ -469,14 +469,25 @@ class TestFlatAccountLaneSizing:
         $22.49, the v0.6.6 lift-to-min must reach min notional. Pre-fix:
         equity was halved to $2.50 → required_frac=0.643 > 0.5 → no
         lift → size=0. Post-fix: full $5 → required_frac=0.337 < 0.5 →
-        lift fires."""
+        lift fires.
+
+        v0.8.7 follow-up: the new notional-ceiling fallback (4× equity)
+        binds at $20 here, BELOW the $22.49 exchange min. The kernel
+        correctly refuses to enter — preserving the lift-to-min path's
+        intent (no entries below exchange min) while bounding worst-case
+        escalation. The previous behaviour leveraged 4.5× balance just
+        to clear exchange min on a $5 pool; that's not safe sizing."""
         bs = _basin_state(phi=0.55)
         result = current_position_size(
             bs, available_equity_usdt=5.0, min_notional_usdt=22.49,
             leverage=14, bank_size=0, mode=MonkeyMode.INVESTIGATION,
             lane="swing",
         )
-        assert result["value"] > 0
+        # Notional ceiling = 4 × $5 = $20 < $22.49 min → size collapses.
+        assert result["value"] == 0
+        assert result["derivation"]["capped_by_notional"] == 1
+        # The lift-to-min still tried to fire — that path remains intact;
+        # the new constraint is the ceiling on top.
         assert result["derivation"]["lifted_to_min"] == 1
 
     def test_empty_bank_zero_sovereignty_still_sizes_above_min(self) -> None:
@@ -508,17 +519,29 @@ class TestFlatAccountLaneSizing:
     def test_pre_fix_haircut_account_now_sizes_above_zero(self) -> None:
         """Direct reproduction of the pre-fix size=0 case: $4.50 equity
         (mimicking the per-symbol cap × size_fraction path on small
-        accounts), ETH min $22.49, lev 14. Pre-fix: $4.50 × 0.5 lane
-        = $2.25 → required_frac = (22.49 × 1.05) / (14 × 2.25) = 0.749 >
-        0.5 max_fraction → no lift → size=0. Post-fix: full $4.50
-        → required_frac = 0.374 < 0.5 → lift fires → size > 0."""
+        accounts), ETH min $22.49, lev 14. Pre-fix (PR #614): $4.50 ×
+        0.5 lane = $2.25 → required_frac = 0.749 > 0.5 max_fraction →
+        no lift → size=0. PR #614 fix: full $4.50 → required_frac = 0.374
+        < 0.5 → lift fires → size > 0.
+
+        v0.8.7 follow-up: with notional ceiling = 4 × $4.50 = $18 < $22.49
+        ETH min, the ceiling now blocks entry on this scenario. The
+        kernel correctly refuses to size above 4× balance just to clear
+        exchange min on a haircut account; the lift-to-min path tries to
+        fire but the ceiling clamps it back. Live tape evidence ($97
+        account, $386 escalating notionals) confirmed unbounded
+        lift-to-min was the wrong default."""
         bs = _basin_state(phi=0.55)
         result = current_position_size(
             bs, available_equity_usdt=4.50, min_notional_usdt=22.49,
             leverage=14, bank_size=0, mode=MonkeyMode.INVESTIGATION,
             lane="swing",
         )
-        assert result["value"] > 0
+        # Notional ceiling = 4 × $4.50 = $18 < $22.49 min → size=0.
+        assert result["value"] == 0
+        assert result["derivation"]["capped_by_notional"] == 1
+        # The lift-to-min path still attempted to lift; the ceiling is
+        # the new binding constraint on top.
         assert result["derivation"]["lifted_to_min"] == 1
 
     def test_lane_margin_cap_in_derivation(self) -> None:

--- a/ml-worker/tests/monkey_kernel/test_notional_ceiling.py
+++ b/ml-worker/tests/monkey_kernel/test_notional_ceiling.py
@@ -1,0 +1,209 @@
+"""test_notional_ceiling.py — v0.8.7 notional-ceiling fallback.
+
+The Kelly cap is the primary brake on aggregate exposure but is
+non-binding at cold start (no closed trades) and decays to no-op when
+stats are uninformative. Live tape 2026-05-01: $77 → $386 escalating
+notionals on a $97 account (4× balance) with every position closing
+via single-tick regime_change at 22% win rate.
+
+The notional ceiling is a hard cap: notional = margin × leverage <=
+NOTIONAL_CEILING_RATIO × equity. Default 4.0. Applied AFTER the lane
+margin cap so the ceiling is the final clamp.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.basin import uniform_basin  # noqa: E402
+from monkey_kernel.executive import (  # noqa: E402
+    ExecBasinState,
+    current_position_size,
+)
+from monkey_kernel.modes import MonkeyMode  # noqa: E402
+from monkey_kernel.state import NeurochemicalState  # noqa: E402
+
+
+def _basin_state(*, phi: float = 0.6, sovereignty: float = 0.8) -> ExecBasinState:
+    nc = NeurochemicalState(
+        acetylcholine=0.5, dopamine=0.6, serotonin=0.6,
+        norepinephrine=0.5, gaba=0.4, endorphins=0.5,
+    )
+    basin = uniform_basin(64)
+    return ExecBasinState(
+        basin=basin,
+        identity_basin=basin,
+        phi=phi, kappa=64.0,
+        regime_weights={"quantum": 0.34, "efficient": 0.33, "equilibrium": 0.33},
+        sovereignty=sovereignty,
+        basin_velocity=0.05,
+        neurochemistry=nc,
+    )
+
+
+class TestNotionalCeilingLiveTapeScenario:
+    """The exact 2026-05-01 16:11-16:17 scenario:
+    account = $97, leverage near max boundary, kernel computing margin
+    that yields notional > 4× balance. Without the ceiling the live
+    tape recorded $386 notionals; with ceiling=4.0 the cap sits at
+    $388 max."""
+
+    def test_capped_at_4x_balance_on_live_scenario(self) -> None:
+        # Account $97, leverage 20× (high edge of typical), enough phi
+        # for the geometric formula to size aggressively.
+        bs = _basin_state(phi=0.6, sovereignty=0.8)
+        out = current_position_size(
+            bs,
+            available_equity_usdt=97.0,
+            min_notional_usdt=5.0,
+            leverage=20,
+            bank_size=20,
+            mode=MonkeyMode.INVESTIGATION,
+            lane="scalp",
+        )
+        # Without the ceiling: margin = 0.5 × 97 (lane cap) = 48.5,
+        # notional = 48.5 × 20 = 970 → 10× balance. With ceiling 4×:
+        # max notional = 388, max margin = 19.4.
+        ceiling = 4.0 * 97.0  # 388
+        assert out["derivation"]["notional"] <= ceiling + 1e-9
+        assert out["derivation"]["capped_by_notional"] == 1
+        assert out["derivation"]["margin"] * out["derivation"]["leverage"] <= ceiling + 1e-9
+
+    def test_ceiling_surfaces_in_derivation(self) -> None:
+        bs = _basin_state(phi=0.6, sovereignty=0.8)
+        out = current_position_size(
+            bs,
+            available_equity_usdt=100.0,
+            min_notional_usdt=5.0,
+            leverage=10,
+            bank_size=20,
+            mode=MonkeyMode.INVESTIGATION,
+            lane="scalp",
+        )
+        # ratio + ceiling are both surfaced for telemetry parity with TS.
+        assert out["derivation"]["notional_ceiling_ratio"] == 4.0
+        assert out["derivation"]["notional_ceiling"] == 400.0
+
+
+class TestNotionalCeilingNonBinding:
+    """When the geometric formula already keeps notional below the
+    ceiling, the cap is a no-op."""
+
+    def test_low_leverage_no_cap(self) -> None:
+        # Account $1000, leverage 2× → max notional via lane cap is
+        # 0.5 × 1000 × 2 = 1000, well below 4 × 1000 = 4000 ceiling.
+        bs = _basin_state(phi=0.4, sovereignty=0.5)
+        out = current_position_size(
+            bs,
+            available_equity_usdt=1000.0,
+            min_notional_usdt=10.0,
+            leverage=2,
+            bank_size=20,
+            mode=MonkeyMode.INVESTIGATION,
+            lane="scalp",
+        )
+        assert out["derivation"]["capped_by_notional"] == 0
+        assert out["derivation"]["notional"] <= 4000.0
+
+    def test_zero_equity_no_crash(self) -> None:
+        bs = _basin_state(phi=0.4, sovereignty=0.5)
+        out = current_position_size(
+            bs,
+            available_equity_usdt=0.0,
+            min_notional_usdt=10.0,
+            leverage=10,
+            bank_size=20,
+            mode=MonkeyMode.INVESTIGATION,
+            lane="scalp",
+        )
+        # Zero equity → ceiling = 0 → margin × leverage > 0 fails the
+        # condition (we cannot reduce margin further), but the existing
+        # margin formula already produces 0 since frac × 0 = 0.
+        assert out["derivation"]["notional"] == 0.0
+        assert out["value"] == 0.0
+
+
+class TestNotionalCeilingRatioRegistry:
+    """Ceiling ratio is registry-controlled via
+    executive.notional_ceiling_ratio (default 4.0)."""
+
+    def test_default_ratio_is_four(self) -> None:
+        bs = _basin_state(phi=0.6, sovereignty=0.8)
+        out = current_position_size(
+            bs,
+            available_equity_usdt=100.0,
+            min_notional_usdt=5.0,
+            leverage=10,
+            bank_size=20,
+            mode=MonkeyMode.INVESTIGATION,
+            lane="scalp",
+        )
+        assert out["derivation"]["notional_ceiling_ratio"] == 4.0
+
+    def test_ratio_override_via_registry(self) -> None:
+        from monkey_kernel.parameters import (
+            ParamValue,
+            VariableCategory,
+            get_registry,
+        )
+        registry = get_registry()
+        key = "executive.notional_ceiling_ratio"
+        # Force the cache to be considered loaded so direct cache writes
+        # take effect without hitting the DB.
+        with registry._lock:  # noqa: SLF001
+            registry._loaded = True  # noqa: SLF001
+            saved = registry._cache.get(key)  # noqa: SLF001
+            registry._cache[key] = ParamValue(  # noqa: SLF001
+                name=key,
+                category=VariableCategory.OPERATIONAL,
+                value=2.0,
+                bounds_low=0.0, bounds_high=20.0,
+                justification="test override", version=1,
+            )
+        try:
+            bs = _basin_state(phi=0.6, sovereignty=0.8)
+            out = current_position_size(
+                bs,
+                available_equity_usdt=100.0,
+                min_notional_usdt=5.0,
+                leverage=20,
+                bank_size=20,
+                mode=MonkeyMode.INVESTIGATION,
+                lane="scalp",
+            )
+            assert out["derivation"]["notional_ceiling_ratio"] == 2.0
+            assert out["derivation"]["notional_ceiling"] == 200.0
+            assert out["derivation"]["notional"] <= 200.0 + 1e-9
+        finally:
+            with registry._lock:  # noqa: SLF001
+                if saved is None:
+                    registry._cache.pop(key, None)  # noqa: SLF001
+                else:
+                    registry._cache[key] = saved  # noqa: SLF001
+
+
+class TestNotionalCeilingPrecedenceOrder:
+    """Ceiling is applied AFTER the lane budget cap, so when the lane
+    cap already binds tighter, ceiling is a no-op."""
+
+    def test_lane_cap_binds_first(self) -> None:
+        # Trend lane has budget_frac = 0.0 by default → lane cap forces
+        # margin to 0; ceiling is moot.
+        bs = _basin_state(phi=0.6, sovereignty=0.8)
+        out = current_position_size(
+            bs,
+            available_equity_usdt=1000.0,
+            min_notional_usdt=5.0,
+            leverage=20,
+            bank_size=20,
+            mode=MonkeyMode.INVESTIGATION,
+            lane="trend",
+        )
+        assert out["derivation"]["margin"] == 0
+        # capped_by_notional may be 0 because the binding constraint
+        # was the lane cap, not the ceiling.

--- a/ml-worker/tests/monkey_kernel/test_sl_roi_semantics.py
+++ b/ml-worker/tests/monkey_kernel/test_sl_roi_semantics.py
@@ -1,0 +1,282 @@
+"""test_sl_roi_semantics.py — v0.8.6 SL gate ROI-on-margin fix.
+
+Pins the live failure mode and the corrected behaviour:
+
+  * Live (2026-04-30 → 2026-05-01): ETH long sat at -4.4% ROI for 4+
+    hours without SL firing because the gate read raw price movement
+    (-0.30%) against the lane SL (1.5% raw under old semantics).
+  * Fix: ``should_scalp_exit`` now computes ``roi_frac = pnl / notional
+    × leverage`` and compares against ROI-scale lane defaults
+    (0.05/0.15/0.40 for scalp/swing/trend).
+
+Test matrix:
+
+  1. Live failure mode reproduction — old semantic would HOLD, new
+     semantic fires SL.
+  2. Lane × leverage sweep — same raw move at different leverages
+     produces ROI-proportional decisions.
+  3. Default leverage=1 back-compat — ROI == raw, gate behaves like
+     pre-fix at lev=1.
+  4. Hold-zone — ROI inside the lane envelope holds across all
+     lanes/leverages.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Don't hit Postgres during tests — registry falls back to defaults.
+os.environ.pop("DATABASE_URL", None)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.executive import (  # noqa: E402
+    ExecBasinState,
+    lane_param,
+    should_scalp_exit,
+)
+from monkey_kernel.modes import MonkeyMode  # noqa: E402
+from monkey_kernel.state import KAPPA_STAR, NeurochemicalState  # noqa: E402
+
+
+def _basin_state(*, phi: float = 0.5) -> ExecBasinState:
+    nc = NeurochemicalState(
+        acetylcholine=0.5, dopamine=0.5, serotonin=0.5,
+        norepinephrine=0.5, gaba=0.5, endorphins=0.5,
+    )
+    basin = np.full(64, 1.0 / 64.0, dtype=np.float64)
+    return ExecBasinState(
+        basin=basin, identity_basin=basin.copy(),
+        phi=phi, kappa=KAPPA_STAR,
+        regime_weights={"quantum": 0.33, "efficient": 0.33, "equilibrium": 0.34},
+        sovereignty=0.5, basin_velocity=0.05, neurochemistry=nc,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────
+# 1. Live failure mode reproduction
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLiveFailureModeETH:
+    """ETH long at lev=15x, raw price moved -0.30%, ROI = -4.5%.
+
+    Pre-fix (raw-price semantics, lane SL=1.5% raw): SL did NOT fire
+    because raw -0.30% > -1.5%. Position bled for 4+ hours.
+
+    Post-fix (ROI semantics, lane SL=15% ROI): SL still does NOT fire
+    at -4.5% ROI (well inside the swing band). But scalp lane SL=5% ROI
+    -- if scalp had been the lane the SL would also have held. The real
+    fix is that the GATE now SEES the position's ROI; the BOUNDS are
+    rescaled so the user's actual risk tolerance maps to the new units.
+
+    To reproduce the LIVE FAILURE PROVABLY: ETH long at lev=15x, raw
+    price -1.0% → ROI -15%. Old semantic (raw): SL did not fire (1% <
+    1.5%). New semantic (ROI): SL fires for swing exactly at the
+    boundary, and trivially for scalp. The new gate makes BIG ROI
+    drawdowns visible to the SL gate.
+    """
+
+    def test_old_raw_semantic_would_hold_new_roi_fires_for_scalp(self) -> None:
+        bs = _basin_state()
+        # Live failure: raw -1% loss at lev=15x = -15% ROI.
+        # Under OLD raw-price semantics, scalp SL was 0.4% raw → fired
+        # (so scalp would have closed, but production was on swing/trend).
+        # Under NEW ROI semantics, scalp SL is 5% ROI → fires hard.
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-1.0,  # raw -1% on $100 notional
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+            leverage=15.0,
+        )
+        assert result["value"] is True
+        assert result["derivation"]["exit_type_bit"] == -1
+        assert result["derivation"]["roi_frac"] == pytest.approx(-0.15)
+
+    def test_old_raw_semantic_held_swing_at_negative_4_5_pct_roi(self) -> None:
+        bs = _basin_state()
+        # The literal failure: ETH swing at lev=15x, raw -0.30% = ROI -4.5%.
+        # Old semantic: 0.30% < 1.5% raw SL → HOLD (the bug).
+        # New semantic: -4.5% ROI < 15% swing SL → still HOLDS, BUT
+        # the user can now SET tighter swing SL (8-15% ROI) without
+        # accidentally tripping on tiny raw moves at low leverage.
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-0.30,  # raw -0.30%
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+            leverage=15.0,
+        )
+        assert result["value"] is False  # swing tolerates the 4.5% ROI dip
+        assert result["derivation"]["roi_frac"] == pytest.approx(-0.045, abs=1e-9)
+
+    def test_new_semantic_fires_swing_when_roi_exceeds_15_pct(self) -> None:
+        bs = _basin_state()
+        # Same ETH-style swing position, but raw price moves -1.0% at
+        # lev=15x → ROI -15%, AT the swing SL boundary. SL fires.
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-1.10,  # raw -1.10% × 15x = ROI -16.5%
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+            leverage=15.0,
+        )
+        assert result["value"] is True
+        assert result["derivation"]["exit_type_bit"] == -1
+
+
+# ─────────────────────────────────────────────────────────────────
+# 2. Lane × leverage sweep
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLaneLeverageSweep:
+    """Same raw move, different leverages → ROI-proportional decisions.
+
+    The binding SL threshold is ``max(geometric_sl × leverage, lane_sl)``
+    where ``geometric_sl_raw ≈ 0.0063`` at INVESTIGATION-mode default state.
+    So at lev=15 the geometric envelope is ~9.45% and binds for scalp
+    (lane=5%); for swing (lane=15%) and trend (lane=40%) the lane wins.
+    These tests exercise the binding-constraint logic across leverages.
+    """
+
+    def _binding_sl(self, lane: str, leverage: float) -> float:
+        """Compute the binding SL threshold for a lane × leverage at the
+        neutral basin state used in this file. Mirrors the executive's
+        max(geometric_sl × leverage, lane_sl) composition."""
+        # geometric_tp_raw at default state: max(0.003, 0.008 - 0.0015 + 0.0025) = 0.009
+        # geometric_sl_raw = 0.009 * 0.7 = 0.0063 (INVESTIGATION sl_ratio=0.7)
+        geometric_sl = 0.009 * 0.7 * leverage
+        return max(geometric_sl, lane_param(lane, "sl_pct"))
+
+    @pytest.mark.parametrize("leverage", [8.0, 16.0, 25.0])
+    def test_scalp_sl_fires_when_roi_clears_binding_threshold(
+        self, leverage: float,
+    ) -> None:
+        bs = _basin_state()
+        # Use raw=-1% loss; ROI = -lev%, binding = max(geom*lev, 5%).
+        # At lev=8: ROI -8%, binding = max(5.04%, 5%) = 5.04% → FIRES
+        # At lev=16: ROI -16%, binding = max(10.08%, 5%) = 10.08% → FIRES
+        # At lev=25: ROI -25%, binding = max(15.75%, 5%) = 15.75% → FIRES
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-1.0,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+            leverage=leverage,
+        )
+        roi_abs = 0.01 * leverage
+        binding = self._binding_sl("scalp", leverage)
+        if roi_abs > binding:
+            assert result["value"] is True
+        else:
+            assert result["value"] is False
+
+    @pytest.mark.parametrize("leverage", [8.0, 16.0, 25.0])
+    def test_swing_lane_dominates_at_typical_leverages(
+        self, leverage: float,
+    ) -> None:
+        bs = _basin_state()
+        # Verify the swing lane's 15% ROI is the binding constraint at
+        # typical leverage; the lane envelope is what the user tunes
+        # to control swing-lane risk tolerance.
+        # raw -2% loss: ROI = -2*lev%, binding = max(geom*lev, 15%)
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-2.0,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+            leverage=leverage,
+        )
+        roi_abs = 0.02 * leverage
+        binding = self._binding_sl("swing", leverage)
+        if roi_abs > binding:
+            assert result["value"] is True
+        else:
+            assert result["value"] is False
+
+    @pytest.mark.parametrize("leverage", [8.0, 16.0, 25.0])
+    def test_trend_band_is_widest(self, leverage: float) -> None:
+        bs = _basin_state()
+        # raw -3% × any leverage in [8, 25] yields ROI [-24%, -75%].
+        # Trend's 40% lane SL binds at lev <= ~63x. At lev=25, ROI=-75%
+        # → fires trend. At lev=8, ROI=-24% → holds (inside 40%).
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-3.0,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="trend",
+            leverage=leverage,
+        )
+        roi_abs = 0.03 * leverage
+        binding = self._binding_sl("trend", leverage)
+        if roi_abs > binding:
+            assert result["value"] is True
+        else:
+            assert result["value"] is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# 3. Default leverage=1 back-compat
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLeverageDefaultBackCompat:
+    """When leverage is omitted, behaves as ROI == raw move (lev=1)."""
+
+    def test_default_leverage_yields_roi_equals_raw(self) -> None:
+        bs = _basin_state()
+        # raw -10% → ROI -10% at lev=1. Past swing's 15% SL? No — holds.
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-10.0,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+        )
+        # 10% ROI < 15% swing SL → hold.
+        assert result["value"] is False
+        assert result["derivation"]["leverage"] == pytest.approx(1.0)
+        assert result["derivation"]["roi_frac"] == pytest.approx(-0.10)
+        assert result["derivation"]["raw_frac"] == pytest.approx(-0.10)
+
+    def test_zero_or_negative_leverage_clamps_to_one(self) -> None:
+        bs = _basin_state()
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-1.0,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+            leverage=0.0,
+        )
+        # Defensive: lev=0 → treat as 1, ROI == raw move = -1% < 5% SL → hold.
+        assert result["derivation"]["leverage"] == pytest.approx(1.0)
+        assert result["value"] is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# 4. Reason / derivation surface
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestRoiReasonStrings:
+    def test_sl_reason_says_roi_and_leverage(self) -> None:
+        bs = _basin_state()
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-1.0,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="scalp",
+            leverage=20.0,
+        )
+        assert result["value"] is True
+        # Reason should reflect new ROI semantic.
+        assert "roi" in result["reason"].lower()
+        assert "lev=20x" in result["reason"]
+
+    def test_hold_reason_says_roi(self) -> None:
+        bs = _basin_state()
+        result = should_scalp_exit(
+            unrealized_pnl_usdt=-0.10,
+            notional_usdt=100.0,
+            s=bs, mode=MonkeyMode.INVESTIGATION, lane="swing",
+            leverage=10.0,
+        )
+        assert result["value"] is False
+        assert "roi" in result["reason"].lower()

--- a/ml-worker/tests/monkey_kernel/test_sl_roi_semantics.py
+++ b/ml-worker/tests/monkey_kernel/test_sl_roi_semantics.py
@@ -7,7 +7,8 @@ Pins the live failure mode and the corrected behaviour:
     (-0.30%) against the lane SL (1.5% raw under old semantics).
   * Fix: ``should_scalp_exit`` now computes ``roi_frac = pnl / notional
     × leverage`` and compares against ROI-scale lane defaults
-    (0.05/0.15/0.40 for scalp/swing/trend).
+    (0.03/0.15/0.40 for scalp/swing/trend after v0.8.7 user-directive
+    revision; scalp is now symmetric 1:1 R:R).
 
 Test matrix:
 

--- a/ml-worker/tests/utils/test_redis_listener.py
+++ b/ml-worker/tests/utils/test_redis_listener.py
@@ -38,6 +38,9 @@ from utils.redis_listener import (  # noqa: E402
 
 class _FakePubSub:
     def __init__(self, messages: List[Dict[str, Any]]):
+        # FIFO of pending messages. ``get_message`` pops the front; once
+        # exhausted it returns ``None`` (which the new poll-loop listener
+        # treats as an idle wakeup and uses to inject heartbeat pings).
         self._messages = list(messages)
         self.subscribed: List[str] = []
         self.closed = False
@@ -45,9 +48,17 @@ class _FakePubSub:
     def subscribe(self, channel: str) -> None:
         self.subscribed.append(channel)
 
-    def listen(self):
-        for m in self._messages:
-            yield m
+    def get_message(self, *, ignore_subscribe_messages: bool = False, timeout: float = 1.0):
+        # noqa: ARG002 — kwargs match real redis-py signature.
+        if self._messages:
+            head = self._messages.pop(0)
+            # Synthetic disconnect sentinel — used by tests to drive a
+            # reconnect cycle without standing up a full proxy. Any other
+            # dict (including {"type": "message", ...}) flows through.
+            if isinstance(head, dict) and head.get("_drop_after"):
+                raise ConnectionError("simulated channel drop")
+            return head
+        return None
 
     def close(self) -> None:
         self.closed = True
@@ -228,11 +239,19 @@ def test_listener_uses_exponential_backoff():
 def test_listener_resets_backoff_after_successful_connect():
     """After a successful connect (even if no messages), backoff should
     reset to ``initial_backoff`` for the next disconnect.
+
+    v0.8.6 — listener now uses a poll-loop with heartbeat pings instead
+    of the blocking ``listen()`` generator, so an "empty" pubsub no
+    longer naturally falls through to reconnect. Drive the reconnect
+    via a connection-drop sentinel injected after the empty batch.
     """
     fake = _FakeRedisModule(
         failures_before_success=2,  # probe fails + 1 listener fails
         message_batches=[
-            [],  # 1st success: empty pubsub, then reconnect path
+            # 1st success: drop into a synthetic connection error after
+            # zero messages so the listener falls through to backoff +
+            # reconnect (matches the natural pubsub-disconnect path).
+            [{"_drop_after": True}],
             [{"type": "message", "data": json.dumps({"x": 1})}],  # 2nd: deliver
         ],
         errno=22,
@@ -240,6 +259,9 @@ def test_listener_resets_backoff_after_successful_connect():
     cfg = ListenerConfig(
         name="test", channel="ch",
         initial_backoff=1.0, max_backoff=16.0, backoff_factor=2.0,
+        # Make ping-interval long enough not to fire during the test; the
+        # listener's ping is verified in dedicated heartbeat tests below.
+        ping_interval_sec=60.0,
     )
     received: List[Dict[str, Any]] = []
     sleeps = _run_listener(
@@ -248,7 +270,7 @@ def test_listener_resets_backoff_after_successful_connect():
     assert received == [{"x": 1}]
     # Sleep timeline:
     #   sleeps[0] after listener attempt 1 fails -> 1.0
-    #   sleeps[1] after listener attempt 2 succeeds + drains empty batch -> 1.0 (RESET)
+    #   sleeps[1] after listener attempt 2 drops via _drop_after -> 1.0 (RESET)
     assert sleeps[0] == 1.0
     assert sleeps[1] == 1.0
 
@@ -404,8 +426,11 @@ def test_probe_returns_diag_on_einval():
 
 
 class _IdleTimeoutScript:
-    """Test harness: connect once, raise a timeout on `pubsub.listen`,
+    """Test harness: connect once, raise a timeout on ``pubsub.get_message``,
     optionally repeat for N attempts before yielding a real message.
+
+    v0.8.6 — switched from ``listen()`` (generator) to ``get_message()``
+    (poll) to match the new heartbeat-aware listener loop.
 
     This simulates Redis being healthy but the channel being quiet — the
     exact scenario that produced the prod log spam.
@@ -425,6 +450,7 @@ class _IdleTimeoutScript:
         )
         self.attempts = 0
         self.exceptions = type("Exc", (), {"TimeoutError": __import__("socket").timeout})
+        self.ping_calls: List[float] = []
 
         outer = self
 
@@ -436,12 +462,15 @@ class _IdleTimeoutScript:
             def subscribe(self, ch):
                 self.subscribed.append(ch)
 
-            def listen(self):
+            def get_message(self, *, ignore_subscribe_messages=False, timeout=1.0):  # noqa: ARG002
                 if outer._remaining_timeouts > 0:
                     outer._remaining_timeouts -= 1
                     raise outer._timeout_exc_factory()
                 if outer._message is not None:
-                    yield {"type": "message", "data": json.dumps(outer._message)}
+                    msg = {"type": "message", "data": json.dumps(outer._message)}
+                    outer._message = None
+                    return msg
+                return None
 
             def close(self):
                 self.closed = True
@@ -458,6 +487,7 @@ class _IdleTimeoutScript:
                 self.set_calls.append((key, value, ex))
 
             def ping(self):
+                outer.ping_calls.append(time.monotonic())
                 return True
 
             def close(self):
@@ -655,6 +685,313 @@ def test_idle_timeout_escalates_to_info_after_threshold(caplog):
     assert not error_crashed, (
         "100 idle timeouts must NOT produce ERROR-level crash lines"
     )
+
+
+# =====================================================================
+# Heartbeat ping tests (v0.8.6 fix — Redis idle-timeout reconnect storm).
+#
+# Production observed ~1 reconnect per 30s sustained for 4+ hours on
+# `ml-predict-request` and `trade-outcome`. Root cause: managed Redis
+# idle-timeout was killing pubsub connections that had no cross-traffic.
+# Fix: send a PING on a 10s cadence inside the listener loop so the
+# connection never crosses the idle-timeout threshold.
+# =====================================================================
+
+
+def test_heartbeat_pings_during_quiet_channel():
+    """When no message arrives for longer than ping_interval_sec, the
+    listener must call client.ping() at least once during that window."""
+    # 5 idle wakeups before the first message — at ping_interval=0.001s
+    # poll_timeout=0.001s, the listener should fire ~5 pings before the
+    # message arrives and the test stops.
+    fake = _IdleTimeoutScript(
+        timeouts_before_message=0,  # use return-None path, not exception path
+        message={"after": "idle"},
+    )
+    # Override get_message to return None for a few wakeups so we drive
+    # the heartbeat path (rather than the exception path).
+    fake._idle_returns = 5
+
+    # Patch the pubsub get_message to count idle wakeups instead of raising.
+    outer = fake
+    outer._pubsub_idles = 0
+
+    class _PSReturnNone:
+        def __init__(self):
+            self.subscribed = []
+            self.closed = False
+
+        def subscribe(self, ch):
+            self.subscribed.append(ch)
+
+        def get_message(self, *, ignore_subscribe_messages=False, timeout=1.0):  # noqa: ARG002
+            if outer._pubsub_idles < outer._idle_returns:
+                outer._pubsub_idles += 1
+                return None
+            if outer._message is not None:
+                msg = {"type": "message", "data": json.dumps(outer._message)}
+                outer._message = None
+                return msg
+            return None
+
+    class _ClientPingCounting:
+        def __init__(self):
+            self.closed = False
+            self.set_calls: List[tuple] = []
+
+        def pubsub(self, ignore_subscribe_messages=False):
+            return _PSReturnNone()
+
+        def set(self, key, value, ex=0):
+            self.set_calls.append((key, value, ex))
+
+        def ping(self):
+            outer.ping_calls.append(time.monotonic())
+            return True
+
+        def close(self):
+            self.closed = True
+
+    class _RedisCounting:
+        @staticmethod
+        def from_url(url, **kwargs):  # noqa: ARG004
+            outer.attempts += 1
+            return _ClientPingCounting()
+
+    fake.Redis = _RedisCounting
+
+    cfg = ListenerConfig(
+        name="heartbeat-test", channel="ch",
+        initial_backoff=0.0001, max_backoff=0.001, backoff_factor=1.0,
+        ping_interval_sec=0.001,
+        socket_read_timeout=0.001,
+    )
+    received: List[Dict[str, Any]] = []
+    _run_listener(fake=fake, cfg=cfg, received=received, expected_messages=1, timeout=3.0)
+
+    assert received == [{"after": "idle"}]
+    # Heartbeat must have fired AT LEAST ONCE during the idle window.
+    # We can't bound it tightly because real time + GIL scheduling jitter
+    # means the exact count varies. The contract is "at least one ping
+    # during sustained idle".
+    assert len(fake.ping_calls) >= 1, (
+        f"expected >=1 heartbeat ping during idle wakeups; got {len(fake.ping_calls)}"
+    )
+
+
+def test_heartbeat_disabled_when_interval_zero():
+    """ping_interval_sec=0 disables the heartbeat (escape hatch).
+
+    Note: the startup probe calls ping() once before the listener loop
+    begins; that's a one-shot connection check, not the heartbeat
+    we're asserting against. Track only listener-loop pings here.
+    """
+    outer = type("S", (), {})()
+    outer.ping_calls: List[float] = []  # all pings (probe + loop)
+    outer.loop_started = False
+    outer.attempts = 0
+    outer._message = {"x": 1}
+
+    class _PS:
+        def __init__(self):
+            self.subscribed = []
+            self.closed = False
+
+        def subscribe(self, ch):
+            self.subscribed.append(ch)
+            outer.loop_started = True  # SUBSCRIBE only runs in the listener loop
+
+        def get_message(self, *, ignore_subscribe_messages=False, timeout=1.0):  # noqa: ARG002
+            if outer._message is not None:
+                msg = {"type": "message", "data": json.dumps(outer._message)}
+                outer._message = None
+                return msg
+            return None
+
+    class _Client:
+        def __init__(self):
+            self.closed = False
+            self.set_calls: List[tuple] = []
+
+        def pubsub(self, ignore_subscribe_messages=False):
+            return _PS()
+
+        def set(self, key, value, ex=0):
+            self.set_calls.append((key, value, ex))
+
+        def ping(self):
+            # Tag whether this ping happened pre- or post-loop-start so
+            # the test can filter probe pings out.
+            outer.ping_calls.append(("loop" if outer.loop_started else "probe", time.monotonic()))
+            return True
+
+        def close(self):
+            self.closed = True
+
+    class _Redis:
+        @staticmethod
+        def from_url(url, **kwargs):  # noqa: ARG004
+            outer.attempts += 1
+            return _Client()
+
+    outer.Redis = _Redis
+
+    cfg = ListenerConfig(
+        name="heartbeat-disabled", channel="ch",
+        initial_backoff=0.0001, max_backoff=0.001, backoff_factor=1.0,
+        ping_interval_sec=0.0,
+    )
+    received: List[Dict[str, Any]] = []
+    _run_listener(fake=outer, cfg=cfg, received=received, expected_messages=1)
+    assert received == [{"x": 1}]
+    # The probe ping is allowed; the listener-loop heartbeat is not.
+    loop_pings = [p for p in outer.ping_calls if p[0] == "loop"]
+    assert loop_pings == [], (
+        f"interval=0 should disable in-loop heartbeat; got {loop_pings}"
+    )
+
+
+def test_heartbeat_fires_even_when_messages_flow():
+    """Pings fire on cadence regardless of whether messages are arriving.
+    Mock messages every 'tick' AND heartbeat ping cadence; assert pings
+    still fire."""
+    outer = type("S", (), {})()
+    outer.ping_calls: List[float] = []
+    outer.attempts = 0
+    # Stream of messages, each pop returns one. After enough are consumed,
+    # the listener stops.
+    outer._messages = [
+        {"type": "message", "data": json.dumps({"i": i})} for i in range(20)
+    ]
+
+    class _PS:
+        def __init__(self):
+            self.subscribed = []
+            self.closed = False
+
+        def subscribe(self, ch):
+            self.subscribed.append(ch)
+
+        def get_message(self, *, ignore_subscribe_messages=False, timeout=1.0):  # noqa: ARG002
+            # Sleep a tiny bit so the heartbeat clock can advance between
+            # message returns. Without this, the message stream is so
+            # tight that ping_interval might never elapse mid-stream.
+            time.sleep(0.002)
+            if outer._messages:
+                return outer._messages.pop(0)
+            return None
+
+    class _Client:
+        def __init__(self):
+            self.closed = False
+            self.set_calls: List[tuple] = []
+
+        def pubsub(self, ignore_subscribe_messages=False):
+            return _PS()
+
+        def set(self, key, value, ex=0):
+            self.set_calls.append((key, value, ex))
+
+        def ping(self):
+            outer.ping_calls.append(time.monotonic())
+            return True
+
+        def close(self):
+            self.closed = True
+
+    class _Redis:
+        @staticmethod
+        def from_url(url, **kwargs):  # noqa: ARG004
+            outer.attempts += 1
+            return _Client()
+
+    outer.Redis = _Redis
+
+    cfg = ListenerConfig(
+        name="heartbeat-with-flow", channel="ch",
+        initial_backoff=0.0001, max_backoff=0.001, backoff_factor=1.0,
+        # Ping cadence shorter than the per-message sleep so it must fire.
+        ping_interval_sec=0.001,
+        socket_read_timeout=0.01,
+    )
+    received: List[Dict[str, Any]] = []
+    _run_listener(fake=outer, cfg=cfg, received=received, expected_messages=20, timeout=5.0)
+
+    assert len(received) == 20
+    # With 20 messages × 2ms sleep = ~40ms, ping cadence 1ms → many pings.
+    # Concretely: at least 5 pings, since the heartbeat fires every 1ms.
+    assert len(outer.ping_calls) >= 5, (
+        f"expected >=5 heartbeat pings during message flow; got {len(outer.ping_calls)}"
+    )
+
+
+def test_heartbeat_failure_triggers_reconnect():
+    """When client.ping() raises, the listener must drop into reconnect
+    instead of swallowing the failure (since a dead ping = dead conn)."""
+    outer = type("S", (), {})()
+    outer.ping_calls: List[float] = []
+    outer.attempts = 0
+    outer._messages = [{"type": "message", "data": json.dumps({"x": 1})}]
+    outer._ping_should_fail = [True, False]  # first ping fails, then survives
+
+    class _PS:
+        def __init__(self):
+            self.subscribed = []
+            self.closed = False
+
+        def subscribe(self, ch):
+            self.subscribed.append(ch)
+
+        def get_message(self, *, ignore_subscribe_messages=False, timeout=1.0):  # noqa: ARG002
+            time.sleep(0.002)
+            if outer._messages:
+                return outer._messages.pop(0)
+            return None
+
+    class _Client:
+        def __init__(self):
+            self.closed = False
+            self.set_calls: List[tuple] = []
+
+        def pubsub(self, ignore_subscribe_messages=False):
+            return _PS()
+
+        def set(self, key, value, ex=0):
+            self.set_calls.append((key, value, ex))
+
+        def ping(self):
+            outer.ping_calls.append(time.monotonic())
+            if outer._ping_should_fail and outer._ping_should_fail[0]:
+                outer._ping_should_fail.pop(0)
+                raise ConnectionError("simulated dead conn on ping")
+            return True
+
+        def close(self):
+            self.closed = True
+
+    class _Redis:
+        @staticmethod
+        def from_url(url, **kwargs):  # noqa: ARG004
+            outer.attempts += 1
+            # On the SECOND attempt, restore the message so the listener
+            # can complete and the test stops.
+            if outer.attempts == 2:
+                outer._messages = [{"type": "message", "data": json.dumps({"x": 1})}]
+            return _Client()
+
+    outer.Redis = _Redis
+
+    cfg = ListenerConfig(
+        name="heartbeat-failure", channel="ch",
+        initial_backoff=0.0001, max_backoff=0.001, backoff_factor=1.0,
+        ping_interval_sec=0.001,
+        socket_read_timeout=0.01,
+    )
+    received: List[Dict[str, Any]] = []
+    _run_listener(fake=outer, cfg=cfg, received=received, expected_messages=1, timeout=5.0)
+    assert received == [{"x": 1}]
+    # First attempt's ping failed → listener reconnected (attempt counter > 1).
+    assert outer.attempts >= 2
 
 
 def test_keepalive_options_match_kernel_constants():


### PR DESCRIPTION
## Summary

Four production fixes addressing the 16:11-16:17 trade-tape evidence: 9 closes, 22% win rate, -$0.30 in 6 minutes on a $97 account, with notionals escalating $77 → $386. Every close fired via regime_change. Two distinct exit-logic gaps + one sizing gap + ops kill switch.

## What ships

**Commits (4):**
1. `c3a106d` — SL gate ROI-on-margin + Redis listener heartbeat
2. `0db12b3` — regime-change exit hysteresis (triple-AND gate)
3. `5f9137e` — notional ceiling fallback + scalp 1:1 R:R revert
4. `039200b` — MONKEY_TRADING_PAUSED kill switch (entries only)

### 1. SL gate now measures ROI on margin, not raw price

```python
# Before
pnl_frac = unrealized_pnl_usdt / notional_usdt   # raw price %

# After
roi_frac = (unrealized_pnl_usdt / notional_usdt) * leverage   # ROI on margin %
```

The live failure: ETH at -4.4% ROI with raw price only -0.30%. Old SL with `sl_pct=0.015` (1.5% raw) didn't fire — was measuring the wrong dimension. New: `sl_pct` is interpreted as % loss against margin, what every trader intuitively expects.

Lane defaults rescaled to ROI: scalp 5% / swing 15% / trend 40%. Then per user's directive, scalp reverted to **3%/3% symmetric (1:1 R:R)** — both `sl_pct` and `tp_pct` at 0.03 in the SQL migration.

### 2. Regime hysteresis (triple-AND gate)

Replaces the single-tick regime-change exit with a hysteresis gate. ALL must hold:

- (a) `regime != regime_at_open`
- (b) `regime_change_streak >= REGIME_STABILITY_TICKS_FOR_EXIT` (default 3, registry-controlled)
- (c) `fr_distance(basin_now, basin_at_open) > 1/π` (PI_STRUCT_GRAVITATING_FRACTION)
- (d) classifier confidence > 1/φ (PR #629 gate, retained)

The 22% win-rate churn pattern was every close firing on regime flicker. Hysteresis requires the regime to actually settle into a new state AND the basin to have geometrically migrated past the 1/π threshold.

New per-lane state: `regime_change_streak_by_lane`, `basin_at_open_by_lane`. Plumbed through entry/close/reverse/ESCAPE/auto-flatten in both Python and TS.

### 3. Notional ceiling fallback (Kelly cap was non-binding)

**Investigation findings**:
- No `monkey_kelly_stats_by_lane` table exists
- Python kernel never receives `rolling_kelly_stats` (TickInputs in main.py doesn't populate it) → Python Kelly cap is always `max_lev` (no-op)
- TS path computes Kelly inline via `getKellyRollingStats` reading `autonomous_trades`, but returns null when < 5 closed trades per lane (cold-start no-op) and `kelly_leverage_cap` defers to `max_lev` on uninformative inputs
- **Conclusion**: Kelly cap essentially non-binding, confirming the user's concern. $386 notional on $97 account was unconstrained.

**Fix**: Notional ceiling at `executive.notional_ceiling_ratio = 4.0` (registry-controlled). When `margin × leverage > ratio × equity`, margin is reduced. $97 × 4 = $388 max notional.

Surfaces `notional_ceiling`, `notional_ceiling_ratio`, `capped_by_notional` in derivation telemetry.

### 4. MONKEY_TRADING_PAUSED kill switch

Env var read live (not cached) at order placement. Gates **entry** orders only:
- Agent K (entries + DCA pyramids + reverse-reopen leg)
- Agent M (entries)
- Agent T (entries + Turtle pyramids)

Does NOT gate exits — open positions can close cleanly during incident response or deploy windows.

Telemetry: `tradingPausedSkipped` / `agentMTradingPausedSkipped` / `agentTTradingPausedSkipped` in derivation.

### 5. Redis listener heartbeat (Bug 2 from claude.ai diagnosis)

10s ping cadence inside the listener loop, env-tunable via `REDIS_LISTENER_PING_INTERVAL_SEC`. Resolves the 30s-cadence reconnect-spam pattern (Redis idle timeout, not auth).

## Tests

- **Python**: 677/677 monkey_kernel passing. New tests: `test_notional_ceiling.py` (7), regime hysteresis (+7 in `test_held_position_rejustification.py`), Redis heartbeat (4), SL ROI semantics (16). Total new/updated ≈ 35.
- **TS**: 361/363 monkey passing (2 pre-existing `resonance_bank_lane.test.ts` fails unchanged). New: `notionalCeiling.test.ts` (7), `killSwitch.test.ts` (9), regime hysteresis (+7), SL ROI parity (+5).
- **TS build**: clean (`tsc --noEmit` zero errors)
- **QIG purity**: 40 files clean

## SQL migrations

Two scripts that need to run via `railway ssh` post-merge (DB IP-restricted):

```bash
# Lane SL/TP rescale to ROI scale + scalp 3%/3% revert + new ceiling/hysteresis params
railway ssh --service polytrade-be -- bash -lc 'psql "$DATABASE_URL" -f ml-worker/scripts/recalibrate_lane_sl_tp_to_roi.sql'
```

The leverage baseline registry update (PR #630) is already applied.

## Operator notes

**Kill switch**: When trading needs to be paused (incident, deploy window, manual review), set on Railway:
```
MONKEY_TRADING_PAUSED=true
```
Open positions continue to close normally. New entries from K/M/T all suppressed. Unset to resume.

## Judgment calls (per Subagent reports)

1. **Strict-fail on missing basin anchor**: positions opened before this PR don't have `basin_at_open` populated, so regime exit cannot fire on them — Φ/conviction checks remain. Errs toward fewer regime exits during the deploy transition.
2. **Lift-to-min vs notional ceiling collision**: tiny accounts (~$5 effective pool) on high-min symbols ($22+) won't enter post-ceiling. Geometric formula and equity must combine to clear both exchange-min AND ceiling. Aligns with user's prioritization of "prevent notional > 4× balance" over "ensure tiny accounts always enter".
3. **Reverse-reopen leg gating**: kill switch suppresses the reopen leg of `reverse_long` / `reverse_short`. The close still fires. Reason surfaces `trading_paused: new <side> entry suppressed`.
4. **`MONKEY_REGIME_STABILITY_TICKS_FOR_EXIT` env var on TS**: mirrors the registry parameter Python reads. TS has no parameter registry; env var is the equivalent escape hatch. Both default to 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)