### PR TITLE
fix(monkey): align loop.ts with chopSuppressEntry rename — unbreaks build

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -85,7 +85,13 @@ import {
   trendProxy as computeTrendProxy,
   type OHLCVCandle,
 } from './perception.js';
-import { classifyRegime, chopSuppressEntry, type RegimeReading } from './regime.js';
+import {
+  CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT,
+  CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT,
+  chopSuppressEntry,
+  classifyRegime,
+  type RegimeReading,
+} from './regime.js';
 import {
   detectStrongest as detectStrongestCandlePattern,
   hammerAgainstLongSl,
@@ -1247,7 +1253,7 @@ export class MonkeyKernel extends EventEmitter {
       direction !== 'flat' &&
       size.value > 0 &&
       !sideShortRefused &&
-      !isChopSuppressed(regimeReading)
+      !chopSuppressEntry(regimeReading, positionLane).suppressed
     ) {
       // Regime suppression check (issue #623): before opening a new entry,
       // consult the regime classifier reading. Held positions are unaffected —
@@ -1278,13 +1284,17 @@ export class MonkeyKernel extends EventEmitter {
       }
     } else {
       action = 'hold';
-      const chopSuppressed = isChopSuppressed(regimeReading);
+      const chopSuppressionForLane = chopSuppressEntry(regimeReading, positionLane);
+      const chopSuppressed = chopSuppressionForLane.suppressed;
+      const chopThresholdForLane = positionLane === 'trend'
+        ? CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT
+        : CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT;
       const why = !MODE_PROFILES[mode].canEnter
         ? `mode=${mode} blocks entry (${MODE_PROFILES[mode].description})`
         : direction === 'flat'
           ? `[${mode}] direction=flat (basinDir=${basinDir.toFixed(3)} tape=${tapeTrend.toFixed(3)})`
           : chopSuppressed
-            ? `[${mode}] chop regime confidence=${regimeReading.confidence.toFixed(2)} > ${CHOP_SUPPRESSION_CONFIDENCE.toFixed(2)} — suspend new entries`
+            ? `[${mode}] chop regime confidence=${regimeReading.confidence.toFixed(2)} > ${chopThresholdForLane.toFixed(2)} — suspend new entries (lane=${positionLane})`
             : size.value <= 0
               ? `[${mode}] size ${size.value.toFixed(2)} below min notional ${minNotional.toFixed(2)}`
               : sideShortRefused
@@ -1297,11 +1307,15 @@ export class MonkeyKernel extends EventEmitter {
     // this tick AND whether it actually blocked entry. ``active`` reads
     // the regime classifier output; ``blocked`` is true only when the
     // suspension would have flipped a would-be entry into a hold.
+    const chopTelemetry = chopSuppressEntry(regimeReading, positionLane);
     derivation.chopSuppression = {
-      active: isChopSuppressed(regimeReading),
+      active: chopTelemetry.suppressed,
       regime: regimeReading.regime,
       confidence: regimeReading.confidence,
-      threshold: CHOP_SUPPRESSION_CONFIDENCE,
+      lane: positionLane,
+      threshold: positionLane === 'trend'
+        ? CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT
+        : CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT,
     };
 
     // v0.8.3b — shadow the full Python tick pipeline. Fire-and-forget:


### PR DESCRIPTION
## Summary

**Production hotfix.** Build of `ba115b8` (PR #631) failed on Railway:

```
src/services/monkey/loop.ts(1250,8): error TS2304: Cannot find name 'isChopSuppressed'.
src/services/monkey/loop.ts(1281,30): error TS2552: Cannot find name 'isChopSuppressed'. Did you mean 'chopSuppressed'?
src/services/monkey/loop.ts(1287,92): error TS2304: Cannot find name 'CHOP_SUPPRESSION_CONFIDENCE'.
src/services/monkey/loop.ts(1301,15): error TS2304: Cannot find name 'isChopSuppressed'.
src/services/monkey/loop.ts(1304,18): error TS2304: Cannot find name 'CHOP_SUPPRESSION_CONFIDENCE'.
```

## Cause

The chop-suppression API in `regime.ts` was renamed in PR #627/#628 from a simple `isChopSuppressed(reading): boolean` to a lane-aware `chopSuppressEntry(reading, lane): ChopSuppressionResult`. The new API uses lane-conditioned thresholds (`CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT = 0.70`, `CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT = 0.85`) since chop is the scalp lane's home regime and shouldn't suppress there.

`regime.ts` was updated; `loop.ts` line 1255 was updated to use the new API; but lines 1250, 1281, 1287, 1301, 1304 were missed during the PR #631 worktree merge. PR #631's preview build cached an older artifact and didn't catch this; production build does.

## Fix

- Import `CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT` and `CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT` alongside `chopSuppressEntry`
- Replace boolean `isChopSuppressed(reading)` with `chopSuppressEntry(reading, positionLane).suppressed`
- Replace `CHOP_SUPPRESSION_CONFIDENCE` with lane-conditioned threshold in reason string and telemetry
- Add `lane` to `chopSuppression` derivation block

## Verification

- `yarn build` clean locally
- 20 insertions / 6 deletions in one file (`apps/api/src/services/monkey/loop.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)