### PR TITLE
feat(monkey): per-position contracts cap + manual user action recognition

### DIFF
--- a/apps/api/src/services/monkey/__tests__/positionContractsBound.test.ts
+++ b/apps/api/src/services/monkey/__tests__/positionContractsBound.test.ts
@@ -1,0 +1,111 @@
+/**
+ * positionContractsBound.test.ts — pure-helper tests for the per-position
+ * contracts cap that prevents 21010-class oversized-position bugs at the
+ * source rather than via the chunker downstream.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_CONTRACTS_PER_POSITION_DEFAULT,
+  getMaxContractsPerPosition,
+  headroomContracts,
+  clampNewContractsToCap,
+} from '../positionContractsBound.js';
+
+describe('MAX_CONTRACTS_PER_POSITION_DEFAULT', () => {
+  it('is 8000 (2000-contract buffer below Poloniex 10000 cap)', () => {
+    expect(MAX_CONTRACTS_PER_POSITION_DEFAULT).toBe(8000);
+  });
+});
+
+describe('getMaxContractsPerPosition', () => {
+  it('returns default when env var is unset', () => {
+    delete process.env.MONKEY_MAX_CONTRACTS_PER_POSITION;
+    expect(getMaxContractsPerPosition()).toBe(8000);
+  });
+
+  it('honors env var override', () => {
+    process.env.MONKEY_MAX_CONTRACTS_PER_POSITION = '5000';
+    expect(getMaxContractsPerPosition()).toBe(5000);
+    delete process.env.MONKEY_MAX_CONTRACTS_PER_POSITION;
+  });
+
+  it('falls back to default on non-numeric env', () => {
+    process.env.MONKEY_MAX_CONTRACTS_PER_POSITION = 'abc';
+    expect(getMaxContractsPerPosition()).toBe(8000);
+    delete process.env.MONKEY_MAX_CONTRACTS_PER_POSITION;
+  });
+});
+
+describe('headroomContracts', () => {
+  it('returns full cap when no contracts are open', () => {
+    expect(headroomContracts(0, 8000)).toBe(8000);
+  });
+
+  it('returns difference when within cap', () => {
+    expect(headroomContracts(3000, 8000)).toBe(5000);
+  });
+
+  it('returns zero at cap', () => {
+    expect(headroomContracts(8000, 8000)).toBe(0);
+  });
+
+  it('floors at zero when over cap (does not return negative)', () => {
+    expect(headroomContracts(12000, 8000)).toBe(0);
+  });
+
+  it('returns full cap on negative current (defensive)', () => {
+    expect(headroomContracts(-100, 8000)).toBe(8000);
+  });
+
+  it('returns zero on degenerate cap', () => {
+    expect(headroomContracts(0, 0)).toBe(0);
+    expect(headroomContracts(0, NaN)).toBe(0);
+    expect(headroomContracts(0, -10)).toBe(0);
+  });
+});
+
+describe('clampNewContractsToCap', () => {
+  it('returns desired when fully within headroom', () => {
+    expect(clampNewContractsToCap(2000, 3000, 8000)).toBe(2000);
+  });
+
+  it('clamps to headroom when desired exceeds it', () => {
+    expect(clampNewContractsToCap(6000, 5000, 8000)).toBe(3000);
+  });
+
+  it('returns zero when at cap', () => {
+    expect(clampNewContractsToCap(2000, 8000, 8000)).toBe(0);
+  });
+
+  it('returns zero when over cap', () => {
+    expect(clampNewContractsToCap(2000, 12000, 8000)).toBe(0);
+  });
+
+  it('returns zero on degenerate desired', () => {
+    expect(clampNewContractsToCap(0, 0, 8000)).toBe(0);
+    expect(clampNewContractsToCap(-100, 0, 8000)).toBe(0);
+    expect(clampNewContractsToCap(NaN, 0, 8000)).toBe(0);
+  });
+});
+
+describe('positionContractsBound — live-tape scenario', () => {
+  it('reproduces the 2026-05-06 BTC stale_bleed prevention case', () => {
+    // 12 BTC trend rows had cumulative quantity > 10,000 contracts.
+    // With the cap at 8,000, the 9th pyramid unit would have been clamped
+    // before crossing — closeChunker stays as the safety net for edge
+    // cases (manual entries, hot reloads), but normal operation never
+    // produces a position the kernel can't close in one order.
+    const currentContracts = 7900;
+    const desiredAdd = 1500;
+    const clamped = clampNewContractsToCap(desiredAdd, currentContracts, 8000);
+    expect(clamped).toBe(100);  // exactly the headroom remaining
+    expect(currentContracts + clamped).toBe(8000);
+  });
+
+  it('full-cap rejection — no entry placed when at-cap', () => {
+    const currentContracts = 8000;
+    const desiredAdd = 500;
+    const clamped = clampNewContractsToCap(desiredAdd, currentContracts, 8000);
+    expect(clamped).toBe(0);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -122,6 +122,10 @@ import {
 import { evaluateRejustification } from './held_position_rejustification.js';
 import { computeAgentHeadroom, clampSizeToHeadroom } from './agentEquityBound.js';
 import { planCloseChunks } from './closeChunker.js';
+import {
+  clampNewContractsToCap,
+  getMaxContractsPerPosition,
+} from './positionContractsBound.js';
 
 /** Default Monkey watchlist — matches liveSignalEngine for side-by-side. */
 const DEFAULT_SYMBOLS = ['BTC_USDT_PERP', 'ETH_USDT_PERP'];
