### PR TITLE
fix(ui): show stacked-rows count on the sync banner

### DIFF
--- a/apps/web/src/components/agent/StateOfTheBotCard.tsx
+++ b/apps/web/src/components/agent/StateOfTheBotCard.tsx
@@ -36,7 +36,11 @@ interface StateOfBot {
   tradesPerHour: number;
   winRateLast20: number;
   exchangeOpenPositions: number;
+  /** Distinct (symbol, side) positions in DB. Stacked rows aggregate. */
   dbOpenPositions: number;
+  /** Raw open-row count — diverges from dbOpenPositions under stacking.
+   *  rows >> positions signals phantom-row accumulation. */
+  dbOpenRows?: number;
   positionStateInSync: boolean;
   balance: { equity: number; currency: string };
   currentLeverage: number;
@@ -212,7 +216,11 @@ const StateOfTheBotCard: React.FC = () => {
           <AlertTriangle className="w-4 h-4" />
         )}
         <span>
-          Exchange: {state.exchangeOpenPositions} open · DB: {state.dbOpenPositions} open
+          Exchange: {state.exchangeOpenPositions} open · DB: {state.dbOpenPositions} position
+          {state.dbOpenPositions === 1 ? '' : 's'}
+          {state.dbOpenRows !== undefined && state.dbOpenRows !== state.dbOpenPositions
+            ? ` (${state.dbOpenRows} rows stacked)`
+            : ''}
           {state.positionStateInSync ? ' · in sync' : ' · DIVERGENCE — phantom state likely'}
         </span>
       </div>


### PR DESCRIPTION
## Summary

Follow-up to #658. Surfaces the raw row count next to position count when they diverge under stacking, so phantom-row accumulation is visible at a glance.

Examples:
- `Exchange: 2 open · DB: 2 positions · in sync` (no stacks)
- `Exchange: 2 open · DB: 2 positions (10 rows stacked) · in sync` (healthy stacks — normal under K/M/T/L)
- `Exchange: 2 open · DB: 0 positions · DIVERGENCE` (phantom state — should alarm)

## Test plan

- [x] tsc clean
- [ ] Live: banner shows `(N rows stacked)` text when L is stacked

## Summary by Sourcery

Surface stacked database row counts in the bot state sync banner to highlight divergences between raw rows and logical positions.

New Features:
- Display stacked DB row counts alongside DB position counts when they differ in the bot state banner.

Enhancements:
- Extend bot state model with an optional raw DB open-row count field to support stacked row reporting in the UI.