### PR TITLE
fix(ui): leverage in use displays + slider cap raised to 75x

### DIFF
--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -773,8 +773,15 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
           return qty > 0;
         }).length;
         // Derive leverage from the largest open position; 0 when flat.
+        // 2026-05-12 — Poloniex v3 position responses use abbreviated
+        // `lever` (stringified) NOT `leverage`. Reading the wrong key
+        // returned 0 for every position → UI rendered "Leverage in use: —"
+        // even with 12 open positions. Read both shapes.
         currentLeverage = positionsList.reduce(
-          (max: number, p: Record<string, unknown>) => Math.max(max, Number(p.leverage ?? 0)),
+          (max: number, p: Record<string, unknown>) => {
+            const lev = Number(p.lever ?? p.leverage ?? 0);
+            return Number.isFinite(lev) && lev > max ? lev : max;
+          },
           0,
         );
         balance = {

--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -832,14 +832,21 @@ const AutonomousAgentDashboard: React.FC = () => {
                 <input
                   type="range"
                   min={1}
-                  max={20}
+                  max={75}
                   step={1}
                   value={config.defaultLeverage}
                   onChange={e => setConfig(c => ({ ...c, defaultLeverage: parseInt(e.target.value) }))}
                   disabled={agentStatus?.status === 'running'}
                   className="w-full accent-cyan-600"
                 />
-                <div className="flex justify-between text-xs text-gray-400"><span>1x (no leverage)</span><span>20x</span></div>
+                <div className="flex justify-between text-xs text-gray-400">
+                  <span>1x (no leverage)</span>
+                  <span>75x (BTC/ETH max)</span>
+                </div>
+                <p className="text-xs text-gray-500 mt-1">
+                  Per-symbol exchange maximums may be lower than 75x. The kernel
+                  clamps to each symbol&apos;s actual cap at order placement.
+                </p>
               </div>
               {/* Margin Mode */}
               <div>

--- a/apps/web/src/components/settings/TradingSettings.tsx
+++ b/apps/web/src/components/settings/TradingSettings.tsx
@@ -57,9 +57,9 @@ const TradingSettings: React.FC = () => {
         <div className="space-y-4">
           <div>
             <Label htmlFor="leverage">Leverage</Label>
-            <Select 
-              id="leverage" 
-              value={leverage.toString()} 
+            <Select
+              id="leverage"
+              value={leverage.toString()}
               onChange={handleLeverageChange}
               className="w-full"
             >
@@ -69,9 +69,14 @@ const TradingSettings: React.FC = () => {
               <option value="5">5x</option>
               <option value="10">10x</option>
               <option value="20">20x</option>
+              <option value="30">30x</option>
+              <option value="50">50x</option>
+              <option value="75">75x (BTC/ETH max)</option>
             </Select>
             <p className="text-xs text-neutral-500 mt-1">
               Higher leverage increases both potential profits and risks.
+              Per-symbol exchange maximums may be lower; the kernel clamps to
+              each symbol&apos;s actual cap at order placement.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary

Two leverage-UI fixes flagged in the dashboard screenshot.

### 1. "Leverage in use" panel always blank

`/api/agent/state-of-bot` read `p.leverage` from Poloniex v3 position responses. **Poloniex v3 uses abbreviated `lever`** (stringified) — the wrong key returned `undefined` → `Number(undefined)` → 0 → UI rendered `—` even with 12 open positions. Now reads both keys and coerces safely.

### 2. Agent configuration leverage slider capped at 20x

Poloniex BTC/ETH USDT perps support up to 75x; the UI cap was below the actual exchange ceiling.

- `AutonomousAgentDashboard` slider max raised to 75
- `TradingSettings` `<Select>` adds 30 / 50 / 75x options
- Explanatory copy notes that per-symbol caps may be lower and the kernel clamps at order placement
- No server-side cap to lift — kernel already queries `marketCatalog.getMaxLeverage(symbol)`

## Test plan

- [x] tsc clean for modified files
- [ ] Live: "Leverage in use" shows actual leverage (e.g. 15x) on open positions
- [ ] Live: agent config slider goes to 75x; can save 30x+ values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Raise leverage configuration limits in the UI and fix reporting of current leverage from Poloniex positions.

New Features:
- Allow configuring agent leverage up to 75x via both the dashboard slider and trading settings selector.

Bug Fixes:
- Correct the leverage-in-use calculation by reading the appropriate leverage field from Poloniex v3 position responses.

Enhancements:
- Update leverage UI labels and helper text to clarify BTC/ETH maximums and that actual per-symbol caps are enforced by the kernel.