### PR TITLE
feat(monkey): MTF L Phase 1 — 15m/1h/4h parallel classifiers + agreement combiner

### DIFF
--- a/apps/api/src/services/monkey/__tests__/mtfLClassifier.test.ts
+++ b/apps/api/src/services/monkey/__tests__/mtfLClassifier.test.ts
@@ -1,0 +1,183 @@
+/**
+ * mtfLClassifier.test.ts — verify per-timeframe down-sampling and
+ * agreement-count combiner logic.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  newMTFState,
+  onTickAppend,
+  setBootstrapHistory,
+  mtfDecide,
+  recordAgreementTimestamps,
+  isLongestHorizonExpired,
+  DEFAULT_TIMEFRAMES,
+  type TimeframeConfig,
+} from '../mtfLClassifier.js';
+import { uniformBasin } from '../basin.js';
+import type { Basin } from '../basin.js';
+
+const BASIN_DIM = 64;
+
+describe('newMTFState', () => {
+  it('initializes empty histories + sentinel last-sample ticks', () => {
+    const s = newMTFState();
+    expect(s.historiesByTf['15m']).toEqual([]);
+    expect(s.historiesByTf['1h']).toEqual([]);
+    expect(s.historiesByTf['4h']).toEqual([]);
+    expect(s.lastSampleTickByTf['15m']).toBe(-Infinity);
+    expect(s.lastAgreementByTfSide['1h'].long).toBe(null);
+  });
+});
+
+describe('onTickAppend (down-sampling)', () => {
+  it('appends to 15m every 30 ticks', () => {
+    const s = newMTFState();
+    const b = uniformBasin(BASIN_DIM);
+    // First tick: appends to all (boundary always crossed from -Infinity).
+    onTickAppend(s, b, 0);
+    expect(s.historiesByTf['15m'].length).toBe(1);
+    expect(s.historiesByTf['1h'].length).toBe(1);
+    expect(s.historiesByTf['4h'].length).toBe(1);
+    // Tick 29: still within 15m boundary (30-tick spacing).
+    onTickAppend(s, b, 29);
+    expect(s.historiesByTf['15m'].length).toBe(1);
+    // Tick 30: 15m boundary crossed.
+    onTickAppend(s, b, 30);
+    expect(s.historiesByTf['15m'].length).toBe(2);
+    expect(s.historiesByTf['1h'].length).toBe(1);  // still within 1h boundary
+  });
+
+  it('appends to 1h every 120 ticks', () => {
+    const s = newMTFState();
+    const b = uniformBasin(BASIN_DIM);
+    onTickAppend(s, b, 0);
+    expect(s.historiesByTf['1h'].length).toBe(1);
+    onTickAppend(s, b, 60);
+    expect(s.historiesByTf['1h'].length).toBe(1);  // not yet
+    onTickAppend(s, b, 120);
+    expect(s.historiesByTf['1h'].length).toBe(2);
+  });
+
+  it('caps history at maxSamples', () => {
+    // Use tiny maxSamples for the test.
+    const tfs: TimeframeConfig[] = [{
+      label: '15m', ticksPerSample: 1, maxSamples: 3,
+      config: DEFAULT_TIMEFRAMES[0].config,
+    }];
+    const s = newMTFState(tfs);
+    for (let i = 0; i < 10; i++) onTickAppend(s, uniformBasin(BASIN_DIM), i, tfs);
+    expect(s.historiesByTf['15m'].length).toBe(3);
+  });
+});
+
+describe('setBootstrapHistory', () => {
+  it('replaces the history for a timeframe', () => {
+    const s = newMTFState();
+    const bootstrap: Basin[] = [];
+    for (let i = 0; i < 100; i++) bootstrap.push(uniformBasin(BASIN_DIM));
+    setBootstrapHistory(s, '4h', bootstrap);
+    expect(s.historiesByTf['4h'].length).toBe(100);
+  });
+
+  it('caps bootstrap at maxSamples', () => {
+    const s = newMTFState();
+    const bootstrap: Basin[] = [];
+    for (let i = 0; i < 3000; i++) bootstrap.push(uniformBasin(BASIN_DIM));
+    setBootstrapHistory(s, '4h', bootstrap);
+    expect(s.historiesByTf['4h'].length).toBe(2000);  // capped at maxSamples
+  });
+});
+
+describe('mtfDecide (combiner)', () => {
+  it('holds when no timeframes are warm', () => {
+    const s = newMTFState();
+    const d = mtfDecide(s);
+    expect(d.action).toBe('hold');
+    expect(d.agreementCount).toBe(0);
+    expect(d.sizeMultiplier).toBe(0);
+    expect(d.reason).toBe('no_warm_timeframes');
+  });
+
+  it('reports per-TF warm status', () => {
+    const s = newMTFState();
+    // Build a 200-basin history (insufficient — minSamplesNeeded = 480 + 120 = 600).
+    for (let i = 0; i < 200; i++) {
+      onTickAppend(s, uniformBasin(BASIN_DIM), i * 30);
+    }
+    const d = mtfDecide(s);
+    // All TFs not warm yet.
+    for (const entry of d.perTimeframe) {
+      expect(entry.warm).toBe(false);
+      expect(entry.decision).toBe(null);
+    }
+  });
+});
+
+describe('per-TF horizon expiry', () => {
+  it('returns false when no agreement timestamp recorded', () => {
+    const s = newMTFState();
+    const expired = isLongestHorizonExpired(s, 'long', '1h', Date.now(), 30_000);
+    expect(expired).toBe(false);
+  });
+
+  it('returns false when within horizon', () => {
+    const s = newMTFState();
+    // 1h config has horizon=120 ticks × 120 ticksPerSample × 30s tickMs
+    // = 432_000_000ms = 5 days. Way longer than any reasonable test.
+    // For test simplicity use a 1-tick-per-sample config.
+    const tfs: TimeframeConfig[] = [{
+      label: '1h', ticksPerSample: 1, maxSamples: 100,
+      config: { ...DEFAULT_TIMEFRAMES[1].config, horizon: 60 },
+    }];
+    const state = newMTFState(tfs);
+    state.lastAgreementByTfSide['1h'].long = Date.now() - 1000;  // 1s ago
+    const expired = isLongestHorizonExpired(state, 'long', '1h', Date.now(), 30_000, tfs);
+    // horizon = 60 * 1 * 30000 = 1,800,000ms, much greater than 1s elapsed.
+    expect(expired).toBe(false);
+  });
+
+  it('returns true when horizon exceeded', () => {
+    const tfs: TimeframeConfig[] = [{
+      label: '15m', ticksPerSample: 1, maxSamples: 100,
+      config: { ...DEFAULT_TIMEFRAMES[0].config, horizon: 1 },
+    }];
+    const state = newMTFState(tfs);
+    state.lastAgreementByTfSide['15m'].long = Date.now() - 60_000;  // 60s ago
+    // horizon = 1 * 1 * 30000 = 30s. 60s elapsed > 30s horizon → expired.
+    const expired = isLongestHorizonExpired(state, 'long', '15m', Date.now(), 30_000, tfs);
+    expect(expired).toBe(true);
+  });
+});
+
+describe('recordAgreementTimestamps', () => {
+  it('does nothing on hold', () => {
+    const s = newMTFState();
+    recordAgreementTimestamps(s, {
+      action: 'hold', agreementCount: 0, totalTfs: 3, sizeMultiplier: 0,
+      perTimeframe: [], longestAgreeingLabel: null, reason: 'test',
+    }, Date.now());
+    expect(s.lastAgreementByTfSide['15m'].long).toBe(null);
+  });
+
+  it('records on each TF that voted with majority', () => {
+    const s = newMTFState();
+    const now = Date.now();
+    recordAgreementTimestamps(s, {
+      action: 'enter_long',
+      agreementCount: 2,
+      totalTfs: 3,
+      sizeMultiplier: 0.5,
+      perTimeframe: [
+        { label: '15m', warm: true, decision: { action: 'enter_long' } as never },
+        { label: '1h', warm: true, decision: { action: 'enter_long' } as never },
+        { label: '4h', warm: true, decision: { action: 'hold' } as never },
+      ],
+      longestAgreeingLabel: '1h',
+      reason: 'test',
+    }, now);
+    expect(s.lastAgreementByTfSide['15m'].long).toBe(now);
+    expect(s.lastAgreementByTfSide['1h'].long).toBe(now);
+    expect(s.lastAgreementByTfSide['4h'].long).toBe(null);  // didn't vote long
+    expect(s.lastAgreementByTfSide['15m'].short).toBe(null);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -129,6 +129,12 @@ import {
 import { planCloseChunks } from './closeChunker.js';
 import { agentLDecide } from './agent_L_classifier.js';
 import {
+  newMTFState,
+  onTickAppend as mtfOnTickAppend,
+  mtfDecide,
+  recordAgreementTimestamps as mtfRecordAgreement,
+} from './mtfLClassifier.js';
+import {
   applyOutcomeToState,
   decayPerAgentState,
   newPerAgentState,
@@ -384,6 +390,16 @@ interface SymbolState {
    *
    *  Cleared on harvest. */
   lModeAtConfirmedBySide: { long: string | null; short: string | null };
