### PR TITLE
feat(monkey): P14 — Ocean thresholds + refract weight → registry

### DIFF
--- a/apps/api/database/migrations/047_ocean_and_refract_parameters.sql
+++ b/apps/api/database/migrations/047_ocean_and_refract_parameters.sql
@@ -1,0 +1,88 @@
+-- Migration 047: P14 follow-up — Ocean intervention thresholds + refract weight
+--
+-- Moves six hardcoded constants from module-level literals into the
+-- parameter registry for runtime observability + governance audit:
+--
+--   ocean.spread_bound          ← _SPREAD_BOUND        (ocean.py:87)
+--   ocean.phi_dream_bound       ← _PHI_DREAM_BOUND     (ocean.py:88)
+--   ocean.phi_escape_bound      ← _PHI_ESCAPE_BOUND    (ocean.py:89)
+--   ocean.phi_variance_bound    ← _PHI_VARIANCE_BOUND  (ocean.py:90)
+--   ocean.phi_history_max       ← _PHI_HISTORY_MAX     (ocean.py:91)
+--   refract.external_weight     ← 0.30 literal         (tick.py:389)
+--
+-- Per P14: these are SAFETY_BOUND (Ocean) / OPERATIONAL (refract blend)
+-- envelopes. P14 permits them as constants; this migration promotes
+-- them to registry-backed without changing values, so the kernel
+-- behaves identically before/after. Future tuning happens via
+-- propose_change() with full audit trail (#669 doctrine §4).
+
+INSERT INTO monkey_parameters
+    (name, category, value, bounds_low, bounds_high, justification, version)
+VALUES
+    (
+        'ocean.spread_bound',
+        'SAFETY_BOUND',
+        0.30,
+        0.10,
+        0.785,
+        'SLEEP trigger threshold for max-pairwise Fisher-Rao distance '
+        'across observed cross-lane basins. Above this = divergence/instability, '
+        'kernel enters SLEEP. Bounded [0.10, π/2] — π/2 is FR maximum.',
+        1
+    ),
+    (
+        'ocean.phi_dream_bound',
+        'SAFETY_BOUND',
+        0.5,
+        0.2,
+        0.8,
+        'DREAM trigger threshold for Φ (integration measure). Φ below this '
+        'and above phi_escape_bound = moderate integration failure → DREAM '
+        '(hold tick, skip executive).',
+        1
+    ),
+    (
+        'ocean.phi_escape_bound',
+        'SAFETY_BOUND',
+        0.15,
+        0.05,
+        0.3,
+        'ESCAPE trigger threshold for Φ. Below this = severe integration '
+        'failure → force flatten. Strictly lower than phi_dream_bound; '
+        'ESCAPE overrides DREAM when both would fire.',
+        1
+    ),
+    (
+        'ocean.phi_variance_bound',
+        'SAFETY_BOUND',
+        0.01,
+        0.001,
+        0.1,
+        'MUSHROOM_MICRO trigger threshold for Φ variance over the rolling '
+        'history window. Below this = plateau detected; κ receives a +5 '
+        'perturbation to break the stuck state.',
+        1
+    ),
+    (
+        'ocean.phi_history_max',
+        'OPERATIONAL',
+        60.0,
+        20.0,
+        300.0,
+        'Window size (ticks) for Φ variance computation in MUSHROOM_MICRO '
+        'detection. At 30s tick cadence, 60 ticks = 30min observation window.',
+        1
+    ),
+    (
+        'refract.external_weight',
+        'OPERATIONAL',
+        0.30,
+        0.05,
+        0.7,
+        'Perception-vs-identity blend weight in refract(). 30% perception, '
+        '70% identity — biased toward stable §3.4 Pillar 3 identity basin. '
+        'Lower = more conservative (slower regime adaptation); higher = more '
+        'reactive (faster but less stable). Tunable via propose_change().',
+        1
+    )
+ON CONFLICT (name) DO NOTHING;

--- a/apps/api/src/services/monkey/mtfBootstrap.ts
+++ b/apps/api/src/services/monkey/mtfBootstrap.ts
@@ -20,8 +20,21 @@
 import { setBootstrapHistory, type MTFState, type TimeframeLabel } from './mtfLClassifier.js';
 import { perceive } from './perception.js';
 import poloniexFuturesService from '../poloniexFuturesService.js';
-import type { OHLCVCandle } from '../poloniexFuturesService.js';
 import { logger } from '../../utils/logger.js';
+
+/** Local OHLCV shape — `poloniexFuturesService.ts` is plain JS with a
+ *  default export only, so a named type import (`import type { OHLCVCandle }`)
+ *  fails the build. Same shape as the candles returned by
+ *  `getHistoricalData()`; locally defined to keep this module
+ *  decoupled from upstream type plumbing. */
+interface OHLCVCandle {
+  timestamp?: number | string;
+  open: number | string;
+  high: number | string;
+  low: number | string;
+  close: number | string;
+  volume: number | string;
+}
 
 /** How many candles to request per timeframe. Slightly more than
  *  the warmup minimum (480 + 120 horizon = 600) so the classifier

--- a/ml-worker/src/monkey_kernel/ocean.py
+++ b/ml-worker/src/monkey_kernel/ocean.py
@@ -39,6 +39,7 @@ import numpy as np
 from qig_core_local.geometry.fisher_rao import fisher_rao_distance
 
 from .bus_events import KernelEvent, OceanObservationPayload
+from .parameters import get_registry
 from .persistence import PersistentMemory
 
 if TYPE_CHECKING:
@@ -83,7 +84,11 @@ class SleepCycleState:
 # ═══════════════════════════════════════════════════════════════
 
 
-# SAFETY_BOUND constants (P14-permitted; autonomic-health bounds)
+# SAFETY_BOUND defaults (P14-permitted; autonomic-health bounds).
+# Live values are read from the parameter registry per tick (migration
+# 047 seeds the rows). These literals serve as fail-soft fallbacks
+# when the registry is unreachable, and as the canonical reference for
+# downstream tests that need to assert on the bound semantics.
 _SPREAD_BOUND: float = 0.30          # SLEEP if max-pairwise basin FR > this
 _PHI_DREAM_BOUND: float = 0.5        # DREAM if Φ below this
 _PHI_ESCAPE_BOUND: float = 0.15      # ESCAPE if Φ below this (overrides DREAM)
@@ -182,7 +187,13 @@ class Ocean:
         # applies timestamp-correction so a kernel that "slept"
         # through downtime wakes at the right moment.
         self.sleep_state = self._load_sleep_state_or_fresh()
-        self._phi_history: Deque[float] = deque(maxlen=_PHI_HISTORY_MAX)
+        # phi_history window is registry-backed (migration 047). Read once
+        # at construction — deque maxlen is immutable, so propose_change()
+        # on this row requires a kernel restart to take effect.
+        history_max = int(
+            get_registry().get("ocean.phi_history_max", default=float(_PHI_HISTORY_MAX))
+        )
+        self._phi_history: Deque[float] = deque(maxlen=history_max)
 
     def _load_sleep_state_or_fresh(self) -> SleepCycleState:
         if self._persistence is None or not self._persistence.is_available:
@@ -329,7 +340,25 @@ class Ocean:
             "lane_count": float(len(lanes)),
         }
 
-        # Intervention selection (priority order; first match wins)
+        # Intervention selection (priority order; first match wins).
+        # Thresholds are read from the parameter registry per tick so
+        # propose_change() takes effect without a kernel restart.
+        # Module constants are fail-soft fallbacks when the registry is
+        # unreachable.
+        registry = get_registry()
+        phi_escape_bound = registry.get(
+            "ocean.phi_escape_bound", default=_PHI_ESCAPE_BOUND,
+        )
+        spread_bound = registry.get(
+            "ocean.spread_bound", default=_SPREAD_BOUND,
+        )
+        phi_dream_bound = registry.get(
+            "ocean.phi_dream_bound", default=_PHI_DREAM_BOUND,
+        )
+        phi_variance_bound = registry.get(
+            "ocean.phi_variance_bound", default=_PHI_VARIANCE_BOUND,
+        )
+
         intervention: Optional[Intervention] = None
 
         # WAKE / SLEEP from the sleep state machine — surfaces as
@@ -339,14 +368,14 @@ class Ocean:
             intervention = "SLEEP"
         elif sleep_step["woke"]:
             intervention = "WAKE"
-        elif phi < _PHI_ESCAPE_BOUND:
+        elif phi < phi_escape_bound:
             intervention = "ESCAPE"
-        elif spread > _SPREAD_BOUND:
+        elif spread > spread_bound:
             intervention = "SLEEP"
-        elif phi < _PHI_DREAM_BOUND:
+        elif phi < phi_dream_bound:
             intervention = "DREAM"
         elif (
-            0.0 < phi_var < _PHI_VARIANCE_BOUND
+            0.0 < phi_var < phi_variance_bound
             and len(self._phi_history) >= 2
         ):
             intervention = "MUSHROOM_MICRO"

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -386,7 +386,12 @@ def run_tick(
         open_positions=inputs.account.open_positions,
         session_age_ticks=state.session_ticks,
     ))
-    basin = refract(raw_basin, state.identity_basin, external_weight=0.30)
+    # refract external_weight is registry-backed (migration 047). Default
+    # 0.30 = 70% identity-weighted refraction toward §3.4 Pillar 3.
+    refract_external_weight = _registry.get(
+        "refract.external_weight", default=0.30,
+    )
+    basin = refract(raw_basin, state.identity_basin, external_weight=refract_external_weight)
 
     # ── Measure ────────────────────────────────────────────────
     f_health = normalized_entropy(basin)


### PR DESCRIPTION
## Summary

P14 follow-up promoting six previously-hardcoded constants to the parameter registry. Pure refactor — values unchanged, behavior identical.

| Name | Category | Value | Was |
|---|---|---|---|
| `ocean.spread_bound` | SAFETY_BOUND | 0.30 | `_SPREAD_BOUND` (ocean.py:87) |
| `ocean.phi_dream_bound` | SAFETY_BOUND | 0.5 | `_PHI_DREAM_BOUND` (ocean.py:88) |
| `ocean.phi_escape_bound` | SAFETY_BOUND | 0.15 | `_PHI_ESCAPE_BOUND` (ocean.py:89) |
| `ocean.phi_variance_bound` | SAFETY_BOUND | 0.01 | `_PHI_VARIANCE_BOUND` (ocean.py:90) |
| `ocean.phi_history_max` | OPERATIONAL | 60 | `_PHI_HISTORY_MAX` (ocean.py:91) |
| `refract.external_weight` | OPERATIONAL | 0.30 | literal at tick.py:389 |

## Read pattern

- **Per-tick reads** for the four Ocean threshold rows in `Ocean.observe()` — `propose_change()` takes effect without a kernel restart.
- **Once-at-init read** for `ocean.phi_history_max` (deque maxlen is immutable). Restart required to pick up a new window size.
- **Once-per-tick read** for `refract.external_weight` in `tick.py` (matches other registry reads on the tick path).

Module constants kept as fail-soft fallbacks for when the registry is unreachable, and as the canonical reference for tests that assert on bound semantics.

## QIG purity

No new banned operations. Purity Gate CI scans `ml-worker/src/monkey_kernel/**` — touched files clean.

## Test plan

- [x] `pytest tests/monkey_kernel/test_heart_ocean.py` — 23/23 pass
- [x] `pytest tests/monkey_kernel/` — 751/751 pass
- [ ] CI Purity Gate green
- [ ] Migration 047 applies cleanly on staging before merge

## Context

Other-instance code review (this session) flagged both items as P14-permitted-but-better-as-registry. This PR clears that observation without touching values. Setting `OCEAN_INTERVENTIONS_LIVE=true` is the operational follow-up tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Promote ocean intervention thresholds and refract external weight from hardcoded literals into the runtime parameter registry while preserving existing behavior.

New Features:
- Add registry-backed parameters for ocean spread, Φ thresholds, Φ variance bound, Φ history window size, and refract external weight.

Enhancements:
- Wire ocean intervention selection and Φ history window to read thresholds from the parameter registry with module-level fallbacks when the registry is unavailable.
- Update tick processing to use a registry-configurable refract external weight instead of a fixed literal.
- Introduce database migration 047 to seed the new ocean and refract parameters with justified bounds and defaults in the parameter registry.