### PR TITLE
feat(fat): FAT_MANAGES_USER_POSITIONS env override

### DIFF
--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -1356,25 +1356,33 @@ class FullyAutonomousTrader extends EventEmitter {
 
         // 2026-05-06 incident: FAT closed a user-opened ETH LONG via
         // stop_loss_roi because it iterates ALL exchange positions and
-        // applies its SL/TP rules without checking ownership. Add a
-        // user-position guard: if the reconciler has tracked this symbol
-        // as a user-opened position (agent='USER', lane='manual'), skip
-        // it — FAT must not manage what the user opened on Poloniex UI.
-        try {
-          const userOwned = await pool.query(
-            `SELECT 1 FROM autonomous_trades
-              WHERE user_id = $1 AND symbol = $2 AND status = 'open'
-                AND agent = 'USER' LIMIT 1`,
-            [userId, symbol],
-          );
-          if (userOwned.rows.length > 0) {
-            logger.info(`[FAT] skipping ${symbol} — user-owned position (agent='USER'), not FAT's to manage`);
-            continue;
+        // applies its SL/TP rules without checking ownership. The
+        // user-position guard skips agent='USER' rows so FAT doesn't
+        // manage manually-opened positions.
+        //
+        // 2026-05-08: opt-in override. When the user wants FAT to
+        // manage their manual positions (e.g. add to / hand off
+        // ongoing supervision), set FAT_MANAGES_USER_POSITIONS=true.
+        // Default false preserves the safer guard.
+        const fatManagesUserPositions =
+          process.env.FAT_MANAGES_USER_POSITIONS === 'true';
+        if (!fatManagesUserPositions) {
+          try {
+            const userOwned = await pool.query(
+              `SELECT 1 FROM autonomous_trades
+                WHERE user_id = $1 AND symbol = $2 AND status = 'open'
+                  AND agent = 'USER' LIMIT 1`,
+              [userId, symbol],
+            );
+            if (userOwned.rows.length > 0) {
+              logger.info(`[FAT] skipping ${symbol} — user-owned position (agent='USER'), not FAT's to manage`);
+              continue;
+            }
+          } catch (ownerErr) {
+            logger.debug('[FAT] user-owned check failed (continuing — fail-open)', {
+              symbol, err: ownerErr instanceof Error ? ownerErr.message : String(ownerErr),
+            });
           }
-        } catch (ownerErr) {
-          logger.debug('[FAT] user-owned check failed (continuing — fail-open)', {
-            symbol, err: ownerErr instanceof Error ? ownerErr.message : String(ownerErr),
-          });
         }
         const markPx = parseFloat(position.markPx || position.markPrice || '0');
         const entryPrice = parseFloat(position.openAvgPx || position.entryPrice || '0');


### PR DESCRIPTION
## TL;DR

PR #645 added a guard so FAT skips \`agent='USER'\` positions to protect manual user trades from auto-managed SL/TP. This adds an opt-in env override so the behaviour is configurable per session.

## Toggle

- \`FAT_MANAGES_USER_POSITIONS=true\` → FAT manages all positions including \`agent='USER'\` (guard disabled)
- unset / \`'false'\` / anything else → guard active (default, safer)

## Use case

Session 2026-05-08: user wanted FAT to take over supervision of their manual orphan shorts. Without this toggle, the only way is to delete/re-tag the USER rows manually, which doesn't survive a restart. The env-var pattern lets the user flip behaviour from Railway dashboard with one variable, no redeploy needed since Node reads env on each call.

## Test plan

- [x] TypeScript typecheck clean
- [ ] CI pipeline + Railway deploys
- [ ] Production smoke: with env=true, no \`[FAT] skipping ... user-owned\` lines; with env unset, the existing behaviour preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Introduce FAT_MANAGES_USER_POSITIONS environment toggle to control whether FAT skips or manages agent='USER' positions.