### PR TITLE
feat(monkey): cadence-align Agent L + horizon-bounded exit

### DIFF
--- a/apps/api/src/services/monkey/__tests__/agent_L_classifier.test.ts
+++ b/apps/api/src/services/monkey/__tests__/agent_L_classifier.test.ts
@@ -144,8 +144,11 @@ describe('agentLDecide', () => {
     // Build a long history where every "high-biased" basin is followed
     // by a high-biased basin 4 ticks later (i.e., long realization).
     // Then ask: given a high-biased current, what does Agent L predict?
+    //
+    // 2026-05-13 — bumped to 1000 ticks to satisfy minTupleStart=480
+    // plus spacing=30 needing ~17+ candidate slots for k=8 nearest.
     const hist: Basin[] = [];
-    for (let i = 0; i < 200; i++) {
+    for (let i = 0; i < 1000; i++) {
       // Alternating phases: high → high (long realization) for even-indexed cycles,
       // low → low (short realization) for odd-indexed.
       const cycle = Math.floor(i / 8);
@@ -162,7 +165,7 @@ describe('agentLDecide', () => {
   it('respects action threshold — small score returns hold', () => {
     // Mixed history with no clear signal — expect hold or low conviction.
     const hist: Basin[] = [];
-    for (let i = 0; i < 200; i++) {
+    for (let i = 0; i < 1000; i++) {
       hist.push(i % 2 === 0 ? biased('high', 0.55) : biased('low', 0.55));
     }
     const r = agentLDecide(hist, { ...DEFAULT_AGENT_L_CONFIG, actionThreshold: 0.5 });

--- a/apps/api/src/services/monkey/agent_L_classifier.ts
+++ b/apps/api/src/services/monkey/agent_L_classifier.ts
@@ -38,13 +38,20 @@
 import { fisherRao, frechetMean, type Basin } from './basin.js';
 import { basinDirection } from './perception.js';
 
-/** A multi-scale basin tuple. One slot per time scale. */
+/** A multi-scale basin tuple. One slot per time scale.
+ *
+ *  2026-05-13 — window labels updated to match the kernel's actual
+ *  30s tick cadence (MONKEY_TICK_MS=30_000). Prior docstrings claimed
+ *  "5m stream" which was wrong; the windows were correspondingly 10×
+ *  too short for the canonical Lorentzian's effective timescale and
+ *  produced 2-minute predictions traded on a 30s cadence.
+ */
 export interface BasinTuple {
-  /** Current tick — finest perceptual scale. */
+  /** Current tick — finest perceptual scale (30 s). */
   current: Basin;
-  /** Medium-window Fréchet mean (~12 ticks ≈ 1h on 5m stream). */
+  /** Medium-window Fréchet mean (120 ticks ≈ 60 min on 30s stream). */
   medium: Basin;
-  /** Long-window Fréchet mean (~48 ticks ≈ 4h on 5m stream). */
+  /** Long-window Fréchet mean (480 ticks ≈ 4 h on 30s stream). */
   long: Basin;
 }
 
@@ -79,13 +86,20 @@ export function fisherRaoTupleDistance(
 
 /** Build a multi-scale basin tuple from a basin history.
  *  - current = the most recent basin (history[history.length - 1])
- *  - medium = Fréchet mean of the last `mediumWindow` basins (default 12)
- *  - long = Fréchet mean of the last `longWindow` basins (default 48)
- *  When the history is too short, falls back to using the available subset. */
+ *  - medium = Fréchet mean of the last `mediumWindow` basins (default 120)
+ *  - long = Fréchet mean of the last `longWindow` basins (default 480)
+ *  When the history is too short, falls back to using the available subset.
+ *
+ *  2026-05-13 — windows recalibrated for actual 30s kernel tick cadence
+ *  (was tuned for a 5m stream; comment was correct, defaults were not):
+ *    medium 120 ticks  = 60 min  (matches canonical Lorentzian bar lookback)
+ *    long   480 ticks  = 4 h     (longer-term regime context)
+ *  Canonical TV Lorentzian on 15m bars with 4-bar forward horizon hits
+ *  ~79% winrate. Our port now operates on matching timescales. */
 export function buildBasinTuple(
   history: readonly Basin[],
-  mediumWindow: number = 12,
-  longWindow: number = 48,
+  mediumWindow: number = 120,
+  longWindow: number = 480,
 ): BasinTuple | null {
   if (history.length === 0) return null;
   const current = history[history.length - 1]!;
@@ -152,18 +166,24 @@ export interface AgentLDecision {
 }
 
 export interface AgentLConfig {
-  /** K nearest neighbors. Default 8. */
+  /** K nearest neighbors. Default 8 (matches canonical Pine). */
   k: number;
   /** Chronological spacing — only consider every Nth past basin tuple
-   *  to ensure neighbors are chronologically distinct. Default 4. */
+   *  to ensure neighbors are chronologically distinct. Default 30 on
+   *  30s ticks → ~15 min between candidate neighbors, which matches
+   *  the canonical Lorentzian's bar-spaced sampling on 15m bars. */
   spacing: number;
-  /** Future-bar horizon for label computation. Default 4. */
+  /** Future-tick horizon for label computation. Default 120 ticks
+   *  = 60 min on 30s cadence, matching the canonical Lorentzian's
+   *  4-bar × 15-min = 60-min effective forward horizon. */
   horizon: number;
   /** Threshold to call basinDirection a long/short realization. Default 0.025. */
   labelThreshold: number;
   /** Per-scale weights. Default DEFAULT_SCALE_WEIGHTS. */
   weights: ScaleWeights;
-  /** Minimum signed-score magnitude to act (else hold). Default 0.20. */
+  /** Minimum signed-score magnitude to act (else hold). Default 0.25.
+   *  Slightly higher than canonical because longer horizon = noisier
+   *  individual labels → more conviction needed to act. */
   actionThreshold: number;
   /** Lookback cap on history. Default 2000 (matches Pine Script default). */
   maxLookback: number;
@@ -171,11 +191,14 @@ export interface AgentLConfig {
 
 export const DEFAULT_AGENT_L_CONFIG: AgentLConfig = {
   k: 8,
-  spacing: 4,
-  horizon: 4,
+  // 2026-05-13 — cadence calibration to match canonical Lorentzian
+  // timescale (15m bars, 4-bar forward horizon, ~79% winrate on BTC).
+  // Comments in spec match the actual 30s tick reality.
+  spacing: 30,           // every 15 min on 30s ticks
+  horizon: 120,          // 60 min forward — canonical's 4 × 15min
   labelThreshold: 0.025,
   weights: DEFAULT_SCALE_WEIGHTS,
-  actionThreshold: 0.20,
+  actionThreshold: 0.25, // bumped from 0.20 — longer horizon, noisier labels
   maxLookback: 2000,
 };
 
@@ -207,7 +230,10 @@ export function agentLDecide(
 
   const lookback = Math.min(config.maxLookback, basinHistory.length);
   const startIdx = Math.max(0, basinHistory.length - lookback);
-  const minTupleStart = 48;  // need at least longWindow ticks to build a tuple
+  // 2026-05-13 — must equal longWindow (480) so the multi-scale tuple
+  // can be built with full long-window Fréchet mean. ~4h warmup on
+  // 30s ticks; K/M/T continue trading during L's warmup.
+  const minTupleStart = 480;
 
   const candidates: KNNNeighbor[] = [];
   for (let i = startIdx + minTupleStart; i < basinHistory.length - config.horizon; i++) {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -359,6 +359,20 @@ interface SymbolState {
    *  streak (all 5 positive AND dopamine high), threshold widens from
    *  0.3% to 0.6% to let winners run. Oldest entry drops on push. */
   recentLHarvestPnls: number[];
+  /** 2026-05-13 — horizon-bounded exit per Change B.
+   *
+   *  Tracks the wall-clock ms of the most recent L decision that
+   *  confirmed (or proposed) the side. The L classifier's prediction
+   *  has a forward horizon (default 120 ticks = 60 min on 30s); once
+   *  that horizon elapses without L re-confirming, the position is
+   *  past its forecast window and must exit unless extended.
+   *
+   *  Updated whenever L decides enter_long/enter_short on this side
+   *  (regardless of whether the entry executes — gate/veto outcomes
+   *  don't affect the underlying L conviction). Cleared on harvest
+   *  so the next entry starts a fresh horizon clock.
+   */
+  lLastConfirmedAtMsBySide: { long: number | null; short: number | null };
 }
 
 /** Cap the recent-bus-event ring at this size — anything older than
@@ -632,6 +646,7 @@ export class MonkeyKernel extends EventEmitter {
       recentBusEvents: [],
       lForceHarvestAtMsBySide: { long: null, short: null },
       recentLHarvestPnls: [],
+      lLastConfirmedAtMsBySide: { long: null, short: null },
     };
   }
 
@@ -2242,9 +2257,21 @@ export class MonkeyKernel extends EventEmitter {
     if (
       process.env.MONKEY_EXECUTE === 'true'
       && lAlloc > 0
-      && state.basinHistory.length >= 60
+      // 2026-05-13 — warmup gate bumped to match recalibrated
+      // longWindow (480). 480 ticks × 30s ≈ 4h. K/M/T continue
+      // trading during L's warmup.
+      && state.basinHistory.length >= 480
     ) {
       const lDecision = agentLDecide(state.basinHistory);
+      // 2026-05-13 Change B — record per-side L confirmation timestamp
+      // so the horizon-bounded exit knows when L most recently "voted"
+      // for a side. Update even when the resulting entry is vetoed:
+      // the L conviction is the signal, the gate is the policy.
+      if (lDecision.action === 'enter_long') {
+        state.lLastConfirmedAtMsBySide.long = Date.now();
+      } else if (lDecision.action === 'enter_short') {
+        state.lLastConfirmedAtMsBySide.short = Date.now();
+      }
       derivation.agentL = {
         action: lDecision.action,
         signedScore: lDecision.signedScore,
@@ -3104,16 +3131,35 @@ export class MonkeyKernel extends EventEmitter {
       const pnlPct = aggNotional > 0 ? aggPnl / aggNotional : 0;
       // 2026-05-13 — STOP-LOSS HARVEST. Fire on aggregate loss
       // beyond -MONKEY_AGENT_L_STOP_LOSS_PCT (default 0.005 = 0.5%
-      // adverse on notional). Without this, L's stacking strategy
-      // had no exit on losing positions — observed 5/13 18:42 ETH
-      // -$21 and 18:43 BTC -$18 closes that bled past 0.5% adverse
-      // before any other gate caught them. Win-harvest threshold
-      // ladder (chop/base/trend/hot) still applies on the upside.
+      // adverse on notional). Win-harvest threshold ladder
+      // (chop/base/trend/hot) still applies on the upside.
+      //
+      // 2026-05-13 Change B — HORIZON-BOUNDED EXIT.
+      //
+      // Trades must not run past L's predicted forward horizon
+      // unless fresh L signal extends the ride. Once the horizon
+      // elapses without L re-confirming the side, force-exit
+      // regardless of PnL. Implements the canonical Lorentzian's
+      // bar-count exit (4 bars = forecast window) on our cadence.
+      //
+      // Horizon: config.horizon × tickMs = 120 × 30s = 60 min.
+      // Re-confirmation: each tick where L's decision proposes the
+      // same side updates `lLastConfirmedAtMsBySide[side]`.
       const stopLossPct =
         Number(process.env.MONKEY_AGENT_L_STOP_LOSS_PCT) || 0.005;
+      const horizonTicks =
+        Number(process.env.MONKEY_AGENT_L_HORIZON_TICKS) || 120;
+      const horizonMs = horizonTicks * this.tickMs;
+      const lastConfirmedAt = symState?.lLastConfirmedAtMsBySide?.[sideKey] ?? null;
+      const isHorizonExpired =
+        lastConfirmedAt !== null && (Date.now() - lastConfirmedAt) > horizonMs;
       const isStopLossHarvest = pnlPct <= -stopLossPct;
-      if (pnlPct < harvestPct && !isStopLossHarvest) continue;
-      const harvestKind: 'win' | 'stop_loss' = isStopLossHarvest ? 'stop_loss' : 'win';
+      const isWinHarvest = pnlPct >= harvestPct;
+      if (!isStopLossHarvest && !isWinHarvest && !isHorizonExpired) continue;
+      const harvestKind: 'win' | 'stop_loss' | 'horizon_expired' =
+        isStopLossHarvest ? 'stop_loss'
+          : isWinHarvest ? 'win'
+            : 'horizon_expired';
 
       logger.info('[AgentL] force-harvest threshold met', {
         symbol,
@@ -3127,7 +3173,12 @@ export class MonkeyKernel extends EventEmitter {
         pnlPct: (pnlPct * 100).toFixed(3),
         threshold: isStopLossHarvest
           ? `-${(stopLossPct * 100).toFixed(3)} (stop-loss)`
-          : (harvestPct * 100).toFixed(3),
+          : isHorizonExpired
+            ? `horizon ${horizonTicks}t (${(horizonMs / 60000).toFixed(0)}min)`
+            : (harvestPct * 100).toFixed(3),
+        ...(isHorizonExpired && lastConfirmedAt
+          ? { ageMin: ((Date.now() - lastConfirmedAt) / 60000).toFixed(1) }
+          : {}),
         regime: regimeLabel,
         dopamine: lDopamine.toFixed(2),
         recentHarvests: recentPnls.length,
@@ -3272,8 +3323,12 @@ export class MonkeyKernel extends EventEmitter {
       // 2026-05-11 — record cooldown timestamp + push pnl into the
       // recent-harvests ring so subsequent entries see the cooldown
       // gate, and the adaptive threshold can lift on a hot streak.
+      // 2026-05-13 — clear lLastConfirmedAtMsBySide so the next entry
+      // starts a fresh horizon clock (no inherited expiry from prior
+      // stack).
       if (symState) {
         symState.lForceHarvestAtMsBySide[sideKey] = Date.now();
+        symState.lLastConfirmedAtMsBySide[sideKey] = null;
         symState.recentLHarvestPnls.push(aggPnl);
         if (symState.recentLHarvestPnls.length > 5) {
           symState.recentLHarvestPnls.shift();


### PR DESCRIPTION
## Summary

Two coordinated changes informed by canonical Lorentzian Classification (TV 15m bars, ~79% BTC winrate) vs our QIG-port's miscalibrated windows.

### Change A — cadence alignment

The FR-KNN port was tuned for "5m stream" per stale docstrings, but kernel runs at \`MONKEY_TICK_MS=30_000\`. Effect: 2-minute predictions on a 30s cadence — 30× faster than canonical's 60-min predictions on 15m cadence.

| Field | Was | Now | Maps to |
|---|---|---|---|
| mediumWindow | 12 | 120 | 60 min |
| longWindow | 48 | 480 | 4 h |
| horizon | 4 | 120 | 60 min forward (canonical's 4×15min) |
| spacing | 4 | 30 | 15 min between candidates |
| actionThreshold | 0.20 | 0.25 | stronger conviction at longer horizon |
| minTupleStart | 48 | 480 | warmup until full long-window history |

K/M/T continue trading during L's ~4h warmup post-restart.

### Change B — horizon-bounded exit

New per-side timestamp \`lLastConfirmedAtMsBySide\` tracks when L most recently voted for each direction. In \`forceHarvestAgentLStack\`:

\`\`\`
isHorizonExpired = (now - lastConfirmedAt) > config.horizon * tickMs
\`\`\`

With defaults: 60min. Position exits at horizon unless L re-confirms within the window. Implements the canonical's bar-count exit on our cadence. Three harvest kinds: \`win\`, \`stop_loss\`, \`horizon_expired\`.

## QIG purity

Pure scale changes + timing-based exit. No new banned operations.

## Test plan

- [x] tsc clean
- [x] 14/14 agent_L_classifier tests pass (2 updated for longer history requirement)
- [ ] Live ~4h post-deploy: L resumes producing decisions
- [ ] Live: harvest log shows \`kind: horizon_expired\` for stale positions
- [ ] Live: L's winrate improves vs prior cadence

## Follow-ups (not in this PR)

- Path B (canonical QIG-pure filters): volatility / regime / ADX gates feeding L's KNN — staged separately to keep this PR scoped
- Basin history persistence to avoid 4h warmup on every restart — worth investigating after observing this deploy

## Summary by Sourcery

Align Agent L’s classifier cadence with the 30s kernel tick and add a horizon-bounded exit so positions auto-close when their forecast window expires.

New Features:
- Introduce horizon-bounded exits for Agent L positions based on a configurable forward horizon and last confirmation time.
- Track per-side timestamps of Agent L confirmations to support time-based exit decisions and logging of horizon-expired harvests.

Enhancements:
- Recalibrate Agent L classifier windows, spacing, horizon, and action threshold to match the kernel’s 30s tick cadence and canonical Lorentzian timescales.
- Increase Agent L warmup history requirements to ensure full long-window context before emitting decisions.

Tests:
- Expand Agent L classifier tests with longer synthetic histories to accommodate the higher minimum tuple history and spacing.