+  /** 2026-05-13 — Multi-timeframe L state (Phase 1).
+   *
+   *  Per-timeframe down-sampled basin histories + agreement clocks.
+   *  Sampled on every tick (cheap conditional appends); mtfDecide
+   *  runs per tick once warm. Phase 1 ships in OBSERVATION MODE —
+   *  decisions are logged but don't yet gate entries; Phase 2 will
+   *  promote MTF agreement to a sizing multiplier on L entries.
+   *
+   *  See mtfLClassifier.ts. */
+  mtfState: import('./mtfLClassifier.js').MTFState;
 }
 
 /** Cap the recent-bus-event ring at this size — anything older than
@@ -659,6 +675,7 @@ export class MonkeyKernel extends EventEmitter {
       recentLHarvestPnls: [],
       lLastConfirmedAtMsBySide: { long: null, short: null },
       lModeAtConfirmedBySide: { long: null, short: null },
+      mtfState: newMTFState(),
     };
   }
 
@@ -2599,6 +2616,30 @@ export class MonkeyKernel extends EventEmitter {
     if (state.basinHistory.length > HISTORY_MAX) state.basinHistory.shift();
     if (state.basinHistory.length >= 50 && state.sessionTicks % 10 === 0) {
       state.identityBasin = frechetMean(state.basinHistory.slice(-50));
+    }
+
+    // 2026-05-13 — MTF Phase 1: down-sample basin into per-timeframe
+    // stores (15m / 1h / 4h) and run agreement-count decision in
+    // observation mode. Logged but NOT yet gating entries; Phase 2
+    // will promote MTF agreement to a size multiplier on L entries.
+    mtfOnTickAppend(state.mtfState, basin, state.sessionTicks);
+    const mtfDec = mtfDecide(state.mtfState);
+    if (mtfDec.action !== 'hold') {
+      mtfRecordAgreement(state.mtfState, mtfDec, Date.now());
+    }
+    // Log every 10 ticks (5 min on 30s) to avoid noise; or always when
+    // action != hold so non-hold MTF signals are visible.
+    if (mtfDec.action !== 'hold' || state.sessionTicks % 10 === 0) {
+      logger.info('[MTF-L] decision', {
+        symbol,
+        action: mtfDec.action,
+        agreement: `${mtfDec.agreementCount}/${mtfDec.totalTfs}`,
+        sizeMult: mtfDec.sizeMultiplier.toFixed(2),
+        longest: mtfDec.longestAgreeingLabel ?? '—',
+        perTf: mtfDec.perTimeframe.map(t =>
+          `${t.label}:${t.warm ? (t.decision?.action ?? 'hold') : 'cold'}`,
+        ).join(','),
+      });
     }
 
     state.lastBasin = basin;

--- a/apps/api/src/services/monkey/mtfLClassifier.ts
+++ b/apps/api/src/services/monkey/mtfLClassifier.ts
@@ -1,0 +1,315 @@
+/**
+ * mtfLClassifier.ts — multi-timeframe Agent L (Phase 1).
+ *
+ * Runs three FR-KNN classifier instances in parallel on independently
+ * down-sampled basin streams:
+ *
+ *    15m    sample every 30 ticks  (15 min on 30s kernel cadence)
+ *    1h     sample every 120 ticks (matches canonical Lorentzian 60min)
+ *    4h     sample every 480 ticks
+ *
+ * Each timeframe keeps its own history store. On each kernel tick we
+ * append the current basin to the 1-tick (raw) stream and conditionally
+ * append to each down-sampled stream when that timeframe's "next sample"
+ * boundary has been crossed.
+ *
+ * The combiner (option c from the design conversation): AGREEMENT COUNT.
+ * Each classifier votes long / short / hold. The MTF decision is:
+ *   - 3 votes same direction → enter at full size
+ *   - 2 votes same direction → enter at reduced size
+ *   - else                   → hold
+ *
+ * Exit policy (longest-agreeing horizon): per-timeframe horizon clocks
+ * track the most recent re-confirmation on each side. The position
+ * exits when the LONGEST timeframe that agreed at entry stops agreeing
+ * (= its clock expires). Aligns hold-time with conviction depth.
+ *
+ * Bootstrap: 4h timeframe needs ~480 samples at the 4h cadence =
+ * 320 days of basin synthesis, unworkable from live ticks alone.
+ * Caller injects a pre-warmed history via setBootstrapHistory().
+ *
+ * QIG purity: each instance is a pure agentLDecide() over its
+ * timeframe's basin history. No new operations, only sampling rate
+ * and history-store wrappers. Composes Δ⁶³ + Fisher-Rao primitives
+ * exclusively. See QIG_PURITY_KERNEL_REFERENCE.md §1.
+ */
+import {
+  agentLDecide,
+  type AgentLConfig,
+  type AgentLDecision,
+  DEFAULT_AGENT_L_CONFIG,
+} from './agent_L_classifier.js';
+import type { Basin } from './basin.js';
+
+/** Supported timeframe identifiers (Phase 1 = 15m / 1h / 4h). */
+export type TimeframeLabel = '15m' | '1h' | '4h';
+
+/** Per-timeframe configuration. */
+export interface TimeframeConfig {
+  label: TimeframeLabel;
+  /** Sample every N kernel ticks. On 30s ticks:
+   *  30 → 15m, 120 → 1h, 480 → 4h. */
+  ticksPerSample: number;
+  /** Classifier config — windows / horizon / spacing already in time
+   *  units of this timeframe's samples (not raw ticks). */
+  config: AgentLConfig;
+  /** Lookback cap in SAMPLES (not ticks) for this timeframe's history.
+   *  2000 samples covers canonical Lorentzian's maxBarsBack default. */
+  maxSamples: number;
+}
+
+/** Default timeframe configs aligned with canonical Lorentzian
+ *  effective windows + the user's MTF stack request (Phase 1 = 15m /
+ *  1h / 4h; 1m and 1d are Phase 2/3 add-ons). */
+export const DEFAULT_TIMEFRAMES: TimeframeConfig[] = [
+  {
+    label: '15m',
+    ticksPerSample: 30,
+    config: {
+      ...DEFAULT_AGENT_L_CONFIG,
+      // 15m timeframe: lookback in SAMPLES — each sample = 15 min
+      // window/horizon already in sample units
+    },
+    maxSamples: 2000,
+  },
+  {
+    label: '1h',
+    ticksPerSample: 120,
+    config: { ...DEFAULT_AGENT_L_CONFIG },
+    maxSamples: 2000,
+  },
+  {
+    label: '4h',
+    ticksPerSample: 480,
+    config: { ...DEFAULT_AGENT_L_CONFIG },
+    maxSamples: 2000,
+  },
+];
+
+export interface MTFDecision {
+  /** Aggregated action across timeframes. */
+  action: 'enter_long' | 'enter_short' | 'hold';
+  /** Number of TFs voting for the chosen direction (max = TF count). */
+  agreementCount: number;
+  /** Total TFs available (some may not yet be warm). */
+  totalTfs: number;
+  /** Size multiplier ∈ [0, 1] proportional to agreement strength:
+   *   3-of-3 = 1.00, 2-of-3 = 0.50, 1-of-3 or less = 0 (hold). */
+  sizeMultiplier: number;
+  /** Per-TF decisions for telemetry. */
+  perTimeframe: Array<{
+    label: TimeframeLabel;
+    warm: boolean;
+    decision: AgentLDecision | null;
+  }>;
+  /** Side of the longest timeframe that voted with the majority,
+   *  used by the exit-horizon manager. Null when action=hold. */
+  longestAgreeingLabel: TimeframeLabel | null;
+  reason: string;
+}
+
+/** State for the MTF runner. Per-timeframe basin histories +
+ *  last-sample-tick tracking. Owned by the caller (typically
+ *  SymbolState in loop.ts). */
+export interface MTFState {
+  /** Per-timeframe basin history. */
+  historiesByTf: Record<TimeframeLabel, Basin[]>;
+  /** Tick index at which each TF most recently appended a sample.
+   *  -Infinity means never appended (cold start). */
+  lastSampleTickByTf: Record<TimeframeLabel, number>;
+  /** Per-timeframe per-side last-agreement-tick for the
+   *  longest-horizon exit policy. */
+  lastAgreementByTfSide: Record<
+    TimeframeLabel,
+    { long: number | null; short: number | null }
+  >;
+}
+
+export function newMTFState(timeframes: TimeframeConfig[] = DEFAULT_TIMEFRAMES): MTFState {
+  const histories: Record<string, Basin[]> = {};
+  const lastSample: Record<string, number> = {};
+  const lastAgreement: Record<string, { long: number | null; short: number | null }> = {};
+  for (const tf of timeframes) {
+    histories[tf.label] = [];
+    lastSample[tf.label] = -Infinity;
+    lastAgreement[tf.label] = { long: null, short: null };
+  }
+  return {
+    historiesByTf: histories as MTFState['historiesByTf'],
+    lastSampleTickByTf: lastSample as MTFState['lastSampleTickByTf'],
+    lastAgreementByTfSide: lastAgreement as MTFState['lastAgreementByTfSide'],
+  };
+}
+
+/** Append the current basin to each timeframe's history whose
+ *  sampling boundary has been crossed. Caller invokes once per kernel
+ *  tick with the freshly perceived basin and the current tick index.
+ *
+ *  Pure update of state in-place; no I/O. */
+export function onTickAppend(
+  state: MTFState,
+  basin: Basin,
+  tickIndex: number,
+  timeframes: TimeframeConfig[] = DEFAULT_TIMEFRAMES,
+): void {
+  for (const tf of timeframes) {
+    const last = state.lastSampleTickByTf[tf.label];
+    if (tickIndex - last >= tf.ticksPerSample) {
+      const hist = state.historiesByTf[tf.label];
+      hist.push(basin);
+      if (hist.length > tf.maxSamples) {
+        // Drop oldest to maintain cap.
+        hist.splice(0, hist.length - tf.maxSamples);
+      }
+      state.lastSampleTickByTf[tf.label] = tickIndex;
+    }
+  }
+}
+
+/** Bootstrap a timeframe's history from a pre-computed basin sequence.
+ *  Called once at startup after fetching OHLCV from Poloniex and
+ *  synthesising basins. Skipping this means 4h timeframe never warms up
+ *  in any reasonable runtime; 15m + 1h can warm up from live ticks alone
+ *  but they're faster with bootstrap too. */
+export function setBootstrapHistory(
+  state: MTFState,
+  label: TimeframeLabel,
+  history: Basin[],
+  timeframes: TimeframeConfig[] = DEFAULT_TIMEFRAMES,
+): void {
+  const tf = timeframes.find((t) => t.label === label);
+  if (!tf) return;
+  const capped = history.length > tf.maxSamples
+    ? history.slice(history.length - tf.maxSamples)
+    : [...history];
+  state.historiesByTf[label] = capped;
+}
+
+/** Compute the multi-timeframe agreement decision.
+ *
+ *  Each timeframe whose history is warm enough produces an
+ *  AgentLDecision. The aggregated action is decided by agreement
+ *  count + the size multiplier scales with agreement strength.
+ *
+ *  Pure function — no state mutation. The caller invokes this on
+ *  every kernel tick after onTickAppend has updated histories.
+ */
+export function mtfDecide(
+  state: MTFState,
+  timeframes: TimeframeConfig[] = DEFAULT_TIMEFRAMES,
+): MTFDecision {
+  const perTimeframe: MTFDecision['perTimeframe'] = [];
+  let longCount = 0;
+  let shortCount = 0;
+  let warmCount = 0;
+
+  for (const tf of timeframes) {
+    const hist = state.historiesByTf[tf.label];
+    // A timeframe is "warm" when its history reaches the classifier's
+    // own minimum (longWindow ticks + horizon). Below that, agentLDecide
+    // returns hold.
+    const minSamplesNeeded = 480 + tf.config.horizon;  // matches minTupleStart
+    const warm = hist.length >= minSamplesNeeded;
+    let decision: AgentLDecision | null = null;
+    if (warm) {
+      decision = agentLDecide(hist, tf.config);
+      if (decision.action === 'enter_long') longCount++;
+      else if (decision.action === 'enter_short') shortCount++;
+      warmCount++;
+    }
+    perTimeframe.push({ label: tf.label, warm, decision });
+  }
+
+  if (warmCount === 0) {
+    return {
+      action: 'hold',
+      agreementCount: 0,
+      totalTfs: timeframes.length,
+      sizeMultiplier: 0,
+      perTimeframe,
+      longestAgreeingLabel: null,
+      reason: 'no_warm_timeframes',
+    };
+  }
+
+  // Agreement-count combiner (option c).
+  const action: MTFDecision['action'] =
+    longCount > shortCount && longCount >= 2 ? 'enter_long'
+      : shortCount > longCount && shortCount >= 2 ? 'enter_short'
+        : 'hold';
+
+  const agreementCount = action === 'enter_long' ? longCount
+    : action === 'enter_short' ? shortCount
+      : 0;
+
+  // Size multiplier: 3-of-3 → 1.00, 2-of-3 → 0.50, else 0.
+  const sizeMultiplier =
+    action === 'hold' ? 0
+      : agreementCount >= 3 ? 1.0
+        : agreementCount === 2 ? 0.5
+          : 0;
+
+  // Longest-agreeing label for exit-horizon scheduling. The
+  // timeframes array is in ascending order (15m, 1h, 4h); take the
+  // last that voted with the majority.
+  let longestAgreeing: TimeframeLabel | null = null;
+  if (action !== 'hold') {
+    const wantAction = action;
+    for (const entry of perTimeframe) {
+      if (entry.decision?.action === wantAction) {
+        longestAgreeing = entry.label;  // overwrite — last match wins (longest)
+      }
+    }
+  }
+
+  return {
+    action,
+    agreementCount,
+    totalTfs: timeframes.length,
+    sizeMultiplier,
+    perTimeframe,
+    longestAgreeingLabel: longestAgreeing,
+    reason: `mtf:${longCount}L/${shortCount}S/${warmCount}warm`,
+  };
+}
+
+/** Record agreement timestamps for the per-TF horizon exit. Caller
+ *  invokes after mtfDecide to update the agreement clocks; the
+ *  forceHarvestAgentLStack exit check reads these to determine when
+ *  the longest-agreeing TF's horizon has elapsed. */
+export function recordAgreementTimestamps(
+  state: MTFState,
+  decision: MTFDecision,
+  nowMs: number,
+): void {
+  if (decision.action === 'hold') return;
+  const side: 'long' | 'short' = decision.action === 'enter_long' ? 'long' : 'short';
+  for (const entry of decision.perTimeframe) {
+    if (entry.decision?.action === decision.action) {
+      state.lastAgreementByTfSide[entry.label][side] = nowMs;
+    }
+  }
+}
+
+/** Check whether the longest-agreeing-at-entry timeframe's horizon
+ *  has elapsed without re-confirmation. Returns true when the
+ *  position should exit per the longest-agreeing-horizon policy.
+ *
+ *  Pure function. Caller (forceHarvestAgentLStack) decides what to
+ *  do with the result. */
+export function isLongestHorizonExpired(
+  state: MTFState,
+  side: 'long' | 'short',
+  longestLabelAtEntry: TimeframeLabel | null,
+  nowMs: number,
+  tickMs: number,
+  timeframes: TimeframeConfig[] = DEFAULT_TIMEFRAMES,
+): boolean {
+  if (!longestLabelAtEntry) return false;
+  const tf = timeframes.find((t) => t.label === longestLabelAtEntry);
+  if (!tf) return false;
+  const horizonMs = tf.config.horizon * tf.ticksPerSample * tickMs;
+  const lastAgreement = state.lastAgreementByTfSide[longestLabelAtEntry]?.[side] ?? null;
+  if (lastAgreement === null) return false;
+  return (nowMs - lastAgreement) > horizonMs;
+}


