### PR TITLE
fix(monkey): TS stale-bleed time stop for dormant conviction gate

### DIFF
--- a/apps/api/src/services/monkey/__tests__/staleBleedStop.test.ts
+++ b/apps/api/src/services/monkey/__tests__/staleBleedStop.test.ts
@@ -1,0 +1,199 @@
+/**
+ * staleBleedStop.test.ts — verifies the time-based stale-position stop
+ * that compensates for the dormant TS conviction gate.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  shouldStaleBleedExit,
+  STALE_BLEED_HOLD_MS_BY_LANE,
+  STALE_BLEED_HOLD_MS_FALLBACK,
+  STALE_BLEED_PRICE_BAND_DEFAULT,
+} from '../staleBleedStop.js';
+
+describe('shouldStaleBleedExit defaults', () => {
+  it('scalp lane threshold is 10 minutes', () => {
+    expect(STALE_BLEED_HOLD_MS_BY_LANE.scalp).toBe(10 * 60_000);
+  });
+  it('swing lane threshold is 75 minutes (1.5x trailing_harvest avg)', () => {
+    expect(STALE_BLEED_HOLD_MS_BY_LANE.swing).toBe(75 * 60_000);
+  });
+  it('trend lane threshold is 180 minutes', () => {
+    expect(STALE_BLEED_HOLD_MS_BY_LANE.trend).toBe(180 * 60_000);
+  });
+  it('unknown-lane fallback is 60 minutes', () => {
+    expect(STALE_BLEED_HOLD_MS_FALLBACK).toBe(60 * 60_000);
+  });
+  it('price band is 0.3%', () => {
+    expect(STALE_BLEED_PRICE_BAND_DEFAULT).toBeCloseTo(0.003);
+  });
+});
+
+describe('shouldStaleBleedExit — fire conditions per lane', () => {
+  it('scalp: fires when held > 10m and price move within ±0.3%', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 100,
+      unrealizedPnl: 0.10,            // +0.10% on notional
+      nowMs: 11 * 60_000,             // held 11 minutes
+      lane: 'scalp',
+    });
+    expect(out.fire).toBe(true);
+    expect(out.reason).toContain('stale_bleed_stop');
+    expect(out.reason).toContain('lane=scalp');
+    expect(out.derivation.holdMinutes).toBeCloseTo(11, 0);
+    expect(out.derivation.armed).toBe(true);
+  });
+
+  it('swing: does NOT fire at 30m even with flat price (75m threshold)', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 100,
+      unrealizedPnl: 0,
+      nowMs: 30 * 60_000,
+      lane: 'swing',
+    });
+    expect(out.fire).toBe(false);
+    expect(out.derivation.holdMsThreshold).toBe(75 * 60_000);
+  });
+
+  it('swing: fires at 80m with flat price', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 100,
+      unrealizedPnl: 0.10,
+      nowMs: 80 * 60_000,
+      lane: 'swing',
+    });
+    expect(out.fire).toBe(true);
+    expect(out.reason).toContain('lane=swing');
+  });
+
+  it('trend: does NOT fire at 60m (180m threshold)', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 100,
+      unrealizedPnl: 0,
+      nowMs: 60 * 60_000,
+      lane: 'trend',
+    });
+    expect(out.fire).toBe(false);
+    expect(out.derivation.holdMsThreshold).toBe(180 * 60_000);
+  });
+
+  it('unknown lane: uses 60m fallback', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 100,
+      unrealizedPnl: 0,
+      nowMs: 65 * 60_000,
+      lane: 'wat',
+    });
+    expect(out.fire).toBe(true);
+    expect(out.derivation.holdMsThreshold).toBe(60 * 60_000);
+  });
+
+  it('fires symmetrically on negative side (swing)', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 100,
+      unrealizedPnl: -0.20,           // -0.20% on notional
+      nowMs: 80 * 60_000,
+      lane: 'swing',
+    });
+    expect(out.fire).toBe(true);
+    expect(out.derivation.priceMoveFrac).toBeCloseTo(-0.002);
+  });
+});
+
+describe('shouldStaleBleedExit — non-fire conditions', () => {
+  it('scalp: does not fire when held < 10m even with flat price', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 100,
+      unrealizedPnl: 0,
+      nowMs: 5 * 60_000,
+      lane: 'scalp',
+    });
+    expect(out.fire).toBe(false);
+  });
+
+  it('swing winner at 80m: does not fire when price moved meaningfully', () => {
+    // Live tape 2026-05-01 21:18 — BTC swing held 47m at +0.50% would have been killed
+    // by the original 10m / ±0.3% cut. With per-lane threshold (75m for swing) AND
+    // price band exclusion, this winner is correctly preserved.
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 100,
+      unrealizedPnl: 0.50,            // +0.50% > 0.3% band
+      nowMs: 80 * 60_000,
+      lane: 'swing',
+    });
+    expect(out.fire).toBe(false);
+    expect(out.derivation.priceMoveFrac).toBeCloseTo(0.005);
+  });
+
+  it('does not fire when price has moved meaningfully (loser)', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 100,
+      unrealizedPnl: -0.40,           // -0.40% > 0.3% band
+      nowMs: 200 * 60_000,
+      lane: 'trend',
+    });
+    expect(out.fire).toBe(false);
+  });
+
+  it('does not arm when lastEntryAtMs is null (flat)', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: null,
+      positionNotional: 100,
+      unrealizedPnl: 0,
+      nowMs: 200 * 60_000,
+      lane: 'scalp',
+    });
+    expect(out.fire).toBe(false);
+    expect(out.derivation.armed).toBe(false);
+  });
+
+  it('does not arm when notional is zero', () => {
+    const out = shouldStaleBleedExit({
+      lastEntryAtMs: 0,
+      positionNotional: 0,
+      unrealizedPnl: 0,
+      nowMs: 200 * 60_000,
+      lane: 'scalp',
+    });
+    expect(out.fire).toBe(false);
+    expect(out.derivation.armed).toBe(false);
+  });
+});
+
+describe('shouldStaleBleedExit — option overrides', () => {
+  it('respects custom holdMs', () => {
+    const out = shouldStaleBleedExit(
+      {
+        lastEntryAtMs: 0,
+        positionNotional: 100,
+        unrealizedPnl: 0,
+        nowMs: 4 * 60_000,
+        lane: 'scalp',
+      },
+      { holdMs: 3 * 60_000 },          // 3 min hold threshold
+    );
+    expect(out.fire).toBe(true);
+  });
+
+  it('respects custom priceBand', () => {
+    const out = shouldStaleBleedExit(
+      {
+        lastEntryAtMs: 0,
+        positionNotional: 100,
+        unrealizedPnl: 0.40,             // +0.40%
+        nowMs: 30 * 60_000,
+        lane: 'scalp',
+      },
+      { priceBand: 0.005 },              // ±0.5% band — now within
+    );
+    expect(out.fire).toBe(true);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -118,6 +118,7 @@ import {
   type LaneType,
 } from './executive.js';
 import { evaluateRejustification } from './held_position_rejustification.js';
+import { shouldStaleBleedExit } from './staleBleedStop.js';
 
 /** Default Monkey watchlist — matches liveSignalEngine for side-by-side. */
 const DEFAULT_SYMBOLS = ['BTC_USDT_PERP', 'ETH_USDT_PERP'];
