### PR TITLE
fix(reconciler): widen manual_close_user classification (legacy 'reconciled' rows)

### DIFF
--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -260,19 +260,33 @@ class StateReconciliationService {
           let ghostReason = 'reconciled_not_on_exchange';
           try {
             const ctxRow = await pool.query(
-              `SELECT exit_order_id, reason FROM autonomous_trades WHERE id = $1`,
+              `SELECT exit_order_id, reason, agent FROM autonomous_trades WHERE id = $1`,
               [dbTrade.id]
             );
             const ctx = ctxRow.rows[0] as
-              | { exit_order_id: string | null; reason: string | null }
+              | { exit_order_id: string | null; reason: string | null; agent: string | null }
               | undefined;
             if (ctx?.exit_order_id) {
               ghostReason = 'reconciled_post_close_race';
             } else if (
-              ctx?.reason && (
-                ctx.reason.startsWith('monkey|') ||
-                ctx.reason.startsWith('live_signal|') ||
-                ctx.reason.startsWith('autoTrader|')
+              // Any of these signal a kernel/user-tracked row whose
+              // disappearance from the exchange means the user closed
+              // it manually (or some out-of-band actor did):
+              //   - kernel/livesignal/autotrader-issued rows (reason
+              //     prefixes monkey|, live_signal|, autoTrader|)
+              //   - reconciler-inserted user-tracking rows (reason
+              //     'reconciled' from pre-PR #641 code, or
+              //     'manual_open_user|...' from post-#641 code, or
+              //     agent='USER' for any reason format)
+              (
+                ctx?.agent === 'USER' ||
+                (ctx?.reason && (
+                  ctx.reason.startsWith('monkey|') ||
+                  ctx.reason.startsWith('live_signal|') ||
+                  ctx.reason.startsWith('autoTrader|') ||
+                  ctx.reason.startsWith('manual_open_user') ||
+                  ctx.reason === 'reconciled'
+                ))
               )
             ) {
               ghostReason = 'manual_close_user';


### PR DESCRIPTION
## Summary

Live tape 2026-05-06 08:34: when user manually closed positions on UI, two ghost-closed rows got tagged \`reconciled_not_on_exchange\` (the generic fallback) instead of \`manual_close_user\`. These rows had \`reason='reconciled'\` (legacy reconciler INSERTs from pre-PR #641 code) which the original heuristic didn't recognize as user-tracked.

## Fix

Widen the classification to include:
- \`agent='USER'\` rows — PR #641's new user-tracking format
- \`reason='reconciled'\` — legacy reconciler tracking inserts (pre-PR #641)
- \`reason LIKE 'manual_open_user|%'\` — PR #641's new tracking reason format

All three represent positions the kernel didn't directly issue but was tracking. If they disappear from the exchange without our \`exit_order_id\` being set, the user closed them on UI.

## Why this matters

The classification is operational signal:
- \`manual_close_user\` → "you intervened on UI" — counts toward user-action retrospectives
- \`reconciled_post_close_race\` → "our close raced past the reconcile" — infra timing artifact
- \`reconciled_not_on_exchange\` → genuinely unknown — funding-induced auto-close, exchange-side liquidation, or bug

Without this fix, every user manual close on a tracked-position would mis-attribute as the third category, polluting retrospective queries.

## Test plan

- [x] TypeScript typecheck clean
- [ ] CI pipeline (type-check + Railway deploys)
- [ ] Production smoke: any future ghost-close on a \`reason='reconciled'\` or \`agent='USER'\` row classifies as \`manual_close_user\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correctly classify ghost-closed autonomous_trades rows with legacy or new user-tracking metadata as manual_close_user when the user manually closes positions on the exchange UI.