### PR TITLE
fix: kill-switch auto re-arm + FAT skips user-owned positions

### DIFF
--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -1353,6 +1353,29 @@ class FullyAutonomousTrader extends EventEmitter {
         if (qtyNum === 0) continue;
 
         const symbol = position.symbol;
+
+        // 2026-05-06 incident: FAT closed a user-opened ETH LONG via
+        // stop_loss_roi because it iterates ALL exchange positions and
+        // applies its SL/TP rules without checking ownership. Add a
+        // user-position guard: if the reconciler has tracked this symbol
+        // as a user-opened position (agent='USER', lane='manual'), skip
+        // it — FAT must not manage what the user opened on Poloniex UI.
+        try {
+          const userOwned = await pool.query(
+            `SELECT 1 FROM autonomous_trades
+              WHERE user_id = $1 AND symbol = $2 AND status = 'open'
+                AND agent = 'USER' LIMIT 1`,
+            [userId, symbol],
+          );
+          if (userOwned.rows.length > 0) {
+            logger.info(`[FAT] skipping ${symbol} — user-owned position (agent='USER'), not FAT's to manage`);
+            continue;
+          }
+        } catch (ownerErr) {
+          logger.debug('[FAT] user-owned check failed (continuing — fail-open)', {
+            symbol, err: ownerErr instanceof Error ? ownerErr.message : String(ownerErr),
+          });
+        }
         const markPx = parseFloat(position.markPx || position.markPrice || '0');
         const entryPrice = parseFloat(position.openAvgPx || position.entryPrice || '0');
         const unrealizedPnL = parseFloat(position.upl || position.unrealizedPnl || '0');

--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -295,6 +295,37 @@ export class LiveSignalEngine extends EventEmitter {
       if (!Number.isFinite(equity) || equity <= 0) return;
       const ddRatio = upl / equity;
 
+      // Auto re-arm: if execution mode was paused by the kill switch and
+      // drawdown has recovered above KILL_SWITCH_RECOVERY_THRESHOLD, flip
+      // mode back to 'auto'. Hysteresis (-15% trip / -5% recovery) prevents
+      // oscillation. Without this, every kill-switch event leaves the
+      // account permanently paused until manual reset — observed
+      // 2026-05-06: kill switch tripped at 08:34, account recovered to
+      // +DD by 09:04 but mode stayed pause; Monkey detected breakouts
+      // every tick but every entry was vetoed by execution_mode_paused.
+      const KILL_SWITCH_RECOVERY_THRESHOLD = -0.05;
+      if (ddRatio > KILL_SWITCH_RECOVERY_THRESHOLD) {
+        try {
+          const cur = await pool.query(
+            `SELECT mode, updated_by FROM agent_execution_mode WHERE id = 1`,
+          );
+          const row = cur.rows[0] as { mode?: string; updated_by?: string } | undefined;
+          if (row?.mode === 'pause' && row?.updated_by === 'kill_switch') {
+            await pool.query(
+              `UPDATE agent_execution_mode
+                  SET mode = 'auto', updated_by = 'kill_switch_auto_rearm',
+                      updated_at = NOW(), reason = $1
+                WHERE id = 1`,
+              [`Auto-rearm at DD=${(ddRatio * 100).toFixed(2)}% > ${(KILL_SWITCH_RECOVERY_THRESHOLD * 100).toFixed(0)}% recovery threshold`],
+            );
+            logger.info('[LiveSignal] kill-switch auto-rearmed', {
+              ddRatio,
+              recoveryThreshold: KILL_SWITCH_RECOVERY_THRESHOLD,
+            });
+          }
+        } catch { /* fail-soft; manual reset still works */ }
+      }
+
       if (ddRatio <= KILL_SWITCH_DD_THRESHOLD) {
         logger.error('[LiveSignal] kill-switch auto-flatten TRIGGERED', {
           equity,


### PR DESCRIPTION
## TL;DR

Two bugs that just bit live:
1. **Kill switch never re-armed after DD recovery** — paused at 08:34 with DD=-17%, account recovered to $685 (+DD), but mode stayed paused. Every Monkey breakout entry vetoed by \`execution_mode_paused\`.
2. **FAT closed a user-opened ETH LONG** — FAT's managePositions iterates all exchange positions and applies SL/TP without checking ownership. User's manual position got \`stop_loss_roi\` exit.

## Fix 1 — Kill switch hysteresis

\`liveSignalEngine.ts checkAutoFlatten\` now re-arms when ddRatio > -5% (recovery threshold). Trip stays at -15%; the gap prevents oscillation.

\`\`\`ts
if (ddRatio > -0.05) {
  // Check if mode was set by kill_switch
  if (row?.mode === 'pause' && row?.updated_by === 'kill_switch') {
    UPDATE agent_execution_mode SET mode='auto',
      updated_by='kill_switch_auto_rearm', reason='Auto-rearm at DD=...'
  }
}
\`\`\`

A pause persists during recovery up to -5%, then re-arms. No more "stuck in pause" requiring manual SQL reset.

## Fix 2 — FAT user-owned guard

\`fullyAutonomousTrader.ts managePositions\` now skips positions that the reconciler tracked as user-opened (\`agent='USER'\`):

\`\`\`ts
const userOwned = await pool.query(
  \`SELECT 1 FROM autonomous_trades
    WHERE user_id=$1 AND symbol=$2 AND status='open' AND agent='USER' LIMIT 1\`,
  [userId, symbol],
);
if (userOwned.rows.length > 0) {
  logger.info('[FAT] skipping ' + symbol + ' — user-owned position');
  continue;
}
\`\`\`

Paired with PR #641's reconciler tracking, this means: user opens on UI → reconciler tags as USER → FAT skips → user keeps full control of their manual position.

## Scope clarification

This is the minimal fix. **FAT still manages positions opened by Monkey or LiveSignal** because we don't have stable agent attribution for those rows in autonomous_trades. A broader fix — FAT only manages FAT-tagged rows — is a deeper refactor for a future PR.

For now: **USER positions are protected**.

## Test plan

- [x] TypeScript typecheck clean
- [ ] CI pipeline (type-check + Railway deploys)
- [ ] Production smoke:
  - Confirm \`kill_switch_auto_rearm\` log appears next time DD recovers above -5%
  - Confirm \`[FAT] skipping ... — user-owned position\` log when user opens on UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Re-arm the kill-switch execution mode automatically once drawdown has sufficiently recovered and prevent the fully autonomous trader from managing user-owned positions.

Bug Fixes:
- Automatically switch agent execution mode back to auto after a kill-switch pause when drawdown recovers above a configured threshold to avoid staying stuck in pause.
- Skip management of exchange positions that are tracked as user-opened so the fully autonomous trader no longer closes user-controlled trades.