### PR TITLE
fix(ui): correct dashboard metric reporting end-to-end

### DIFF
--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -182,16 +182,42 @@ router.get('/status', authenticateToken, async (req: Request, res: Response) => 
     if (execMode?.mode === 'pause') status = 'paused';
     else if (running) status = 'running';
     else status = 'stopped';
+    // 2026-05-11 — flatten the most-asked stats onto status so the
+    // frontend AgentStatus interface in AutonomousAgentDashboard
+    // reads them at the top level. Previously nested under
+    // status.trader, so the Dashboard Total P&L card rendered $0.00.
+    // totalPnl is computed live from autonomous_trades because
+    // traderStatus.metrics only tracks equity/drawdown, not P&L.
+    let totalPnl = 0;
+    let liveTradesExecuted = 0;
+    try {
+      const pnlRow = await pool.query(
+        `SELECT COALESCE(SUM(pnl), 0) AS total_pnl,
+                COUNT(*) FILTER (WHERE order_id IS NULL OR order_id NOT LIKE 'paper_%') AS live_trades
+           FROM autonomous_trades
+          WHERE user_id = $1 AND pnl IS NOT NULL`,
+        [userId],
+      );
+      totalPnl = parseFloat(pnlRow.rows[0]?.total_pnl ?? '0') || 0;
+      liveTradesExecuted = parseInt(pnlRow.rows[0]?.live_trades ?? '0', 10) || 0;
+    } catch { /* fail-soft: leave at 0 */ }
     res.json({
       success: true,
       status: {
         id: userId,
+        userId,
         status,
         executionMode: execMode?.mode ?? null,
         startedAt: null,
+        totalPnl,
+        strategiesGenerated: Number((sleStatus as { activeStrategies?: number }).activeStrategies ?? 0),
+        backtestsCompleted: Number((sleStatus as { backtestsCompleted?: number }).backtestsCompleted ?? 0),
+        paperTradesExecuted: 0,
+        liveTradesExecuted,
+        openPositions: Number(traderStatus.openPositions ?? 0),
         sle: sleStatus,
-        trader: traderStatus
-      }
+        trader: traderStatus,
+      },
     });
   } catch (error: unknown) {
     logger.error('Error getting agent status:', error);
@@ -281,13 +307,44 @@ router.get('/performance', authenticateToken, async (req: Request, res: Response
   try {
     const userId = (req.user?.id || req.user?.userId)?.toString();
     if (!userId) return res.status(401).json({ success: false, error: 'User ID not found in token' });
-    const defaultPerformance = { totalPnl: 0, winRate: 0, totalTrades: 0, winningTrades: 0, losingTrades: 0, averageWin: 0, averageLoss: 0, sharpeRatio: 0, maxDrawdown: 0 };
+    // 2026-05-11 — full camelCase payload mirroring the frontend
+    // PerformanceData interface. Adds profitFactor / bestTrade /
+    // worstTrade / totalPnlPercent (previously missing — UI cards
+    // rendered 0) and nests dailyPerformance + strategyPerformance
+    // + symbolPerformance inside `performance` so the frontend reads
+    // from a single object.
+    const defaultPerformance = {
+      totalPnl: 0, totalPnlPercent: 0,
+      winRate: 0, totalTrades: 0,
+      winningTrades: 0, losingTrades: 0,
+      averageWin: 0, averageLoss: 0,
+      bestTrade: 0, worstTrade: 0,
+      profitFactor: 0,
+      sharpeRatio: 0, maxDrawdown: 0,
+      dailyPerformance: [] as Array<{ date: string; pnl: number; cumulativePnL: number; trades: number }>,
+      strategyPerformance: [] as Array<{ strategyName: string; pnl: number; trades: number; winRate: number }>,
+      symbolPerformance: [] as Array<{ symbol: string; pnl: number; trades: number; winRate: number }>,
+    };
     const traderStatus = await fullyAutonomousTrader.getStatus(userId);
-    if (!traderStatus.enabled && !traderStatus.metrics) return res.json({ success: true, performance: defaultPerformance, dailyPerformance: [] });
+    if (!traderStatus.enabled && !traderStatus.metrics) return res.json({ success: true, performance: defaultPerformance });
     try {
       const mode = req.query.mode as string | undefined;
       const modeFilter = mode === 'paper' ? " AND order_id LIKE 'paper_%'" : mode === 'live' ? " AND (order_id IS NULL OR order_id NOT LIKE 'paper_%')" : '';
-      const tradesResult = await pool.query(`SELECT COUNT(*) as total_trades, SUM(CASE WHEN pnl > 0 THEN 1 ELSE 0 END) as winning_trades, SUM(CASE WHEN pnl < 0 THEN 1 ELSE 0 END) as losing_trades, SUM(pnl) as total_pnl, AVG(CASE WHEN pnl > 0 THEN pnl END) as avg_win, AVG(CASE WHEN pnl < 0 THEN pnl END) as avg_loss FROM autonomous_trades WHERE user_id = $1${modeFilter}`, [userId]);
+      const tradesResult = await pool.query(
+        `SELECT
+            COUNT(*) AS total_trades,
+            SUM(CASE WHEN pnl > 0 THEN 1 ELSE 0 END) AS winning_trades,
+            SUM(CASE WHEN pnl < 0 THEN 1 ELSE 0 END) AS losing_trades,
+            SUM(pnl) AS total_pnl,
+            AVG(CASE WHEN pnl > 0 THEN pnl END) AS avg_win,
+            AVG(CASE WHEN pnl < 0 THEN pnl END) AS avg_loss,
+            MAX(pnl) AS best_trade,
+            MIN(pnl) AS worst_trade,
+            SUM(CASE WHEN pnl > 0 THEN pnl ELSE 0 END) AS gross_wins,
+            SUM(CASE WHEN pnl < 0 THEN ABS(pnl) ELSE 0 END) AS gross_losses
+         FROM autonomous_trades WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter}`,
+        [userId],
+      );
       const metrics = tradesResult.rows[0];
       let sharpeRatio = 0; let maxDrawdown = 0;
       try {
@@ -304,14 +361,104 @@ router.get('/performance', authenticateToken, async (req: Request, res: Response
       } catch { /* keep defaults */ }
       let dailyPerformance: Array<{ date: string; pnl: number; cumulativePnL: number; trades: number }> = [];
       try {
-        const dailyResult = await pool.query(`SELECT DATE(created_at) as trade_date, SUM(pnl) as daily_pnl, COUNT(*) as daily_trades FROM autonomous_trades WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter} GROUP BY DATE(created_at) ORDER BY trade_date ASC`, [userId]);
+        const dailyResult = await pool.query(`SELECT DATE(created_at) AS trade_date, SUM(pnl) AS daily_pnl, COUNT(*) AS daily_trades FROM autonomous_trades WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter} GROUP BY DATE(created_at) ORDER BY trade_date ASC`, [userId]);
         let cumPnl = 0;
-        dailyPerformance = dailyResult.rows.map((r: { trade_date: string; daily_pnl: string; daily_trades: string }) => { const dayPnl = parseFloat(r.daily_pnl) || 0; cumPnl += dayPnl; return { date: new Date(r.trade_date).toISOString().slice(0, 10), pnl: parseFloat(dayPnl.toFixed(2)), cumulativePnL: parseFloat(cumPnl.toFixed(2)), trades: parseInt(r.daily_trades, 10) || 0 }; });
+        dailyPerformance = dailyResult.rows.map((r: { trade_date: string; daily_pnl: string; daily_trades: string }) => {
+          const dayPnl = parseFloat(r.daily_pnl) || 0;
+          cumPnl += dayPnl;
+          return {
+            date: new Date(r.trade_date).toISOString().slice(0, 10),
+            pnl: parseFloat(dayPnl.toFixed(2)),
+            cumulativePnL: parseFloat(cumPnl.toFixed(2)),
+            trades: parseInt(r.daily_trades, 10) || 0,
+          };
+        });
       } catch { /* daily unavailable */ }
-      res.json({ success: true, mode: mode || 'all', performance: { totalPnl: parseFloat(metrics.total_pnl || 0), winRate: metrics.total_trades > 0 ? (parseFloat(metrics.winning_trades || 0) / parseFloat(metrics.total_trades)) * 100 : 0, totalTrades: parseInt(metrics.total_trades || 0, 10), winningTrades: parseInt(metrics.winning_trades || 0, 10), losingTrades: parseInt(metrics.losing_trades || 0, 10), averageWin: parseFloat(metrics.avg_win || 0), averageLoss: parseFloat(metrics.avg_loss || 0), sharpeRatio: parseFloat(sharpeRatio.toFixed(2)), maxDrawdown: parseFloat((maxDrawdown * 100).toFixed(2)) }, dailyPerformance });
+      // Per-agent breakdown — the strategy IS the agent (K/M/T/L)
+      // in this kernel. Surfaces in the Strategy Performance UI panel.
+      let strategyPerformance: Array<{ strategyName: string; pnl: number; trades: number; winRate: number }> = [];
+      try {
+        const agentResult = await pool.query(
+          `SELECT COALESCE(agent, 'K') AS agent,
+                  SUM(pnl) AS pnl,
+                  COUNT(*) AS trades,
+                  CASE WHEN COUNT(*) > 0
+                    THEN (SUM(CASE WHEN pnl > 0 THEN 1 ELSE 0 END)::float * 100.0 / COUNT(*))
+                    ELSE 0 END AS win_rate
+             FROM autonomous_trades
+            WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter}
+            GROUP BY agent
+            ORDER BY pnl DESC NULLS LAST`,
+          [userId],
+        );
+        strategyPerformance = agentResult.rows.map((r: { agent: string; pnl: string; trades: string; win_rate: string }) => ({
+          strategyName: `Agent ${r.agent}`,
+          pnl: parseFloat(r.pnl) || 0,
+          trades: parseInt(r.trades, 10) || 0,
+          winRate: parseFloat(r.win_rate) || 0,
+        }));
+      } catch { /* unavailable */ }
+      // Per-symbol breakdown.
+      let symbolPerformance: Array<{ symbol: string; pnl: number; trades: number; winRate: number }> = [];
+      try {
+        const symResult = await pool.query(
+          `SELECT symbol,
+                  SUM(pnl) AS pnl,
+                  COUNT(*) AS trades,
+                  CASE WHEN COUNT(*) > 0
+                    THEN (SUM(CASE WHEN pnl > 0 THEN 1 ELSE 0 END)::float * 100.0 / COUNT(*))
+                    ELSE 0 END AS win_rate
+             FROM autonomous_trades
+            WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter}
+            GROUP BY symbol
+            ORDER BY pnl DESC NULLS LAST`,
+          [userId],
+        );
+        symbolPerformance = symResult.rows.map((r: { symbol: string; pnl: string; trades: string; win_rate: string }) => ({
+          symbol: r.symbol,
+          pnl: parseFloat(r.pnl) || 0,
+          trades: parseInt(r.trades, 10) || 0,
+          winRate: parseFloat(r.win_rate) || 0,
+        }));
+      } catch { /* unavailable */ }
+      const totalPnl = parseFloat(metrics.total_pnl || 0) || 0;
+      const grossWins = parseFloat(metrics.gross_wins || 0) || 0;
+      const grossLosses = parseFloat(metrics.gross_losses || 0) || 0;
+      const profitFactor = grossLosses > 0 ? grossWins / grossLosses : (grossWins > 0 ? 999 : 0);
+      let totalPnlPercent = 0;
+      try {
+        const eqRow = await pool.query(
+          `SELECT current_equity FROM autonomous_performance WHERE user_id = $1 ORDER BY timestamp DESC LIMIT 1`,
+          [userId],
+        );
+        const equity = parseFloat(eqRow.rows[0]?.current_equity || 0) || 0;
+        if (equity > 0) totalPnlPercent = (totalPnl / equity) * 100;
+      } catch { /* equity unavailable; leave at 0 */ }
+      res.json({
+        success: true,
+        mode: mode || 'all',
+        performance: {
+          totalPnl: parseFloat(totalPnl.toFixed(2)),
+          totalPnlPercent: parseFloat(totalPnlPercent.toFixed(2)),
+          winRate: metrics.total_trades > 0 ? (parseFloat(metrics.winning_trades || 0) / parseFloat(metrics.total_trades)) * 100 : 0,
+          totalTrades: parseInt(metrics.total_trades || 0, 10),
+          winningTrades: parseInt(metrics.winning_trades || 0, 10),
+          losingTrades: parseInt(metrics.losing_trades || 0, 10),
+          averageWin: parseFloat(metrics.avg_win || 0) || 0,
+          averageLoss: parseFloat(metrics.avg_loss || 0) || 0,
+          bestTrade: parseFloat(metrics.best_trade || 0) || 0,
+          worstTrade: parseFloat(metrics.worst_trade || 0) || 0,
+          profitFactor: parseFloat(profitFactor.toFixed(2)),
+          sharpeRatio: parseFloat(sharpeRatio.toFixed(2)),
+          maxDrawdown: parseFloat((maxDrawdown * 100).toFixed(2)),
+          dailyPerformance,
+          strategyPerformance,
+          symbolPerformance,
+        },
+      });
     } catch (dbError: unknown) {
       logger.warn('Autonomous trades table query failed: ' + (dbError instanceof Error ? dbError.message : String(dbError)));
-      res.json({ success: true, performance: defaultPerformance, dailyPerformance: [] });
+      res.json({ success: true, performance: defaultPerformance });
     }
   } catch (error: unknown) {
     logger.error('Error getting performance:', error);

--- a/apps/api/src/routes/autonomousTrader.ts
+++ b/apps/api/src/routes/autonomousTrader.ts
@@ -249,8 +249,16 @@ router.get('/trades', authenticateToken, async (req: Request, res: Response) => 
         entryTime: trade.entry_time ?? trade.created_at,
         exitTime: trade.exit_time,
         confidence: trade.confidence ? parseFloat(trade.confidence) : null,
-        reason: trade.reason
-      }))
+        reason: trade.reason,
+        agent: trade.agent ?? null,
+        // 2026-05-11 — surface exchange order IDs so the TradeHistory
+        // UI can dedup against /api/dashboard/trades fills.
+        // Previously the UI summed bot rows + exchange fills naively
+        // → double-counted realized PnL on every closed trade.
+        // orderId = OPEN fill, exitOrderId = CLOSE fill.
+        orderId: trade.order_id ?? null,
+        exitOrderId: trade.exit_order_id ?? null,
+      })),
     });
   } catch (error: unknown) {
     logger.error('Error getting trades:', error);

--- a/apps/web/src/components/agent/PerformanceAnalytics.tsx
+++ b/apps/web/src/components/agent/PerformanceAnalytics.tsx
@@ -8,23 +8,22 @@ import { safeNum } from '@/utils/safeNum';
 const API_BASE_URL = getBackendUrl();
 
 interface PerformanceData {
-  total_pnl: number;
-  total_pnl_percent: number;
-  total_trades: number;
-  winning_trades: number;
-  losing_trades: number;
-  win_rate: number;
-  profit_factor: number;
-  sharpe_ratio: number;
-  max_drawdown: number;
-  avg_win: number;
-  avg_loss: number;
-  best_trade: number;
-  worst_trade: number;
-  daily_pnl: { date: string; pnl: number; cumulative_pnl: number }[];
-  strategy_performance: { strategy_name: string; pnl: number; trades: number; win_rate: number }[];
-  symbol_performance: { symbol: string; pnl: number; trades: number; win_rate: number }[];
-  hourly_distribution: { hour: number; trades: number; avg_pnl: number }[];
+  totalPnl: number;
+  totalPnlPercent: number;
+  totalTrades: number;
+  winningTrades: number;
+  losingTrades: number;
+  winRate: number;
+  profitFactor: number;
+  sharpeRatio: number;
+  maxDrawdown: number;
+  averageWin: number;
+  averageLoss: number;
+  bestTrade: number;
+  worstTrade: number;
+  dailyPerformance: { date: string; pnl: number; cumulativePnL: number; trades: number }[];
+  strategyPerformance: { strategyName: string; pnl: number; trades: number; winRate: number }[];
+  symbolPerformance: { symbol: string; pnl: number; trades: number; winRate: number }[];
 }
 
 interface PerformanceAnalyticsProps {
@@ -92,9 +91,9 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
   };
 
   const renderDailyPnLChart = () => {
-    if (!data || !data.daily_pnl || data.daily_pnl.length === 0) return null;
+    if (!data || !data.dailyPerformance || data.dailyPerformance.length === 0) return null;
 
-    const maxPnl = Math.max(...data.daily_pnl.map(d => Math.abs(d.pnl)));
+    const maxPnl = Math.max(...data.dailyPerformance.map(d => Math.abs(d.pnl)));
     const chartHeight = 200;
 
     return (
@@ -104,12 +103,12 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
           Daily P&L
         </h4>
         <div className="relative" style={{ height: `${chartHeight}px` }}>
-          <svg className="w-full h-full" viewBox={`0 0 ${data.daily_pnl.length * 40} ${chartHeight}`} preserveAspectRatio="xMidYMid meet">
+          <svg className="w-full h-full" viewBox={`0 0 ${data.dailyPerformance.length * 40} ${chartHeight}`} preserveAspectRatio="xMidYMid meet">
             {/* Zero line */}
             <line
               x1="0"
               y1={chartHeight / 2}
-              x2={data.daily_pnl.length * 40}
+              x2={data.dailyPerformance.length * 40}
               y2={chartHeight / 2}
               stroke="#9ca3af"
               strokeWidth="1"
@@ -117,7 +116,7 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
             />
 
             {/* Bars */}
-            {data.daily_pnl.map((day, idx) => {
+            {data.dailyPerformance.map((day, idx) => {
               const barHeight = (Math.abs(day.pnl) / maxPnl) * (chartHeight / 2 - 10);
               const x = idx * 40 + 10;
               const y = day.pnl >= 0 ? chartHeight / 2 - barHeight : chartHeight / 2;
@@ -153,10 +152,10 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
   };
 
   const renderCumulativePnLChart = () => {
-    if (!data || !data.daily_pnl || data.daily_pnl.length === 0) return null;
+    if (!data || !data.dailyPerformance || data.dailyPerformance.length === 0) return null;
 
-    const maxCumPnl = Math.max(...data.daily_pnl.map(d => d.cumulative_pnl));
-    const minCumPnl = Math.min(...data.daily_pnl.map(d => d.cumulative_pnl));
+    const maxCumPnl = Math.max(...data.dailyPerformance.map(d => d.cumulativePnL));
+    const minCumPnl = Math.min(...data.dailyPerformance.map(d => d.cumulativePnL));
     const range = maxCumPnl - minCumPnl;
     const padding = range * 0.1;
 
@@ -183,13 +182,13 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
 
             {/* Cumulative P&L line */}
             <polyline
-              points={data.daily_pnl.map((day, idx) => {
-                const x = (idx / (data.daily_pnl.length - 1)) * 800;
-                const y = 150 - ((day.cumulative_pnl - minCumPnl + padding) / (range + 2 * padding)) * 150;
+              points={data.dailyPerformance.map((day, idx) => {
+                const x = (idx / (data.dailyPerformance.length - 1)) * 800;
+                const y = 150 - ((day.cumulativePnL - minCumPnl + padding) / (range + 2 * padding)) * 150;
                 return `${x},${y}`;
               }).join(' ')}
               fill="none"
-              stroke={data.total_pnl >= 0 ? '#10b981' : '#ef4444'}
+              stroke={data.totalPnl >= 0 ? '#10b981' : '#ef4444'}
               strokeWidth="3"
             />
 
@@ -197,14 +196,14 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
             <polygon
               points={`
                 0,150
-                ${data.daily_pnl.map((day, idx) => {
-                  const x = (idx / (data.daily_pnl.length - 1)) * 800;
-                  const y = 150 - ((day.cumulative_pnl - minCumPnl + padding) / (range + 2 * padding)) * 150;
+                ${data.dailyPerformance.map((day, idx) => {
+                  const x = (idx / (data.dailyPerformance.length - 1)) * 800;
+                  const y = 150 - ((day.cumulativePnL - minCumPnl + padding) / (range + 2 * padding)) * 150;
                   return `${x},${y}`;
                 }).join(' ')}
                 800,150
               `}
-              fill={data.total_pnl >= 0 ? '#10b981' : '#ef4444'}
+              fill={data.totalPnl >= 0 ? '#10b981' : '#ef4444'}
               opacity="0.2"
             />
           </svg>
@@ -214,7 +213,7 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
   };
 
   const renderStrategyPerformance = () => {
-    if (!data || !data.strategy_performance || data.strategy_performance.length === 0) return null;
+    if (!data || !data.strategyPerformance || data.strategyPerformance.length === 0) return null;
 
     return (
       <div className="bg-white rounded-lg border border-gray-200 p-4">
@@ -223,12 +222,12 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
           Strategy Performance
         </h4>
         <div className="space-y-3">
-          {data.strategy_performance.map((strategy, idx) => (
+          {data.strategyPerformance.map((strategy, idx) => (
             <div key={idx} className="flex items-center gap-3">
               <div className="flex-1">
                 <div className="flex items-center justify-between mb-1">
                   <span className="text-sm font-medium text-gray-900">
-                    {strategy.strategy_name}
+                    {strategy.strategyName}
                   </span>
                   <span className={`text-sm font-bold ${getPnLColor(strategy.pnl)}`}>
                     ${safeNum(strategy.pnl).toFixed(2)}
@@ -236,13 +235,13 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
                 </div>
                 <div className="flex items-center gap-4 text-xs text-gray-600">
                   <span>{strategy.trades} trades</span>
-                  <span>Win rate: {safeNum(strategy.win_rate).toFixed(1)}%</span>
+                  <span>Win rate: {safeNum(strategy.winRate).toFixed(1)}%</span>
                 </div>
                 {/* Progress bar */}
                 <div className="mt-2 h-2 bg-gray-200 rounded-full overflow-hidden">
                   <div
                     className={`h-full ${strategy.pnl >= 0 ? 'bg-green-500' : 'bg-red-500'}`}
-                    style={{ width: `${Math.min(100, (strategy.win_rate / 100) * 100)}%` }}
+                    style={{ width: `${Math.min(100, (strategy.winRate / 100) * 100)}%` }}
                   />
                 </div>
               </div>
@@ -254,9 +253,9 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
   };
 
   const renderSymbolPerformance = () => {
-    if (!data || !data.symbol_performance || data.symbol_performance.length === 0) return null;
+    if (!data || !data.symbolPerformance || data.symbolPerformance.length === 0) return null;
 
-    const maxPnl = Math.max(...data.symbol_performance.map(s => Math.abs(s.pnl)));
+    const maxPnl = Math.max(...data.symbolPerformance.map(s => Math.abs(s.pnl)));
 
     return (
       <div className="bg-white rounded-lg border border-gray-200 p-4">
@@ -265,7 +264,7 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
           Symbol Performance
         </h4>
         <div className="space-y-3">
-          {data.symbol_performance.map((symbol, idx) => (
+          {data.symbolPerformance.map((symbol, idx) => (
             <div key={idx}>
               <div className="flex items-center justify-between mb-1">
                 <span className="text-sm font-medium text-gray-900">{symbol.symbol}</span>
@@ -275,7 +274,7 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
               </div>
               <div className="flex items-center gap-4 text-xs text-gray-600 mb-2">
                 <span>{symbol.trades} trades</span>
-                <span>Win rate: {safeNum(symbol.win_rate).toFixed(1)}%</span>
+                <span>Win rate: {safeNum(symbol.winRate).toFixed(1)}%</span>
               </div>
               {/* Horizontal bar */}
               <div className="h-6 bg-gray-100 rounded-lg overflow-hidden relative">
@@ -371,39 +370,39 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
         <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
           <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-4 border border-green-200">
             <p className="text-xs text-green-700 font-semibold mb-1">Total P&L</p>
-            <p className={`text-2xl font-bold ${getPnLColor(data.total_pnl || 0)}`}>
-              ${(data.total_pnl || 0).toFixed(2)}
+            <p className={`text-2xl font-bold ${getPnLColor(data.totalPnl || 0)}`}>
+              ${(data.totalPnl || 0).toFixed(2)}
             </p>
-            <p className={`text-xs ${getPnLColor(data.total_pnl || 0)} mt-1`}>
-              {(data.total_pnl_percent || 0) >= 0 ? '+' : ''}{(data.total_pnl_percent || 0).toFixed(2)}%
+            <p className={`text-xs ${getPnLColor(data.totalPnl || 0)} mt-1`}>
+              {(data.totalPnlPercent || 0) >= 0 ? '+' : ''}{(data.totalPnlPercent || 0).toFixed(2)}%
             </p>
           </div>
           <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
             <p className="text-xs text-gray-600 font-semibold mb-1">Total Trades</p>
-            <p className="text-2xl font-bold text-gray-900">{data.total_trades || 0}</p>
+            <p className="text-2xl font-bold text-gray-900">{data.totalTrades || 0}</p>
           </div>
           <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
             <p className="text-xs text-gray-600 font-semibold mb-1">Win Rate</p>
-            <p className={`text-2xl font-bold ${(data.win_rate || 0) >= 50 ? 'text-green-600' : 'text-red-600'}`}>
-              {(data.win_rate || 0).toFixed(1)}%
+            <p className={`text-2xl font-bold ${(data.winRate || 0) >= 50 ? 'text-green-600' : 'text-red-600'}`}>
+              {(data.winRate || 0).toFixed(1)}%
             </p>
           </div>
           <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
             <p className="text-xs text-gray-600 font-semibold mb-1">Profit Factor</p>
-            <p className={`text-2xl font-bold ${(data.profit_factor || 0) >= 1.5 ? 'text-green-600' : 'text-orange-600'}`}>
-              {(data.profit_factor || 0).toFixed(2)}
+            <p className={`text-2xl font-bold ${(data.profitFactor || 0) >= 1.5 ? 'text-green-600' : 'text-orange-600'}`}>
+              {(data.profitFactor || 0).toFixed(2)}
             </p>
           </div>
           <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
             <p className="text-xs text-gray-600 font-semibold mb-1">Sharpe Ratio</p>
-            <p className={`text-2xl font-bold ${(data.sharpe_ratio || 0) >= 1 ? 'text-green-600' : 'text-orange-600'}`}>
-              {(data.sharpe_ratio || 0).toFixed(2)}
+            <p className={`text-2xl font-bold ${(data.sharpeRatio || 0) >= 1 ? 'text-green-600' : 'text-orange-600'}`}>
+              {(data.sharpeRatio || 0).toFixed(2)}
             </p>
           </div>
           <div className="bg-gray-50 rounded-lg p-4 border border-gray-200">
             <p className="text-xs text-gray-600 font-semibold mb-1">Max Drawdown</p>
             <p className="text-2xl font-bold text-red-600">
-              {(data.max_drawdown || 0).toFixed(1)}%
+              {(data.maxDrawdown || 0).toFixed(1)}%
             </p>
           </div>
         </div>
@@ -423,21 +422,21 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <div className="bg-green-50 border border-green-200 rounded-lg p-4">
             <p className="text-xs text-green-700 font-semibold mb-1">Winning Trades</p>
-            <p className="text-2xl font-bold text-green-600">{data.winning_trades || 0}</p>
-            <p className="text-xs text-green-600 mt-1">Avg: ${(data.avg_win || 0).toFixed(2)}</p>
+            <p className="text-2xl font-bold text-green-600">{data.winningTrades || 0}</p>
+            <p className="text-xs text-green-600 mt-1">Avg: ${(data.averageWin || 0).toFixed(2)}</p>
           </div>
           <div className="bg-red-50 border border-red-200 rounded-lg p-4">
             <p className="text-xs text-red-700 font-semibold mb-1">Losing Trades</p>
-            <p className="text-2xl font-bold text-red-600">{data.losing_trades || 0}</p>
-            <p className="text-xs text-red-600 mt-1">Avg: ${safeNum(Math.abs(data.avg_loss || 0)).toFixed(2)}</p>
+            <p className="text-2xl font-bold text-red-600">{data.losingTrades || 0}</p>
+            <p className="text-xs text-red-600 mt-1">Avg: ${safeNum(Math.abs(data.averageLoss || 0)).toFixed(2)}</p>
           </div>
           <div className="bg-green-50 border border-green-200 rounded-lg p-4">
             <p className="text-xs text-green-700 font-semibold mb-1">Best Trade</p>
-            <p className="text-2xl font-bold text-green-600">${(data.best_trade || 0).toFixed(2)}</p>
+            <p className="text-2xl font-bold text-green-600">${(data.bestTrade || 0).toFixed(2)}</p>
           </div>
           <div className="bg-red-50 border border-red-200 rounded-lg p-4">
             <p className="text-xs text-red-700 font-semibold mb-1">Worst Trade</p>
-            <p className="text-2xl font-bold text-red-600">${safeNum(Math.abs(data.worst_trade || 0)).toFixed(2)}</p>
+            <p className="text-2xl font-bold text-red-600">${safeNum(Math.abs(data.worstTrade || 0)).toFixed(2)}</p>
           </div>
         </div>
       </div>

--- a/apps/web/src/pages/TradeHistory.tsx
+++ b/apps/web/src/pages/TradeHistory.tsx
@@ -48,14 +48,39 @@ const TradeHistory: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage] = useState(20);
 
+  // 2026-05-11 — dedup against double-counting.
+  // Bot rows are truth for system-managed trades; exchange fills
+  // get filtered out when their exchange order IDs already appear
+  // in a bot row (orderId or exitOrderId). Without this, the "all"
+  // tab summed both lists and double-counted every realized PnL
+  // (Trade History page showed -$2.97 across 200 trades on a day
+  // when Agent L harvested +$153 alone).
+  const botKnownOrderIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of botTrades) {
+      if (t.orderId) set.add(String(t.orderId));
+      // bot trade structure also surfaces exitOrderId via t.id or an
+      // attached field; we conservatively add all string IDs that
+      // could match an exchange fill.
+      const extra = (t as TradeHistoryItem & { exitOrderId?: string | null }).exitOrderId;
+      if (extra) set.add(String(extra));
+    }
+    return set;
+  }, [botTrades]);
+
+  const dedupedExchangeTrades = useMemo(() => {
+    if (botKnownOrderIds.size === 0) return exchangeTrades;
+    return exchangeTrades.filter(t => !botKnownOrderIds.has(String(t.orderId)));
+  }, [exchangeTrades, botKnownOrderIds]);
+
   // Combine trades based on active tab
   const trades = useMemo(() => {
     switch (activeTab) {
-      case 'exchange': return exchangeTrades;
+      case 'exchange': return exchangeTrades;  // raw exchange view shows everything
       case 'bot': return botTrades;
-      default: return [...exchangeTrades, ...botTrades];
+      default: return [...dedupedExchangeTrades, ...botTrades];
     }
-  }, [activeTab, exchangeTrades, botTrades]);
+  }, [activeTab, exchangeTrades, dedupedExchangeTrades, botTrades]);
 
   // Fetch bot trades from internal DB
   useEffect(() => {
@@ -69,6 +94,9 @@ const TradeHistory: React.FC = () => {
       pnl: number | null;
       reason: string | null;
       status: string;
+      agent: string | null;
+      orderId: string | null;
+      exitOrderId: string | null;
     }
 
     const fetchBotTrades = async () => {
@@ -95,10 +123,14 @@ const TradeHistory: React.FC = () => {
               fee: 0,
               feeCurrency: 'USDT',
               pnl: t.pnl ?? undefined,
-              strategy: t.reason || undefined,
-              orderId: t.id,
+              strategy: t.agent ? `Agent ${t.agent}` : (t.reason || undefined),
+              // Prefer the exchange OPEN order id for dedup; fall back to row id.
+              orderId: t.orderId || t.id,
+              // Carry the exchange CLOSE order id so the dedup pass
+              // can also filter out the matching close fill.
+              exitOrderId: t.exitOrderId || null,
               status: t.status === 'open' ? 'filled' as const : t.status === 'closed' ? 'filled' as const : 'cancelled' as const,
-              source: 'bot' as const
+              source: 'bot' as const,
             })));
             return;
           }

--- a/apps/web/src/pages/TransactionHistory.tsx
+++ b/apps/web/src/pages/TransactionHistory.tsx
@@ -78,21 +78,42 @@ const TransactionHistory: React.FC = () => {
         const headers: Record<string, string> = { 'Content-Type': 'application/json' };
         if (token) headers['Authorization'] = `Bearer ${token}`;
 
-        const response = await fetch(`${backendUrl}/api/futures/account-bills`, { headers });
+        // 2026-05-11 — Transaction History was calling /api/futures/account-bills
+        // which doesn't exist (404 → page rendered empty). Real endpoint is
+        // /api/dashboard/bills which proxies Poloniex's getAccountBills.
+        // Response shape: { success, data: [...] } where each item carries
+        // Poloniex's bill fields (createTime, opTypeName, currency, amount, etc).
+        const response = await fetch(`${backendUrl}/api/dashboard/bills?limit=200`, { headers });
         if (response.ok) {
-          const data = await response.json();
-          if (data.success && Array.isArray(data.bills)) {
-            setTransactions(data.bills.map((b: ApiBill, idx: number) => ({
-              id: b.id || `tx-${idx}`,
-              timestamp: new Date(b.timestamp || b.createdAt || Date.now()),
-              type: (b.type || 'trade') as Transaction['type'],
-              currency: b.currency || 'USDT',
-              amount: parseFloat(b.amount || '0'),
-              status: 'completed' as const,
-              txHash: b.txHash || undefined,
-              description: b.description || getTransactionDescription((b.type || 'trade') as Transaction['type'], b.currency || 'USDT', parseFloat(b.amount || '0')),
-              balance: parseFloat(b.balance || '0')
-            })));
+          const json = await response.json();
+          const billsArray = Array.isArray(json?.data) ? json.data
+            : Array.isArray(json?.data?.bills) ? json.data.bills
+              : Array.isArray(json?.bills) ? json.bills
+                : [];
+          if (json.success) {
+            setTransactions(billsArray.map((b: ApiBill & Record<string, unknown>, idx: number) => {
+              const rawType = String(b.type ?? b.opType ?? b.opTypeName ?? 'trade').toLowerCase();
+              const type = (
+                rawType.includes('deposit') ? 'deposit'
+                : rawType.includes('withdraw') ? 'withdrawal'
+                : rawType.includes('fee') ? 'fee'
+                : rawType.includes('funding') ? 'funding'
+                : 'trade'
+              ) as Transaction['type'];
+              const tsRaw = (b.createTime ?? b.timestamp ?? b.createdAt ?? Date.now()) as string | number;
+              const tsMs = typeof tsRaw === 'string' ? Number(tsRaw) || Date.parse(tsRaw) : Number(tsRaw);
+              return {
+                id: String(b.id ?? b.bizId ?? `tx-${idx}`),
+                timestamp: new Date(tsMs),
+                type,
+                currency: String(b.currency ?? b.coin ?? 'USDT'),
+                amount: parseFloat(String(b.amount ?? b.amt ?? '0')),
+                status: 'completed' as const,
+                txHash: (b.txHash as string | undefined) || undefined,
+                description: (b.description as string | undefined) || (b.opTypeName as string | undefined) || getTransactionDescription(type, String(b.currency ?? 'USDT'), parseFloat(String(b.amount ?? '0'))),
+                balance: parseFloat(String(b.balance ?? b.bal ?? '0')),
+              };
+            }));
             return;
           }
         }


### PR DESCRIPTION
## Summary

User-reported "UI is far from accurate" → ran `/frontend-backend-mapping` audit and found four distinct bugs, all the same class (frontend/backend shape drift). No data loss — all four are render/transport bugs.

### 1. Performance Analytics — casing mismatch (×9 fields)

Backend returned camelCase (`totalPnl`); frontend read snake_case (`total_pnl`). Every card rendered 0. **Adopted camelCase TS surface.** PerformanceAnalytics.tsx interface + accessors re-keyed; backend nests `dailyPerformance`/`strategyPerformance`/`symbolPerformance` inside `performance` and adds missing `profitFactor`, `bestTrade`, `worstTrade`, `totalPnlPercent`. strategyPerformance maps to per-agent K/M/T/L.

### 2. AgentStatus — nesting mismatch

Dashboard "Total P&L $0.00" because backend returned the value under `status.trader.metrics.totalPnl` (and FAT's metrics field doesn't even carry totalPnl — only equity/drawdown). Backend now queries `autonomous_trades` inline for `SUM(pnl)` and flattens onto `status.totalPnl`.

### 3. Transaction History — wrong endpoint path

Frontend called `/api/futures/account-bills` (404). Real route is `/api/dashboard/bills`. Frontend now points at correct path and tolerates the actual response shape, mapping Poloniex `createTime`/`opTypeName`/`amount` into the Transaction type.

### 4. Trade History — double-counting on "All Trades" tab

Bot rows + exchange fills both carry realized PnL on the same closed trades. Summing both = double-count. Reported -$2.97 on a day Agent L harvested +$153 alone.

Bot rows are truth for system-managed trades. `/api/autonomous/trades` now surfaces `orderId` (OPEN fill) and `exitOrderId` (CLOSE fill). Frontend Set-filters exchange fills against those IDs. Exchange tab still shows raw fills for audit.

## Test plan

- [x] tsc clean on both apps (no new errors in modified files)
- [ ] Live: Performance Analytics 6 cards show real numbers
- [ ] Live: Dashboard Total P&L card shows real number
- [ ] Live: Transaction History populates from Poloniex bills
- [ ] Live: Trade History "All Trades" total P&L matches reality
- [ ] Live: Trade Statistics 4 cards populated (winning/losing/best/worst)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align dashboard backend responses and frontend consumption to restore accurate end-to-end trading metrics and histories.

Bug Fixes:
- Fix Agent status payload so dashboard Total P&L and related counters read correct, flattened metrics.
- Correct performance analytics API and frontend shape mismatches so P&L and summary cards render real values instead of zeros.
- Point Transaction History to the actual dashboard bills endpoint and adapt to the Poloniex bill schema so transactions populate correctly.
- Prevent Trade History "All" tab from double-counting realized P&L by deduplicating exchange fills against bot-managed trades.

Enhancements:
- Extend performance analytics metrics with profit factor, best/worst trade, P&L percentage, and per-strategy and per-symbol breakdowns in a consistent camelCase schema.