### PR TITLE
fix(db): add 'manual' to autonomous_trades.lane constraint (unblock reconciler)

### DIFF
--- a/apps/api/database/migrations/045_lane_manual.sql
+++ b/apps/api/database/migrations/045_lane_manual.sql
@@ -1,0 +1,29 @@
+-- 045_lane_manual.sql
+--
+-- Add 'manual' to the autonomous_trades.lane CHECK constraint so the
+-- reconciler can INSERT user-originated positions (PR #641 manual user
+-- action recognition). The constraint previously enforced
+-- lane ∈ {scalp, swing, trend} which silently rejected the
+-- reconciler's lane='manual' inserts inside its try/catch — the orphan
+-- "Exchange has positions not tracked in DB" warning persisted every
+-- 60s on prod 2026-05-06 07:51 onward despite the new code being live.
+--
+-- 'manual' is reserved for the agent='USER' rows the reconciler emits
+-- when it detects an exchange position with no matching DB row (user
+-- opened on Poloniex UI). The kernel's own lane logic (scalp/swing/
+-- trend chooseLane + budgetFrac envelope) only operates on the three
+-- canonical lanes; manual rows are visible for accounting and audit
+-- but the kernel ignores them via reason LIKE 'monkey|kernel=%'.
+--
+-- Live fix already applied 2026-05-06 to prod via railway run. This
+-- migration codifies the change for fresh deploys.
+--
+-- Idempotent — drops and re-adds the constraint with the wider check.
+
+BEGIN;
+
+ALTER TABLE autonomous_trades DROP CONSTRAINT IF EXISTS autonomous_trades_lane_check;
+ALTER TABLE autonomous_trades ADD CONSTRAINT autonomous_trades_lane_check
+  CHECK (lane = ANY (ARRAY['scalp'::text, 'swing'::text, 'trend'::text, 'manual'::text]));
+
+COMMIT;


### PR DESCRIPTION
## Summary

PR #641 added orphan auto-tracking with \`lane='manual'\` / \`agent='USER'\` rows, but the \`autonomous_trades.lane\` CHECK constraint still enforced \`lane ∈ {scalp, swing, trend}\`. The reconciler INSERT failed silently inside its try/catch every 60 seconds — the "Exchange has positions not tracked in DB" warning persisted with no rows actually being inserted, defeating the whole point of the user-action recognition.

## Diagnosis evidence

Production logs after PR #641 deploy (2026-05-06 07:51-07:55):
\`\`\`
[RECONCILE] Exchange has positions not tracked in DB: BTC_USDT_PERP — 
  these may have been opened manually or by another system
\`\`\`
Repeating every minute.

DB constraint check confirmed:
\`\`\`sql
\\d autonomous_trades
"autonomous_trades_lane_check" CHECK (lane = ANY (ARRAY['scalp'::text, 'swing'::text, 'trend'::text]))
\`\`\`

DB query for new rows:
\`\`\`sql
SELECT * FROM autonomous_trades WHERE agent = 'USER' OR lane = 'manual';
(0 rows)
\`\`\`

So the new code is live, but every INSERT silently fails on the constraint.

## Fix

Live fix already applied to prod via \`railway run\`:
\`\`\`sql
ALTER TABLE autonomous_trades DROP CONSTRAINT autonomous_trades_lane_check;
ALTER TABLE autonomous_trades ADD CONSTRAINT autonomous_trades_lane_check
  CHECK (lane = ANY (ARRAY['scalp', 'swing', 'trend', 'manual']));
\`\`\`

This PR commits the same change as migration \`045_lane_manual.sql\` for fresh deploys / other environments.

## Architectural note

\`manual\` is reserved for the \`agent='USER'\` rows the reconciler emits when it detects an exchange position with no matching DB row (user opened on Poloniex UI). The kernel's own lane logic (\`chooseLane\` + \`LANE_PARAMETER_DEFAULTS\` budgetFrac envelope) only operates on the three canonical lanes; manual rows are visible for accounting and audit but the kernel ignores them via \`reason LIKE 'monkey|kernel=%'\`.

## Test plan

- [x] Live constraint update verified via \`pg_get_constraintdef\`
- [ ] CI pipeline (type-check + Railway deploys + migrate workflow)
- [ ] Production smoke: confirm orphan warning stops within 60s of deploy; \`agent='USER'\` row appears in autonomous_trades; \`agent_events\` row \`event_type='manual_position_detected'\` written

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update database schema to allow reconciler to insert manually opened positions into autonomous_trades.

Bug Fixes:
- Adjust autonomous_trades.lane CHECK constraint to include the 'manual' lane, preventing reconciler inserts from failing on constraint violation.

Enhancements:
- Add idempotent migration 045_lane_manual.sql to codify the updated lane constraint across all environments.