### PR TITLE
fix(reconciler): auto-sync DB equity to exchange (handles deposits/withdrawals)

### DIFF
--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -239,7 +239,26 @@ class StateReconciliationService {
         }
       }
 
-      // ── 7. Balance drift check ───────────────────────────────────────────────
+      // ── 7. Balance drift check + auto-sync ───────────────────────────────────
+      //
+      // The exchange is the source of truth for equity. Drift between
+      // DB-recorded equity (latest autonomous_performance row) and
+      // exchange-reported equity has two sources:
+      //   (a) manual cash flows — user deposits/withdrawals on Poloniex UI
+      //   (b) trade closes the DB writer missed (FAT disabled, FAT crash,
+      //       or close-time race)
+      //
+      // Both should be papered over by an authoritative sync from the
+      // exchange. The drift WARN log is preserved as the audit trail —
+      // operator sees the magnitude/direction and can correlate it to
+      // their own deposit/withdrawal activity. The auto-INSERT below
+      // ensures downstream consumers (Arbiter sizing, dashboards,
+      // notional ceilings) see correct equity within one reconciler tick.
+      //
+      // 2026-05-05 incident: FAT was disabled but was the sole writer of
+      // autonomous_performance. DB equity stayed frozen at $113.27 for
+      // hours while exchange balance grew to $369.10 from manual
+      // deposits — Arbiter was sizing against the stale $113.
       if (exchangeBalance !== null && dbBalance !== null && exchangeBalance > 0) {
         const drift = Math.abs(exchangeBalance - dbBalance) / exchangeBalance;
         result.balanceDrift = drift;
@@ -250,6 +269,43 @@ class StateReconciliationService {
             dbBalance,
             driftPercent: (drift * 100).toFixed(2)
           });
+
+          // Auto-sync: write a fresh autonomous_performance row with the
+          // exchange balance. Recompute total_return/drawdown when we have
+          // initial_capital from the config; else NULL them out (operator
+          // sees drift in logs and historical rows preserve old values).
+          try {
+            const cfgRow = await pool.query(
+              `SELECT initial_capital FROM autonomous_trading_configs WHERE user_id = $1 LIMIT 1`,
+              [userId]
+            );
+            const initialCapital =
+              cfgRow.rows[0]?.initial_capital != null
+                ? parseFloat(cfgRow.rows[0].initial_capital)
+                : null;
+            const totalReturn =
+              initialCapital && initialCapital > 0
+                ? ((exchangeBalance - initialCapital) / initialCapital) * 100
+                : null;
+            const drawdown =
+              initialCapital && initialCapital > 0
+                ? Math.max(0, (initialCapital - exchangeBalance) / initialCapital) * 100
+                : null;
+            await pool.query(
+              `INSERT INTO autonomous_performance
+                 (user_id, current_equity, total_return, drawdown, timestamp)
+               VALUES ($1, $2, $3, $4, NOW())`,
+              [userId, exchangeBalance, totalReturn, drawdown]
+            );
+            logger.info(
+              `[RECONCILE] Synced DB equity to exchange for user ${userId}: ${dbBalance.toFixed(2)} -> ${exchangeBalance.toFixed(2)}`
+            );
+          } catch (syncErr) {
+            logger.error(
+              `[RECONCILE] Failed to sync DB equity for user ${userId}:`,
+              syncErr
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

2026-05-05 incident: user deposited ~\$256 to Poloniex account (\$113 → \$369). DB equity (\`autonomous_performance.current_equity\`) stayed at \$113.27 for hours because the **only writer** of that table was \`fullyAutonomousTrader\` — disabled by PR #635 (single-engine architecture).

Result: every downstream consumer (Arbiter sizing, notional ceilings, dashboards) was operating on stale equity. Agent M's per-tick allocation was based on \$113 instead of the real \$369. The reconciler logged the drift loudly but didn't act on it:

\`\`\`
[STATE_DRIFT_WARNING] Balance drift detected for user 7e989bb1...
{"exchangeBalance":369.10, "dbBalance":113.27, "driftPercent":"69.31"}
\`\`\`

## Fix

When drift > 1%, the reconciler now INSERTs a fresh \`autonomous_performance\` row with the exchange balance as authoritative truth.

- **Symmetric**: works for both deposits (positive drift) and withdrawals (negative drift)
- **Audit-preserving**: the WARN log fires first, so operators see the drift magnitude and direction before the sync runs
- **Best-effort recompute**: \`total_return\` and \`drawdown\` are recomputed from \`autonomous_trading_configs.initial_capital\` when available; NULL otherwise. Historical rows preserve old values for backfill.

## Why this is the right architecture

The exchange is the canonical source of truth for equity. Before this PR, the system relied on \`fullyAutonomousTrader\` being the sole writer — a brittle assumption that broke the moment FAT was disabled. After this PR, the **reconciler** is the sync authority. FAT can still write its own metrics rows when re-enabled (append-only with timestamps means the most recent wins), but the system no longer depends on it.

## Test plan

- [x] TypeScript typecheck clean
- [ ] CI pipeline (type-check + Railway deploys)
- [ ] Production smoke: within 60s of deploy, see \`[RECONCILE] Synced DB equity to exchange\` info log; subsequent reconciler ticks should show drift < 1% (no further sync)

## Related

Builds on:
- PR #635 (single-engine architecture, exposed this latent bug)
- PR #636 (per-agent equity bound, which uses Arbiter allocation derived from now-correct equity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)