### PR TITLE
fix(monkey): ghost-close L rows on Poloniex 21002 "Position not enough"

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -3197,10 +3197,40 @@ export class MonkeyKernel extends EventEmitter {
           exchangeOrder?.ordId ?? exchangeOrder?.orderId ??
           exchangeOrder?.id ?? exchangeOrder?.clientOid ?? null;
       } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
         logger.warn('[AgentL] force-harvest exchange order rejected', {
-          symbol, side: sideKey, qty: formattedSize,
-          err: err instanceof Error ? err.message : String(err),
+          symbol, side: sideKey, qty: formattedSize, err: errMsg,
         });
+        // 2026-05-13 — Poloniex 21002 "Position not enough" means the
+        // exchange doesn't have the qty the DB thinks it has. These
+        // rows are PHANTOMS — keeping them open spins this branch
+        // every tick (observed: 11:37→11:47Z BTC stop-loss tried 13×
+        // with same -$6 PnL, never closed, position bled). Ghost the
+        // rows immediately with reason 'position_mismatch_phantom'
+        // so subsequent ticks skip them. PnL = null because we never
+        // had a real close.
+        if (errMsg.includes('code=21002') || errMsg.includes('Position not enough')) {
+          try {
+            for (const row of rows) {
+              await pool.query(
+                `UPDATE autonomous_trades
+                    SET status = 'closed',
+                        exit_reason = 'position_mismatch_phantom',
+                        exit_time = NOW(),
+                        pnl = COALESCE(pnl, 0)
+                  WHERE id = $1`,
+                [row.id],
+              );
+            }
+            logger.warn('[AgentL] phantom rows ghost-closed (Poloniex 21002)', {
+              symbol, side: sideKey, ghostedRows: rows.length,
+            });
+          } catch (updErr) {
+            logger.error('[AgentL] phantom ghost-close DB update failed', {
+              symbol, err: updErr instanceof Error ? updErr.message : String(updErr),
+            });
+          }
+        }
         continue;
       }
       if (!orderId) {


### PR DESCRIPTION
## Production regression

PR #664's stop-loss harvest correctly **detected** an L stack at −0.5% adverse and tried to close it. Poloniex rejected with `code=21002: Position not enough` because the DB's 0.016 BTC stack didn't match the exchange's actual size (phantom rows).

The error handler logged the warn and \`continue\`d to the next side but did **not** mark the rows closed. Result: harvest fired every tick (13× in 10min) on the same dead rows, log spam, position kept bleeding.

## Fix

When Poloniex returns 21002, the rows are phantoms by definition (DB > exchange). Ghost-close them DB-side with `exit_reason='position_mismatch_phantom'`, `pnl=COALESCE(pnl, 0)`. Subsequent ticks skip them because `status='closed'`.

## Why PR #658's reconciler ghost-detection didn't already catch this

Should have, but evidently the timing window between phantom detection and the next harvest tick is too tight (reconciler 60s, harvest 30s). This is defense-in-depth at the close-attempt site itself.

## QIG purity

Pure DB cleanup path, no new banned operations.

## Summary by Sourcery

Bug Fixes:
- Mark phantom autonomous trade rows as closed when Poloniex reports insufficient position size, avoiding repeated stop-loss harvest retries and log spam.