### PR TITLE
fix(monkey): per-agent equity bound on Agent M (prevent runaway stacking)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/agentEquityBound.test.ts
+++ b/apps/api/src/services/monkey/__tests__/agentEquityBound.test.ts
@@ -1,0 +1,79 @@
+/**
+ * agentEquityBound.test.ts — verifies the pure helpers that bound
+ * an agent's cumulative open margin to its Arbiter allocation share.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeAgentHeadroom,
+  clampSizeToHeadroom,
+} from '../agentEquityBound.js';
+
+describe('computeAgentHeadroom', () => {
+  it('returns full allocation when no margin is open', () => {
+    expect(computeAgentHeadroom(50, 0)).toBe(50);
+  });
+
+  it('returns difference when within allocation', () => {
+    expect(computeAgentHeadroom(50, 30)).toBe(20);
+  });
+
+  it('returns zero when fully committed', () => {
+    expect(computeAgentHeadroom(50, 50)).toBe(0);
+  });
+
+  it('floors at zero when over-committed (does not return negative)', () => {
+    expect(computeAgentHeadroom(50, 75)).toBe(0);
+  });
+
+  it('handles zero allocation', () => {
+    expect(computeAgentHeadroom(0, 0)).toBe(0);
+    expect(computeAgentHeadroom(0, 10)).toBe(0);
+  });
+
+  it('returns zero on NaN/Infinity inputs', () => {
+    expect(computeAgentHeadroom(NaN, 10)).toBe(0);
+    expect(computeAgentHeadroom(50, NaN)).toBe(0);
+    expect(computeAgentHeadroom(Infinity, 10)).toBe(0);
+  });
+});
+
+describe('clampSizeToHeadroom', () => {
+  it('returns desired size when fully within headroom', () => {
+    expect(clampSizeToHeadroom(20, 50)).toBe(20);
+  });
+
+  it('clamps to headroom when desired exceeds it', () => {
+    expect(clampSizeToHeadroom(60, 50)).toBe(50);
+  });
+
+  it('returns zero when headroom is zero', () => {
+    expect(clampSizeToHeadroom(20, 0)).toBe(0);
+  });
+
+  it('returns zero when headroom is negative', () => {
+    expect(clampSizeToHeadroom(20, -5)).toBe(0);
+  });
+
+  it('returns zero when desired size is zero or negative', () => {
+    expect(clampSizeToHeadroom(0, 50)).toBe(0);
+    expect(clampSizeToHeadroom(-10, 50)).toBe(0);
+  });
+
+  it('returns zero on NaN/Infinity inputs', () => {
+    expect(clampSizeToHeadroom(NaN, 50)).toBe(0);
+    expect(clampSizeToHeadroom(20, NaN)).toBe(0);
+    expect(clampSizeToHeadroom(20, Infinity)).toBe(0);
+  });
+
+  it('handles the live-tape scenario: M with $50 alloc and $40 already open', () => {
+    // Arbiter says M has $50 this tick, $40 already deployed → $10 headroom.
+    // Agent M's decide() wants to enter at $25 (its 0.5× allocation cap).
+    // The clamp should reduce this to $10 — the last fit before the cap.
+    const allocation = 50;
+    const openMargin = 40;
+    const headroom = computeAgentHeadroom(allocation, openMargin);
+    expect(headroom).toBe(10);
+    const desired = 25;
+    expect(clampSizeToHeadroom(desired, headroom)).toBe(10);
+  });
+});

--- a/apps/api/src/services/monkey/agentEquityBound.ts
+++ b/apps/api/src/services/monkey/agentEquityBound.ts
@@ -1,0 +1,57 @@
+/**
+ * agentEquityBound.ts — per-agent equity discipline.
+ *
+ * The Arbiter splits total equity into per-agent allocations (K-share,
+ * M-share, T-share via PnL softmax). What was missing until 2026-05-05:
+ * a check that an agent's cumulative open margin stays within the
+ * allocation it was granted. Without that bound, Agent M (the ML
+ * control arm, which has no lane discipline like K and no Donchian
+ * pyramid like T) can stack fresh entries every tick the ML signal
+ * stays above its threshold — observed 13 ETH longs in 16 minutes
+ * before Poloniex's 21005 margin-insufficient error caught it.
+ *
+ * The fix preserves agent independence: K, M, and T each operate
+ * under their own discipline. The bound only constrains *the agent
+ * itself* — it never reaches across to gate one agent based on
+ * another's positions.
+ *
+ * Self-regulating: when the agent is profitable, the Arbiter softmax
+ * grants more capital → cap loosens. When the agent loses, allocation
+ * shrinks → cap tightens. The bound rides the agent's own track record.
+ *
+ * Pure functions only — DB queries live on the kernel side.
+ */
+
+/**
+ * Available margin for new entries — the gap between the Arbiter's
+ * per-tick allocation and the agent's currently-committed margin.
+ * Floored at zero (a negative value means the agent is already over
+ * its allocation; new entries should be suppressed, but existing
+ * positions ride out their own exit logic).
+ */
+export function computeAgentHeadroom(
+  allocation: number,
+  openMargin: number,
+): number {
+  if (!Number.isFinite(allocation) || !Number.isFinite(openMargin)) return 0;
+  return Math.max(0, allocation - openMargin);
+}
+
+/**
+ * Clamp a desired entry size to fit within remaining headroom. The
+ * decide() function in ml_agent already caps at allocation × 0.5,
+ * but headroom is the strict-tighter bound when prior entries have
+ * consumed most of the allocation.
+ *
+ * Returns 0 (no entry) when headroom is non-positive or the desired
+ * size is non-positive, so callers can use the result directly in
+ * "if (clamped > 0)" guards.
+ */
+export function clampSizeToHeadroom(
+  desiredSizeUsdt: number,
+  headroom: number,
+): number {
+  if (!Number.isFinite(desiredSizeUsdt) || desiredSizeUsdt <= 0) return 0;
+  if (!Number.isFinite(headroom) || headroom <= 0) return 0;
+  return Math.min(desiredSizeUsdt, headroom);
+}

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -120,6 +120,7 @@ import {
   type LaneType,
 } from './executive.js';
 import { evaluateRejustification } from './held_position_rejustification.js';
