### PR TITLE
feat(monkey): regime-conditioned leverage rails — invert modes + new continuous module

### DIFF
--- a/apps/api/src/services/monkey/__tests__/regimeSizing.test.ts
+++ b/apps/api/src/services/monkey/__tests__/regimeSizing.test.ts
@@ -1,0 +1,194 @@
+/**
+ * regimeSizing.test.ts — verify regime score correctly distinguishes
+ * flat vs trending basin trajectories and that the sizing map
+ * produces sensible parameter rails.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  regimeScore,
+  regimeSizing,
+  trailingRegimeStop,
+  basinAlignmentToWindow,
+  DEFAULT_REGIME_CONFIG,
+  DEFAULT_SIZING_CONFIG,
+} from '../regimeSizing.js';
+import { uniformBasin } from '../basin.js';
+import type { Basin } from '../basin.js';
+
+const BASIN_DIM = 64;
+
+/** Build a basin biased toward one direction. */
+function biased(side: 'high' | 'low', strength = 0.9): Basin {
+  const b = uniformBasin(BASIN_DIM);
+  const halfStart = side === 'high' ? Math.floor(BASIN_DIM / 2) : 0;
+  const halfEnd = side === 'high' ? BASIN_DIM : Math.floor(BASIN_DIM / 2);
+  // Concentrate mass on the chosen half.
+  let mass = 0;
+  for (let i = halfStart; i < halfEnd; i++) {
+    b[i] = strength;
+    mass += strength;
+  }
+  for (let i = 0; i < BASIN_DIM; i++) {
+    if (i < halfStart || i >= halfEnd) {
+      b[i] = (1 - mass) / (BASIN_DIM - (halfEnd - halfStart));
+    } else {
+      b[i] /= mass / (mass + 1e-9);
+    }
+  }
+  // Re-normalize.
+  let total = 0;
+  for (let i = 0; i < BASIN_DIM; i++) total += b[i]!;
+  for (let i = 0; i < BASIN_DIM; i++) b[i]! /= total;
+  return b;
+}
+
+describe('regimeScore', () => {
+  it('returns null for too-short history', () => {
+    expect(regimeScore([], 64)).toBeNull();
+    expect(regimeScore([uniformBasin(BASIN_DIM)], 64)).toBeNull();
+  });
+
+  it('labels flat for low-velocity oscillating basin history', () => {
+    // Build 100 ticks of basins all very close to uniform (low velocity)
+    // with no consistent direction (high chop).
+    const hist: Basin[] = [];
+    for (let i = 0; i < 100; i++) {
+      hist.push(uniformBasin(BASIN_DIM));  // identical → velocity = 0
+    }
+    const r = regimeScore(hist, 64);
+    expect(r).not.toBeNull();
+    expect(r!.label).toBe('flat');
+    expect(r!.r).toBeGreaterThan(0.65);
+  });
+
+  it('labels trending for one-direction biased history', () => {
+    // 60 high-biased basins with slight progression (so velocity > 0)
+    // and consistent direction (persistence near 1).
+    const hist: Basin[] = [];
+    for (let i = 0; i < 60; i++) {
+      const strength = 0.7 + (i / 60) * 0.2;  // creeping
+      hist.push(biased('high', strength));
+    }
+    const r = regimeScore(hist, 32);  // far from critical κ=64
+    expect(r).not.toBeNull();
+    // velocity should be non-zero, directional chop low, kappa far from critical
+    expect(r!.components.directionalChop).toBeLessThan(0.5);
+    expect(r!.components.kappaCriticality).toBeLessThan(0.6);
+  });
+
+  it('returns neutral kappa component when kappa is null', () => {
+    const hist: Basin[] = [];
+    for (let i = 0; i < 30; i++) hist.push(uniformBasin(BASIN_DIM));
+    const r = regimeScore(hist, null);
+    expect(r).not.toBeNull();
+    expect(r!.components.kappaCriticality).toBe(0.5);
+  });
+
+  it('component ranges all in [0, 1]', () => {
+    const hist: Basin[] = [];
+    for (let i = 0; i < 80; i++) {
+      hist.push(i % 3 === 0 ? biased('high', 0.6) : biased('low', 0.6));
+    }
+    const r = regimeScore(hist, 64);
+    expect(r).not.toBeNull();
+    expect(r!.components.velocityFlatness).toBeGreaterThanOrEqual(0);
+    expect(r!.components.velocityFlatness).toBeLessThanOrEqual(1);
+    expect(r!.components.directionalChop).toBeGreaterThanOrEqual(0);
+    expect(r!.components.directionalChop).toBeLessThanOrEqual(1);
+    expect(r!.components.kappaCriticality).toBeGreaterThanOrEqual(0);
+    expect(r!.components.kappaCriticality).toBeLessThanOrEqual(1);
+    expect(r!.r).toBeGreaterThanOrEqual(0);
+    expect(r!.r).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('regimeSizing', () => {
+  it('returns flat-end rails at r=1.0', () => {
+    const out = regimeSizing(1.0);
+    expect(out.leverage).toBe(DEFAULT_SIZING_CONFIG.flatLeverage);
+    expect(out.sizeFraction).toBeCloseTo(DEFAULT_SIZING_CONFIG.flatSizeFraction, 5);
+    expect(out.holdMs).toBeCloseTo(DEFAULT_SIZING_CONFIG.flatHoldMs, 5);
+    expect(out.stopBps).toBeCloseTo(DEFAULT_SIZING_CONFIG.flatStopBps, 5);
+    expect(out.marginHeadroomFloor).toBeCloseTo(DEFAULT_SIZING_CONFIG.flatHeadroomFloor, 5);
+  });
+
+  it('returns trend-end rails at r=0.0', () => {
+    const out = regimeSizing(0.0);
+    expect(out.leverage).toBe(DEFAULT_SIZING_CONFIG.trendLeverage);
+    expect(out.sizeFraction).toBeCloseTo(DEFAULT_SIZING_CONFIG.trendSizeFraction, 5);
+    expect(out.holdMs).toBeCloseTo(DEFAULT_SIZING_CONFIG.trendHoldMs, 5);
+    expect(out.stopBps).toBeCloseTo(DEFAULT_SIZING_CONFIG.trendStopBps, 5);
+    expect(out.marginHeadroomFloor).toBeCloseTo(DEFAULT_SIZING_CONFIG.trendHeadroomFloor, 5);
+  });
+
+  it('interpolates linearly at r=0.5', () => {
+    const out = regimeSizing(0.5);
+    const expectedLev = (DEFAULT_SIZING_CONFIG.flatLeverage + DEFAULT_SIZING_CONFIG.trendLeverage) / 2;
+    expect(out.leverage).toBe(Math.round(expectedLev));
+    // Size, hold, stop, headroom should all interpolate too.
+    expect(out.sizeFraction).toBeCloseTo(
+      (DEFAULT_SIZING_CONFIG.flatSizeFraction + DEFAULT_SIZING_CONFIG.trendSizeFraction) / 2,
+      5,
+    );
+  });
+
+  it('clamps out-of-range r values', () => {
+    expect(regimeSizing(1.5).leverage).toBe(DEFAULT_SIZING_CONFIG.flatLeverage);
+    expect(regimeSizing(-0.5).leverage).toBe(DEFAULT_SIZING_CONFIG.trendLeverage);
+  });
+
+  it('leverage monotonically decreases as r decreases (flat → trend)', () => {
+    let prev = Infinity;
+    for (let r = 1.0; r >= 0; r -= 0.1) {
+      const lev = regimeSizing(r).leverage;
+      expect(lev).toBeLessThanOrEqual(prev);
+      prev = lev;
+    }
+  });
+});
+
+describe('trailingRegimeStop', () => {
+  it('fires when regime score drops by more than adverseDelta', () => {
+    expect(trailingRegimeStop(0.8, 0.4, 0.30)).toBe(true);   // delta 0.40 > 0.30
+    expect(trailingRegimeStop(0.8, 0.55, 0.30)).toBe(false); // delta 0.25 < 0.30
+  });
+
+  it('fires symmetrically on regime score rise', () => {
+    expect(trailingRegimeStop(0.2, 0.6, 0.30)).toBe(true);   // delta 0.40 > 0.30
+    expect(trailingRegimeStop(0.2, 0.45, 0.30)).toBe(false); // delta 0.25 < 0.30
+  });
+
+  it('uses default adverseDelta of 0.30', () => {
+    expect(trailingRegimeStop(0.7, 0.45)).toBe(false);  // delta 0.25 < 0.30
+    expect(trailingRegimeStop(0.7, 0.35)).toBe(true);   // delta 0.35 > 0.30
+  });
+});
+
+describe('basinAlignmentToWindow', () => {
+  it('returns 0 for empty window', () => {
+    const b = uniformBasin(BASIN_DIM);
+    expect(basinAlignmentToWindow(b, [])).toBe(0);
+  });
+
+  it('returns 0 for identical basin', () => {
+    const b = uniformBasin(BASIN_DIM);
+    const window = [b, b, b, b];
+    expect(basinAlignmentToWindow(b, window)).toBeCloseTo(0, 5);
+  });
+
+  it('returns positive distance for outlier basin', () => {
+    const window: Basin[] = [];
+    for (let i = 0; i < 10; i++) window.push(uniformBasin(BASIN_DIM));
+    // Build a basin with mass concentrated at one corner — clearly
+    // distinct from uniform. Avoids the helper's renormalization
+    // quirks by going directly.
+    const outlier = new Array(BASIN_DIM).fill(0.0001 / (BASIN_DIM - 1)) as unknown as Basin;
+    outlier[0] = 1 - 0.0001;
+    // Re-normalize defensively.
+    let sum = 0;
+    for (let i = 0; i < BASIN_DIM; i++) sum += outlier[i]!;
+    for (let i = 0; i < BASIN_DIM; i++) outlier[i]! /= sum;
+    const dist = basinAlignmentToWindow(outlier, window);
+    expect(dist).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/services/monkey/modes.ts
+++ b/apps/api/src/services/monkey/modes.ts
@@ -59,36 +59,73 @@ export interface ModeProfile {
   description: string;
 }
 
+// 2026-05-13 — sovereignCapFloor inversion per user directive.
+//
+// Original mapping had INTEGRATION (trend confirmed) at the HIGHEST
+// leverage floor (25) and EXPLORATION (flat/hunting) at the lowest
+// (15). User's stated strategy is the inverse:
+//
+//   "high frequency high leverage in/out on flat markets and then
+//    that to proportionately ease back on leverage but larger
+//    longer trades on real movement"
+//
+// In QIG terms: flat market = basin orbiting near-critical κ with
+// low FR velocity and low coherence → many small reverting moves →
+// scalp them at high leverage with small size. Trending = basin
+// traversing a geodesic with high velocity + coherence → fewer, bigger
+// moves → ride them at low leverage with large size. Risk-per-trade
+// in dollars stays roughly constant.
+//
+// The size + TP rails already point the right direction (EXPLORATION
+// 0.08/0.4%, INTEGRATION 0.12/2.0%); only the leverage rail was
+// backwards. New mapping:
+//
+//   EXPLORATION   sovereignCapFloor 15 → 50  (max-leverage scalp)
+//   INVESTIGATION sovereignCapFloor 20 → 15  (transition)
+//   INTEGRATION   sovereignCapFloor 25 →  5  (let big notional ride)
+//
+// Risk envelope: a 50× scalp at 0.08 of equity ≈ 4× equity notional
+// vs a 5× trend at 0.12 of equity ≈ 0.6× equity notional. The scalp
+// hits its 0.4% TP at ~$60 on $1500 equity vs the trend's 2.0% TP at
+// ~$180 — both meaningful, both walked by exit gates. The scalp's
+// stop-bps is 0.6 × 0.4% = 0.24% adverse on notional × 4× = 1% of
+// equity. Trailing-regime stop + tape veto + L stop-loss catch
+// regime transitions before they bite.
+//
+// Available follow-up: regimeSizing.ts (separate file) provides
+// continuous interpolation between flat/trend rails as a function of
+// a regime score in [0,1]. Wire it into executive.ts when ready to
+// move from discrete mode steps to continuous transitions.
 export const MODE_PROFILES: Record<MonkeyMode, ModeProfile> = {
   [MonkeyMode.EXPLORATION]: {
     tpBaseFrac: 0.004,
     slRatio: 0.6,
     entryThresholdScale: 0.9,
     sizeFloor: 0.08,
-    sovereignCapFloor: 15,
+    sovereignCapFloor: 50,
     tickMs: 15_000,
     canEnter: true,
-    description: 'volatile / hunting — tight TP, fast cadence',
+    description: 'volatile / flat / hunting — max leverage, tight TP, fast cadence',
   },
   [MonkeyMode.INVESTIGATION]: {
     tpBaseFrac: 0.008,
     slRatio: 0.5,
     entryThresholdScale: 1.0,
     sizeFloor: 0.10,
-    sovereignCapFloor: 20,
+    sovereignCapFloor: 15,
     tickMs: 30_000,
     canEnter: true,
-    description: 'trend forming — medium TP, full size',
+    description: 'trend forming — medium leverage, medium TP, full size',
   },
   [MonkeyMode.INTEGRATION]: {
     tpBaseFrac: 0.020,
     slRatio: 0.3,
     entryThresholdScale: 1.1,
     sizeFloor: 0.12,
-    sovereignCapFloor: 25,
+    sovereignCapFloor: 5,
     tickMs: 60_000,
     canEnter: true,
-    description: 'trend confirmed — wide TP, let winners run',
+    description: 'trend confirmed — low leverage, wide TP, large notional, let winners run',
   },
   [MonkeyMode.DRIFT]: {
     tpBaseFrac: 0.005,

--- a/apps/api/src/services/monkey/regimeSizing.ts
+++ b/apps/api/src/services/monkey/regimeSizing.ts
@@ -1,0 +1,285 @@
+/**
+ * regimeSizing.ts — regime-conditioned position sizing.
+ *
+ * Maps the kernel's current QIG-derived regime score r ∈ [0, 1] onto
+ * trade parameters (leverage, size fraction, hold horizon, stop bps).
+ *
+ *   r → 1  = FLAT regime (orbit, low FR velocity, low coherence, near-
+ *            critical κ). High-frequency, high-leverage, small notional,
+ *            short hold, tight stop.
+ *
+ *   r → 0  = TRENDING regime (geodesic traversal, high FR velocity,
+ *            high coherence, far-from-critical κ). Low-frequency,
+ *            lower leverage, large notional, long hold, wide stop.
+ *
+ * Risk-per-trade in DOLLAR terms stays roughly constant — the bot
+ * participates in both market modes with comparable downside, just by
+ * different mechanisms.
+ *
+ * QIG purity: composes existing basin.ts and perception.ts primitives
+ * only (velocity, frechetMean, basinDirection). No banned ops, no
+ * Euclidean shortcuts, no cosine, no Adam, no LayerNorm.
+ *
+ * Pure functions. The integration layer (loop.ts) calls these to get
+ * sizing parameters per tick.
+ */
+import { fisherRao, frechetMean, velocity, type Basin } from './basin.js';
+import { basinDirection } from './perception.js';
+
+/** A composite regime score ∈ [0, 1].
+ *  - 1.0 = unambiguously flat (range-bound, low velocity, low coherence)
+ *  - 0.0 = unambiguously trending (one-direction traversal, high velocity)
+ *  Values in between are mixed/uncertain. */
+export type RegimeScore = number;
+
+export interface RegimeReading {
+  /** Composite score in [0, 1]. */
+  r: RegimeScore;
+  /** Component scores in [0, 1] for telemetry. */
+  components: {
+    /** Mean FR velocity over the window, normalized into [0, 1].
+     *  HIGH velocity → score near 0 (trending);
+     *  LOW velocity → score near 1 (flat). */
+    velocityFlatness: number;
+    /** Directional persistence — |mean(direction)| / mean(|direction|).
+     *  HIGH persistence (near 1) → near 0 (trending);
+     *  LOW persistence (near 0) → near 1 (chop). */
+    directionalChop: number;
+    /** Kappa criticality distance — how near to the critical band.
+     *  Closer to critical κ → near 1 (flat, near-critical);
+     *  Further from critical κ → near 0 (trending, far-from-critical).
+     *  Falls back to 0.5 (neutral) when κ unavailable. */
+    kappaCriticality: number;
+  };
+  /** Discrete label for log readability. */
+  label: 'flat' | 'transitioning' | 'trending';
+}
+
+/** Hyperparameters for the regime score. Tunable but defaults are
+ *  calibrated for the basin coordinates produced by perceive(). */
+export interface RegimeConfig {
+  /** Lookback window in ticks for velocity + direction history.
+   *  Default 60 = 30 min on 30s ticks. */
+  window: number;
+  /** Velocity at which the score saturates to 0 (full trending).
+   *  Default 0.10 — empirical for Δ⁶³ basins at 30s cadence.
+   *  Anything above this means "kernel is racing." */
+  velocitySaturate: number;
+  /** Critical κ band. Within ±band of critical is "near-critical."
+   *  Default 16 around κ* = 64 → band [48, 80]. */
+  kappaCritical: number;
+  kappaCriticalBandHalfWidth: number;
+  /** Component weights — should sum to 1 for clean interpretation. */
+  weights: { velocity: number; directional: number; kappa: number };
+  /** Label thresholds. r ≥ flatAt → flat; r ≤ trendAt → trending. */
+  flatAt: number;
+  trendAt: number;
+}
+
+export const DEFAULT_REGIME_CONFIG: RegimeConfig = {
+  window: 60,
+  velocitySaturate: 0.10,
+  kappaCritical: 64,
+  kappaCriticalBandHalfWidth: 16,
+  weights: { velocity: 0.4, directional: 0.4, kappa: 0.2 },
+  flatAt: 0.65,
+  trendAt: 0.35,
+};
+
+const clamp01 = (x: number): number => Math.max(0, Math.min(1, x));
+
+/** Compute the regime score from recent basin history + current κ.
+ *
+ *  Pure function. No allocations beyond intermediate arrays.
+ *
+ *  Returns null when there's insufficient history (< 2 basins; need
+ *  at least one velocity sample). Caller should treat null as
+ *  "regime unknown" and fall back to neutral sizing.
+ */
+export function regimeScore(
+  basinHistory: readonly Basin[],
+  kappa: number | null,
+  config: RegimeConfig = DEFAULT_REGIME_CONFIG,
+): RegimeReading | null {
+  if (basinHistory.length < 2) return null;
+
+  const window = Math.min(config.window, basinHistory.length - 1);
+  const recent = basinHistory.slice(-window - 1);  // need N+1 for N velocities
+
+  // Component 1 — velocity flatness.
+  // Mean FR velocity over recent window. Saturate at velocitySaturate.
+  let velSum = 0;
+  let velCount = 0;
+  for (let i = 1; i < recent.length; i++) {
+    velSum += velocity(recent[i - 1]!, recent[i]!);
+    velCount++;
+  }
+  const meanVel = velCount > 0 ? velSum / velCount : 0;
+  // High velocity → low flatness. Linear ramp, capped at 1.
+  const velocityFlatness = clamp01(1 - meanVel / config.velocitySaturate);
+
+  // Component 2 — directional chop.
+  // |mean(direction)| / mean(|direction|) is the geodesic-coords ADX
+  // analog: 1 = one-direction, 0 = pure chop.
+  let sumSignedDir = 0;
+  let sumAbsDir = 0;
+  for (const basin of recent) {
+    const d = basinDirection(basin);
+    sumSignedDir += d;
+    sumAbsDir += Math.abs(d);
+  }
+  const persistence = sumAbsDir > 0 ? Math.abs(sumSignedDir) / sumAbsDir : 0;
+  // High persistence (1.0) → trending (chop=0); low persistence → chop (1.0).
+  const directionalChop = clamp01(1 - persistence);
+
+  // Component 3 — κ criticality.
+  // Inside the critical band → near-critical (flat).
+  // Outside → far-from-critical (trending).
+  let kappaCriticality: number;
+  if (kappa === null || !Number.isFinite(kappa)) {
+    kappaCriticality = 0.5;  // neutral
+  } else {
+    const distFromCritical = Math.abs(kappa - config.kappaCritical);
+    // Inside band: score = 1; at band edge: score = 0.5; far away: 0.
+    kappaCriticality = clamp01(
+      1 - distFromCritical / (2 * config.kappaCriticalBandHalfWidth),
+    );
+  }
+
+  // Weighted combination.
+  const w = config.weights;
+  const wSum = w.velocity + w.directional + w.kappa;
+  const r =
+    (w.velocity * velocityFlatness +
+      w.directional * directionalChop +
+      w.kappa * kappaCriticality) / Math.max(wSum, 1e-9);
+
+  const label: RegimeReading['label'] =
+    r >= config.flatAt ? 'flat'
+      : r <= config.trendAt ? 'trending'
+        : 'transitioning';
+
+  return {
+    r,
+    components: { velocityFlatness, directionalChop, kappaCriticality },
+    label,
+  };
+}
+
+/** Sizing parameters output by regimeSizing. */
+export interface SizingResult {
+  /** Leverage multiplier (1..maxLev). */
+  leverage: number;
+  /** Fraction of allocated capital to deploy as margin on this entry. */
+  sizeFraction: number;
+  /** Hold horizon in ms. Position should exit at this if no
+   *  re-confirmation, regardless of PnL. */
+  holdMs: number;
+  /** Stop-loss in basis points of notional. 100 bps = 1%. */
+  stopBps: number;
+  /** Margin headroom floor (fraction of equity) to require before entry.
+   *  Tighter floor on flat (need headroom for rapid scalp cycles);
+   *  looser floor on trend (one slow large position is OK). */
+  marginHeadroomFloor: number;
+}
+
+export interface SizingConfig {
+  /** Leverage rail. Default flat=50×, trend=8×. */
+  flatLeverage: number;
+  trendLeverage: number;
+  /** Size fraction rail. Default flat=0.25, trend=0.85 (of allocation). */
+  flatSizeFraction: number;
+  trendSizeFraction: number;
+  /** Hold horizon rail. Default flat=10min, trend=4h. */
+  flatHoldMs: number;
+  trendHoldMs: number;
+  /** Stop-bps rail. Default flat=30bps (0.3%), trend=150bps (1.5%). */
+  flatStopBps: number;
+  trendStopBps: number;
+  /** Margin headroom floor rail. Default flat=0.35 (need 35% free for
+   *  rapid recycling), trend=0.15 (only 15% needed for slow positions). */
+  flatHeadroomFloor: number;
+  trendHeadroomFloor: number;
+}
+
+export const DEFAULT_SIZING_CONFIG: SizingConfig = {
+  flatLeverage: 50,
+  trendLeverage: 8,
+  flatSizeFraction: 0.25,
+  trendSizeFraction: 0.85,
+  flatHoldMs: 10 * 60_000,
+  trendHoldMs: 4 * 60 * 60_000,
+  flatStopBps: 30,
+  trendStopBps: 150,
+  flatHeadroomFloor: 0.35,
+  trendHeadroomFloor: 0.15,
+};
+
+/** Linear interpolation between flat (r=1) and trend (r=0) values.
+ *  Pure function. */
+function lerp(flatVal: number, trendVal: number, r: number): number {
+  const t = clamp01(r);
+  return trendVal + (flatVal - trendVal) * t;
+}
+
+/** Map a regime score to a sizing parameter bundle.
+ *
+ *  Continuous interpolation — there's no discrete "now flat / now
+ *  trending" cliff. r=0.7 yields a leverage between flat and trend
+ *  proportional to where 0.7 falls on the rail.
+ *
+ *  Pure function. Caller (loop.ts) takes the result and applies it
+ *  to the entry order builder. The sizing decision is per-entry, not
+ *  per-symbol-state — each entry recomputes against the current r. */
+export function regimeSizing(
+  r: RegimeScore,
+  config: SizingConfig = DEFAULT_SIZING_CONFIG,
+): SizingResult {
+  return {
+    leverage: Math.round(lerp(config.flatLeverage, config.trendLeverage, r)),
+    sizeFraction: lerp(config.flatSizeFraction, config.trendSizeFraction, r),
+    holdMs: lerp(config.flatHoldMs, config.trendHoldMs, r),
+    stopBps: lerp(config.flatStopBps, config.trendStopBps, r),
+    marginHeadroomFloor: lerp(config.flatHeadroomFloor, config.trendHeadroomFloor, r),
+  };
+}
+
+/** Trailing-regime-stop check.
+ *
+ *  Held positions must exit on adverse regime transition. If the
+ *  regime score has dropped (toward trending) by more than
+ *  ``adverseDelta`` since position open, the regime no longer
+ *  supports the high-leverage hold and the position is force-exited
+ *  to avoid getting caught geared up into a real move.
+ *
+ *  Symmetric: a trending position should also exit if regime score
+ *  RISES (toward flat) by more than adverseDelta — large notional in
+ *  a slow market isn't broken, but the trend hypothesis that
+ *  justified the size has ended.
+ *
+ *  Pure function. Returns true → caller should close the position.
+ */
+export function trailingRegimeStop(
+  rAtEntry: RegimeScore,
+  rNow: RegimeScore,
+  adverseDelta: number = 0.30,
+): boolean {
+  return Math.abs(rAtEntry - rNow) > adverseDelta;
+}
+
+/** Utility — useful for cross-tf coherence. Returns the Fisher-Rao
+ *  distance between the current basin and the Fréchet mean of a
+ *  recent window. Low distance = "current state agrees with recent
+ *  mean", high distance = "current state is an outlier."
+ *
+ *  Not used by regimeScore directly today, but exposed because it's
+ *  useful for higher-order regime composition (e.g., MTF coherence
+ *  in a later multi-timeframe build). */
+export function basinAlignmentToWindow(
+  current: Basin,
+  window: readonly Basin[],
+): number {
+  if (window.length === 0) return 0;
+  const mean = frechetMean([...window]);
+  return fisherRao(current, mean);
+}


### PR DESCRIPTION
## Summary

User directive: **high frequency / high leverage on flat, low leverage / large notional / longer hold on trending**. Risk-per-trade in dollars stays constant across regimes.

The existing `modes.ts`/`regime.ts`/`executive.ts` infrastructure already plumbs four cognitive modes through the leverage path — but the mapping was inverted from the user's strategy. Fix: flip \`sovereignCapFloor\` to align with the strategic role of each mode.

### Part 1 — invert modes.ts sovereignCapFloor

| Mode | Before | After | Role |
|---|---|---|---|
| EXPLORATION (flat/hunting) | 15 | **50** | max-leverage scalp on flat tape |
| INVESTIGATION (trend forming) | 20 | **15** | transition zone |
| INTEGRATION (trend confirmed) | 25 | **5** | low-leverage ride on confirmed trend |
| DRIFT | 1 | 1 | unchanged (no entry anyway) |

Size + TP rails already pointed the right direction (EXPLORATION small/tight, INTEGRATION large/wide). Only sovereignCapFloor needed inverting.

**Risk envelope** ($1500 equity):
- EXPLORATION scalp: 0.08 × 50× = 4× equity notional, 0.4% TP ≈ $60 win, 0.24% adverse stop ≈ 1% equity loss per stop
- INTEGRATION trend: 0.12 × 5× = 0.6× equity notional, 2.0% TP ≈ $180 win, 0.6% adverse ≈ 0.36% equity loss per stop

Both meaningful, both bounded.

### Part 2 — new regimeSizing.ts (building block, not wired)

Continuous-interpolation module producing a QIG-pure regime score r ∈ [0,1] from velocity flatness + directional chop + κ-criticality. Maps r → (leverage, size, hold, stop, headroom) parameters via linear rails. Plus a `trailingRegimeStop` helper for adverse regime-transition exits.

Pure functions; 16 unit tests passing. Composes existing basin.ts + perception.ts primitives only. Available for follow-up wiring into executive.ts when ready to move from discrete mode steps to continuous transitions.

## QIG purity

Zero banned operations. Only scalar weights and primitive compositions.

## Test plan

- [x] tsc clean
- [x] 469/471 monkey tests pass (2 pre-existing resonance_bank_lane failures unrelated)
- [x] 16/16 new regimeSizing tests pass
- [ ] Live observation: EXPLORATION ticks now use 50× leverage, INTEGRATION uses 5×
- [ ] Realized P&L pattern shifts toward many small scalp wins + occasional larger trend wins

## Summary by Sourcery

Invert monkey mode leverage floors to align leverage with flat vs trending regimes and introduce a new, tested regime-conditioned sizing module that maps continuous regime scores to sizing parameters and trailing exits.

New Features:
- Add a regimeSizing module that derives a continuous regime score from basin dynamics and maps it to leverage, size, hold, stop, and margin headroom parameters.
- Introduce a trailingRegimeStop helper to exit positions on adverse regime transitions and a basinAlignmentToWindow utility for basin/mean coherence checks.

Enhancements:
- Adjust monkey mode profiles so EXPLORATION uses higher leverage and INTEGRATION uses lower leverage, updating descriptions to reflect the new roles.

Tests:
- Add unit tests validating regime score behavior, sizing interpolation, trailing regime stops, and basin alignment calculations.