### PR TITLE
fix(monkey): chunk close orders > 10,000 contracts (Poloniex 21010)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/closeChunker.test.ts
+++ b/apps/api/src/services/monkey/__tests__/closeChunker.test.ts
@@ -1,0 +1,121 @@
+/**
+ * closeChunker.test.ts — verifies the close-chunking math.
+ *
+ * Live tape evidence: 2026-05-05 02:08 — BTC scalp_exit hit Poloniex code
+ * 21010 because the position was > 10,000 contracts. Pre-chunker, the kernel
+ * retried the same oversized close every tick. This module ensures any
+ * close → ≤ 9,999 contracts per order with lot-size respected.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  planCloseChunks,
+  MAX_CONTRACTS_PER_ORDER,
+} from '../closeChunker.js';
+
+describe('planCloseChunks defaults', () => {
+  it('MAX_CONTRACTS_PER_ORDER is 9999 (under Poloniex 10000 cap)', () => {
+    expect(MAX_CONTRACTS_PER_ORDER).toBe(9999);
+  });
+});
+
+describe('planCloseChunks — single-chunk cases', () => {
+  it('size below cap returns single chunk', () => {
+    const out = planCloseChunks(5000, 1);
+    expect(out.chunks).toEqual([5000]);
+    expect(out.totalCovered).toBe(5000);
+    expect(out.residual).toBe(0);
+  });
+
+  it('size exactly at cap returns single chunk', () => {
+    const out = planCloseChunks(9999, 1);
+    expect(out.chunks).toEqual([9999]);
+    expect(out.totalCovered).toBe(9999);
+  });
+
+  it('size at exchange cap (10000) returns 9999 + 1', () => {
+    const out = planCloseChunks(10000, 1);
+    expect(out.chunks).toEqual([9999, 1]);
+    expect(out.totalCovered).toBe(10000);
+  });
+});
+
+describe('planCloseChunks — oversized positions', () => {
+  it('15000 contracts splits into 9999 + 5001', () => {
+    const out = planCloseChunks(15000, 1);
+    expect(out.chunks).toEqual([9999, 5001]);
+    expect(out.totalCovered).toBe(15000);
+  });
+
+  it('30000 contracts splits into 9999 × 3 + 3', () => {
+    const out = planCloseChunks(30000, 1);
+    expect(out.chunks).toEqual([9999, 9999, 9999, 3]);
+    expect(out.totalCovered).toBe(30000);
+  });
+
+  it('25000 contracts splits into 9999, 9999, 5002', () => {
+    const out = planCloseChunks(25000, 1);
+    expect(out.chunks).toEqual([9999, 9999, 5002]);
+    expect(out.totalCovered).toBe(25000);
+  });
+});
+
+describe('planCloseChunks — lot-size respect', () => {
+  it('lot=10: chunks rounded down to multiples of 10', () => {
+    const out = planCloseChunks(15000, 10);
+    expect(out.chunks).toEqual([9990, 5010]);
+    expect(out.totalCovered).toBe(15000);
+    expect(out.chunks.every((c) => c % 10 === 0)).toBe(true);
+  });
+
+  it('lot=100: 15050 → 9900 + 5100 (residual 50 stranded)', () => {
+    const out = planCloseChunks(15050, 100);
+    expect(out.chunks).toEqual([9900, 5100]);
+    expect(out.totalCovered).toBe(15000);
+    expect(out.residual).toBe(50);
+  });
+
+  it('lot=0 falls back to no rounding', () => {
+    const out = planCloseChunks(12345, 0);
+    expect(out.chunks).toEqual([9999, 2346]);
+    expect(out.totalCovered).toBe(12345);
+  });
+});
+
+describe('planCloseChunks — degenerate inputs', () => {
+  it('zero desired returns empty plan', () => {
+    const out = planCloseChunks(0, 1);
+    expect(out.chunks).toEqual([]);
+    expect(out.totalCovered).toBe(0);
+    expect(out.residual).toBe(0);
+  });
+
+  it('negative desired returns empty plan', () => {
+    const out = planCloseChunks(-100, 1);
+    expect(out.chunks).toEqual([]);
+    expect(out.totalCovered).toBe(0);
+  });
+
+  it('NaN/Infinity desired returns empty plan', () => {
+    expect(planCloseChunks(NaN, 1).chunks).toEqual([]);
+    expect(planCloseChunks(Infinity, 1).chunks).toEqual([]);
+  });
+
+  it('zero maxPerOrder marks everything residual', () => {
+    const out = planCloseChunks(5000, 1, 0);
+    expect(out.chunks).toEqual([]);
+    expect(out.residual).toBe(5000);
+  });
+});
+
+describe('planCloseChunks — live-tape scenario', () => {
+  it('reproduces the 2026-05-05 BTC stale_bleed case (size > 10000, lot=1)', () => {
+    // Position size that triggered code 21010 — anything > 10000 contracts.
+    // Verify we now produce a valid multi-chunk plan instead of a single
+    // oversized order.
+    const stuckSize = 12500;
+    const out = planCloseChunks(stuckSize, 1);
+    expect(out.chunks.length).toBeGreaterThan(1);
+    expect(out.chunks.every((c) => c <= MAX_CONTRACTS_PER_ORDER)).toBe(true);
+    expect(out.totalCovered).toBe(stuckSize);
+  });
+});

--- a/apps/api/src/services/monkey/closeChunker.ts
+++ b/apps/api/src/services/monkey/closeChunker.ts
@@ -1,0 +1,61 @@
+/**
+ * closeChunker.ts — split a position close into per-order-cap chunks.
+ *
+ * Poloniex v3 rejects single orders > 10,000 contracts with code 21010
+ * ("The size per order cannot exceed 10000 Conts."). Before this helper,
+ * any oversized position was permanently uncloseable by the kernel —
+ * scalp_exit / stale_bleed / harvest would all fire correctly but the
+ * close order itself was rejected, leaving the position stranded on
+ * the exchange.
+ *
+ * Live tape 2026-05-05 02:08-02:10: BTC stale_bleed retrying every tick
+ * with code 21010 rejection while position bled from -1.24% to -3.21% ROI.
+ *
+ * Pure function — no I/O, trivially testable.
+ */
+
+export const MAX_CONTRACTS_PER_ORDER = 9999;  // Conservative — Poloniex cap is 10000
+
+export interface ChunkPlan {
+  chunks: number[];
+  /** Sum of chunks (≤ desired). May be < desired if a residual smaller
+   *  than one lot couldn't be fit into a chunk; the reconciler handles
+   *  that residual via its standard ghost-close path. */
+  totalCovered: number;
+  /** Residual that couldn't be allocated (smaller than one lot). */
+  residual: number;
+}
+
+/**
+ * Plan how to split a close into chunks of ≤ ``maxPerOrder`` contracts.
+ * Each chunk is rounded DOWN to a multiple of ``lotSize`` so the exchange
+ * accepts every chunk.
+ *
+ * Returns an empty plan when ``desired <= 0`` or every chunk rounded to
+ * zero (e.g. lot > maxPerOrder is a misconfiguration the caller must
+ * surface).
+ */
+export function planCloseChunks(
+  desired: number,
+  lotSize: number,
+  maxPerOrder: number = MAX_CONTRACTS_PER_ORDER,
+): ChunkPlan {
+  if (!Number.isFinite(desired) || desired <= 0) {
+    return { chunks: [], totalCovered: 0, residual: 0 };
+  }
+  if (!Number.isFinite(maxPerOrder) || maxPerOrder <= 0) {
+    return { chunks: [], totalCovered: 0, residual: desired };
+  }
+  const lot = Number.isFinite(lotSize) && lotSize > 0 ? lotSize : 0;
+  const chunks: number[] = [];
+  let remaining = desired;
+  while (remaining > 0) {
+    const cap = Math.min(remaining, maxPerOrder);
+    const chunk = lot > 0 ? Math.floor(cap / lot) * lot : cap;
+    if (chunk <= 0) break;
+    chunks.push(chunk);
+    remaining -= chunk;
+  }
+  const totalCovered = chunks.reduce((s, v) => s + v, 0);
+  return { chunks, totalCovered, residual: Math.max(0, desired - totalCovered) };
+}

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -121,6 +121,7 @@ import {
 } from './executive.js';
 import { evaluateRejustification } from './held_position_rejustification.js';
 import { computeAgentHeadroom, clampSizeToHeadroom } from './agentEquityBound.js';
