### PR TITLE
fix(monkey): close chunker unit-mismatch (base asset vs contracts)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/closeChunker.test.ts
+++ b/apps/api/src/services/monkey/__tests__/closeChunker.test.ts
@@ -119,3 +119,47 @@ describe('planCloseChunks — live-tape scenario', () => {
     expect(out.totalCovered).toBe(stuckSize);
   });
 });
+
+describe('planCloseChunks — contracts-not-base-asset (2026-05-06 regression)', () => {
+  // 2026-05-06 incident: PR #639 chunker still hit code 21010. Root cause:
+  // Poloniex's cap is in CONTRACTS, but the kernel was passing BASE ASSET
+  // (BTC, ETH) into the chunker. Caller must convert size→contracts BEFORE
+  // calling planCloseChunks, then convert chunks back to base asset for
+  // placeOrder. These tests document the contract.
+
+  it('lot=1 means input is already in contracts (correct call site)', () => {
+    // Caller computes sizeInContracts = formattedSize / lotSize and passes
+    // lot=1 to chunker. 1.5 BTC at lotSize=0.0001 = 15000 contracts.
+    const out = planCloseChunks(15000, 1);
+    expect(out.chunks).toEqual([9999, 5001]);
+    expect(out.chunks.every((c) => c <= MAX_CONTRACTS_PER_ORDER)).toBe(true);
+  });
+
+  it('the previous miscall (lot=lotSize, size=base asset) does NOT chunk', () => {
+    // What the broken caller was doing: passing 1.5 BTC with lotSize=0.0001.
+    // The chunker sees desired=1.5 < maxPerOrder=9999, returns single chunk.
+    // After placeOrder converts: 1.5 / 0.0001 = 15000 contracts → 21010.
+    // This test documents the bug we just fixed; do NOT call the chunker
+    // this way.
+    const broken = planCloseChunks(1.5, 0.0001);
+    expect(broken.chunks).toEqual([1.5]);
+    // 1.5 base asset / 0.0001 lotSize = 15000 contracts — exceeds Poloniex cap.
+    const inContracts = broken.chunks[0]! / 0.0001;
+    expect(inContracts).toBeGreaterThan(10000);  // documents the failure mode
+  });
+
+  it('correct call site for the same 1.5 BTC position', () => {
+    // The right way: convert to contracts first, chunk, convert back.
+    const baseSize = 1.5;
+    const lotSize = 0.0001;
+    const contracts = Math.round(baseSize / lotSize);  // 15000
+    const out = planCloseChunks(contracts, 1);
+    expect(out.chunks).toEqual([9999, 5001]);
+    const baseAssetChunks = out.chunks.map((c) => c * lotSize);
+    // Each base-asset chunk converts back to ≤ 9999 contracts.
+    expect(baseAssetChunks.every((b) => b / lotSize <= MAX_CONTRACTS_PER_ORDER + 1e-9)).toBe(true);
+    // Sum equals original (within float precision).
+    const sumBase = baseAssetChunks.reduce((s, v) => s + v, 0);
+    expect(sumBase).toBeCloseTo(baseSize, 9);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2503,20 +2503,37 @@ export class MonkeyKernel extends EventEmitter {
     const closeSide: 'buy' | 'sell' = heldSide === 'long' ? 'sell' : 'buy';
 
     // Poloniex v3 rejects single orders > 10,000 contracts with code 21010.
-    // Live tape 2026-05-05 02:08: BTC stale_bleed retried every tick because
-    // the position had grown beyond the cap and the close was permanently
-    // rejected. planCloseChunks splits an oversized close into ≤ 9,999-contract
-    // chunks (lot-rounded). No-op when the close fits in a single order.
-    const plan = planCloseChunks(formattedSize, symbolLotSize);
-    const chunkSizes = plan.chunks;
+    // Live tape 2026-05-05 02:08 — and again 2026-05-06 00:20: BTC stale_bleed
+    // retried every tick because the position had grown beyond the cap and
+    // the close was permanently rejected.
+    //
+    // CRITICAL: Poloniex's 10,000 cap is in CONTRACTS, while ``formattedSize``
+    // and ``symbolLotSize`` are in BASE ASSET (BTC, ETH) units. The
+    // poloniexFuturesService.placeOrder converts ``size / lotSize → contracts``
+    // internally before sending. So the chunker must reason in CONTRACTS, not
+    // base asset — passing 1.5 BTC unchunked converts to 15,000 contracts and
+    // hits 21010 even though "1.5" is far below the 9,999 base-asset threshold.
+    //
+    // Chunk in contracts space (lot=1), then convert each chunk back to base
+    // asset for placeOrder by multiplying by symbolLotSize.
+    const sizeInContracts = symbolLotSize > 0
+      ? Math.round(formattedSize / symbolLotSize)
+      : Math.round(formattedSize);
+    const plan = planCloseChunks(sizeInContracts, 1);  // contracts, no lot rounding
+    const chunkContracts = plan.chunks;
     if (plan.residual > 0) {
-      logger.warn('[Monkey] close chunk residual stranded (smaller than lot)', {
-        symbol, formattedSize, residual: plan.residual, lot: symbolLotSize,
+      logger.warn('[Monkey] close chunk residual stranded', {
+        symbol, sizeInContracts, residual: plan.residual,
       });
     }
-    if (chunkSizes.length === 0) {
+    if (chunkContracts.length === 0) {
       return { executed: false, orderId: null, reason: 'chunk_planning_zero' };
     }
+    // Convert chunks back to base asset for placeOrder. lotSize=0 (legacy
+    // path) keeps base-asset == contracts, preserving prior behavior.
+    const chunkSizes = symbolLotSize > 0
+      ? chunkContracts.map((c) => c * symbolLotSize)
+      : chunkContracts;
 
     let orderId: string | null = null;
     try {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2516,14 +2516,31 @@ export class MonkeyKernel extends EventEmitter {
     //
     // Chunk in contracts space (lot=1), then convert each chunk back to base
     // asset for placeOrder by multiplying by symbolLotSize.
+    //
+    // Math.floor (not Math.round) for the conversion: if float precision
+    // noise pushes formattedSize/symbolLotSize slightly above the true
+    // integer (e.g., 15000.0000000001), rounding up would claim 15001
+    // contracts the exchange doesn't actually have on the position, and
+    // the reconciler's "exchange has positions not tracked in DB" branch
+    // would have to clean up. Flooring under-closes by ≤ 1 contract worst
+    // case — that residual is picked up by the reconciler's standard
+    // ghost-close path on the next tick.
     const sizeInContracts = symbolLotSize > 0
-      ? Math.round(formattedSize / symbolLotSize)
-      : Math.round(formattedSize);
+      ? Math.floor(formattedSize / symbolLotSize)
+      : Math.floor(formattedSize);
     const plan = planCloseChunks(sizeInContracts, 1);  // contracts, no lot rounding
     const chunkContracts = plan.chunks;
     if (plan.residual > 0) {
+      const residualBaseAsset = symbolLotSize > 0
+        ? plan.residual * symbolLotSize
+        : plan.residual;
       logger.warn('[Monkey] close chunk residual stranded', {
-        symbol, sizeInContracts, residual: plan.residual,
+        symbol,
+        formattedSize,                  // base-asset (input from lot-rounding)
+        symbolLotSize,
+        sizeInContracts,                // contracts (post-conversion)
+        residualContracts: plan.residual,
+        residualBaseAsset,              // ditto, in base-asset for quick eyeballing
       });
     }
     if (chunkContracts.length === 0) {


### PR DESCRIPTION
## Summary

PR #639 shipped a close-order chunker for Poloniex code 21010, but the bug **recurred 2026-05-06 00:20**: BTC \`stale_bleed\` retried for ~12 hours hitting 21010 every tick. ~5 stale BTC trend positions and 1 stuck swing position couldn't exit.

\`\`\`
[Monkey] BTC_USDT_PERP scalp_exit
  | reason: stale_bleed: held 42796s ≥ 1800s at ROI -4.06% ≤ -1.00%
  | close: close_exchange_rejected: code=21010
\`\`\`

## Root cause — unit mismatch

\`poloniexFuturesService.placeOrder\` accepts size in **base asset** (BTC, ETH) and converts internally: \`szContracts = round(size / lotSize)\`. But \`MAX_CONTRACTS_PER_ORDER = 9999\` was being applied to the base-asset value passed in.

For BTC at \`lotSize = 0.0001\`:
- \`9999\` base-asset units ≈ 9,999 BTC ≈ \$800M — never triggers chunking
- 1.5 BTC passed unchunked → placeOrder converts to 15,000 contracts → 21010

So the chunker was a **no-op for any realistic position size**.

## Fix

The chunker now reasons in **contracts space**, with caller-side conversion:

\`\`\`ts
const sizeInContracts = symbolLotSize > 0
  ? Math.round(formattedSize / symbolLotSize)
  : Math.round(formattedSize);
const plan = planCloseChunks(sizeInContracts, 1);  // lot=1 in contract space

// Convert chunks back to base asset for placeOrder
const chunkSizes = symbolLotSize > 0
  ? plan.chunks.map((c) => c * symbolLotSize)
  : plan.chunks;
\`\`\`

## Test plan

- [x] 18/18 \`closeChunker.test.ts\` passing — 3 new tests document the contract:
  - \`lot=1 means input is already in contracts\` (correct usage)
  - regression test for the broken call site (1.5 BTC + lot=0.0001 doesn't chunk)
  - end-to-end conversion test for the live BTC scenario
- [x] TypeScript typecheck clean
- [ ] CI pipeline (type-check + Railway deploys)
- [ ] Production smoke: confirm BTC \`scalp_exit\` retries stop after deploy. Expect \`[Monkey] close chunk placed { chunk: 1, total: 2, size: 0.9999 }\` etc. for chunked closes

## Live impact

Once deployed: ~5 stuck BTC trend + 1 swing positions held 7-12 hours should exit cleanly on the next stale_bleed tick. Bleed exposure is recoverable (positions at -4% to -5% ROI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust Poloniex close-order chunking to operate in contract units instead of base-asset size so oversized BTC futures positions are split below the exchange contract cap and no longer get permanently rejected.

Bug Fixes:
- Fix close-order chunking for Poloniex futures by converting base-asset position sizes to contracts before planning chunks, preventing repeated 21010 rejections for large BTC positions.

Tests:
- Add regression tests documenting correct contract-based usage of the close chunker and the previously broken base-asset call pattern, including an end-to-end test for the 1.5 BTC incident scenario.