### PR TITLE
fix: reconciler PnL recovery — close the learning-feedback loop for manual closes

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -478,6 +478,40 @@ export class MonkeyKernel extends EventEmitter {
         }
       },
     });
+
+    // 2026-05-08 #11 — OUTCOME subscriber for the reconciler PnL
+    // recovery path. When the user manually closes a kernel-issued
+    // position on Poloniex UI, the reconciler ghosts the DB row with
+    // exit_reason='manual_close_user' AND publishes an OUTCOME event
+    // with the recovered PnL. This subscriber consumes those events
+    // and updates the owning agent's emotion + neurochemistry stack
+    // — closing the learning-feedback loop that was previously broken
+    // for user-closed system trades.
+    this.bus.subscribe({
+      id: `${this.instanceId}-outcome-feedback`,
+      types: [BusEventType.OUTCOME],
+      symbols: this.symbols,
+      handler: (event) => {
+        if (!event.symbol) return;
+        const payload = event.payload as Record<string, unknown> | undefined;
+        if (!payload) return;
+        const agent = String(payload.agent ?? '');
+        if (agent !== 'K' && agent !== 'M' && agent !== 'T' && agent !== 'L') return;
+        const side = String(payload.side ?? '').toLowerCase();
+        if (side !== 'long' && side !== 'short') return;
+        const pnl = Number(payload.pnl ?? 0);
+        if (!Number.isFinite(pnl)) return;
+        // Don't double-fire: closeHeldPosition already calls
+        // applyOutcomeToAgent on its own path. Reconciler-recovered
+        // PnL events have source='manual_close_recovered' to identify
+        // them. Only those reach the agent state via this subscriber.
+        if (payload.source !== 'manual_close_recovered') return;
+        this.applyOutcomeToAgent(event.symbol, agent, side as 'long' | 'short', pnl);
+        logger.info(
+          `[Monkey] Agent ${agent} emotion stack updated from recovered manual close: pnl=${pnl.toFixed(4)} side=${side}`,
+        );
+      },
+    });
     // Proposal #10 — detect (don't auto-flip) account position direction
     // mode. Lane-isolated positions in HEDGE mode let a swing-long and a
     // scalp-short coexist on the exchange; ONE_WAY mode nets opposite

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -12,6 +12,7 @@ import { apiCredentialsService } from './apiCredentialsService.js';
 import { monitoringService } from './monitoringService.js';
 import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