+import { planCloseChunks } from './closeChunker.js';
 
 /** Default Monkey watchlist — matches liveSignalEngine for side-by-side. */
 const DEFAULT_SYMBOLS = ['BTC_USDT_PERP', 'ETH_USDT_PERP'];
@@ -2501,6 +2502,22 @@ export class MonkeyKernel extends EventEmitter {
 
     const closeSide: 'buy' | 'sell' = heldSide === 'long' ? 'sell' : 'buy';
 
+    // Poloniex v3 rejects single orders > 10,000 contracts with code 21010.
+    // Live tape 2026-05-05 02:08: BTC stale_bleed retried every tick because
+    // the position had grown beyond the cap and the close was permanently
+    // rejected. planCloseChunks splits an oversized close into ≤ 9,999-contract
+    // chunks (lot-rounded). No-op when the close fits in a single order.
+    const plan = planCloseChunks(formattedSize, symbolLotSize);
+    const chunkSizes = plan.chunks;
+    if (plan.residual > 0) {
+      logger.warn('[Monkey] close chunk residual stranded (smaller than lot)', {
+        symbol, formattedSize, residual: plan.residual, lot: symbolLotSize,
+      });
+    }
+    if (chunkSizes.length === 0) {
+      return { executed: false, orderId: null, reason: 'chunk_planning_zero' };
+    }
+
     let orderId: string | null = null;
     try {
       // Proposal #10 — in HEDGE mode the close must specify which side
@@ -2516,16 +2533,32 @@ export class MonkeyKernel extends EventEmitter {
       const isHedge = this.positionDirectionMode === 'HEDGE';
       const closePosSide: 'LONG' | 'SHORT' | undefined =
         isHedge ? (heldSide === 'long' ? 'LONG' : 'SHORT') : undefined;
-      const exchangeOrder = await poloniexFuturesService.placeOrder(credentials, {
-        symbol, side: closeSide, type: 'market', size: formattedSize, lotSize: symbolLotSize,
-        reduceOnly: true,
-      }, {
-        positionMode: isHedge ? 'HEDGE' : 'ONE_WAY',
-        ...(closePosSide ? { posSide: closePosSide } : {}),
-      });
-      orderId =
-        exchangeOrder?.ordId ?? exchangeOrder?.orderId ??
-        exchangeOrder?.id ?? exchangeOrder?.clientOid ?? null;
+      const orderIds: string[] = [];
+      for (let i = 0; i < chunkSizes.length; i++) {
+        const chunkSize = chunkSizes[i]!;
+        const exchangeOrder = await poloniexFuturesService.placeOrder(credentials, {
+          symbol, side: closeSide, type: 'market', size: chunkSize, lotSize: symbolLotSize,
+          reduceOnly: true,
+        }, {
+          positionMode: isHedge ? 'HEDGE' : 'ONE_WAY',
+          ...(closePosSide ? { posSide: closePosSide } : {}),
+        });
+        const id =
+          exchangeOrder?.ordId ?? exchangeOrder?.orderId ??
+          exchangeOrder?.id ?? exchangeOrder?.clientOid ?? null;
+        if (id) orderIds.push(String(id));
+        if (chunkSizes.length > 1) {
+          logger.info('[Monkey] close chunk placed', {
+            symbol, chunk: i + 1, total: chunkSizes.length, size: chunkSize, orderId: id,
+          });
+        }
+      }
+      if (orderIds.length === 0) {
+        return { executed: false, orderId: null, reason: 'no_chunk_returned_orderId' };
+      }
+      // Audit: when chunks > 1, expose the full chain so the close row's
+      // exit_order_id reflects every leg. Single-order legacy keeps a single id.
+      orderId = orderIds.length === 1 ? orderIds[0]! : orderIds.join(',');
     } catch (err) {
       return {
         executed: false, orderId: null,


### PR DESCRIPTION
## Summary

Live tape 2026-05-05 02:08-02:10: BTC \`scalp_exit\` fired every tick with \`stale_bleed\` reason but the close order was **rejected by Poloniex** with code \`21010\`:

\`\`\`
[Monkey] BTC_USDT_PERP scalp_exit: stale_bleed: held 1815s ≥ 1800s at ROI -1.24% ≤ -1.00%
  | close: close_exchange_rejected: 
    Poloniex /v3/trade/order returned code=21010: 
    The size per order cannot exceed 10000 Conts.
\`\`\`

The held BTC position had grown beyond Poloniex's per-order cap. The kernel correctly identified the position as stale and tried to close it, but every attempt was rejected — leaving the position stranded while bleeding from -1.24% to -3.21% ROI over 6 ticks.

## Fix

\`closeHeldPosition\` now splits the close into ≤ 9,999-contract chunks (one below the exchange cap as safety margin). Each chunk is lot-rounded so the exchange accepts every leg. The chunker is a **no-op when the close fits in a single order** — preserves legacy behavior for the common case.

- new [closeChunker.ts](apps/api/src/services/monkey/closeChunker.ts) with \`planCloseChunks()\` pure helper
- \`closeHeldPosition\` wires \`planCloseChunks()\` before the place loop
- all chunks share lane / posSide / positionMode flags from the parent close
- orderIds aggregated and joined with \`,\` for audit when chunked (single-chunk legacy keeps a single id)
- residual smaller than one lot is logged (reconciler catches via standard ghost-close path)

## Why this matters

Without this fix, **any oversized position is permanently uncloseable by the kernel**. Same blast radius as the orphaned-FAT-shorts incident from earlier this session, but worse — the kernel KNOWS it should close and is repeatedly failing in a loop. The stale_bleed gate added in PR #633 became a liability rather than a safety net for these positions.

## Test plan

- [x] 15 new unit tests cover: single-chunk, exact-cap, oversized (15k, 25k, 30k), lot-respect, degenerate inputs (NaN/Infinity/zero/negative), live-tape repro
- [x] 373/375 full monkey sweep passing (2 pre-existing failures in \`resonance_bank_lane.test.ts\`, unrelated, baseline-equivalent to main)
- [x] TypeScript typecheck clean
- [ ] CI pipeline (type-check + Railway deploys)
- [ ] Production smoke: confirm BTC \`scalp_exit\` retries stop after deploy. Logs should show \`[Monkey] close chunk placed\` lines for any oversized close

## Affected paths

Mirrors any close path going through \`closeHeldPosition\`: K/M/T agents, scalp_exit, stale_bleed, harvest, regime_change, rejustification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle oversized position closes by chunking them into exchange-compliant orders to prevent uncloseable positions on Poloniex futures.

Bug Fixes:
- Prevent close orders larger than the Poloniex per-order contract cap from being repeatedly rejected, which previously left oversized positions stranded.

Enhancements:
- Introduce a reusable closeChunker helper that plans lot-rounded close chunks under a configurable per-order cap and integrates it into the Monkey kernel close path.
- Improve close auditing and observability by aggregating chunk order IDs and logging per-chunk placements and any residual smaller than one lot.

Tests:
- Add unit test coverage for the closeChunker planning logic across normal, boundary, oversized, and degenerate input scenarios.