### PR TITLE
feat(backfill): startup-gated stacked-ghost PnL repair

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -42,6 +42,7 @@ import paperTradingService from './services/paperTradingService.js';
 import { persistentTradingEngine } from './services/persistentTradingEngine.js';
 import { startPipelineHealthProbe } from './services/pipelineHealthProbe.js';
 import { stateReconciliationService } from './services/stateReconciliationService.js';
+import { maybeRunStartupBackfill } from './services/backfillStackedGhostPnl.js';
 import { shouldExpectPaperTrades } from './services/tradingStateProbe.js';
 import { logger } from './utils/logger.js';
 
@@ -386,6 +387,12 @@ server.listen(PORT, '::', async () => {
     logger.error('\u274c Database migration failed:', error);
     process.exit(1);
   }
+
+  // 2026-05-13 \u2014 one-off PnL backfill gated by POLYTRADE_RUN_PNL_BACKFILL.
+  // Repairs the stacked-ghost over-attribution bug from the
+  // PR-#658-to-#660 window. Idempotent; logs and never throws. Set the
+  // env flag once to trigger; unset after one successful run.
+  await maybeRunStartupBackfill();
 
   // Run state reconciliation for all active users before trading loops start
   try {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { authenticateToken } from '../middleware/auth.js';
 import { logger } from '../utils/logger.js';
+import { runStackedGhostPnlBackfill } from '../services/backfillStackedGhostPnl.js';
 
 const router = express.Router();
 const __filename = fileURLToPath(import.meta.url);
@@ -218,137 +219,21 @@ router.get('/db-status', async (req, res) => {
 router.post('/backfill-stacked-ghost-pnl', async (req, res) => {
   try {
     const apply = req.body?.apply === true;
-    const startTs = String(req.body?.startTs || '2026-05-13T01:32:00Z');
-    const endTs = String(req.body?.endTs || '2026-05-13T05:50:00Z');
-    if (!Number.isFinite(Date.parse(startTs)) || !Number.isFinite(Date.parse(endTs))) {
-      return res.status(400).json({ success: false, error: 'invalid startTs/endTs' });
+    const startTs = req.body?.startTs ? String(req.body.startTs) : undefined;
+    const endTs = req.body?.endTs ? String(req.body.endTs) : undefined;
+    if (startTs && !Number.isFinite(Date.parse(startTs))) {
+      return res.status(400).json({ success: false, error: 'invalid startTs' });
     }
-
-    // Find candidate groups: ghost-closed rows in the window, grouped
-    // by (symbol, side, second-truncated exit_time), where two or more
-    // rows share an identical non-null pnl. That signature is the bug
-    // — pre-PR-#660 reconciler attributed the aggregate to every row.
-    const groups = await pool.query(
-      `SELECT symbol,
-              side,
-              date_trunc('second', exit_time) AS ts_sec,
-              COUNT(*) AS n_rows,
-              COUNT(DISTINCT pnl) FILTER (WHERE pnl IS NOT NULL) AS n_distinct_pnl,
-              MAX(pnl) FILTER (WHERE pnl IS NOT NULL) AS aggregate_pnl,
-              array_agg(id ORDER BY entry_time) AS row_ids,
-              array_agg(quantity ORDER BY entry_time) AS quantities,
-              array_agg(pnl ORDER BY entry_time) AS pnls,
-              array_agg(agent ORDER BY entry_time) AS agents,
-              array_agg(exit_reason ORDER BY entry_time) AS exit_reasons
-         FROM autonomous_trades
-        WHERE status = 'closed'
-          AND exit_time BETWEEN $1::timestamptz AND $2::timestamptz
-          AND exit_reason IN ('manual_close_user', 'reconciled_post_close_race', 'reconciled_not_on_exchange')
-        GROUP BY symbol, side, date_trunc('second', exit_time)
-        HAVING COUNT(*) > 1
-           AND COUNT(DISTINCT pnl) FILTER (WHERE pnl IS NOT NULL) = 1
-        ORDER BY date_trunc('second', exit_time) ASC`,
-      [startTs, endTs],
-    );
-
-    type GroupRow = {
-      symbol: string;
-      side: string;
-      ts_sec: string;
-      n_rows: string;
-      n_distinct_pnl: string;
-      aggregate_pnl: string;
-      row_ids: string[];
-      quantities: string[];
-      pnls: (string | null)[];
-      agents: (string | null)[];
-      exit_reasons: (string | null)[];
-    };
-
-    const summary: Array<{
-      symbol: string;
-      side: string;
-      ts: string;
-      nRows: number;
-      aggregatePnl: number;
-      totalQty: number;
-      updates: Array<{ id: string; agent: string | null; qty: number; oldPnl: number | null; newPnl: number; share: number }>;
-    }> = [];
-
-    let totalRowsUpdated = 0;
-    let totalCorrectionUsdt = 0;
-
-    for (const g of groups.rows as GroupRow[]) {
-      const aggregatePnl = parseFloat(g.aggregate_pnl) || 0;
-      const qtys = g.quantities.map((q) => Math.abs(parseFloat(q)) || 0);
-      const totalQty = qtys.reduce((s, q) => s + q, 0);
-      if (totalQty <= 0) continue;
-
-      const updates = g.row_ids.map((id, i) => {
-        const rowQty = qtys[i] ?? 0;
-        const share = rowQty / totalQty;
-        const oldPnl = g.pnls[i] !== null ? parseFloat(g.pnls[i] as string) : null;
-        const newPnl = aggregatePnl * share;
-        return {
-          id,
-          agent: g.agents[i] ?? null,
-          qty: rowQty,
-          oldPnl,
-          newPnl,
-          share,
-        };
-      });
-
-      summary.push({
-        symbol: g.symbol,
-        side: g.side,
-        ts: g.ts_sec,
-        nRows: updates.length,
-        aggregatePnl,
-        totalQty,
-        updates,
-      });
-
-      // Correction magnitude: each over-attributed row currently
-      // contributes (oldPnl - newPnl) of fake P&L to the ledger.
-      for (const u of updates) {
-        if (u.oldPnl !== null) totalCorrectionUsdt += u.oldPnl - u.newPnl;
-      }
-
-      if (apply) {
-        for (const u of updates) {
-          try {
-            await pool.query(
-              `UPDATE autonomous_trades SET pnl = $1 WHERE id = $2`,
-              [u.newPnl, u.id],
-            );
-            totalRowsUpdated++;
-          } catch (updErr) {
-            logger.error('[BACKFILL] row update failed', {
-              id: u.id, err: updErr instanceof Error ? updErr.message : String(updErr),
-            });
-          }
-        }
-      }
+    if (endTs && !Number.isFinite(Date.parse(endTs))) {
+      return res.status(400).json({ success: false, error: 'invalid endTs' });
     }
-
+    const result = await runStackedGhostPnlBackfill({ apply, startTs, endTs });
     logger.info(
       `[BACKFILL] stacked-ghost PnL ${apply ? 'APPLIED' : 'DRY-RUN'}: ` +
-      `${summary.length} groups, ` +
-      `${apply ? totalRowsUpdated : summary.reduce((s, g) => s + g.nRows, 0)} rows, ` +
-      `net ledger correction ${totalCorrectionUsdt.toFixed(4)} USDT`,
+      `${result.groupsFound} groups, ${result.rowsAffected} rows, ` +
+      `net ledger correction ${result.netLedgerCorrectionUsdt.toFixed(4)} USDT`,
     );
-
-    res.json({
-      success: true,
-      apply,
-      window: { startTs, endTs },
-      groupsFound: summary.length,
-      rowsAffected: summary.reduce((s, g) => s + g.nRows, 0),
-      rowsUpdated: apply ? totalRowsUpdated : 0,
-      netLedgerCorrectionUsdt: parseFloat(totalCorrectionUsdt.toFixed(4)),
-      summary,
-    });
+    res.json({ success: true, ...result });
   } catch (err) {
     logger.error('[BACKFILL] stacked-ghost PnL failed', err);
     res.status(500).json({

--- a/apps/api/src/services/backfillStackedGhostPnl.ts
+++ b/apps/api/src/services/backfillStackedGhostPnl.ts
@@ -1,0 +1,201 @@
+/**
+ * backfillStackedGhostPnl.ts — one-off repair for the reconciler
+ * PnL over-attribution bug live between PR #658 (2026-05-13 01:32Z)
+ * and PR #660 (2026-05-13 05:40Z).
+ *
+ * The buggy reconciler applied the FULL aggregate position PnL to
+ * EACH stacked ghost row instead of distributing pro-rata by qty.
+ * Result: realized P&L ledger amplified by N× for every multi-row
+ * close cycle.
+ *
+ * Detection signature: closed rows in the corruption window that
+ *   • share a (symbol, side) and exit_time-truncated-to-second
+ *   • have ≥ 2 rows in the group
+ *   • all non-null pnls in the group are identical (the duplicated
+ *     aggregate)
+ *
+ * Repair: rewrite each row's pnl as (rowQty / sumGroupQty) * aggregate.
+ *
+ * Idempotent: re-running on already-corrected data is a no-op because
+ * after repair the distinct-pnl-count detection no longer fires
+ * (pro-rata shares are different values).
+ */
+import { pool } from '../db/connection.js';
+import { logger } from '../utils/logger.js';
+
+export interface BackfillResult {
+  apply: boolean;
+  window: { startTs: string; endTs: string };
+  groupsFound: number;
+  rowsAffected: number;
+  rowsUpdated: number;
+  netLedgerCorrectionUsdt: number;
+  summary: Array<{
+    symbol: string;
+    side: string;
+    ts: string;
+    nRows: number;
+    aggregatePnl: number;
+    totalQty: number;
+    updates: Array<{
+      id: string;
+      agent: string | null;
+      qty: number;
+      oldPnl: number | null;
+      newPnl: number;
+      share: number;
+    }>;
+  }>;
+}
+
+interface GroupRow {
+  symbol: string;
+  side: string;
+  ts_sec: string;
+  n_rows: string;
+  n_distinct_pnl: string;
+  aggregate_pnl: string;
+  row_ids: string[];
+  quantities: string[];
+  pnls: (string | null)[];
+  agents: (string | null)[];
+  exit_reasons: (string | null)[];
+}
+
+const DEFAULT_START = '2026-05-13T01:32:00Z';
+const DEFAULT_END = '2026-05-13T05:50:00Z';
+
+export async function runStackedGhostPnlBackfill(opts: {
+  apply: boolean;
+  startTs?: string;
+  endTs?: string;
+}): Promise<BackfillResult> {
+  const apply = opts.apply === true;
+  const startTs = opts.startTs ?? DEFAULT_START;
+  const endTs = opts.endTs ?? DEFAULT_END;
+
+  const groups = await pool.query(
+    `SELECT symbol,
+            side,
+            date_trunc('second', exit_time) AS ts_sec,
+            COUNT(*) AS n_rows,
+            COUNT(DISTINCT pnl) FILTER (WHERE pnl IS NOT NULL) AS n_distinct_pnl,
+            MAX(pnl) FILTER (WHERE pnl IS NOT NULL) AS aggregate_pnl,
+            array_agg(id ORDER BY entry_time) AS row_ids,
+            array_agg(quantity ORDER BY entry_time) AS quantities,
+            array_agg(pnl ORDER BY entry_time) AS pnls,
+            array_agg(agent ORDER BY entry_time) AS agents,
+            array_agg(exit_reason ORDER BY entry_time) AS exit_reasons
+       FROM autonomous_trades
+      WHERE status = 'closed'
+        AND exit_time BETWEEN $1::timestamptz AND $2::timestamptz
+        AND exit_reason IN ('manual_close_user', 'reconciled_post_close_race', 'reconciled_not_on_exchange')
+      GROUP BY symbol, side, date_trunc('second', exit_time)
+      HAVING COUNT(*) > 1
+         AND COUNT(DISTINCT pnl) FILTER (WHERE pnl IS NOT NULL) = 1
+      ORDER BY date_trunc('second', exit_time) ASC`,
+    [startTs, endTs],
+  );
+
+  const summary: BackfillResult['summary'] = [];
+  let totalRowsUpdated = 0;
+  let totalCorrectionUsdt = 0;
+
+  for (const g of groups.rows as GroupRow[]) {
+    const aggregatePnl = parseFloat(g.aggregate_pnl) || 0;
+    const qtys = g.quantities.map((q) => Math.abs(parseFloat(q)) || 0);
+    const totalQty = qtys.reduce((s, q) => s + q, 0);
+    if (totalQty <= 0) continue;
+
+    const updates = g.row_ids.map((id, i) => {
+      const rowQty = qtys[i] ?? 0;
+      const share = rowQty / totalQty;
+      const oldPnl = g.pnls[i] !== null ? parseFloat(g.pnls[i] as string) : null;
+      const newPnl = aggregatePnl * share;
+      return { id, agent: g.agents[i] ?? null, qty: rowQty, oldPnl, newPnl, share };
+    });
+
+    summary.push({
+      symbol: g.symbol,
+      side: g.side,
+      ts: g.ts_sec,
+      nRows: updates.length,
+      aggregatePnl,
+      totalQty,
+      updates,
+    });
+
+    for (const u of updates) {
+      if (u.oldPnl !== null) totalCorrectionUsdt += u.oldPnl - u.newPnl;
+    }
+
+    if (apply) {
+      for (const u of updates) {
+        try {
+          await pool.query(`UPDATE autonomous_trades SET pnl = $1 WHERE id = $2`, [
+            u.newPnl,
+            u.id,
+          ]);
+          totalRowsUpdated++;
+        } catch (updErr) {
+          logger.error('[BACKFILL] row update failed', {
+            id: u.id,
+            err: updErr instanceof Error ? updErr.message : String(updErr),
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    apply,
+    window: { startTs, endTs },
+    groupsFound: summary.length,
+    rowsAffected: summary.reduce((s, g) => s + g.nRows, 0),
+    rowsUpdated: apply ? totalRowsUpdated : 0,
+    netLedgerCorrectionUsdt: parseFloat(totalCorrectionUsdt.toFixed(4)),
+    summary,
+  };
+}
+
+/**
+ * Startup helper: runs the backfill if POLYTRADE_RUN_PNL_BACKFILL=1.
+ * Always applies (no dry-run on startup). Logs result; never throws.
+ * Idempotent — safe to leave the env flag set, but recommend unsetting
+ * after one successful run for hygiene.
+ */
+export async function maybeRunStartupBackfill(): Promise<void> {
+  if (process.env.POLYTRADE_RUN_PNL_BACKFILL !== '1') return;
+  try {
+    const result = await runStackedGhostPnlBackfill({ apply: true });
+    logger.info('[BACKFILL] startup stacked-ghost PnL repair complete', {
+      groupsFound: result.groupsFound,
+      rowsAffected: result.rowsAffected,
+      rowsUpdated: result.rowsUpdated,
+      netLedgerCorrectionUsdt: result.netLedgerCorrectionUsdt,
+      window: result.window,
+    });
+    // Per-group detail at info level so the audit trail is in logs.
+    for (const g of result.summary) {
+      logger.info('[BACKFILL] group repaired', {
+        symbol: g.symbol,
+        side: g.side,
+        ts: g.ts,
+        nRows: g.nRows,
+        aggregatePnl: g.aggregatePnl,
+        updates: g.updates.map((u) => ({
+          id: u.id.slice(0, 8),
+          agent: u.agent,
+          qty: u.qty,
+          oldPnl: u.oldPnl,
+          newPnl: parseFloat(u.newPnl.toFixed(4)),
+          share: parseFloat(u.share.toFixed(4)),
+        })),
+      });
+    }
+  } catch (err) {
+    logger.error('[BACKFILL] startup repair failed (continuing)', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Extracts the PR-#661 backfill logic into a shared service and wires a startup runner gated by \`POLYTRADE_RUN_PNL_BACKFILL=1\`. Lets the repair run server-side without needing admin-auth curl — set the env flag, Railway restarts the API, backfill runs once on startup, logs per-group repair, proceeds normally.

Operation is idempotent — distinct-pnl detection won't re-fire on already-repaired rows.

Admin route still works, now delegating to the same shared service.

## Run plan

1. Merge → Railway redeploys
2. Set \`POLYTRADE_RUN_PNL_BACKFILL=1\` → triggers restart
3. Watch logs for "[BACKFILL] startup stacked-ghost PnL repair complete"
4. Unset env flag after one successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a reusable stacked-ghost PnL backfill service and wire it to run both via the admin API and as an optional startup repair gated by an environment flag.

Bug Fixes:
- Repair historical PnL over-attribution for stacked ghost trades in the specified corruption window by recomputing per-row PnL pro-rata by quantity.

Enhancements:
- Refactor stacked-ghost PnL backfill logic from the admin route into a shared service with structured results and logging.
- Add optional startup-time execution of the stacked-ghost PnL backfill when POLYTRADE_RUN_PNL_BACKFILL=1, ensuring idempotent, non-fatal operation.
- Relax and clarify admin backfill request validation to accept optional custom time windows while defaulting to the corruption window.