@@ -1167,6 +1168,38 @@ export class MonkeyKernel extends EventEmitter {
           }
         }
 
+        // 3.5. Stale-bleed time stop — TS path's conviction gate is
+        // dormant (NEUTRAL_EMOTIONS hardcoded zeros above), so chronic
+        // flat positions never get an emotion-driven exit. This stop
+        // mirrors what Python's frustration > 0.6 would do here:
+        // when held > 10m with price move inside ±0.3%, force-close.
+        // 2026-05-01 live tape: scalp_exits average 62-96s; positions
+        // held > 10m almost always resolve via reconciliation. Once
+        // Layer 2B emotion stack ports to TS, this stop becomes
+        // redundant and can be removed.
+        if (!exitFired) {
+          const stale = shouldStaleBleedExit({
+            lastEntryAtMs: state.lastEntryAtMs,
+            positionNotional,
+            unrealizedPnl,
+            nowMs: Date.now(),
+            lane: heldLane,
+          });
+          derivation.staleBleed = { ...stale.derivation, tradeId };
+          if (stale.fire) {
+            action = 'scalp_exit';
+            reason = stale.reason;
+            exitFired = true;
+            derivation.scalp = {
+              exitTypeBit: 6,  // stale-bleed time stop
+              unrealizedPnl,
+              markPrice: lastPrice,
+              tradeId,
+              lane: heldLane,
+            };
+          }
+        }
+
         // 4. Scalp TP — only TP can reach here (SL was returned above
         // unless deferred; rejustification and harvest also returned).
         if (!exitFired && scalp.value && !isStopLoss) {
@@ -1513,6 +1546,7 @@ export class MonkeyKernel extends EventEmitter {
           exitTypeBit === -1 ? 'stop_loss' :
           exitTypeBit === 2 ? 'trailing_harvest' :
           exitTypeBit === 3 ? 'trend_flip_harvest' :
+          exitTypeBit === 6 ? 'stale_bleed_stop' :
           'scalp_exit';
         const pnlAtDecision = Number(scalpDeriv?.unrealizedPnl ?? 0);
         const scalpLane = (

--- a/apps/api/src/services/monkey/staleBleedStop.ts
+++ b/apps/api/src/services/monkey/staleBleedStop.ts
@@ -1,0 +1,125 @@
+/**
+ * staleBleedStop.ts — TS-only stale-position time stop.
+ *
+ * The TS hot path's conviction gate is currently dormant: ``loop.ts``
+ * passes ``NEUTRAL_EMOTIONS`` (all zeros) into the rejustification
+ * evaluator until Layer 2B emotion stack gets ported from Python.
+ * That collapses the conviction comparator to ``0 > 0 = false`` on
+ * every tick, so emotion-driven exits never fire on this path.
+ *
+ * Live tape evidence 2026-05-01: monkey-* scalp_exits average
+ * 62-96 seconds; positions held longer almost always resolve via
+ * exchange-side reconciliation rather than a clean kernel exit.
+ * The `position not found` reason has ~16-27 minute average duration
+ * — those are stale rows the kernel never closed itself.
+ *
+ * This module fills the gap with a deterministic, geometry-free
+ * stop: when a position has been held longer than ``holdMs`` AND
+ * its price-level move is inside ``priceBand``, force a close. It is
+ * deliberately a coarse safety bound, not a tuned signal — once
+ * Layer 2B ports, the conviction gate reactivates and this stop
+ * should rarely if ever bind.
+ *
+ * Bit 6 in the exitTypeBit space (1 take_profit, -1 stop_loss,
+ * 2 trailing_harvest, 3 trend_flip_harvest, 5 rejustification).
+ */
+
+/**
+ * Per-lane hold thresholds calibrated against live tape 2026-05-01.
+ * Last-hour ``trailing_harvest`` exits averaged ~47.5 minutes — swing
+ * positions legitimately need that long to develop. Setting the
+ * threshold below that would prematurely kill profitable winners.
+ *
+ * Threshold rule of thumb: 1.5× the lane's median legit-exit duration.
+ * Reconciliation noise events (``position not found on exchange``)
+ * averaged ~16-27 minutes — these are the actual targets.
+ */
+export const STALE_BLEED_HOLD_MS_BY_LANE: Record<string, number> = {
+  scalp: 10 * 60_000,    // 10 min — scalp exits average <2min, anything > 10m is anomalous
+  swing: 75 * 60_000,    // 75 min — 1.5× the live trailing_harvest avg (47.5m)
+  trend: 180 * 60_000,   // 3h — trend lane operates on a much longer horizon
+};
+export const STALE_BLEED_HOLD_MS_FALLBACK = 60 * 60_000;     // unknown-lane safety
+export const STALE_BLEED_PRICE_BAND_DEFAULT = 0.003;         // ±0.3% on notional
+
+export interface StaleBleedInput {
+  lastEntryAtMs: number | null;
+  positionNotional: number;
+  unrealizedPnl: number;
+  nowMs: number;
+  lane: string;
+}
+
+export interface StaleBleedOptions {
+  /** Override the hold threshold entirely (useful in tests). */
+  holdMs?: number;
+  /** Override the per-lane hold map (useful for registry-driven tuning). */
+  holdMsByLane?: Record<string, number>;
+  priceBand?: number;
+}
+
+export interface StaleBleedResult {
+  fire: boolean;
+  reason: string;
+  derivation: {
+    holdMs: number;
+    holdMinutes: number;
+    priceMoveFrac: number;
+    holdMsThreshold: number;
+    priceBand: number;
+    lane: string;
+    armed: boolean;
+  };
+}
+
+/**
+ * Decide whether to fire the stale-bleed time stop.
+ *
+ * Returns ``fire: false`` when the position is fresh, the inputs
+ * are degenerate (zero/negative notional, null entry timestamp),
+ * or the position is making real price progress in either
+ * direction — only chronic-flat positions qualify.
+ */
+export function shouldStaleBleedExit(
+  input: StaleBleedInput,
+  opts: StaleBleedOptions = {},
+): StaleBleedResult {
+  const holdMap = opts.holdMsByLane ?? STALE_BLEED_HOLD_MS_BY_LANE;
+  const laneThreshold = holdMap[input.lane] ?? STALE_BLEED_HOLD_MS_FALLBACK;
+  const holdMsThreshold = opts.holdMs ?? laneThreshold;
+  const priceBand = opts.priceBand ?? STALE_BLEED_PRICE_BAND_DEFAULT;
+
+  const armed =
+    input.lastEntryAtMs !== null &&
+    Number.isFinite(input.lastEntryAtMs) &&
+    input.positionNotional > 0 &&
+    Number.isFinite(input.unrealizedPnl);
+
+  if (!armed) {
+    return {
+      fire: false,
+      reason: '',
+      derivation: {
+        holdMs: 0, holdMinutes: 0, priceMoveFrac: 0,
+        holdMsThreshold, priceBand, lane: input.lane, armed: false,
+      },
+    };
+  }
+
+  const holdMs = Math.max(0, input.nowMs - (input.lastEntryAtMs as number));
+  const priceMoveFrac = input.unrealizedPnl / input.positionNotional;
+  const holdMinutes = holdMs / 60_000;
+
+  const fire = holdMs > holdMsThreshold && Math.abs(priceMoveFrac) < priceBand;
+
+  return {
+    fire,
+    reason: fire
+      ? `stale_bleed_stop hold=${holdMinutes.toFixed(1)}m price_move=${(priceMoveFrac * 100).toFixed(3)}% lane=${input.lane}`
+      : '',
+    derivation: {
+      holdMs, holdMinutes, priceMoveFrac,
+      holdMsThreshold, priceBand, lane: input.lane, armed: true,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

The TS hot path passes `NEUTRAL_EMOTIONS` (all zeros) into the rejustification evaluator until Layer 2B emotion stack ports from Python — collapsing the conviction comparator to `0 > 0 = false` so emotion-driven exits never fire on TS. This adds a per-lane time-based safety net.

- `shouldStaleBleedExit()` helper fires when held > lane threshold AND price-level move from entry inside ±0.3% of notional
- Per-lane thresholds calibrated to live tape 2026-05-01:
  - **scalp**: 10m (lane median ~62-96s)
  - **swing**: 75m (1.5× live `trailing_harvest` avg of 47.5m)
  - **trend**: 180m (slow horizon)
  - unknown-lane fallback: 60m
- Wired between profit harvest and scalp TP in `loop.ts`; tagged `exitTypeBit=6` / `exit_reason='stale_bleed_stop'` for diagnostic SQL

The 0.3% price band excludes positions making real progress in either direction — only chronic-flat ones qualify, so legitimate winners (live BTC went 0.04% → 0.50% over 25m and harvested cleanly at 47m) are preserved.

Once Layer 2B emotions port to TS and the conviction gate reactivates, this stop becomes redundant and can be removed.

## Test plan

- [x] 18 new unit tests cover per-lane firing, symmetric ±0.3% band, non-firing on winners, non-firing on freshness, non-arming on null entry/zero notional, custom-threshold overrides
- [x] 75 other exit-related tests still pass (regime, chopSuppression, notionalCeiling, heldPositionRejustification)
- [x] TypeScript typecheck clean (no new errors)
- [ ] Production: monitor `exit_reason = 'stale_bleed_stop'` rate; expect rare firing on stuck positions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)