@@ -2365,6 +2369,57 @@ export class MonkeyKernel extends EventEmitter {
   }
 
   /**
+   * Sum of currently-open contracts for a given (agent, symbol, side, lane).
+   * Quantities in autonomous_trades are stored in BASE ASSET units; this
+   * helper converts to contracts by dividing by lotSize before summing,
+   * matching the exchange's per-order cap units.
+   *
+   * Used by the per-position contracts cap (#11): the kernel checks
+   * cumulative open contracts against MAX_CONTRACTS_PER_POSITION before
+   * letting any agent stack a fresh entry that would push the cumulative
+   * position past the exchange's 10,000-contract per-order limit.
+   *
+   * Fail-soft returns 0 — the closeChunker remains as the downstream
+   * safety net if this query fails.
+   */
+  private async sumOpenContractsForPosition(
+    symbol: string,
+    agent: 'K' | 'M' | 'T',
+    side: 'long' | 'short',
+    lane: 'scalp' | 'swing' | 'trend',
+    lotSize: number,
+  ): Promise<number> {
+    if (!Number.isFinite(lotSize) || lotSize <= 0) return 0;
+    try {
+      const reasonPattern = `monkey|kernel=${this.instanceId}|%`;
+      // DB stores 'buy'|'sell' historically AND 'long'|'short' on newer
+      // rows — match either to be safe.
+      const sideAlternates =
+        side === 'long' ? ['buy', 'long'] : ['sell', 'short'];
+      const result = await pool.query(
+        `SELECT COALESCE(SUM(ABS(quantity)), 0) AS sum_qty
+           FROM autonomous_trades
+          WHERE status = 'open'
+            AND symbol = $1
+            AND agent = $2
+            AND lane = $3
+            AND side = ANY($4)
+            AND reason LIKE $5`,
+        [symbol, agent, lane, sideAlternates, reasonPattern],
+      );
+      const row = result.rows[0] as { sum_qty: string | number } | undefined;
+      const sumBaseAsset = Number(row?.sum_qty ?? 0);
+      // Convert base-asset quantity to contracts.
+      return Math.floor(sumBaseAsset / lotSize);
+    } catch (err) {
+      logger.debug('[Monkey] sumOpenContractsForPosition failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return 0;
+    }
+  }
+
+  /**
    * Sum of currently-open margin (USDT) for a given agent on a symbol.
    * Margin = quantity × entry_price ÷ leverage (legacy rows without
    * leverage fall back to notional).
@@ -2812,6 +2867,52 @@ export class MonkeyKernel extends EventEmitter {
         executed: false, orderId: null,
         reason: `post_round_below_min_notional: ${(formattedSize * entryPrice).toFixed(2)} < ${minNotional.toFixed(2)}`,
       };
+    }
+
+    // Per-position contracts cap (#11) — keep cumulative open contracts
+    // for (agent, symbol, side, lane) below MAX_CONTRACTS_PER_POSITION
+    // (default 8000, with 2000-contract buffer below Poloniex's 10000
+    // per-order rejection threshold). When already-open contracts plus
+    // this new entry's contracts would exceed the cap, clamp the new
+    // entry; if no headroom, suppress the entry entirely. Independent
+    // per-agent — K, M, T each get their own envelope.
+    if (symbolLotSize > 0) {
+      const effectiveAgent = (req.agent ?? 'K') as 'K' | 'M' | 'T';
+      const effectiveLane = (req.lane ?? 'swing') as 'scalp' | 'swing' | 'trend';
+      const newContracts = Math.floor(formattedSize / symbolLotSize);
+      const currentContracts = await this.sumOpenContractsForPosition(
+        symbol, effectiveAgent, side, effectiveLane, symbolLotSize,
+      );
+      const cap = getMaxContractsPerPosition();
+      const clampedNewContracts = clampNewContractsToCap(
+        newContracts, currentContracts, cap,
+      );
+      if (clampedNewContracts === 0) {
+        logger.info('[Monkey] entry suppressed by contracts cap', {
+          symbol, agent: effectiveAgent, side, lane: effectiveLane,
+          currentContracts, attemptedNew: newContracts, cap,
+        });
+        return {
+          executed: false, orderId: null,
+          reason: `at_position_contracts_cap: open=${currentContracts} desired=${newContracts} cap=${cap}`,
+        };
+      }
+      if (clampedNewContracts < newContracts) {
+        logger.info('[Monkey] entry clamped by contracts cap', {
+          symbol, agent: effectiveAgent, side, lane: effectiveLane,
+          currentContracts, requested: newContracts,
+          granted: clampedNewContracts, cap,
+        });
+        formattedSize = clampedNewContracts * symbolLotSize;
+        // Re-check min notional with the clamped size; the cap may push
+        // a small entry below the exchange minimum.
+        if (formattedSize * entryPrice < minNotional) {
+          return {
+            executed: false, orderId: null,
+            reason: `cap_clamp_below_min_notional: ${(formattedSize * entryPrice).toFixed(2)} < ${minNotional.toFixed(2)} (cap headroom too small)`,
+          };
+        }
+      }
     }
 
     // Proposal #10 — when the live account is in HEDGE position-direction

--- a/apps/api/src/services/monkey/positionContractsBound.ts
+++ b/apps/api/src/services/monkey/positionContractsBound.ts
@@ -1,0 +1,72 @@
+/**
+ * positionContractsBound.ts — per-(agent, symbol, lane) hard cap on
+ * cumulative open contracts.
+ *
+ * Why this exists:
+ *
+ * Poloniex v3 rejects single orders > 10,000 contracts with code 21010.
+ * The closeChunker (closeChunker.ts) splits an oversized close into chunks
+ * — necessary defense, but it treats the symptom. The disease is the
+ * kernel letting positions grow that large in the first place. Live tape
+ * 2026-05-06 02:08-12hr: Agent T (Turtle pyramid on Donchian breakouts)
+ * accumulated 9 BTC swing/trend rows over 12 hours, cumulative quantity
+ * far exceeded 10,000 contracts. Stale_bleed correctly fired but every
+ * close was rejected. User had to manually flatten on Poloniex UI.
+ *
+ * The cap below is set well under the exchange limit (8,000 vs 10,000)
+ * so the kernel always retains headroom for partial closes / chunked
+ * exits. It bounds CUMULATIVE quantity per (agent, symbol, lane),
+ * not per-order — so DCA adds, T pyramids, and consecutive M entries
+ * all funnel into the same envelope.
+ *
+ * Independence preserved: K, M, T each get their own cap (the cap is
+ * scoped per agent label). One agent maxing out doesn't suppress the
+ * others. Mirrors the agentEquityBound discipline (PR #636).
+ */
+
+/**
+ * Default ceiling. 8,000 contracts at BTC's 0.0001 lot size = 0.8 BTC
+ * (~ \$80k notional at typical prices); at ETH's 0.01 lot = 80 ETH
+ * (~ \$200k). These are large but within typical Poloniex retail
+ * tolerances. The 2,000-contract buffer below the exchange's 10,000
+ * cap leaves room for one-shot full closes (no chunking needed).
+ */
+export const MAX_CONTRACTS_PER_POSITION_DEFAULT = 8000;
+
+/** Env override: set ``MONKEY_MAX_CONTRACTS_PER_POSITION`` to tune. */
+export function getMaxContractsPerPosition(): number {
+  const raw = Number(process.env.MONKEY_MAX_CONTRACTS_PER_POSITION);
+  if (Number.isFinite(raw) && raw > 0) return raw;
+  return MAX_CONTRACTS_PER_POSITION_DEFAULT;
+}
+
+/**
+ * Compute the maximum new contracts that can be added without exceeding
+ * the per-position cap. Returns 0 when the position is already at-cap.
+ *
+ * Pure function — caller queries the DB for ``currentContracts``, then
+ * uses this to decide whether to clamp or skip the entry.
+ */
+export function headroomContracts(
+  currentContracts: number,
+  maxCap: number,
+): number {
+  if (!Number.isFinite(currentContracts) || currentContracts < 0) return maxCap;
+  if (!Number.isFinite(maxCap) || maxCap <= 0) return 0;
+  return Math.max(0, maxCap - currentContracts);
+}
+
+/**
+ * Clamp a desired new entry's contracts to the available headroom.
+ * Returns 0 when the headroom is exhausted (caller should suppress
+ * the entry rather than place a 0-contract order).
+ */
+export function clampNewContractsToCap(
+  desiredContracts: number,
+  currentContracts: number,
+  maxCap: number,
+): number {
+  if (!Number.isFinite(desiredContracts) || desiredContracts <= 0) return 0;
+  const headroom = headroomContracts(currentContracts, maxCap);
+  return Math.min(desiredContracts, headroom);
+}

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -170,25 +170,53 @@ class StateReconciliationService {
           };
           result.orphans.push(orphan);
 
-          // Insert reconciled record into autonomous_trades
+          // Insert reconciled record into autonomous_trades, tagged as
+          // user-originated (agent='USER', lane='manual'). This lets the
+          // kernel's own queries — which filter by reason LIKE 'monkey|%' —
+          // continue to ignore manual positions, while dashboards and PnL
+          // accounting can identify them as user-placed. The reason field
+          // also embeds the source so historic queries can distinguish
+          // user opens from system retries.
           try {
+            const userReason = `manual_open_user|exchange_pid=${
+              exPos.positionId ?? exPos.id ?? 'na'
+            }|src=reconciler`;
             await pool.query(
               `INSERT INTO autonomous_trades
-               (user_id, symbol, side, entry_price, quantity, reason, status, engine_version)
-               VALUES ($1, $2, $3, $4, $5, $6, 'open', $7)`,
+               (user_id, symbol, side, entry_price, quantity, reason, status,
+                engine_version, agent, lane)
+               VALUES ($1, $2, $3, $4, $5, $6, 'open', $7, 'USER', 'manual')`,
               [
                 userId,
                 symbol,
                 side,
                 entryPrice,
                 size,
-                'reconciled',
+                userReason,
                 getEngineVersion(),
               ]
             );
             logger.info(
-              `[RECONCILE] Inserted orphaned position for user ${userId}: ${symbol} ${side}`
+              `[RECONCILE] Tracked user-opened position for user ${userId}: ${symbol} ${side} qty=${size} @${entryPrice}`
             );
+            // Emit an agent_events row so the audit trail captures the
+            // user action explicitly. metadata column was added in
+            // migration 044 (2026-05-02 incident).
+            await pool.query(
+              `INSERT INTO agent_events
+                 (user_id, event_type, execution_mode, description, market, metadata, created_at)
+               VALUES ($1, 'manual_position_detected', 'auto', $2, $3, $4, NOW())`,
+              [
+                userId,
+                `User-opened ${symbol} ${side} qty=${size} @${entryPrice} detected and tracked by reconciler`,
+                symbol,
+                JSON.stringify({
+                  source: 'reconciler',
+                  side, size, entryPrice,
+                  exchange_position_id: exPos.positionId ?? exPos.id ?? null,
+                }),
+              ]
+            ).catch(() => { /* fail-soft; main insert above is the source of truth */ });
           } catch (insertErr) {
             logger.error(
               `[RECONCILE] Failed to insert orphaned position for user ${userId}:`,
@@ -217,18 +245,52 @@ class StateReconciliationService {
           };
           result.ghosts.push(ghost);
 
-          // Close the ghost record
+          // Close the ghost record. Classification heuristic:
+          //   - If exit_order_id is set, our system tried to close (close
+          //     went through after the row was queried but before this
+          //     reconcile, OR a partial close came through). Tag as
+          //     'reconciled_post_close_race' for audit clarity.
+          //   - If exit_order_id is NULL and the DB row was kernel-issued
+          //     (reason LIKE 'monkey|%' or 'live_signal|%'): the user
+          //     likely closed the position manually on Poloniex UI. Tag
+          //     as 'manual_close_user' so audit trails distinguish user
+          //     interventions from infra issues.
+          //   - Otherwise (orphan/legacy/unknown): keep the original
+          //     'reconciled_not_on_exchange' tag for back-compat.
+          let ghostReason = 'reconciled_not_on_exchange';
+          try {
+            const ctxRow = await pool.query(
+              `SELECT exit_order_id, reason FROM autonomous_trades WHERE id = $1`,
+              [dbTrade.id]
+            );
+            const ctx = ctxRow.rows[0] as
+              | { exit_order_id: string | null; reason: string | null }
+              | undefined;
+            if (ctx?.exit_order_id) {
+              ghostReason = 'reconciled_post_close_race';
+            } else if (
+              ctx?.reason && (
+                ctx.reason.startsWith('monkey|') ||
+                ctx.reason.startsWith('live_signal|') ||
+                ctx.reason.startsWith('autoTrader|')
+              )
+            ) {
+              ghostReason = 'manual_close_user';
+            }
+          } catch {
+            /* fail-soft: keep generic reason */
+          }
           try {
             await pool.query(
               `UPDATE autonomous_trades
                SET status = 'closed',
-                   exit_reason = 'reconciled_not_on_exchange',
+                   exit_reason = $1,
                    exit_time = NOW()
-               WHERE id = $1`,
-              [dbTrade.id]
+               WHERE id = $2`,
+              [ghostReason, dbTrade.id]
             );
             logger.info(
-              `[RECONCILE] Closed ghost DB record ${dbTrade.id} for user ${userId}: ${dbTrade.symbol} ${dbTrade.side}`
+              `[RECONCILE] Closed ghost DB record ${dbTrade.id} for user ${userId}: ${dbTrade.symbol} ${dbTrade.side} (reason=${ghostReason})`
             );
           } catch (updateErr) {
             logger.error(


### PR DESCRIPTION
## Summary

Two related changes following the 2026-05-06 incident where Agent T pyramided BTC trend positions until cumulative contracts exceeded Poloniex's 10,000-per-order threshold (code 21010), and stale_bleed couldn't close them. You had to manually flatten on the UI.

## Part 1 — Per-position contracts cap (prevent the 21010 root cause)

The closeChunker (PR #639/#640) treats the **symptom**. This treats the **disease** — bounds cumulative contracts per `(agent, symbol, side, lane)` so the kernel never opens a position the exchange can't close in one shot.

- new [positionContractsBound.ts](apps/api/src/services/monkey/positionContractsBound.ts):
  - \`MAX_CONTRACTS_PER_POSITION_DEFAULT = 8000\` (2000-contract buffer below the 10000 exchange cap)
  - \`getMaxContractsPerPosition()\` — env-overridable via \`MONKEY_MAX_CONTRACTS_PER_POSITION\`
  - \`headroomContracts(current, cap)\`, \`clampNewContractsToCap(desired, current, cap)\`
- new \`sumOpenContractsForPosition\` DB method on \`MonkeyKernel\`: \`SUM(quantity)/lotSize\` for open rows matching \`(agent, symbol, side, lane)\`
- \`executeEntry\` now clamps new entry contracts to headroom or suppresses if at-cap; surfaces reason as \`at_position_contracts_cap: open=X desired=Y cap=Z\`

**Independence preserved**: K, M, T each get their own envelope. Mirrors the per-agent equity bound (PR #636).

## Part 2 — Manual user action recognition

Until now, when you manually open or close a position on Poloniex UI, the reconciler only LOGGED (orphan) or generically tagged (\`reconciled_not_on_exchange\`) the event. Now the system recognizes your actions explicitly and updates DB accordingly.

### Orphan detection (you opened a position on UI):
- INSERT \`autonomous_trades\` row with \`agent='USER'\`, \`lane='manual'\`, \`reason='manual_open_user|exchange_pid=X|src=reconciler'\`
- INSERT \`agent_events\` row \`event_type='manual_position_detected'\` with metadata JSONB capturing side/size/entry/exchange_pid

The kernel's filters (\`reason LIKE 'monkey|kernel=%'\`) continue to exclude USER rows so manual positions ride independently — the kernel won't try to manage them.

### Ghost detection (you closed a system-placed position on UI):
Classification heuristic:
| condition | new exit_reason |
|---|---|
| \`exit_order_id\` NULL + reason from kernel/livesignal/autoTrader | **\`manual_close_user\`** (you closed our position) |
| \`exit_order_id\` present | \`reconciled_post_close_race\` (close raced past reconcile) |
| default | \`reconciled_not_on_exchange\` (back-compat) |

## Why this composition

Cap + recognition compose into a clean operational story:
1. Cap prevents kernel-originated 21010 fail-loops at the source
2. Chunker (PR #639/#640) catches edge cases that bypass the cap
3. Reconciler explicitly attributes user actions when they happen
4. Audit trail (\`agent_events.metadata\`) makes user/system attribution queryable for retrospectives

## Test plan

- [x] 17 new unit tests on positionContractsBound (boundary, env override, live-tape repro)
- [x] 393/395 full monkey sweep passing (2 pre-existing in \`resonance_bank_lane.test.ts\`)
- [x] TypeScript typecheck clean
- [ ] CI pipeline (type-check + Railway deploys)
- [ ] Production smoke: confirm \`[Monkey] entry suppressed/clamped by contracts cap\` appears when positions approach 8000-contract envelope; confirm \`exit_reason='manual_close_user'\` when you close a system position on UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)