### PR TITLE
fix(monkey): loosen L harvest cooldown to 60s — wiggle room, not fee brake

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -347,10 +347,12 @@ interface SymbolState {
    *  ring; older events drop. Each agent reads from this on its tick. */
   recentBusEvents: import('./kernel_bus.js').BusEvent[];
   /** 2026-05-11 — wall-clock ms of the last force-harvest by side. Used
-   *  to enforce a per-symbol L entry cooldown so L doesn't immediately
-   *  re-stack the position it just dissolved (was observed as fee-churn
-   *  in the 24h post-PR-#652 tape). Window is governed by
-   *  MONKEY_AGENT_L_HARVEST_COOLDOWN_MS (default 5 min). */
+   *  to give L one tick of "wiggle room" after a sweep so the next
+   *  entry sees a market that has actually moved, rather than re-entering
+   *  at a price within fractions of the close. Window is governed by
+   *  MONKEY_AGENT_L_HARVEST_COOLDOWN_MS (default 60 s — one tick).
+   *  Fees are not a concern (user has fee-free subscription); this is
+   *  about market-microstructure breathing room. */
   lForceHarvestAtMsBySide: { long: number | null; short: number | null };
   /** 2026-05-11 — ring of last N=5 L force-harvest PnLs on this symbol.
    *  Consumed by the adaptive harvest threshold: when L is on a hot
@@ -2217,11 +2219,15 @@ export class MonkeyKernel extends EventEmitter {
         labelDistribution: lDecision.labelDistribution,
         reason: lDecision.reason,
       };
-      // 2026-05-11 — per-symbol L harvest cooldown. After a force-
-      // harvest fires on a side, suppress new L entries on that side
-      // for MONKEY_AGENT_L_HARVEST_COOLDOWN_MS (default 5 min). The
-      // notional cap eventually limits re-stacking too, but the
-      // cooldown is the cleaner fee-churn brake.
+      // 2026-05-11 — minimal L harvest "wiggle room" after a sweep.
+      //
+      // Not a fee brake (user has fee-free Poloniex subscription); this
+      // is about market microstructure. Re-entering on the same tick a
+      // close lands risks fills at prices within fractions of the close
+      // price, before the book has visibly moved. One tick (60 s) of
+      // space is plenty — the kernel runs at 30s ticks, so this gives
+      // 1-2 ticks of breathing room. Configurable via
+      // MONKEY_AGENT_L_HARVEST_COOLDOWN_MS; set to 0 to disable.
       let lCooldownActive = false;
       const lProposedSideForCooldown: 'long' | 'short' | null =
         lDecision.action === 'enter_long' ? 'long'
@@ -2229,7 +2235,9 @@ export class MonkeyKernel extends EventEmitter {
             : null;
       if (lProposedSideForCooldown) {
         const cooldownMs =
-          Number(process.env.MONKEY_AGENT_L_HARVEST_COOLDOWN_MS) || 5 * 60_000;
+          process.env.MONKEY_AGENT_L_HARVEST_COOLDOWN_MS !== undefined
+            ? Number(process.env.MONKEY_AGENT_L_HARVEST_COOLDOWN_MS)
+            : 60_000;
         const lastHarvestAt = state.lForceHarvestAtMsBySide[lProposedSideForCooldown];
         if (
           lastHarvestAt !== null


### PR DESCRIPTION
## Summary

PR #653 added a 5-min cooldown framed as fee-churn prevention. User has fee-free Poloniex subscription — that rationale doesn't apply.

The actual value of the cooldown is **market-microstructure breathing room**: one kernel tick of space after a close so the next entry sees a market that has actually moved, rather than filling within fractions of a bp of the close price.

- New default: **60 s** (one tick → 1-2 ticks of breathing room).
- \`MONKEY_AGENT_L_HARVEST_COOLDOWN_MS=0\` now disables entirely.

## Test plan

- [x] tsc clean
- [ ] Live tape: confirm L re-entries land within 1-2 ticks of force-harvest, not on the same tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust L harvest cooldown behavior for the monkey kernel to provide minimal post-sweep breathing room instead of a long fee-oriented delay.

Enhancements:
- Reduce the default L harvest cooldown from 5 minutes to 60 seconds to align with kernel tick timing and market microstructure needs.
- Allow the MONKEY_AGENT_L_HARVEST_COOLDOWN_MS environment variable to disable the cooldown entirely when set to 0.
- Clarify inline documentation around the purpose of the L harvest cooldown as market-structure wiggle room rather than a fee-churn brake.