### PR TITLE
fix(db): flip autonomous_trades.paper_trade default to FALSE

### DIFF
--- a/apps/api/database/migrations/046_paper_trade_default_false.sql
+++ b/apps/api/database/migrations/046_paper_trade_default_false.sql
@@ -1,0 +1,28 @@
+-- 046_paper_trade_default_false.sql
+--
+-- Flip the autonomous_trades.paper_trade column default from TRUE to
+-- FALSE. The pre-existing default was a holdover from when paper trading
+-- was the system's primary execution mode; with live trading now the
+-- norm, defaulting any column-omitted INSERT to TRUE meant real
+-- positions could quietly be flagged paper and excluded from FAT's
+-- reconciler (which filters paper_trade = false) and from PnL accounting.
+--
+-- 2026-05-06 incident: stateReconciliationService's old orphan INSERT
+-- (lines pre-PR #641) omitted paper_trade — the schema default landed
+-- TRUE on real exchange positions tracked by the reconciler. FAT's
+-- internal reconciler then re-detected those as orphans every 60s
+-- because its dbSymbols query filters paper_trade = false. The warning
+-- spam cleared 2026-05-06 only after manual UPDATE of the mis-flagged
+-- rows. This migration removes the default trap so future omitted-column
+-- INSERTs land paper_trade=false (the safer default for a live system).
+--
+-- All current writers (monkey/loop.ts, liveSignalEngine.ts,
+-- fullyAutonomousTrader.ts) explicitly set paper_trade so behavior is
+-- unchanged for them. New writers (or hot-fixes that omit the column)
+-- will see the safer default.
+
+BEGIN;
+
+ALTER TABLE autonomous_trades ALTER COLUMN paper_trade SET DEFAULT false;
+
+COMMIT;


### PR DESCRIPTION
## Summary

The \`paper_trade\` column on \`autonomous_trades\` defaulted to TRUE — a holdover from when the system was paper-first. Real-trading became the norm, but the default trap meant any column-omitted INSERT silently created a paper-flagged row.

## Diagnosis evidence

2026-05-06 incident: \`stateReconciliationService\`'s pre-PR #641 orphan INSERT omitted \`paper_trade\`, so the schema default landed TRUE on real exchange positions tracked via \`reason='reconciled'\`. FAT's internal reconciler then re-detected these as orphans every 60s because its \`dbSymbols\` query filters \`paper_trade=false\`, excluding the wrongly-flagged tracking rows.

Two real positions sat with \`paper_trade=true\` for hours:

| id | symbol | side | held | reason |
|---|---|---|---|---|
| bf3b5c60 | BTC_USDT_PERP | long | 442 min | reconciled |
| e7f9300a | ETH_USDT_PERP | long | 888 min | reconciled |

Live-fixed via \`UPDATE\` 2026-05-06. This migration prevents recurrence.

## Fix

\`\`\`sql
ALTER TABLE autonomous_trades ALTER COLUMN paper_trade SET DEFAULT false;
\`\`\`

Already applied to prod via \`railway run\` for immediate effect. This PR codifies the change in \`046_paper_trade_default_false.sql\` for fresh deploys / other environments.

## Why this is safe

All current writers explicitly set \`paper_trade\`:
- \`monkey/loop.ts\`: hardcoded \`false\` (line 2988)
- \`liveSignalEngine.ts\`: hardcoded \`false\` (line 1336)
- \`fullyAutonomousTrader.ts\`: \`config.paperTrading\` (line 1119, 1146)
- New PR #641 reconciler INSERT (post-merge): not yet deployed; explicit values planned

Behavior is bit-identical for them. Only column-omitted INSERTs (which were the bug surface) get the new safer default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update database schema to change the default value of autonomous_trades.paper_trade to better align with live trading as the primary mode.

Bug Fixes:
- Prevent real trading positions from being silently marked as paper trades when paper_trade is omitted in INSERTs by setting a safer default of false.

Enhancements:
- Add a migration script to codify the new paper_trade default for autonomous_trades across all environments.