### PR DESCRIPTION
Multi-timeframe Agent L. Three FR-KNN instances on independently down-sampled basin streams; agreement-count combiner.

**Cadences** (30s tick): 30→15m, 120→1h, 480→4h.

**Combiner** (option c, agreement count): 3-of-3 → size×1.0; 2-of-3 → size×0.5; else hold.

**Phase 1 = observation mode**: `mtfDecide` runs per tick, logs results, doesn't yet gate entries. Phase 2 wires the size multiplier + longest-agreeing-horizon exit.

13/13 new tests pass. QIG-pure (composes existing primitives only). 482/484 monkey suite pass.

## Summary by Sourcery

Introduce a multi-timeframe Agent L classifier pipeline and wire it into the monkey kernel in observation mode, logging aggregated decisions without affecting trade entries.

New Features:
- Add a multi-timeframe Agent L classifier that runs 15m, 1h, and 4h FR-KNN instances in parallel with an agreement-count combiner.
- Track per-symbol multi-timeframe state, including down-sampled basin histories and agreement clocks, to support future position sizing and exit logic.
- Expose bootstrap and horizon-expiry helpers for multi-timeframe histories to enable prewarming and longest-horizon-based exits.

Enhancements:
- Integrate the multi-timeframe classifier into the main loop to down-sample basins each tick and periodically log consensus decisions for monitoring.

Tests:
- Add unit tests covering multi-timeframe state initialization, down-sampling cadence, bootstrap capping, agreement combiner behavior, agreement timestamp recording, and horizon-expiry checks.