+import { computeAgentHeadroom, clampSizeToHeadroom } from './agentEquityBound.js';
 
 /** Default Monkey watchlist — matches liveSignalEngine for side-by-side. */
 const DEFAULT_SYMBOLS = ['BTC_USDT_PERP', 'ETH_USDT_PERP'];
@@ -1698,7 +1699,23 @@ export class MonkeyKernel extends EventEmitter {
     // HOLD AND mlStrength >= 0.55 AND M has > 0 capital. Same risk
     // kernel + position-write pipeline as K (executeEntry handles
     // veto, exchange order, DB INSERT with agent='M').
+    //
+    // Per-agent equity bound (2026-05-05 #10): M's cumulative open
+    // margin is held within the Arbiter's per-tick allocation. K and T
+    // are unaffected — each agent operates on its own discipline. Bound
+    // is self-regulating: profitable streaks loosen the cap (Arbiter
+    // grants more), drawdowns tighten it. See agentEquityBound.ts.
     if (process.env.MONKEY_EXECUTE === 'true' && arbiterAllocation.m > 0) {
+      const mOpenMargin = await this.sumOpenAgentMargin(symbol, 'M');
+      const mHeadroom = computeAgentHeadroom(arbiterAllocation.m, mOpenMargin);
+      if (mHeadroom <= 0) {
+        derivation.agentM = {
+          skipped: true,
+          reason: 'at_alloc_cap',
+          openMargin: Number(mOpenMargin.toFixed(2)),
+          allocation: Number(arbiterAllocation.m.toFixed(2)),
+        };
+      } else {
       const mInputs: MLAgentInputs = {
         symbol,
         ohlcv: ohlcv.map((c) => ({
@@ -1721,9 +1738,14 @@ export class MonkeyKernel extends EventEmitter {
         allocatedCapitalUsdt: arbiterAllocation.m,
       };
       const mDecision = mlAgentDecide(mInputs);
+      const clampedSize = clampSizeToHeadroom(mDecision.sizeUsdt, mHeadroom);
       derivation.agentM = {
         action: mDecision.action,
-        sizeUsdt: mDecision.sizeUsdt,
+        sizeUsdt: clampedSize,
+        requestedSize: mDecision.sizeUsdt,
+        headroom: Number(mHeadroom.toFixed(2)),
+        openMargin: Number(mOpenMargin.toFixed(2)),
+        allocation: Number(arbiterAllocation.m.toFixed(2)),
         leverage: mDecision.leverage,
         reason: mDecision.reason,
         mlSignal: mInputs.mlSignal,
@@ -1731,7 +1753,7 @@ export class MonkeyKernel extends EventEmitter {
       };
       if (
         (mDecision.action === 'enter_long' || mDecision.action === 'enter_short')
-        && mDecision.sizeUsdt > 0
+        && clampedSize > 0
       ) {
         // v0.8.7 kill switch — pause new entries from Agent M.
         if (isTradingPaused()) {
@@ -1743,7 +1765,7 @@ export class MonkeyKernel extends EventEmitter {
         const mResult = await this.executeEntry({
           symbol,
           side: mDecision.action === 'enter_long' ? 'long' : 'short',
-          marginUsdt: mDecision.sizeUsdt,
+          marginUsdt: clampedSize,
           leverage: mDecision.leverage,
           entryPrice: lastPrice,
           minNotional,
@@ -1763,11 +1785,13 @@ export class MonkeyKernel extends EventEmitter {
         } else {
           logger.info('[AgentM] entry placed', {
             symbol, side: mDecision.action, orderId: mResult.orderId,
-            margin: mDecision.sizeUsdt.toFixed(2), leverage: mDecision.leverage,
+            margin: clampedSize.toFixed(2), leverage: mDecision.leverage,
+            headroom: mHeadroom.toFixed(2),
           });
         }
         }  // close v0.8.7 trading-paused else branch
       }
+      }  // close mHeadroom > 0 else branch
     }
 
     // 6c-T. AGENT T EXECUTE — Turtle System 1 (classical TA control arm).
@@ -2336,6 +2360,47 @@ export class MonkeyKernel extends EventEmitter {
         err: err instanceof Error ? err.message : String(err),
       });
       return [];
+    }
+  }
+
+  /**
+   * Sum of currently-open margin (USDT) for a given agent on a symbol.
+   * Margin = quantity × entry_price ÷ leverage (legacy rows without
+   * leverage fall back to notional).
+   *
+   * Used by the per-agent equity bound (#10): the kernel checks this
+   * against the Arbiter's per-tick allocation before letting an agent
+   * stack a fresh entry. Fail-soft returns 0 — the exchange-side
+   * margin enforcement (Poloniex 21005) is the hard ceiling, this
+   * guard is the soft preventative.
+   */
+  private async sumOpenAgentMargin(
+    symbol: string,
+    agent: 'K' | 'M' | 'T',
+  ): Promise<number> {
+    try {
+      const reasonPattern = `monkey|kernel=${this.instanceId}|%`;
+      const result = await pool.query(
+        `SELECT COALESCE(SUM(
+            CASE
+              WHEN leverage > 0 THEN (quantity * entry_price / leverage)
+              ELSE quantity * entry_price
+            END
+          ), 0) AS sum_margin
+           FROM autonomous_trades
+          WHERE status = 'open'
+            AND symbol = $1
+            AND agent = $2
+            AND reason LIKE $3`,
+        [symbol, agent, reasonPattern],
+      );
+      const row = result.rows[0] as { sum_margin: string | number } | undefined;
+      return Number(row?.sum_margin ?? 0);
+    } catch (err) {
+      logger.debug('[Monkey] sumOpenAgentMargin failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return 0;
     }
   }
 


### PR DESCRIPTION
## Summary

2026-05-05 incident: after \`MONKEY_TRADING_PAUSED\` was lifted, Agent M opened **13 ETH long positions in 16 minutes**. The ML signal stayed BUY at strength ≥ 0.55 for many consecutive ticks, so M's \`decide()\` returned enter_long on every one. Each entry consumed fresh margin until Poloniex's 21005 \"available balance insufficient\" errors became the only ceiling.

## Root cause

The Arbiter splits equity into per-agent allocations via PnL softmax (K-share, M-share, T-share), but **no layer checked that an agent's cumulative open margin stays within its allocation**. K is naturally bounded by lane discipline (max 3 concurrent positions across scalp/swing/trend). T is bounded by Donchian pyramid units. M, the ML control arm, has neither — its \`decide()\` is intentionally thin, and the kernel's per-symbol exit cascade only gated K's entries.

## Fix — independence-preserving

User direction: agents trade independently. The fix bounds an agent's blast radius **without** coupling agents to each other.

- New [agentEquityBound.ts](apps/api/src/services/monkey/agentEquityBound.ts) with two pure helpers:
  - \`computeAgentHeadroom(allocation, openMargin)\` → \`max(0, allocation - openMargin)\`
  - \`clampSizeToHeadroom(desired, headroom)\` → \`min(desired, max(0, headroom))\`
- New \`sumOpenAgentMargin\` DB method on \`MonkeyKernel\` summing \`quantity × entry_price ÷ leverage\` for open rows matching \`(agent, symbol)\`. Fail-soft: returns 0 on DB error (Poloniex 21005 is the hard ceiling, this is the soft preventative).
- Agent M execute block at [loop.ts:1701](apps/api/src/services/monkey/loop.ts#L1701) now:
  1. Computes \`mHeadroom = allocation - openMargin\` before \`decide()\`
  2. Skips with \`derivation.agentM.skipped='at_alloc_cap'\` when headroom ≤ 0
  3. Clamps \`decide().sizeUsdt\` to headroom otherwise

## Self-regulating

When M is profitable → Arbiter softmax grants more capital → cap loosens. When M loses → allocation shrinks → cap tightens. The bound rides M's own track record.

## Independence preserved

K, T, and any future agents are **completely untouched**. The bound only constrains *the agent itself* — it never reaches across to gate one agent based on another's positions.

## Test plan

- [x] 13 new unit tests on the pure helpers (boundary, NaN, the live-tape \$50 alloc / \$40 open / \$25 desired → \$10 clamped scenario)
- [x] 358/360 monkey tests passing (2 pre-existing failures in \`resonance_bank_lane.test.ts\`, unrelated, baseline-equivalent to main)
- [x] TypeScript typecheck clean (only pre-existing \`@shared/types/strategy\` errors remain)
- [ ] CI pipeline (type-check + Railway deploys)
- [ ] Production smoke: monitor \`derivation.agentM.skipped='at_alloc_cap'\` rate; expect occasional firing on long ML-BUY streaks

## Live impact

Existing 13 ETH longs ride out via their own exit logic (TP / harvest). No fresh M entries on ETH until some close (M is at-cap right now). K and T continue normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)