+import { BusEventType, getKernelBus } from './monkey/kernel_bus.js';
 
 export interface OrphanedPosition {
   symbol: string;
@@ -99,7 +100,7 @@ class StateReconciliationService {
 
       // ── 4. Fetch DB-recorded open trades ────────────────────────────────────
       const dbResult = await pool.query(
-        `SELECT id, symbol, side, entry_price, quantity, order_id
+        `SELECT id, symbol, side, entry_price, quantity, order_id, entry_time
          FROM autonomous_trades
          WHERE user_id = $1 AND status = 'open'`,
         [userId]
@@ -111,6 +112,7 @@ class StateReconciliationService {
         entry_price: string;
         quantity: string;
         order_id: string | null;
+        entry_time: Date | string;
       }[] = dbResult.rows;
 
       // Use the last recorded equity from autonomous_performance as DB balance.
@@ -294,18 +296,116 @@ class StateReconciliationService {
           } catch {
             /* fail-soft: keep generic reason */
           }
+          // 2026-05-08 #11 — PnL recovery for manual-close ghosts.
+          // When the user closes a kernel-issued position on the
+          // Poloniex UI, the close fires through Poloniex's order
+          // pipeline but never reaches our closeHeldPosition (which is
+          // the only path that records realized PnL + fires the
+          // per-agent emotion update via applyOutcomeToAgent). This
+          // path closes that loop: query Poloniex's position-history
+          // endpoint, find the closed position matching this DB row by
+          // (symbol, side, entry_time), extract realized PnL, and
+          // publish a kernel-bus OUTCOME event. The kernel's bus
+          // subscriber consumes that and updates the owning agent's
+          // emotion stack.
+          //
+          // Only fires for kernel-issued rows (agent IN K/M/T/L) when
+          // ghostReason='manual_close_user'. Other ghost-close reasons
+          // either already had PnL recorded (post_close_race) or are
+          // not kernel-issued (orphan/legacy).
+          let recoveredPnl: number | null = null;
+          let recoveredAgent: 'K' | 'M' | 'T' | 'L' | null = null;
+          if (
+            ghostReason === 'manual_close_user' &&
+            credentials &&
+            dbTrade.entry_time
+          ) {
+            try {
+              const ctxRow = await pool.query(
+                `SELECT agent FROM autonomous_trades WHERE id = $1`,
+                [dbTrade.id]
+              );
+              const a = ctxRow.rows[0]?.agent as string | undefined;
+              if (a === 'K' || a === 'M' || a === 'T' || a === 'L') {
+                recoveredAgent = a;
+                const polHistory = await poloniexFuturesService.getPositionHistory(
+                  credentials,
+                  { symbol: dbTrade.symbol, limit: 20 }
+                );
+                const histRows: any[] = Array.isArray(polHistory)
+                  ? polHistory
+                  : (polHistory?.data ?? []);
+                const dbEntryMs = new Date(dbTrade.entry_time).getTime();
+                // Match by symbol + side + entry-time within ±90s window.
+                const match = histRows.find((p: any) => {
+                  const polEntryMs = Number(
+                    p.openTime ?? p.cTime ?? p.openTimestamp ?? 0
+                  );
+                  const polSide = String(p.posSide ?? p.side ?? '').toUpperCase();
+                  const wantSide = normalizeDbSide(dbTrade.side) === 'long' ? 'LONG' : 'SHORT';
+                  return (
+                    polEntryMs > 0 &&
+                    Math.abs(polEntryMs - dbEntryMs) < 90_000 &&
+                    polSide === wantSide
+                  );
+                });
+                if (match) {
+                  const rawPnl = parseFloat(
+                    match.realisedPnl ?? match.realizedPnl ?? match.pnl ?? '0'
+                  );
+                  if (Number.isFinite(rawPnl)) recoveredPnl = rawPnl;
+                }
+              }
+            } catch (recErr) {
+              logger.debug('[RECONCILE] PnL recovery query failed (non-fatal)', {
+                tradeId: dbTrade.id,
+                err: recErr instanceof Error ? recErr.message : String(recErr),
+              });
+            }
+          }
+
           try {
             await pool.query(
               `UPDATE autonomous_trades
                SET status = 'closed',
                    exit_reason = $1,
-                   exit_time = NOW()
+                   exit_time = NOW(),
+                   pnl = COALESCE($3, pnl)
                WHERE id = $2`,
-              [ghostReason, dbTrade.id]
+              [ghostReason, dbTrade.id, recoveredPnl]
             );
             logger.info(
-              `[RECONCILE] Closed ghost DB record ${dbTrade.id} for user ${userId}: ${dbTrade.symbol} ${dbTrade.side} (reason=${ghostReason})`
+              `[RECONCILE] Closed ghost DB record ${dbTrade.id} for user ${userId}: ${dbTrade.symbol} ${dbTrade.side} (reason=${ghostReason}${
+                recoveredPnl !== null ? `, recovered_pnl=${recoveredPnl.toFixed(4)}` : ''
+              })`
             );
+            // Publish OUTCOME event so the kernel's bus subscriber
+            // updates the per-agent emotion stack. Only fires when we
+            // recovered PnL for a kernel-issued row.
+            if (recoveredPnl !== null && recoveredAgent !== null) {
+              try {
+                const bus = getKernelBus();
+                bus.publish({
+                  type: BusEventType.OUTCOME,
+                  source: 'reconciler',
+                  symbol: dbTrade.symbol,
+                  payload: {
+                    agent: recoveredAgent,
+                    side: normalizeDbSide(dbTrade.side),
+                    pnl: recoveredPnl,
+                    source: 'manual_close_recovered',
+                    tradeId: dbTrade.id,
+                  },
+                });
+                logger.info(
+                  `[RECONCILE] Published OUTCOME for manual close: agent=${recoveredAgent} symbol=${dbTrade.symbol} pnl=${recoveredPnl.toFixed(4)}`
+                );
+              } catch (busErr) {
+                logger.debug('[RECONCILE] OUTCOME publish failed', {
+                  err: busErr instanceof Error ? busErr.message : String(busErr),
+                });
+              }
+            }
           } catch (updateErr) {
             logger.error(
               `[RECONCILE] Failed to close ghost record ${dbTrade.id} for user ${userId}:`,


### PR DESCRIPTION
## TL;DR

Closes the gap surfaced by today's CSV-vs-DB comparison: when the user closed kernel-issued positions on Poloniex UI, **realized PnL didn't propagate to the per-agent emotion stack** (PR #649) — dopamine/frustration didn't update from those events.

After this PR, all three close routes feed `applyOutcomeToAgent`:

| Close route | PnL feedback | Status |
|---|---|---|
| `closeHeldPosition` (system close) | direct call | existing |
| Reconciler ghost-close `manual_close_user` (user UI close) | OUTCOME bus event | **NEW (this PR)** |
| Reconciler ghost-close other reasons | n/a (already recorded or non-kernel-owned) | unchanged |

## Evidence

User's exported transaction history (CSV) showed ~\$50 in realized PnL across the 15:16-15:21 window. Our `autonomous_trades` table showed only 4 system-closed ETH rows totaling -\$8.21 in the same window. The ~\$42 gap was kernel-issued positions the user closed manually — DB ghost-close happened but PnL was never extracted.

## How

In `stateReconciliationService.ts` ghost-close branch, when `exit_reason='manual_close_user'` AND `agent IN (K,M,T,L)`:
1. Query `poloniexFuturesService.getPositionHistory` (limit=20, filter by symbol)
2. Match by `(symbol, side, entry_time)` within ±90s window
3. Extract realized PnL from the matched record
4. UPDATE the DB row with recovered `pnl`
5. Publish kernel-bus OUTCOME event with `source='manual_close_recovered'`

In `loop.ts` MonkeyKernel.start(), a new bus subscriber consumes OUTCOME events with that source tag and calls `applyOutcomeToAgent` — exact same code path used by `closeHeldPosition` for system-issued closes.

## No double-fire

`closeHeldPosition` calls `applyOutcomeToAgent` directly, doesn't go through the bus. Reconciler-recovered events carry `source='manual_close_recovered'` which is the only source the new subscriber acts on. Clean separation.

## Test plan

- [x] 68/68 existing tests pass (no regressions)
- [x] TypeScript typecheck clean
- [ ] CI pipeline (type-check + Railway deploys)
- [ ] Production verification: next time you close a kernel-issued position on Poloniex UI, expect logs:
  - `[RECONCILE] Closed ghost DB record ... reason=manual_close_user, recovered_pnl=X.XXXX`
  - `[RECONCILE] Published OUTCOME for manual close: agent=K symbol=BTC_USDT_PERP pnl=X.XXXX`
  - `[Monkey] Agent K emotion stack updated from recovered manual close: pnl=X.XXXX side=long`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Recover and propagate realized PnL for kernel-issued positions that users close manually on Poloniex so agents receive proper outcome feedback.

Bug Fixes:
- Recover missing realized PnL for manually closed kernel-issued Poloniex positions by reconciling against exchange position history during ghost-close handling.
- Ensure recovered manual-close PnL updates the owning agent’s emotion stack via kernel bus OUTCOME events without double-counting existing system-close paths.

Enhancements:
- Extend trade reconciliation to store entry timestamps and emit richer logging around ghost-close processing and recovered PnL.
- Introduce a kernel bus subscriber that consumes reconciler OUTCOME events for recovered manual closes and routes them through the standard applyOutcomeToAgent feedback path.