### PR TITLE
fix(reconciler): close phantom rows from stacking + clarify dashboard

### DIFF
--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -740,14 +740,18 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
         ? 0
         : lastTrades.filter((r) => Number(r.pnl) > 0).length / lastTrades.length;
 
-    // Open-trade counts: exchange-authoritative vs DB-authoritative.
+    // Open-position counts: exchange-authoritative vs DB-authoritative.
     // Divergence = phantom state — should alarm.
-    // Count BOTH live_signal AND monkey trades — otherwise the divergence
-    // alert false-triggers as soon as Monkey opens a position (2026-04-20
-    // 10:31 UTC was the first, and state-of-bot immediately flagged as
-    // out-of-sync because Monkey's row wasn't in the count).
+    //
+    // 2026-05-13 — count UNIQUE (symbol, side) positions, NOT raw rows.
+    // Agent K/M/T/L stack multiple entries per logical position, so the
+    // raw row count overstates the position count by a factor of ~5-10.
+    // The dashboard banner used to read "12 open positions" when the
+    // bot held 2 actual positions with stacked rows — falsely flagging
+    // DIVERGENCE on every healthy stack.
     const dbOpenResult = await pool.query(
-      `SELECT COUNT(*) AS n FROM autonomous_trades
+      `SELECT COUNT(DISTINCT (symbol, side)) AS n
+         FROM autonomous_trades
         WHERE status = 'open'
           AND (reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%')
           AND user_id = $1
@@ -755,6 +759,18 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
       [userId],
     );
     const dbOpenPositions = parseInt((dbOpenResult.rows[0] as { n: string }).n, 10) || 0;
+    // Also expose the raw row count for debugging — phantom-row
+    // accumulation (rows-per-position > ~10) signals a reconciler lag.
+    const dbOpenRowsResult = await pool.query(
+      `SELECT COUNT(*) AS n
+         FROM autonomous_trades
+        WHERE status = 'open'
+          AND (reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%')
+          AND user_id = $1
+          AND deleted_at IS NULL`,
+      [userId],
+    );
+    const dbOpenRows = parseInt((dbOpenRowsResult.rows[0] as { n: string }).n, 10) || 0;
 
     let exchangeOpenPositions = 0;
     let balance = { equity: 0, currency: 'USDT' as const };
@@ -828,7 +844,12 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
       phaseReason = `${recentlyOpened} order${recentlyOpened === 1 ? '' : 's'} placed in last 90s`;
     } else if (dbOpenPositions > 0) {
       phase = 'skipping';
-      phaseReason = `${dbOpenPositions} open position${dbOpenPositions === 1 ? '' : 's'} (live-signal + monkey) — stacking guard blocks new entries until they close`;
+      // 2026-05-13 — re-worded. "Stacking guard blocks new entries" was
+      // misleading: the kernel's actual entry gates read exchange state,
+      // not DB row count. The bot is HOLDING through its exit cascade
+      // (rejustification + harvest + scalp), not blocked by a stacking
+      // guard. New entries on other symbols are still permitted.
+      phaseReason = `${dbOpenPositions} position${dbOpenPositions === 1 ? '' : 's'} held — agents managing exits via rejustification + harvest`;
     } else {
       phase = 'evaluating';
       phaseReason = 'No qualifying signal this tick — watching';
@@ -853,6 +874,11 @@ router.get('/state-of-bot', authenticateToken, async (req: Request, res: Respons
       winRateLast20,
       exchangeOpenPositions,
       dbOpenPositions,
+      // 2026-05-13 — raw row count exposed for debugging. UI ignores
+      // this in normal mode; a large gap between dbOpenRows and
+      // dbOpenPositions (rows/positions > 8) indicates phantom-row
+      // accumulation that should fire reconciler attention.
+      dbOpenRows,
       positionStateInSync: exchangeOpenPositions === dbOpenPositions,
       balance,
       currentLeverage,

--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -1130,9 +1130,20 @@ export class LiveSignalEngine extends EventEmitter {
       return;
     }
 
-    // Flip matching DB rows to closed. The reconciler would catch
-    // them on its next cycle anyway, but being prompt keeps the
-    // dashboard honest.
+    // Flip matching DB rows to closed.
+    //
+    // 2026-05-13 — broaden the filter to ALSO close Monkey rows on
+    // the same (symbol, side). poloniexFuturesService.closePosition
+    // flattens the EXCHANGE net position; if Monkey has stacked
+    // entries on the same side, those rows are now phantoms (DB
+    // open, exchange flat) and the reconciler's (symbol, side)
+    // ghost check can't distinguish them from valid rows when ANY
+    // exchange position remains on that key.
+    //
+    // Side normalization: LiveSignal writes side='buy'/'sell',
+    // Monkey writes side='long'/'short'. heldSide is long|short;
+    // we match both shapes.
+    const dbSideForMatch = heldSide === 'long' ? ['long', 'buy'] : ['short', 'sell'];
     try {
       await pool.query(
         `UPDATE autonomous_trades
@@ -1141,8 +1152,9 @@ export class LiveSignalEngine extends EventEmitter {
                 pnl = COALESCE(pnl, 0)
           WHERE symbol = $1
             AND status = 'open'
-            AND reason LIKE 'live_signal|%'`,
-        [symbol, closeReason],
+            AND side = ANY($3::text[])
+            AND (reason LIKE 'live_signal|%' OR reason LIKE 'monkey|%')`,
+        [symbol, closeReason, dbSideForMatch],
       );
     } catch (err) {
       logger.warn('[LiveSignal] DB close-row update failed (reconciler will catch up)', {

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -229,14 +229,64 @@ class StateReconciliationService {
       }
 
       // ── 6. Ghost detection: in DB but not on exchange ────────────────────────
-      for (const dbTrade of dbTrades) {
+      //
+      // 2026-05-13 — aggregate-qty check.
+      //
+      // Original (symbol, side) match handled the simple case (1 DB row
+      // per position). With Agent K/M/T/L stacking, a single exchange
+      // position can correspond to many DB rows. When the exchange has
+      // a partial close (force-harvest of half the stack, or user
+      // closes some manually), the simple match marked ALL stacked
+      // rows as still-valid because the (symbol, side) tuple still
+      // matches one exchange position — even when DB qty sum vastly
+      // exceeds exchange qty.
+      //
+      // Result observed 2026-05-13: dashboard reported DB=12 vs
+      // exchange=2 ("phantom state likely") because 10 of 12 rows were
+      // dead but unghosted.
+      //
+      // Per-key exchange qty map: aggregate exchange position qty by
+      // (symbol, side). We treat DB rows as ghosts in FIFO order
+      // (oldest first) until aggregate matches exchange qty on that
+      // key. Floor-only — never expand exchange qty by adding "phantom
+      // longs" of our own.
+      const exchangeQtyByKey = new Map<string, number>();
+      for (const exPos of exchangePositions) {
+        const exSymbol: string = exPos.symbol ?? exPos.instId ?? '';
+        if (!exSymbol) continue;
+        const exQty = Math.abs(parseFloat(exPos.qty ?? exPos.availQty ?? '0')) || 0;
+        if (exQty === 0) continue;
+        const exSide = parseFloat(exPos.qty ?? '0') > 0 ? 'long' : 'short';
+        const key = `${exSymbol}|${exSide}`;
+        exchangeQtyByKey.set(key, (exchangeQtyByKey.get(key) ?? 0) + exQty);
+      }
+      // Track running DB-attributed qty per key. Once we've "consumed"
+      // the exchange qty on a key, additional DB rows on that key are
+      // phantoms even though the (symbol, side) match succeeds.
+      const consumedQtyByKey = new Map<string, number>();
+      const sortedDbTrades = [...dbTrades].sort((a, b) => {
+        // Oldest-first — keep the freshest rows aligned to the
+        // current exchange position; older rows are the phantoms.
+        const ta = new Date(a.entry_time).getTime() || 0;
+        const tb = new Date(b.entry_time).getTime() || 0;
+        return ta - tb;
+      });
+
+      for (const dbTrade of sortedDbTrades) {
         const dbSide = normalizeDbSide(dbTrade.side);
-        const matched = exchangePositions.some(exPos => {
-          const exSymbol: string = exPos.symbol ?? exPos.instId ?? '';
-          const exQty = parseFloat(exPos.qty ?? exPos.availQty ?? '0');
-          const exSide = exQty > 0 ? 'long' : 'short';
-          return exSymbol === dbTrade.symbol && exSide === dbSide;
-        });
+        const key = `${dbTrade.symbol}|${dbSide}`;
+        const exchangeQty = exchangeQtyByKey.get(key) ?? 0;
+        const consumedQty = consumedQtyByKey.get(key) ?? 0;
+        const remainingExchangeQty = exchangeQty - consumedQty;
+        const rowQty = Math.abs(parseFloat(dbTrade.quantity)) || 0;
+        // A row is valid when the exchange still has untaken qty on
+        // this key. Use a small tolerance because exchange and DB
+        // qty may differ by lot-rounding rounding noise.
+        const QTY_TOLERANCE = 1e-9;
+        const matched = remainingExchangeQty > QTY_TOLERANCE;
+        if (matched) {
+          consumedQtyByKey.set(key, consumedQty + rowQty);
+        }
 
         if (!matched) {
           const ghost: GhostRecord = {


### PR DESCRIPTION
## Summary

User-reported "DIVERGENCE — phantom state likely · Exchange: 2 open · DB: 12 open" on a healthy bot. Three bugs share one pattern: every assumed "1 DB row per position", which breaks under the K/M/T/L stacking model where multiple agent entries aggregate into one exchange position.

### 1. LiveSignal close UPDATE missed Monkey rows

`closeExistingPosition` flattens the exchange position via `closePosition()` but the DB UPDATE only matched `reason LIKE 'live_signal|%'`. Monkey rows on the same (symbol, side) stayed `status='open'` → phantoms. Fix: include `monkey|%` rows; scope to the actual side; normalize buy/sell vs long/short.

### 2. Reconciler ghost detection assumed 1 row per position

The `(symbol, side)` match made ALL stacked rows look valid when ANY residual exchange position remained on that key. Result observed: 12 DB rows / 2 exchange positions never converging.

Fix: aggregate exchange qty by (symbol, side). FIFO-walk DB rows consuming exchange qty; rows past the qty boundary are ghosts. Oldest-first ordering keeps freshest rows aligned to the current position.

### 3. Dashboard SKIPPING phaseReason

Banner said "12 open positions — stacking guard blocks new entries until they close". Two errors:
- "12 positions" was raw row count, overcounting by ~5-10× under stacking
- The bot wasn't blocked — kernel entry gates read exchange state. It was HOLDING through its exit cascade.

Fix: `dbOpenPositions` counts `DISTINCT (symbol, side)`; raw row count exposed as `dbOpenRows` for debugging. Banner now reads "X positions held — agents managing exits via rejustification + harvest".

## QIG purity

Zero changes under `monkey/`. All edits in liveSignalEngine, reconciler, and agent routes — pure data-plane fixes.

## Test plan

- [x] tsc clean
- [x] FAT + futures.leverage unit tests pass
- [ ] Live: DIVERGENCE banner clears after next reconciler tick (60s) once aggregate-qty check ghosts the trailing phantoms
- [ ] Live: SKIPPING banner reads "X positions held — agents managing exits" instead of "stacking guard blocks"
- [ ] Live: dbOpenPositions reflects unique (symbol, side) count rather than raw rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update reconciliation, live signal closing, and dashboard state reporting to correctly handle stacked positions and eliminate phantom rows.

Bug Fixes:
- Ensure ghost detection treats excess stacked DB trades beyond aggregate exchange quantity as phantoms using FIFO ordering.
- Close both live_signal and monkey DB rows for a symbol/side when an exchange position is flattened, normalizing long/short vs buy/sell.

Enhancements:
- Report DB open positions as distinct (symbol, side) pairs, expose raw open row count for debugging, and clarify the dashboard message when positions are being managed by exit agents.