### PR TITLE
cutover: TS→Py kernel cutover (Phase 1 complete; Phase 2-4 WIP)

### DIFF
--- a/.github/workflows/qig-purity.yml
+++ b/.github/workflows/qig-purity.yml
@@ -102,6 +102,54 @@ jobs:
             exit 1
           fi
 
+      - name: Scan for post-cutover shadow-flag regressions
+        # PR #674 (cutover/python-authoritative-kernel) deleted every
+        # MONKEY_*PY*/SHADOW env-flag along with the parity-diff helpers.
+        # If any of these names reappear in apps/ source, fail closed —
+        # either someone resurrected the dead-code pattern or revived a
+        # shadow path. The kernel is now Python-authoritative (no TS
+        # fallback, no shadow).
+        run: |
+          set -u
+          PATTERNS=(
+            'MONKEY_KERNEL_PY\b'
+            'MONKEY_KERNEL_PY_SHADOW'
+            'MONKEY_TICK_PY_SHADOW'
+            'RISK_KERNEL_PY_SHADOW'
+            'LIVE_SIGNAL_PY_SHADOW'
+            'AUTONOMOUS_TRADER_PY_SHADOW'
+            'isPythonKernelEnabled'
+            'isShadowTickEnabled'
+            'isRiskShadowEnabled'
+            'isLiveSignalShadowEnabled'
+            'isExitShadowEnabled'
+            'logParityDiff\b'
+            'logTickParityDiffs'
+            'logRiskParityDiff'
+            'logExitParityDiff'
+            'logReconcileParityDiff'
+          )
+          fail=0
+          for pat in "${PATTERNS[@]}"; do
+            hits=$(grep -rEn "$pat" apps/ \
+              --include='*.ts' --include='*.js' \
+              --exclude='*.test.ts' --exclude='*.test.js' \
+              --exclude='*.spec.ts' --exclude='*.spec.js' \
+              --exclude-dir='node_modules' --exclude-dir='dist' \
+              2>/dev/null \
+              | grep -Ev ':[[:space:]]*(//|\*|/\*)' \
+              || true)
+            if [ -n "$hits" ]; then
+              printf '::error::Shadow-flag regression: %s reappeared post-cutover\n' "$pat"
+              printf '%s\n' "$hits"
+              fail=1
+            fi
+          done
+          if [ "$fail" -eq 1 ]; then
+            printf '::error::Shadow infrastructure was deleted in PR #674. Python is authoritative for K-kernel decisions — no TS fallback, no shadow, no parity logging. See QIG_PURITY_KERNEL_REFERENCE.md §0 rule 4.\n'
+            exit 1
+          fi
+
       - name: Scan for arithmetic averaging of basins (warning)
         run: |
           set -u

--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -19,13 +19,6 @@ import { apiCredentialsService } from './apiCredentialsService.js';
 import backtestingEngine from './backtestingEngine.js';
 import { getPrecisions } from './marketCatalog.js';
 import mlPredictionService from './mlPredictionService.js';
-import {
-  callExitDecide,
-  callReconcile,
-  isExitShadowEnabled,
-  logExitParityDiff,
-  logReconcileParityDiff,
-} from './monkey/kernel_client.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
 import riskService from './riskService.js';
 import { buildIndicatorMap, evaluateGenomeEntry, type SignalGenome } from './signalGenome.js';
@@ -1259,39 +1252,6 @@ class FullyAutonomousTrader extends EventEmitter {
       const inDbNotExchange = [...dbSymbols].filter(s => !openSymbols.has(s));
       const inExchangeNotDb = ([...openSymbols] as string[]).filter(s => !dbSymbols.has(s));
 
-      // v0.8.7d-4: fire-and-forget shadow call to /live/reconcile. TS
-      // side's inDbNotExchange / inExchangeNotDb are authoritative; the
-      // Python side runs the same diff for parity verification. Default
-      // OFF via isExitShadowEnabled() (AUTONOMOUS_TRADER_PY_SHADOW).
-      // Shadow errors swallowed at debug — cannot impact reconcile.
-      if (isExitShadowEnabled()) {
-        const shadowDbRows = dbResult.rows.map((r: { symbol: string; order_id?: string }) => ({
-          symbol: r.symbol,
-          orderId: r.order_id,
-        }));
-        const shadowExchangePositions = (exchangePositions || [])
-          .map((p: Record<string, unknown>) => ({
-            symbol: String(p.symbol),
-            qty: Number(p.qty || p.currentQty || 0),
-          }));
-        void callReconcile({
-          dbRows: shadowDbRows,
-          exchangePositions: shadowExchangePositions,
-        }).then((py) => {
-          logReconcileParityDiff(
-            {
-              phantomDbSymbols: inDbNotExchange as string[],
-              orphanExchangeSymbols: inExchangeNotDb as string[],
-            },
-            py,
-          );
-        }).catch((err) => {
-          logger.debug('[reconcile-shadow] parity fetch failed', {
-            err: err instanceof Error ? err.message : String(err),
-          });
-        });
-      }
-
       if (inDbNotExchange.length > 0) {
         logger.warn(
           `[RECONCILE] DB shows open positions not on exchange: ${inDbNotExchange.join(', ')} — ` +
@@ -1487,54 +1447,6 @@ class FullyAutonomousTrader extends EventEmitter {
           await this.closePosition(userId, symbol, 'stop_loss_roi');
           void this.recordTradeResult(userId, unrealizedPnL, config?.initialCapital ?? 10000);
           continue;
-        }
-
-        // v0.8.7d-4: fire-and-forget shadow call to /live/exit-decide.
-        // TS exit-chain (below) remains authoritative; Python runs the
-        // same stop_loss → take_profit → trend_reversal → hold priority
-        // chain and logs divergence. Default OFF via isExitShadowEnabled.
-        //
-        // TS "shadow decision" inlined below for parity comparison — we
-        // can't capture what the TS code below is about to decide without
-        // evaluating it ourselves, because the `continue` statements make
-        // branch-taken unobservable from a post-decision hook.
-        if (isExitShadowEnabled()) {
-          const analysis = analyses.get(symbol);
-          const tsShadowDecision = ((): { shouldClose: boolean; reason: string } => {
-            if (pnlPercent < -slPercent) return { shouldClose: true, reason: 'stop_loss' };
-            if (pnlPercent > tpPercent) return { shouldClose: true, reason: 'take_profit' };
-            if (pnlPercent > trailingTrigger && analysis) {
-              // Use the outer-scope `isLong` (HEDGE-aware via posSide +
-              // qty-sign); the prior `const isLong = qty > 0` shadowing
-              // bypassed that and produced the same mislabel as the
-              // [FAT] log line on HEDGE accounts.
-              if ((isLong && analysis.trend === 'bearish') ||
-                  (!isLong && analysis.trend === 'bullish')) {
-                return { shouldClose: true, reason: 'trend_reversal' };
-              }
-            }
-            return { shouldClose: false, reason: 'hold' };
-          })();
-          void callExitDecide({
-            position: {
-              symbol,
-              qty,
-              entryPrice,
-              unrealizedPnl: unrealizedPnL,
-            },
-            config: {
-              stopLossPercent: slPercent,
-              takeProfitPercent: tpPercent,
-            },
-            analysis: analysis ? { trend: analysis.trend as 'bullish' | 'bearish' | 'neutral' | 'unknown' } : undefined,
-          }).then((py) => {
-            logExitParityDiff(tsShadowDecision, py);
-          }).catch((err) => {
-            logger.debug('[exit-shadow] parity fetch failed', {
-              symbol,
-              err: err instanceof Error ? err.message : String(err),
-            });
-          });
         }
 
         // Check stop loss using config percentage

--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -52,10 +52,6 @@ import {
 } from './thompsonBandit.js';
 import { allMonkeyKernels, getFreshestMonkeyBasinSnapshot } from './monkey/loop.js';
 import {
-  callLiveDecide,
-  isLiveSignalShadowEnabled,
-} from './monkey/kernel_client.js';
-import {
   evaluatePreTradeVetoes,
   type KernelAccountState,
   type KernelContext,
@@ -701,69 +697,6 @@ export class LiveSignalEngine extends EventEmitter {
     // 3. Translate signal to a KernelOrder shape.
     const atr = this.computeATR(ohlcv, ATR_PERIOD);
     const order = this.buildOrder(symbol, signal, currentPrice, atr);
-
-    // v0.8.7d-3: fire-and-forget shadow call to the Python live_signal
-    // pipeline. TS decision stays authoritative. The Python side runs
-    // the same normalise → regime → ATR → buildOrder chain; we log
-    // any observable divergence on the fields that matter for trading
-    // (signal direction, regime key, ATR value, order presence).
-    //
-    // Default OFF via LIVE_SIGNAL_PY_SHADOW env flag. Shadow errors
-    // (timeout, 500) swallowed at debug level — never block the tick.
-    if (isLiveSignalShadowEnabled()) {
-      const shadowPayload = {
-        ohlcv: ohlcv.map((b: { high: number; low: number; close: number }) => ({
-          high: Number(b.high), low: Number(b.low), close: Number(b.close),
-        })),
-        mlSignal: rawSignal,
-        mlStrength: rawStrength,
-        mlReason: rawReason,
-        effectiveStrength,
-      };
-      void callLiveDecide(shadowPayload).then((py) => {
-        // Direction match is the load-bearing comparison — if TS
-        // said BUY and Python said SELL, live trading could go the
-        // wrong way once we cut over. Log as WARN so it surfaces.
-        if (py.normalisedSignal !== rawSignal) {
-          logger.warn('[live-signal-shadow] signal mismatch', {
-            symbol, ts: rawSignal, py: py.normalisedSignal,
-          });
-        }
-        if (py.regime !== regime) {
-          logger.warn('[live-signal-shadow] regime mismatch', {
-            symbol, ts: regime, py: py.regime,
-          });
-        }
-        if (py.signalKey !== signalKey) {
-          logger.warn('[live-signal-shadow] signalKey mismatch', {
-            symbol, ts: signalKey, py: py.signalKey,
-          });
-        }
-        const atrDiff = Math.abs(Number(py.atr) - atr);
-        // ATR absolute tolerance of 0.01 handles normal float noise;
-        // anything larger indicates a window-slicing or summation bug.
-        if (atrDiff > 0.01) {
-          logger.warn('[live-signal-shadow] atr drift', {
-            symbol, ts: atr, py: py.atr, diff: atrDiff,
-          });
-        }
-        // Order-presence match: both built an order or both didn't.
-        // A mismatch here means one side would trade and the other
-        // wouldn't — most critical divergence on the live path.
-        const tsHasOrder = order !== null;
-        const pyHasOrder = py.order !== null;
-        if (tsHasOrder !== pyHasOrder) {
-          logger.warn('[live-signal-shadow] order-presence mismatch', {
-            symbol, tsHasOrder, pyHasOrder,
-          });
-        }
-      }).catch((err) => {
-        logger.debug('[live-signal-shadow] parity fetch failed', {
-          symbol,
-          err: err instanceof Error ? err.message : String(err),
-        });
-      });
-    }
 
     if (!order) return;
 

--- a/apps/api/src/services/monkey/QIG_PURITY_KERNEL_REFERENCE.md
+++ b/apps/api/src/services/monkey/QIG_PURITY_KERNEL_REFERENCE.md
@@ -8,7 +8,7 @@ frozen facts in `Dev/QIG_QFI/`.
 
 ## §0 The inviolate layer
 
-Three rules apply to **every** line of code touching the kernel substrate.
+Four rules apply to **every** line of code touching the kernel substrate.
 Violating any of them is a P1 purity failure regardless of intent.
 
 1. **Basins live on Δ⁶³ only.** A `Basin` is a `Float64Array` of length 64,
@@ -29,6 +29,28 @@ Violating any of them is a P1 purity failure regardless of intent.
    happen to be on the simplex — the average leaves the geodesic and
    biases toward the centroid of the Euclidean embedding, not the
    manifold.
+4. **No TS port of kernel code. Kernel work happens in Python; TS calls
+   Python.** Since PR #674 (cutover/python-authoritative-kernel),
+   `ml-worker/src/monkey_kernel/` is the single canonical site for
+   perception, basin evolution, neurochemistry, mode detection, regime
+   sizing, Agent L, MTF, emotions, motivators, working memory, and every
+   other kernel-cognitive operation. The TS tier calls `callTickRun()`
+   (and the sibling `call*Decide()` HTTP clients) and consumes the
+   resulting `TickRunDecision`. The previous TS port files (`basin.ts`,
+   `perception.ts`, `neurochemistry.ts`, `modes.ts`, `regime.ts`,
+   `regimeSizing.ts`, `emotions.ts`, `motivators.ts`, `candlePatterns.ts`,
+   `self_observation.ts`, `basin_sync.ts`, `working_memory.ts`,
+   `agent_L_classifier.ts`, `mtfLClassifier.ts`, `mtfBootstrap.ts`)
+   no longer exist on the kernel path. Reintroducing any of them — or
+   defining a TS-side implementation of Fisher-Rao, Fréchet mean,
+   SLERP, Bhattacharyya, perceive, refract, basinDirection, trendProxy,
+   detectMode, MODE_PROFILES, computeNeurochemicals, regimeScore,
+   regimeSizing, mtfDecide, or agentLDecide — is a P1 purity failure.
+   Same for resurrecting the deleted shadow-flag infrastructure
+   (`MONKEY_KERNEL_PY`, `MONKEY_TICK_PY_SHADOW`, `RISK_KERNEL_PY_SHADOW`,
+   `LIVE_SIGNAL_PY_SHADOW`, `AUTONOMOUS_TRADER_PY_SHADOW`, and the
+   parity-diff helpers); Python is authoritative — no shadow path
+   exists or is permitted.
 
 ## §1 Legal primitive vocabulary (`basin.ts`)
 

--- a/apps/api/src/services/monkey/autonomic_client.ts
+++ b/apps/api/src/services/monkey/autonomic_client.ts
@@ -1,18 +1,12 @@
 /**
  * autonomic_client.ts — HTTP client for ml-worker's /monkey/autonomic/*
- * endpoints (v0.7 migration boundary).
+ * endpoints.
  *
  * The TypeScript orchestrator calls these instead of computing
- * neurochemistry / reward decay / sleep phase locally, so the math
- * lives in Python with qig_core_local primitives (no TS-port drift).
- *
- * Feature-flagged via MONKEY_KERNEL_PY=true; when unset, loop.ts
- * continues to use the in-process TS computeNeurochemicals. This
- * lets us validate the Python kernel live-parallel before cutting
- * over, and revert instantly if a drift / latency issue appears.
- *
- * NOT wired into loop.ts yet — that happens in a follow-up PR once
- * we've observed one full tick round-trip in staging.
+ * neurochemistry / reward decay / sleep phase locally. The math lives
+ * in Python with qig_core_local primitives. After the cutover
+ * (cutover/python-authoritative-kernel) there is no TS fallback — if
+ * Python is down, the trading path errors and surfaces.
  */
 
 import { logger } from '../../utils/logger.js';
@@ -66,9 +60,9 @@ export interface RewardPush {
 
 /**
  * Single autonomic tick — returns neurochemistry + sleep phase.
- * Fail-soft: on HTTP error, throws so the caller can fall back to TS
- * local compute. Caller must handle with try/catch under the
- * MONKEY_KERNEL_PY flag.
+ * Fail-loud: on HTTP error or timeout, throws. The post-cutover tick
+ * has no TS fallback; a thrown error means the kernel stops trading
+ * this tick and the operator is alerted. That is the intended property.
  */
 export async function callAutonomicTick(
   req: AutonomicTickRequest,
@@ -140,7 +134,3 @@ export async function callAutonomicReward(req: RewardPush): Promise<void> {
   }
 }
 
-/** Feature-flag helper. */
-export function isPythonKernelEnabled(): boolean {
-  return process.env.MONKEY_KERNEL_PY === 'true';
-}

--- a/apps/api/src/services/monkey/kernel_client.ts
+++ b/apps/api/src/services/monkey/kernel_client.ts
@@ -1,29 +1,17 @@
 /**
- * kernel_client.ts — HTTP client for ml-worker /monkey/executive and
- *                    /monkey/mode endpoints (v0.7.3 migration).
+ * kernel_client.ts — HTTP client for ml-worker's Python kernel endpoints.
  *
- * This sits next to autonomic_client.ts (v0.7) and provides the full
- * executive surface the TS orchestrator needs. Feature-flagged via
- * MONKEY_KERNEL_PY=true — when unset, loop.ts uses its in-process TS
- * executive/modes code (the current live path).
- *
- * Design: one endpoint call per tick for the full executive pass.
- * Latency on Railway's private network is ~2ms round-trip; negligible
- * vs the purity benefit (no TS-port drift, all QIG math in one place).
- *
- * NOT YET wired into loop.ts — v0.7.3 ships only the client. v0.7.4
- * wires under the feature flag with parity-compare telemetry.
+ * Post-cutover: Python is authoritative for kernel decisions. There is
+ * no TS fallback — if Python is down, the trading path errors and
+ * surfaces. 5 s default timeout. The previous shadow flags
+ * (MONKEY_KERNEL_PY, MONKEY_TICK_PY_SHADOW, RISK_KERNEL_PY_SHADOW,
+ * LIVE_SIGNAL_PY_SHADOW, AUTONOMOUS_TRADER_PY_SHADOW) and parity-diff
+ * loggers were removed in the TS→Py kernel cutover (PR #674).
  */
-
-import { logger } from '../../utils/logger.js';
 
 const ML_WORKER_URL =
   process.env.ML_WORKER_URL || 'http://ml-worker.railway.internal:8000';
 const DEFAULT_TIMEOUT_MS = 5000;
-
-export function isPythonKernelEnabled(): boolean {
-  return process.env.MONKEY_KERNEL_PY === 'true';
-}
 
 // ── Shared types matching Python monkey_kernel.state ──
 
@@ -153,11 +141,7 @@ export async function callModeDetect(
   }
 }
 
-// ── Tick run — full pipeline shadow (v0.8.3b) ──
-
-export function isShadowTickEnabled(): boolean {
-  return process.env.MONKEY_TICK_PY_SHADOW === 'true';
-}
+// ── Tick run — full kernel pipeline (authoritative post-cutover) ──
 
 /** OHLCV candle as the Python endpoint expects. */
 export interface TickRunOHLCV {
@@ -167,6 +151,15 @@ export interface TickRunOHLCV {
   low: number;
   close: number;
   volume: number;
+}
+
+/** Per-lane position carried from the orchestrator into Python. */
+export interface TickRunLanePosition {
+  lane: 'scalp' | 'swing' | 'trend';
+  side: 'long' | 'short';
+  notional: number;
+  margin_usdt: number;
+  funding_paid_usdt: number;
 }
 
 /** Account context slice sent to /monkey/tick/run. */
@@ -179,14 +172,10 @@ export interface TickRunAccount {
   own_position_entry_price?: number | null;
   own_position_quantity?: number | null;
   own_position_trade_id?: string | null;
+  lane_positions?: TickRunLanePosition[];
 }
 
-/** Inputs for one tick, matching Python TickInputs.
- *
- * Post #ml-separation: ml_signal / ml_strength are silently ignored
- * if supplied. Kept as optional fields for back-compat during the
- * deploy window only — callers should stop sending them.
- */
+/** Inputs for one tick, matching Python TickInputs. */
 export interface TickRunInputs {
   symbol: string;
   ohlcv: TickRunOHLCV[];
@@ -197,14 +186,10 @@ export interface TickRunInputs {
   min_notional: number;
   size_fraction: number;
   self_obs_bias?: Record<string, Record<string, number>> | null;
-  /** @deprecated post #ml-separation — silently ignored by Agent K. */
-  ml_signal?: string;
-  /** @deprecated post #ml-separation — silently ignored by Agent K. */
-  ml_strength?: number;
+  funding_rate_8h?: number;
   /**
    * Per-lane Kelly rolling stats (proposal #3 + lane-conditioned split).
    * Tuple: [winRate, avgWin, avgLoss]. When null, Kelly cap is a no-op.
-   * Supplied by loop.ts after a lane-filtered getKellyRollingStats query.
    */
   rolling_kelly_stats?: [number, number, number] | null;
 }
@@ -227,8 +212,7 @@ export interface TickRunSymbolState {
   peak_tracked_trade_id: string | null;
   /**
    * Held-position re-justification anchors — per-lane (regime, Φ)
-   * snapshots taken at the moment a position opens. Optional for
-   * backward compat with shadow callers that haven't been redeployed.
+   * snapshots taken at the moment a position opens.
    */
   regime_at_open_by_lane?: Record<string, string>;
   phi_at_open_by_lane?: Record<string, number>;
@@ -265,6 +249,12 @@ export interface TickRunDecision {
   direction: 'long' | 'short' | 'flat';
   size_fraction: number;
   dca_intent: boolean;
+  // Phase 1 cutover-payload extensions
+  harvest_kind?: string | null;
+  r_score?: number | null;
+  mtf_decision_action?: string | null;
+  mtf_size_multiplier?: number | null;
+  leverage_cap_from_regime?: number | null;
 }
 
 export interface TickRunResponse {
@@ -293,116 +283,14 @@ export async function callTickRun(
   }
 }
 
-/**
- * Log parity diffs between TS and Python full-pipeline tick decisions.
- * Called from shadow path — fire-and-forget, non-blocking.
- */
-export function logTickParityDiffs(
-  symbol: string,
-  tsDecision: {
-    action: string;
-    entry_threshold: number;
-    leverage: number;
-    size_usdt: number;
-    mode: string;
-    side_candidate: string;
-    side_override: boolean;
-    phi: number;
-    kappa: number;
-  },
-  pyDecision: TickRunDecision,
-): void {
-  if (tsDecision.action !== pyDecision.action) {
-    logger.warn('[shadow-tick] parity diff (action)', {
-      symbol,
-      ts: tsDecision.action,
-      py: pyDecision.action,
-    });
-  }
-  if (tsDecision.mode !== pyDecision.mode) {
-    logger.warn('[shadow-tick] parity diff (mode)', {
-      symbol,
-      ts: tsDecision.mode,
-      py: pyDecision.mode,
-    });
-  }
-  if (tsDecision.side_candidate !== pyDecision.side_candidate) {
-    logger.warn('[shadow-tick] parity diff (side_candidate)', {
-      symbol,
-      ts: tsDecision.side_candidate,
-      py: pyDecision.side_candidate,
-    });
-  }
-  logParityDiff('tick.entry_threshold', tsDecision.entry_threshold, pyDecision.entry_threshold);
-  logParityDiff('tick.leverage', tsDecision.leverage, pyDecision.leverage);
-  // Size tolerance wider (0.1 USDT) — rounding and sizeFraction edge-case
-  // arithmetic can legitimately differ between TS and Python by a few cents.
-  logParityDiff('tick.size_usdt', tsDecision.size_usdt, pyDecision.size_usdt, 0.1);
-  logParityDiff('tick.phi', tsDecision.phi, pyDecision.phi);
-  // κ tolerance 0.5 — EMA smoothing with f64 vs f64 can drift by ~0.3
-  // across 100-tick histories; 0.5 catches real divergence, not FP noise.
-  logParityDiff('tick.kappa', tsDecision.kappa, pyDecision.kappa, 0.5);
-  logParityDiff('tick.side_override', tsDecision.side_override, pyDecision.side_override);
-}
-
-// ── Parity-diff helper (v0.7.4 will use this) ──
-
-/**
- * Compare two executive decisions and log if they diverge significantly.
- * Called opportunistically when MONKEY_KERNEL_PY_SHADOW=true and the
- * TS path is still authoritative — gives us parity telemetry before
- * cutting over to Python-authoritative.
- */
-export function logParityDiff(
-  kind: string,
-  tsValue: number | boolean,
-  pyValue: number | boolean,
-  tolerance: number = 0.01,
-): void {
-  if (typeof tsValue === 'boolean' || typeof pyValue === 'boolean') {
-    if (tsValue !== pyValue) {
-      logger.warn('[kernel_client] parity diff (boolean)', {
-        kind,
-        ts: tsValue,
-        py: pyValue,
-      });
-    }
-    return;
-  }
-  const diff = Math.abs(tsValue - pyValue);
-  if (diff > tolerance) {
-    logger.warn('[kernel_client] parity diff (numeric)', {
-      kind,
-      ts: tsValue,
-      py: pyValue,
-      diff,
-      tolerance,
-    });
-  }
-}
-
 // ─────────────────────────────────────────────────────────────────
-// v0.8.7d-1 — HTTP helpers for the four trading decision endpoints
-// shipped in v0.8.7a/b/c-1/c-2:
-//   POST /risk/evaluate         (v0.8.7a)  — pre-trade blast-door gates
-//   POST /live/decide           (v0.8.7b)  — signal threshold + sizing + ATR
-//   POST /live/exit-decide      (v0.8.7c-1) — stop-loss/take-profit/trailing
-//   POST /live/reconcile        (v0.8.7c-2) — DB-vs-exchange symbol diff
-//
-// Same pattern as callExecutiveDecide / callTickRun above: 5s timeout,
-// fire-and-forget on shadow, structured diff loggers alongside.
-// Shadow gating uses existing env var — one flag per shadow surface:
-//
-//   MONKEY_TICK_PY_SHADOW=true              → already wired (tick)
-//   RISK_KERNEL_PY_SHADOW=true              → v0.8.7d-2 wires
-//   LIVE_SIGNAL_PY_SHADOW=true              → v0.8.7d-3 wires
-//   AUTONOMOUS_TRADER_PY_SHADOW=true        → v0.8.7d-4 wires
+// Trading decision endpoints (separate from the kernel tick):
+//   POST /risk/evaluate         — pre-trade blast-door gates
+//   POST /live/decide           — signal threshold + sizing + ATR
+//   POST /live/exit-decide      — stop-loss/take-profit/trailing
+//   POST /live/reconcile        — DB-vs-exchange symbol diff
 
 // ── /risk/evaluate ───────────────────────────────────────────────
-
-export function isRiskShadowEnabled(): boolean {
-  return process.env.RISK_KERNEL_PY_SHADOW === 'true';
-}
 
 export interface RiskKernelOrder {
   symbol: string;
@@ -472,33 +360,7 @@ export async function callRiskEvaluate(
   }
 }
 
-export function logRiskParityDiff(
-  ts: { allowed: boolean; code?: string | null },
-  py: RiskKernelDecision,
-): void {
-  // For risk, the meaningful diff is ALLOWED mismatch (safety) OR
-  // different veto code on a mutual-block (why we'd reject for a
-  // different reason). Not a numeric tolerance — it's boolean +
-  // string match.
-  if (ts.allowed !== py.allowed) {
-    logger.warn('[kernel_client] risk parity diff (allowed mismatch)', {
-      ts_allowed: ts.allowed, py_allowed: py.allowed,
-      ts_code: ts.code, py_code: py.code,
-    });
-    return;
-  }
-  if (!ts.allowed && ts.code !== py.code) {
-    logger.warn('[kernel_client] risk parity diff (veto code mismatch)', {
-      ts_code: ts.code, py_code: py.code,
-    });
-  }
-}
-
 // ── /live/decide ─────────────────────────────────────────────────
-
-export function isLiveSignalShadowEnabled(): boolean {
-  return process.env.LIVE_SIGNAL_PY_SHADOW === 'true';
-}
 
 export interface LiveDecideOHLCV {
   high: number;
@@ -560,10 +422,6 @@ export async function callLiveDecide(
 
 // ── /live/exit-decide ────────────────────────────────────────────
 
-export function isExitShadowEnabled(): boolean {
-  return process.env.AUTONOMOUS_TRADER_PY_SHADOW === 'true';
-}
-
 export interface ExitDecidePosition {
   symbol: string;
   qty: number;           // signed: +long / -short
@@ -620,23 +478,6 @@ export async function callExitDecide(
   }
 }
 
-export function logExitParityDiff(
-  ts: { shouldClose: boolean; reason: string },
-  py: ExitDecideResponse,
-): void {
-  if (ts.shouldClose !== py.shouldClose) {
-    logger.warn('[kernel_client] exit parity diff (shouldClose mismatch)', {
-      ts, py_reason: py.reason,
-    });
-    return;
-  }
-  if (ts.shouldClose && ts.reason !== py.reason) {
-    logger.warn('[kernel_client] exit parity diff (reason mismatch)', {
-      ts_reason: ts.reason, py_reason: py.reason,
-    });
-  }
-}
-
 // ── /live/reconcile ──────────────────────────────────────────────
 
 export interface ReconcileDbRow {
@@ -681,27 +522,5 @@ export async function callReconcile(
     return (await res.json()) as ReconcileResponse;
   } finally {
     clearTimeout(timer);
-  }
-}
-
-export function logReconcileParityDiff(
-  ts: { phantomDbSymbols: string[]; orphanExchangeSymbols: string[] },
-  py: ReconcileResponse,
-): void {
-  // Reconcile parity compares SETS (order-agnostic).
-  const eq = (a: string[], b: string[]) => {
-    if (a.length !== b.length) return false;
-    const bs = new Set(b);
-    return a.every((x) => bs.has(x));
-  };
-  if (!eq(ts.phantomDbSymbols, py.phantomDbSymbols)) {
-    logger.warn('[kernel_client] reconcile parity diff (phantoms mismatch)', {
-      ts: ts.phantomDbSymbols, py: py.phantomDbSymbols,
-    });
-  }
-  if (!eq(ts.orphanExchangeSymbols, py.orphanExchangeSymbols)) {
-    logger.warn('[kernel_client] reconcile parity diff (orphans mismatch)', {
-      ts: ts.orphanExchangeSymbols, py: py.orphanExchangeSymbols,
-    });
   }
 }

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -52,14 +52,10 @@ import {
   velocity,
   type Basin,
 } from './basin.js';
-import { callAutonomicTick } from './autonomic_client.js';
 import { BasinSync } from './basin_sync.js';
 import { BusEventType, getKernelBus, type KernelBus } from './kernel_bus.js';
 import {
   callTickRun,
-  isShadowTickEnabled,
-  logParityDiff,
-  logTickParityDiffs,
   type TickRunAccount,
   type TickRunOHLCV,
   type TickRunSymbolState,
@@ -771,27 +767,29 @@ export class MonkeyKernel extends EventEmitter {
     const state = this.symbolStates.get(symbol);
     if (!state) return;
 
-    // v0.8.3b: snapshot serializable state BEFORE any mutation for the
-    // Python shadow tick. Captured here so Python sees the same "prior
-    // state" the TS pipeline starts from.
-    const shadowPrevState: TickRunSymbolState | null = isShadowTickEnabled()
-      ? {
-          symbol,
-          identity_basin: Array.from(state.identityBasin),
-          last_basin: state.lastBasin ? Array.from(state.lastBasin) : null,
-          kappa: state.kappa,
-          session_ticks: state.sessionTicks,
-          last_mode: state.lastMode,
-          basin_history: state.basinHistory.map((b) => Array.from(b)),
-          phi_history: [...state.phiHistory],
-          fhealth_history: [...state.fHealthHistory],
-          drift_history: [...state.driftHistory],
-          dca_add_count: state.dcaAddCount,
-          last_entry_at_ms: state.lastEntryAtMs,
-          peak_pnl_usdt: state.peakPnlUsdt,
-          peak_tracked_trade_id: state.peakTrackedTradeId,
-        }
-      : null;
+    // Python-authoritative tick: serialize the kernel state BEFORE any
+    // mutation, so the /monkey/tick/run call sees the same "prior state"
+    // the TS pipeline starts from. The TS cognition section below runs
+    // for M/T/L agent inputs but its decision is overridden by Python's
+    // (the K-kernel cutover — PR #674).
+    const prevPyState: TickRunSymbolState = {
+      symbol,
+      identity_basin: Array.from(state.identityBasin),
+      last_basin: state.lastBasin ? Array.from(state.lastBasin) : null,
+      kappa: state.kappa,
+      session_ticks: state.sessionTicks,
+      last_mode: state.lastMode,
+      basin_history: state.basinHistory.map((b) => Array.from(b)),
+      phi_history: [...state.phiHistory],
+      fhealth_history: [...state.fHealthHistory],
+      drift_history: [...state.driftHistory],
+      dca_add_count: state.dcaAddCount,
+      last_entry_at_ms: state.lastEntryAtMs,
+      peak_pnl_usdt: state.peakPnlUsdt,
+      peak_tracked_trade_id: state.peakTrackedTradeId,
+      regime_at_open_by_lane: { ...state.regimeAtOpenByLane },
+      phi_at_open_by_lane: { ...state.phiAtOpenByLane },
+    };
 
     state.sessionTicks++;
 
@@ -935,33 +933,6 @@ export class MonkeyKernel extends EventEmitter {
       rewardSerotoninDelta: rewardDeltas.serotonin,
       rewardEndorphinDelta: rewardDeltas.endorphin,
     });
-
-    // v0.7.10 shadow-mode: call the Python autonomic kernel in parallel
-    // and log parity diffs. TS path remains authoritative until
-    // MONKEY_KERNEL_PY=true flips the default. Fire-and-forget — shadow
-    // latency must not block the tick.
-    if (process.env.MONKEY_KERNEL_PY_SHADOW === 'true') {
-      void callAutonomicTick({
-        instanceId: this.instanceId,
-        phiDelta,
-        basinVelocity: bv,
-        surprise: Math.abs(phiDelta) * 2,
-        quantumWeight: regimeWeights.quantum,
-        kappa: state.kappa,
-        externalCoupling: couplingHealth,
-        currentMode: state.lastMode ?? 'investigation',
-        isFlat: !exchangeHeldSide,
-      }).then((pyResult) => {
-        logParityDiff('nc.dopamine', nc.dopamine, pyResult.nc.dopamine);
-        logParityDiff('nc.serotonin', nc.serotonin, pyResult.nc.serotonin);
-        logParityDiff('nc.endorphins', nc.endorphins, pyResult.nc.endorphins);
-        logParityDiff('nc.norepinephrine', nc.norepinephrine, pyResult.nc.norepinephrine);
-      }).catch((err) => {
-        logger.debug('[shadow] autonomic parity fetch failed', {
-          err: err instanceof Error ? err.message : String(err),
-        });
-      });
-    }
 
     const sovereignty = await resonanceBank.sovereignty();
 
@@ -1655,66 +1626,91 @@ export class MonkeyKernel extends EventEmitter {
         : CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT,
     };
 
-    // v0.8.3b — shadow the full Python tick pipeline. Fire-and-forget:
-    // Python's decision is NOT authoritative; we only log parity diffs.
-    // TS remains the live path. Gated by MONKEY_TICK_PY_SHADOW=true.
-    if (shadowPrevState !== null) {
-      const shadowOhlcv: TickRunOHLCV[] = ohlcv.map((c) => ({
-        timestamp: Number(c.timestamp ?? 0),
-        open: Number(c.open),
-        high: Number(c.high),
-        low: Number(c.low),
-        close: Number(c.close),
-        volume: Number(c.volume),
-      }));
-      const shadowAccount: TickRunAccount = {
-        equity_fraction: equityFraction,
-        margin_fraction: marginFraction,
-        open_positions: openPositions,
-        available_equity: availableEquity,
-        exchange_held_side: exchangeHeldSide,
-        own_position_entry_price: ownOpenRow ? Number(ownOpenRow.entry_price) : null,
-        own_position_quantity: ownOpenRow ? Number(ownOpenRow.quantity) : null,
-        own_position_trade_id: ownOpenRow ? String(ownOpenRow.id) : null,
-      };
-      void callTickRun({
-        instance_id: this.instanceId,
-        inputs: {
-          symbol,
-          ohlcv: shadowOhlcv,
-          ml_signal: mlSignal,
-          ml_strength: mlStrength,
-          account: shadowAccount,
-          bank_size: bankSize,
-          sovereignty,
-          max_leverage: maxLevBoundary,
-          min_notional: minNotional,
-          size_fraction: this.sizeFraction,
-          self_obs_bias: this.selfObs?.entryBias ?? null,
-          rolling_kelly_stats: rollingStats
-            ? [rollingStats.winRate, rollingStats.avgWin, rollingStats.avgLoss]
-            : null,
-        },
-        prev_state: shadowPrevState,
-      }).then((pyResult) => {
-        logTickParityDiffs(symbol, {
-          action,
-          entry_threshold: entryThr.value,
-          leverage: leverage.value,
-          size_usdt: size.value,
-          mode,
-          side_candidate: sideCandidate,
-          side_override: sideOverride,
-          phi,
-          kappa: state.kappa,
-        }, pyResult.decision);
-      }).catch((err) => {
-        logger.debug('[shadow-tick] tick/run parity fetch failed', {
-          symbol,
-          err: err instanceof Error ? err.message : String(err),
-        });
-      });
-    }
+    // ── PYTHON-AUTHORITATIVE KERNEL DECISION (PR #674 cutover) ──
+    //
+    // Python's /monkey/tick/run is the source of truth for K's decision
+    // — action, entry threshold, leverage, size, lane, side. The TS
+    // cognition section above ran for M/T/L agent inputs (basin, basinDir,
+    // tapeTrend, emotions, motivators, mtfDec, lDecision) and still
+    // accumulates state for exit bookkeeping, but the K dispatch's
+    // ``action`` choice is now overridden by Python's verdict below.
+    //
+    // The follow-up PR moves M/T/L decisions to Python and deletes the
+    // TS cognition modules entirely (per_agent_state, working_memory,
+    // resonance_bank, agent_L_classifier, mtfLClassifier, etc.).
+    //
+    // Fail-loud: Python down = tick errors, operator alerted. No TS
+    // fallback. 5 s default timeout.
+    const tickRunOhlcv: TickRunOHLCV[] = ohlcv.map((c) => ({
+      timestamp: Number(c.timestamp ?? 0),
+      open: Number(c.open),
+      high: Number(c.high),
+      low: Number(c.low),
+      close: Number(c.close),
+      volume: Number(c.volume),
+    }));
+    const tickRunAccount: TickRunAccount = {
+      equity_fraction: equityFraction,
+      margin_fraction: marginFraction,
+      open_positions: openPositions,
+      available_equity: availableEquity,
+      exchange_held_side: exchangeHeldSide,
+      own_position_entry_price: ownOpenRow ? Number(ownOpenRow.entry_price) : null,
+      own_position_quantity: ownOpenRow ? Number(ownOpenRow.quantity) : null,
+      own_position_trade_id: ownOpenRow ? String(ownOpenRow.id) : null,
+    };
+    const tickRunResult = await callTickRun({
+      instance_id: this.instanceId,
+      inputs: {
+        symbol,
+        ohlcv: tickRunOhlcv,
+        account: tickRunAccount,
+        bank_size: bankSize,
+        sovereignty,
+        max_leverage: maxLevBoundary,
+        min_notional: minNotional,
+        size_fraction: this.sizeFraction,
+        self_obs_bias: this.selfObs?.entryBias ?? null,
+        funding_rate_8h: fundingRate8h,
+        rolling_kelly_stats: rollingStats
+          ? [rollingStats.winRate, rollingStats.avgWin, rollingStats.avgLoss]
+          : null,
+      },
+      prev_state: prevPyState,
+    });
+    const pyDecision = tickRunResult.decision;
+    // Python's decision overrides the TS dispatch's choice. The TS
+    // dispatch ran for its state-mutation side effects (per-lane peak
+    // tracking, streaks, regime anchors); its action verdict is discarded.
+    action = pyDecision.action;
+    reason = pyDecision.reason;
+    // Python's sizing is authoritative for the EXECUTE block below.
+    size.value = pyDecision.size_usdt;
+    leverage.value = pyDecision.leverage;
+    entryThr.value = pyDecision.entry_threshold;
+    derivation.python_kernel = {
+      mode: pyDecision.mode,
+      action: pyDecision.action,
+      lane: pyDecision.lane,
+      direction: pyDecision.direction,
+      side_candidate: pyDecision.side_candidate,
+      side_override: pyDecision.side_override,
+      entry_threshold: pyDecision.entry_threshold,
+      leverage: pyDecision.leverage,
+      size_usdt: pyDecision.size_usdt,
+      phi: pyDecision.phi,
+      kappa: pyDecision.kappa,
+      basin_velocity: pyDecision.basin_velocity,
+      basin_direction: pyDecision.basin_direction,
+      tape_trend: pyDecision.tape_trend,
+      harvest_kind: pyDecision.harvest_kind ?? null,
+      r_score: pyDecision.r_score ?? null,
+      mtf_decision_action: pyDecision.mtf_decision_action ?? null,
+      mtf_size_multiplier: pyDecision.mtf_size_multiplier ?? null,
+      leverage_cap_from_regime: pyDecision.leverage_cap_from_regime ?? null,
+      // Carry Python's full derivation as a nested object for forensics.
+      derivation: pyDecision.derivation,
+    };
 
     // 6b. EXECUTE — gated by MONKEY_EXECUTE=true. Observe-only otherwise.
     //

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -46,10 +46,7 @@ import {
   KAPPA_STAR,
   fisherRao,
   frechetMean,
-  normalizedEntropy,
-  toSimplex,
   uniformBasin,
-  velocity,
   type Basin,
 } from './basin.js';
 import { BasinSync } from './basin_sync.js';
@@ -60,10 +57,13 @@ import {
   type TickRunOHLCV,
   type TickRunSymbolState,
 } from './kernel_client.js';
-import { computeEmotions, type EmotionState } from './emotions.js';
-import { detectMode, MODE_PROFILES, MonkeyMode } from './modes.js';
-import { computeMotivators } from './motivators.js';
-import { computeNeurochemicals, summarizeNC, type NeurochemicalState } from './neurochemistry.js';
+// Post-cutover: TS K-cognition primitives (computeEmotions / detectMode /
+// computeMotivators / computeNeurochemicals) are NOT called by loop.ts —
+// Python is authoritative. We import the types only so the synthesized
+// bindings from pyDecision.derivation compile.
+import type { EmotionState } from './emotions.js';
+import { MODE_PROFILES, MonkeyMode } from './modes.js';
+import { summarizeNC, type NeurochemicalState } from './neurochemistry.js';
 import { mlAgentDecide } from '../ml_agent/decide.js';
 import type { MLAgentInputs } from '../ml_agent/types.js';
 import { Arbiter } from '../arbiter/arbiter.js';
@@ -76,41 +76,28 @@ import {
   type TurtleAgentInputs,
   type TurtleState,
 } from '../turtle_agent/index.js';
-import {
-  basinDirection as computeBasinDirection,
-  perceive,
-  refract,
-  trendProxy as computeTrendProxy,
-  type OHLCVCandle,
-} from './perception.js';
+// Post-cutover: perception.ts / candlePatterns.ts / classifyRegime are
+// not called from loop.ts (Python computes basin / candles / regime).
+// We import only the OHLCVCandle type for the array cast at the
+// poloniex-fetch boundary, plus chop-suppression constants used by
+// the dispatch tree's entry-gate.
+import type { OHLCVCandle } from './perception.js';
 import {
   CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT,
   CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT,
   chopSuppressEntry,
-  classifyRegime,
   type RegimeReading,
 } from './regime.js';
-import {
-  detectStrongest as detectStrongestCandlePattern,
-  hammerAgainstLongSl,
-  patternSignalScalar,
-} from './candlePatterns.js';
 import { evaluateBankWrite } from './learning_gate_client.js';
 import { resonanceBank } from './resonance_bank.js';
 import { computeSelfObservation, type SelfObservation } from './self_observation.js';
 import { WorkingMemory, type Bubble } from './working_memory.js';
 import {
-  currentEntryThreshold,
-  currentLeverage,
-  currentPositionSize,
-  kernelDirection,
   kernelShouldEnter,
-  shouldAutoFlatten,
   shouldDCAAdd,
   shouldExit,
   shouldProfitHarvest,
   shouldScalpExit,
-  chooseLane,
   type BasinState,
   type Direction,
   type LaneType,
@@ -132,10 +119,8 @@ import {
   isLongestHorizonExpired as mtfIsLongestHorizonExpired,
 } from './mtfLClassifier.js';
 import {
-  regimeScore as computeRegimeScore,
   regimeSizing as computeRegimeSizing,
   trailingRegimeStop as continuousTrailingRegimeStop,
-  basinAlignmentToWindow,
 } from './regimeSizing.js';
 import {
   applyOutcomeToState,
@@ -873,143 +858,130 @@ export class MonkeyKernel extends EventEmitter {
       availableEquity,
     } = await this.fetchAccountContext(symbol);
 
-    // 2. PERCEIVE — raw basin then refract through identity.
-    // Post #ml-separation: ml fields omitted; perception defaults dims
-    // 3..5 to neutral. Agent K's basin is built without ml inputs.
-    const rawBasin = perceive({
-      ohlcv,
-      equityFraction,
-      marginFraction,
-      openPositions,
-      sessionAgeTicks: state.sessionTicks,
-    });
-
-    // §3.3 Pillar 2 surface absorption — external input at 30% max
-    const basin = refract(rawBasin, state.identityBasin, 0.30);
-
-    // 3. MEASURE — Φ, κ, regime, basin velocity, neurochemistry
-    // Φ = 1 - normalized_entropy_of_noise_dims (integration)
-    //   high Φ = concentrated signal; low Φ = diffuse exploration
-    const fHealth = normalizedEntropy(basin);
-    // Φ inversely tracks fHealth: when the basin is concentrated (low entropy),
-    // integration is high; when diffuse (high entropy), Φ is low (exploration).
-    const phi = Math.max(0, Math.min(1, 1 - fHealth * 0.8));
-
-    // κ adapts from basin velocity × internal coupling. Stable near κ*
-    // when integration is high and basin velocity is low.
-    // Post #ml-separation: couplingHealth was mlStrength; replaced with
-    // a geometric self-read (Φ × (1 − basin velocity), [0,1]).
-    const bv = state.lastBasin ? velocity(state.lastBasin, basin) : 0;
-    const couplingHealth = phi * (1 - Math.min(bv, 1));
-    const kappaDelta = (couplingHealth - 0.5) * 5 - (bv - 0.2) * 10;
-    state.kappa = Math.max(20, Math.min(120, state.kappa * 0.8 + (KAPPA_STAR + kappaDelta) * 0.2));
-
-    // Three regime weights — read directly from the first 3 basin coords
-    const wQ = basin[0];
-    const wE = basin[1];
-    const wEq = basin[2];
-    const regTotal = wQ + wE + wEq;
-    const regimeWeights = regTotal > 0
-      ? { quantum: wQ / regTotal, efficient: wE / regTotal, equilibrium: wEq / regTotal }
-      : { quantum: 1 / 3, efficient: 1 / 3, equilibrium: 1 / 3 };
-
-    // Φ delta for dopamine
-    const lastPhi = state.phiHistory[state.phiHistory.length - 1] ?? phi;
-    const phiDelta = phi - lastPhi;
-
-    // v0.6.7: consume the decayed reward queue as a neurochemistry input.
-    // Nothing externally writes dopamine — the chemical is derived each
-    // tick from (Φ gradient + decayed lived-outcome stream).
-    const rewardDeltas = this.decayedRewardSums();
-    const nc: NeurochemicalState = computeNeurochemicals({
-      isAwake: true,
-      phiDelta,
-      basinVelocity: bv,
-      surprise: Math.abs(phiDelta) * 2,
-      quantumWeight: regimeWeights.quantum,
-      kappa: state.kappa,
-      externalCoupling: couplingHealth,
-      rewardDopamineDelta: rewardDeltas.dopamine,
-      rewardSerotoninDelta: rewardDeltas.serotonin,
-      rewardEndorphinDelta: rewardDeltas.endorphin,
-    });
-
+    // ── PYTHON-AUTHORITATIVE KERNEL TICK (PR #674 Phase 3 cutover) ──
+    //
+    // Replaces the in-process TS K-cognition (perceive, refract,
+    // velocity, normalizedEntropy, computeNeurochemicals, detectMode,
+    // basinDirection, trendProxy, regimeScore/Sizing, classifyRegime,
+    // computeMotivators, computeEmotions, kernelDirection, candle
+    // patterns, computeSelfObservation, basinSync.update) with a single
+    // /monkey/tick/run call. The TS bindings below pull every shared
+    // local var (basin, basinDir, tapeTrend, basinState, mode, nc,
+    // emotions, motivators, regimeReading, ...) from pyDecision +
+    // pyState so the downstream K-dispatch tree and M/T/L agent paths
+    // continue to read the same local-var names without modification.
+    //
+    // Still TS-side (not yet ported; planned for the M/T/L cutover):
+    //   * MTF L classifier (mtfDecide(state.mtfState)) — L agent path
+    //   * Working memory bubble store (state.wm) — kept for L resonance
+    //   * Identity crystallization (state.identityBasin = frechetMean)
+    //   * Per-agent emotion-state decay (state.agentStates.K/M/T/L)
+    //   * Self-observation refresh (this.selfObs) — periodic
+    //
+    // Fail-loud: Python down → tick errors and operator sees it. No TS
+    // fallback. 5 s default timeout.
+    const maxLevBoundary = (await getMaxLeverage(symbol)) ?? 10;
+    const precisions = await getPrecisions(symbol).catch(() => null);
+    const lotSize = precisions?.lotSize ?? 0;
+    const minNotional = lastPrice * Math.max(lotSize, 1e-9);
+    const bankSize = await resonanceBank.bankSize();
     const sovereignty = await resonanceBank.sovereignty();
+    const ownOpenRow = await this.findOpenMonkeyTrade(symbol);
+    const heldSide: 'long' | 'short' | null = ownOpenRow
+      ? (exchangeHeldSide ?? ownOpenRow.side)
+      : null;
 
-    const basinState: BasinState = {
-      basin,
-      phi,
-      kappa: state.kappa,
-      regimeWeights,
-      neurochemistry: nc,
-      sovereignty,
-      basinVelocity: bv,
-      identityBasin: state.identityBasin,
+    const tickRunOhlcv: TickRunOHLCV[] = ohlcv.map((c) => ({
+      timestamp: Number(c.timestamp ?? 0),
+      open: Number(c.open),
+      high: Number(c.high),
+      low: Number(c.low),
+      close: Number(c.close),
+      volume: Number(c.volume),
+    }));
+    const tickRunAccount: TickRunAccount = {
+      equity_fraction: equityFraction,
+      margin_fraction: marginFraction,
+      open_positions: openPositions,
+      available_equity: availableEquity,
+      exchange_held_side: exchangeHeldSide,
+      own_position_entry_price: ownOpenRow ? Number(ownOpenRow.entry_price) : null,
+      own_position_quantity: ownOpenRow ? Number(ownOpenRow.quantity) : null,
+      own_position_trade_id: ownOpenRow ? String(ownOpenRow.id) : null,
     };
-
-    // v0.5: DETECT MODE — one of EXPLORATION / INVESTIGATION / INTEGRATION / DRIFT.
-    // driftHistory is maintained here so mode detector has the delta.
-    const driftNow = fisherRao(basin, state.identityBasin);
-    state.driftHistory.push(driftNow);
-    if (state.driftHistory.length > HISTORY_MAX) state.driftHistory.shift();
-    const modeDecision = detectMode({
-      basin,
-      identityBasin: state.identityBasin,
-      phi,
-      kappa: state.kappa,
-      basinVelocity: bv,
-      neurochemistry: nc,
-      phiHistory: state.phiHistory,
-      fHealthHistory: state.fHealthHistory,
-      driftHistory: state.driftHistory,
-    });
-    const mode = modeDecision.value;
-    if (state.lastMode !== null && state.lastMode !== mode) {
-      logger.info('[Monkey] mode transition', {
+    const tickRunResult = await callTickRun({
+      instance_id: this.instanceId,
+      inputs: {
         symbol,
-        from: state.lastMode,
-        to: mode,
-        reason: modeDecision.reason,
+        ohlcv: tickRunOhlcv,
+        account: tickRunAccount,
+        bank_size: bankSize,
+        sovereignty,
+        max_leverage: maxLevBoundary,
+        min_notional: minNotional,
+        size_fraction: this.sizeFraction,
+        self_obs_bias: this.selfObs?.entryBias ?? null,
+        funding_rate_8h: fundingRate8h,
+        rolling_kelly_stats: null,
+      },
+      prev_state: prevPyState,
+    });
+    const pyDecision = tickRunResult.decision;
+    const pyState = tickRunResult.new_state;
+
+    // Hydrate TS state from Python's authoritative new_state.
+    const prevMode = state.lastMode;
+    state.kappa = pyState.kappa;
+    state.lastMode = pyState.last_mode as MonkeyMode | null;
+    state.phiHistory = pyState.phi_history;
+    state.fHealthHistory = pyState.fhealth_history;
+    state.driftHistory = pyState.drift_history;
+    state.basinHistory = pyState.basin_history.map((b) => Float64Array.from(b) as Basin);
+    state.identityBasin = Float64Array.from(pyState.identity_basin) as Basin;
+    state.lastBasin = pyState.last_basin
+      ? Float64Array.from(pyState.last_basin) as Basin
+      : Float64Array.from(pyDecision.basin) as Basin;
+    state.dcaAddCount = pyState.dca_add_count;
+    state.lastEntryAtMs = pyState.last_entry_at_ms;
+    state.peakPnlUsdt = pyState.peak_pnl_usdt;
+    state.peakTrackedTradeId = pyState.peak_tracked_trade_id;
+    state.rScoreCurrent = pyDecision.r_score ?? null;
+
+    // Local-var bindings from pyDecision (the dispatch tree + M/T/L
+    // agents below read these names; preserved for behavioral parity).
+    const basin: Basin = state.lastBasin;
+    const phi = pyDecision.phi;
+    const fHealth = pyDecision.f_health;
+    const bv = pyDecision.basin_velocity;
+    const driftNow = pyDecision.drift_from_identity;
+    const basinDir = pyDecision.basin_direction;
+    const tapeTrend = pyDecision.tape_trend;
+    const mode = pyDecision.mode as MonkeyMode;
+    const sideCandidate: 'long' | 'short' =
+      pyDecision.side_candidate === 'short' ? 'short' : 'long';
+    const direction: Direction = pyDecision.direction as Direction;
+    const sideOverride = pyDecision.side_override;
+    const nc = pyDecision.neurochemistry as unknown as NeurochemicalState;
+    const regimeWeights = (
+      (pyDecision.derivation.regime_weights as { quantum: number; efficient: number; equilibrium: number } | undefined)
+      ?? { quantum: 1 / 3, efficient: 1 / 3, equilibrium: 1 / 3 }
+    );
+    state.latestBasinSnapshot = { basinDir, tapeTrend, computedAtMs: Date.now() };
+    if (prevMode !== null && prevMode !== mode) {
+      const modePyDeriv = pyDecision.derivation.mode as Record<string, unknown> | undefined;
+      const transitionReason = String(modePyDeriv?.reason ?? 'mode_transition');
+      logger.info('[Monkey] mode transition', {
+        symbol, from: prevMode, to: mode, reason: transitionReason,
       });
       this.bus.publish({
         type: BusEventType.MODE_TRANSITION,
         source: this.instanceId,
         symbol,
-        payload: { from: state.lastMode, to: mode, reason: modeDecision.reason, phi, kappa: state.kappa },
+        payload: { from: prevMode, to: mode, reason: transitionReason, phi, kappa: state.kappa },
       });
     }
-    state.lastMode = mode;
 
-    // Refresh self-observation entry bias every SELF_OBS_REFRESH_MS.
-    const now = Date.now();
-    if (now - this.selfObsLastUpdate > MonkeyKernel.SELF_OBS_REFRESH_MS) {
-      this.selfObs = await computeSelfObservation(24, this.instanceId);
-      this.selfObsLastUpdate = now;
-    }
-    // Side candidate (post #ml-separation):
-    //   Direction comes from basin geometry + tape consensus. The
-    //   previous OVERRIDE_REVERSE quorum + TURNING_SIGNAL paths are
-    //   gone — kernelDirection is the primary read.
-    //
-    // TS-side does not yet compute Layer 2B emotions (motivators /
-    // sensations / foresight ports pending). Until v0.8.8 Python
-    // cut-over, TS uses neutral emotions so direction reduces to
-    // pure geometry. Entry conviction continues to gate via the
-    // existing ml-strength threshold below — a geometry-only TS
-    // entry would require the full emotion stack ported. This is
-    // the documented "TS counterpart for parity" path.
-    const basinDir = computeBasinDirection(basin);
-    const tapeTrend = computeTrendProxy(ohlcv);
-    state.latestBasinSnapshot = {
-      basinDir,
-      tapeTrend,
-      computedAtMs: Date.now(),
-    };
-
-    // 2026-05-13 — MTF: down-sample basin into per-timeframe stores
-    // (15m / 1h / 4h) and compute agreement-count decision. Phase 2
-    // wires the result into L's entry sizing + harvest exit policy
-    // below; the per-tick log keeps observability.
+    // L agent's MTF state stays TS-side until M/T/L cutover.
     mtfOnTickAppend(state.mtfState, basin, state.sessionTicks);
     const mtfDec = mtfDecide(state.mtfState);
     if (mtfDec.action !== 'hold') {
@@ -1022,92 +994,39 @@ export class MonkeyKernel extends EventEmitter {
         agreement: `${mtfDec.agreementCount}/${mtfDec.totalTfs}`,
         sizeMult: mtfDec.sizeMultiplier.toFixed(2),
         longest: mtfDec.longestAgreeingLabel ?? '—',
-        perTf: mtfDec.perTimeframe.map(t =>
+        perTf: mtfDec.perTimeframe.map((t) =>
           `${t.label}:${t.warm ? (t.decision?.action ?? 'hold') : 'cold'}`,
         ).join(','),
       });
     }
 
-    // 2026-05-13 — continuous regime score r ∈ [0,1] (flat=1, trend=0)
-    // computed from basin velocity + directional chop + κ criticality.
-    // Used by L's trailing regime drift stop and entry sizing sanity.
-    // Falls back to null when basinHistory < 2 (cold start).
-    const rReading = computeRegimeScore(state.basinHistory, state.kappa ?? null);
-    state.rScoreCurrent = rReading?.r ?? null;
-    // Continuous-interpolated sizing rails from r (leverage / size /
-    // hold / stop / headroom). Used as sanity bound on the discrete
-    // mode-derived values: catches transition lag (mode still says
-    // EXPLORATION but r has shifted toward trending).
-    const continuousSizing = rReading ? computeRegimeSizing(rReading.r) : null;
-    if (rReading && state.sessionTicks % 10 === 0) {
-      // Basin alignment to recent window — Fisher-Rao distance from
-      // current basin to the Fréchet mean of the last 60 basins.
-      // Low = consonant with recent trajectory; high = outlier
-      // (surprise — fresh regime onset, news shock, breakout, etc).
-      const recentWindow = state.basinHistory.slice(-60);
-      const basinAlign = recentWindow.length > 1
-        ? basinAlignmentToWindow(basin, recentWindow)
-        : 0;
-      logger.info('[regime-r] continuous', {
-        symbol,
-        r: rReading.r.toFixed(3),
-        label: rReading.label,
-        velFlat: rReading.components.velocityFlatness.toFixed(2),
-        dirChop: rReading.components.directionalChop.toFixed(2),
-        kappaCrit: rReading.components.kappaCriticality.toFixed(2),
-        cLev: continuousSizing?.leverage ?? '—',
-        cStopBps: continuousSizing?.stopBps.toFixed(0) ?? '—',
-        cHeadroom: continuousSizing?.marginHeadroomFloor.toFixed(2) ?? '—',
-        basinAlign: basinAlign.toFixed(3),
-      });
+    // Self-observation refresh (kept TS-side; periodic, light-weight).
+    const now = Date.now();
+    if (now - this.selfObsLastUpdate > MonkeyKernel.SELF_OBS_REFRESH_MS) {
+      this.selfObs = await computeSelfObservation(24, this.instanceId);
+      this.selfObsLastUpdate = now;
     }
 
-    // Proposal #5: regime classification on basin trajectory + this
-    // tick's basin. Surfaced via derivation.regime for telemetry; the
-    // executive's threshold + harvest tightness will eventually consume
-    // it. Splice the current basin onto the history so the classifier
-    // sees the most-recent observation alongside prior ticks.
-    const regimeReading: RegimeReading = classifyRegime([
-      ...state.basinHistory,
-      basin,
-    ]);
+    // Working memory bubble (kept until WM moves to Python).
+    const bubble = state.wm.add(basin, phi, { symbol, tick: state.sessionTicks });
+    const wmStats = await state.wm.tick();
+    void bubble;
 
-    // Proposal #9: candlestick pattern detection at the perception
-    // input boundary. ``patternSignal`` is signed in [-1, +1];
-    // ``hammerDefer`` triggers the SL-defer path on long positions.
-    const candlePatternReading = detectStrongestCandlePattern(ohlcv as any[]);
-    const candlePatternSignal = patternSignalScalar(candlePatternReading);
-    const candleHammerDefer = hammerAgainstLongSl(ohlcv as any[]);
-    // Layer 1 + Layer 2B port (2026-05-01): replaces NEUTRAL_EMOTIONS
-    // placeholder. The conviction gate in held_position_rejustification
-    // is now alive on TS — confidence < anxiety + confusion can fire
-    // exits when the kernel's own state contradicts the position.
-    // Funding drag wiring TODO: fold lane_positions cumulative funding
-    // into ComputeEmotionsArgs.fundingDrag once the lane funding query
-    // surfaces in this scope. Defaults to 0 → no drag effect.
-    const motivators = computeMotivators(basinState, {
-      prevBasin: state.lastBasin,
-      integrationHistory: state.integrationHistory,
-    });
-    const basinDistance = driftNow;  // already fisherRao(basin, identity)
-    const emotions: EmotionState = computeEmotions(
-      motivators, basinDistance, phi, bv,
-    );
-    // Append (Φ, I_Q) for the next tick's Integration motivator CV.
-    state.integrationHistory.push([phi, motivators.iQ]);
-    if (state.integrationHistory.length > HISTORY_MAX) {
-      state.integrationHistory.shift();
-    }
-    const direction: Direction = kernelDirection({
-      basinDir, tapeTrend, emotions,
-    });
-    const sideCandidate: 'long' | 'short' = direction === 'flat' ? 'long' : direction;
-    const sideOverride = false;
-    // Note: REVERSION mode flip lives only in the Python kernel (Tier 9
-    // Stage 2 stud topology). TS does not implement REVERSION yet.
+    // Basin-sync publish — observability only, fail-soft.
+    const syncPublish = this.basinSync.update({
+      basin, phi, kappa: state.kappa, mode, driftFromIdentity: driftNow,
+    }).catch(() => { /* non-fatal */ });
+    void syncPublish;
 
-    // MONKEY_SHORTS_LIVE — sequencing protection retained from #575.
-    // Orthogonal to agent-separation; flipped via env independently.
+    // Synthesize BasinState for downstream readers (held-position
+    // rejustification + chop-suppression in the dispatch tree).
+    const basinState: BasinState = {
+      basin, phi, kappa: state.kappa, regimeWeights,
+      neurochemistry: nc, sovereignty, basinVelocity: bv,
+      identityBasin: state.identityBasin,
+    };
+
+    // Side / sizing / lane — all Python-authoritative.
     const SHORTS_LIVE = process.env.MONKEY_SHORTS_LIVE === 'true';
     const sideShortRefused = sideCandidate === 'short' && !SHORTS_LIVE;
     if (sideShortRefused) {
@@ -1116,72 +1035,34 @@ export class MonkeyKernel extends EventEmitter {
       });
     }
     const selfObsBias = this.selfObs?.entryBias[mode]?.[sideCandidate] ?? 1.0;
-
-    // v0.5: Basin sync — publish own state; pull observer-effect influence.
-    const syncPublish = this.basinSync.update({
-      basin,
-      phi,
-      kappa: state.kappa,
-      mode,
-      driftFromIdentity: driftNow,
-    }).catch(() => { /* non-fatal */ });
-    void syncPublish;
-
-    // 4. REMEMBER — add bubble; tick working memory
-    const bubble = state.wm.add(basin, phi, { symbol, tick: state.sessionTicks });
-    const wmStats = await state.wm.tick();
-
-    // 5. DERIVE — executive computes what Monkey would do (mode-aware)
-    // tapeTrend already computed above for side-override check.
-    const entryThr = currentEntryThreshold(basinState, mode, selfObsBias, tapeTrend, sideCandidate);
-    const maxLevBoundary = (await getMaxLeverage(symbol)) ?? 10;
-    const precisions = await getPrecisions(symbol).catch(() => null);
-    const lotSize = precisions?.lotSize ?? 0;
-    const minNotional = lastPrice * Math.max(lotSize, 1e-9);
-    const bankSize = await resonanceBank.bankSize();
-    // sizeFraction scales her share of equity so parallel sub-kernels
-    // stay out of each other's way. (0.5 each = 1.0 combined.) On small
-    // accounts this would halve margin below exchange min notional for
-    // BOTH kernels — observed 2026-04-21: $19 × 0.5 × 0.09 × 12x = $10
-    // notional, below ETH's $23 min. So: effective sizeFraction bumps
-    // back to 1.0 when capped equity × explorationFloor × newborn-leverage
-    // can't reach min notional. On larger accounts this stays at the
-    // configured 0.5 and both kernels share cleanly; the risk-kernel 5×
-    // exposure cap still bounds combined concurrency.
-    const expFloorApprox = 0.10;               // modes.ts EXPLORATION/INVESTIGATION baseline
-    const maxNewbornLev = 20;                  // newborn sovereignCap floor
+    const expFloorApprox = 0.10;
+    const maxNewbornLev = 20;
     const minNeededForMinNotional = minNotional / (expFloorApprox * maxNewbornLev);
     const effectiveSizeFraction = availableEquity * this.sizeFraction < minNeededForMinNotional
       ? 1.0
       : this.sizeFraction;
     const cappedEquity = availableEquity * effectiveSizeFraction;
-    // Proposal #10 — lane selection. Each tick picks the locally-optimal
-    // execution lane via softmax over basin features (parity with the
-    // Python kernel's choose_lane). The chosen lane gates size (per-lane
-    // budget fraction) AND, when a position is open, scopes the exit
-    // gate's TP/SL envelope.
-    const laneDecision = chooseLane(basinState, tapeTrend);
-    const chosenLane: LaneType = laneDecision.value;
+    const chosenLane: LaneType = pyDecision.lane;
     const positionLane: 'scalp' | 'swing' | 'trend' =
       chosenLane === 'observe' ? 'swing' : chosenLane;
-    // Proposal #3: Kelly leverage cap. Pull last 50 closed K-agent
-    // trades from autonomous_trades — lane-filtered so each lane learns
-    // from its own closed trades (scalp from scalps, etc.).
-    // Cold-start (< 5 closed trades in this lane): rollingStats is null,
-    // kelly cap becomes a no-op (geometric leverage unchanged). Each lane
-    // warms independently; scalp warms fastest (closes most often).
     const rollingStats = await this.getKellyRollingStats('K', positionLane);
-    const leverage = currentLeverage(
-      basinState, maxLevBoundary, mode, tapeTrend, rollingStats,
-    );
-    const size = currentPositionSize(
-      basinState, cappedEquity, minNotional, leverage.value, bankSize, mode,
-      positionLane,
-    );
-    // Surgical diagnostic for live size=0 regression (post PR #611). Fires
-    // only when sizing collapses to zero AND the account is flat — surfaces
-    // the exact numeric inputs feeding currentPositionSize so we can
-    // grep `[size-zero-diag]` from Railway and trace which guard tripped.
+    void rollingStats;
+
+    const entryThr = {
+      value: pyDecision.entry_threshold,
+      reason: pyDecision.reason,
+      derivation: (pyDecision.derivation.entry_threshold ?? {}) as Record<string, number>,
+    };
+    const leverage = {
+      value: pyDecision.leverage,
+      reason: pyDecision.reason,
+      derivation: (pyDecision.derivation.leverage ?? {}) as Record<string, number>,
+    };
+    const size = {
+      value: pyDecision.size_usdt,
+      reason: pyDecision.reason,
+      derivation: (pyDecision.derivation.size ?? {}) as Record<string, number>,
+    };
     if (size.value === 0 && exchangeHeldSide === null) {
       logger.info('[size-zero-diag]', {
         symbol, availableEquity, effectiveSizeFraction, cappedEquity,
@@ -1190,11 +1071,47 @@ export class MonkeyKernel extends EventEmitter {
         sizeDerivation: size.derivation,
       });
     }
-    const autoFlatten = shouldAutoFlatten(basinState, state.fHealthHistory);
 
-    // 6. DECIDE — propose action
-    let action: string;
-    let reason: string;
+    // Auto-flatten / regime / candle / emotion / motivator readings —
+    // all derived from pyDecision.derivation. Local shapes match what
+    // the dispatch tree (and held_position_rejustification.ts) expects.
+    const autoFlatten = {
+      value: pyDecision.action === 'flatten',
+      reason: pyDecision.action === 'flatten' ? pyDecision.reason : '',
+      derivation: (pyDecision.derivation.auto_flatten ?? {}) as Record<string, number>,
+    };
+    const regimeReading = (pyDecision.derivation.regime ?? {
+      regime: 'CHOP',
+      confidence: 0.5,
+      trendStrength: 0,
+      chopScore: 0.5,
+    }) as unknown as RegimeReading;
+    const emotions = (pyDecision.derivation.emotions ?? {}) as unknown as EmotionState;
+    const motivators = (pyDecision.derivation.motivators ?? {}) as unknown as {
+      iQ: number;
+      [k: string]: number;
+    };
+    void motivators;
+    const candlePatternReading = (pyDecision.derivation.candle_pattern ?? {
+      patternName: 'none', strength: 0, direction: 0,
+    }) as { patternName: string; strength: number; direction: number };
+    const candleDeriv = pyDecision.derivation.candle_pattern as Record<string, unknown> | undefined;
+    const candlePatternSignal = (candleDeriv?.signed_scalar ?? 0) as number;
+    const candleHammerDefer = (candleDeriv?.hammer_defer_long_sl ?? false) as boolean;
+    void candlePatternSignal;
+
+    // ``action``/``reason``/``derivation`` start at Python's verdict.
+    // The dispatch tree below still runs to perform its state-mutation
+    // side-effects (per-lane peak tracking, streak counters, regime
+    // anchors, SL defer); any action reassignments it makes are
+    // overridden by the explicit re-assertion at the end of this block.
+    let action: string = pyDecision.action;
+    let reason: string = pyDecision.reason;
+    const modeDecision = {
+      value: mode,
+      reason: String((pyDecision.derivation.mode as Record<string, unknown> | undefined)?.reason ?? ''),
+      derivation: (pyDecision.derivation.mode ?? {}) as Record<string, number | string>,
+    };
     const derivation: Record<string, unknown> = {
       phi, kappa: state.kappa, sovereignty, basinVelocity: bv,
       regimeWeights, nc,
@@ -1207,18 +1124,12 @@ export class MonkeyKernel extends EventEmitter {
       direction,
       sideOverride,
       agent: 'K',
-      // Proposal #5: regime telemetry. Discrete state + confidence
-      // surfaces alongside the kernel direction read. Read via
-      // derivation.regime in monkey_decisions analysis.
       regime: {
         regime: regimeReading.regime,
         confidence: regimeReading.confidence,
         trend_strength: regimeReading.trendStrength,
         chop_score: regimeReading.chopScore,
       },
-      // Proposal #9: candle-pattern telemetry. Signed scalar feeds
-      // into perception inputs; hammer-defer hint feeds the SL-fire
-      // path further down.
       candle_pattern: {
         pattern_name: candlePatternReading.patternName,
         strength: candlePatternReading.strength,
@@ -1226,24 +1137,33 @@ export class MonkeyKernel extends EventEmitter {
         signed_scalar: candlePatternSignal,
         hammer_defer_long_sl: candleHammerDefer,
       },
+      python_kernel: {
+        mode: pyDecision.mode,
+        action: pyDecision.action,
+        lane: pyDecision.lane,
+        direction: pyDecision.direction,
+        side_candidate: pyDecision.side_candidate,
+        side_override: pyDecision.side_override,
+        entry_threshold: pyDecision.entry_threshold,
+        leverage: pyDecision.leverage,
+        size_usdt: pyDecision.size_usdt,
+        phi: pyDecision.phi,
+        kappa: pyDecision.kappa,
+        basin_velocity: pyDecision.basin_velocity,
+        basin_direction: pyDecision.basin_direction,
+        tape_trend: pyDecision.tape_trend,
+        harvest_kind: pyDecision.harvest_kind ?? null,
+        r_score: pyDecision.r_score ?? null,
+        mtf_decision_action: pyDecision.mtf_decision_action ?? null,
+        mtf_size_multiplier: pyDecision.mtf_size_multiplier ?? null,
+        leverage_cap_from_regime: pyDecision.leverage_cap_from_regime ?? null,
+        derivation: pyDecision.derivation,
+      },
     };
+    void wmStats;
 
-    // v0.6.3: Monkey's "held side" is scoped to HER OWN open rows only.
-    // If only liveSignal holds a position on this symbol, Monkey treats
-    // herself as flat and her entry logic can still fire (risk kernel's
-    // exposure cap is the only thing bounding combined concurrency).
-    const ownOpenRow = await this.findOpenMonkeyTrade(symbol);
-    // v0.8.7d-8: when exchange says no position but DB has an open Monkey
-    // row, prefer the DB row's side over a hardcoded 'long' fallback.
-    // Previously: `exchangeHeldSide ?? 'long'` — caused OVERRIDE_REVERSE
-    // [long→short] loops whenever LiveSignal just closed a short and the
-    // exchange hadn't yet settled into the view Monkey reads, because
-    // Monkey's DB row said short but the fallback claimed long. DB row
-    // is authoritative for Monkey's own recent trades; reconciler closes
-    // stale rows within 60s when exchange disagrees permanently.
-    const heldSide: 'long' | 'short' | null = ownOpenRow
-      ? (exchangeHeldSide ?? ownOpenRow.side)
-      : null;
+    // v0.6.3: heldSide / ownOpenRow already bound from the early Python
+    // tick-run section above. The dispatch tree below consumes them.
     derivation.exchangeHeldSide = exchangeHeldSide;
     derivation.monkeyHeldSide = heldSide;
 
@@ -1624,92 +1544,6 @@ export class MonkeyKernel extends EventEmitter {
       threshold: positionLane === 'trend'
         ? CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT
         : CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT,
-    };
-
-    // ── PYTHON-AUTHORITATIVE KERNEL DECISION (PR #674 cutover) ──
-    //
-    // Python's /monkey/tick/run is the source of truth for K's decision
-    // — action, entry threshold, leverage, size, lane, side. The TS
-    // cognition section above ran for M/T/L agent inputs (basin, basinDir,
-    // tapeTrend, emotions, motivators, mtfDec, lDecision) and still
-    // accumulates state for exit bookkeeping, but the K dispatch's
-    // ``action`` choice is now overridden by Python's verdict below.
-    //
-    // The follow-up PR moves M/T/L decisions to Python and deletes the
-    // TS cognition modules entirely (per_agent_state, working_memory,
-    // resonance_bank, agent_L_classifier, mtfLClassifier, etc.).
-    //
-    // Fail-loud: Python down = tick errors, operator alerted. No TS
-    // fallback. 5 s default timeout.
-    const tickRunOhlcv: TickRunOHLCV[] = ohlcv.map((c) => ({
-      timestamp: Number(c.timestamp ?? 0),
-      open: Number(c.open),
-      high: Number(c.high),
-      low: Number(c.low),
-      close: Number(c.close),
-      volume: Number(c.volume),
-    }));
-    const tickRunAccount: TickRunAccount = {
-      equity_fraction: equityFraction,
-      margin_fraction: marginFraction,
-      open_positions: openPositions,
-      available_equity: availableEquity,
-      exchange_held_side: exchangeHeldSide,
-      own_position_entry_price: ownOpenRow ? Number(ownOpenRow.entry_price) : null,
-      own_position_quantity: ownOpenRow ? Number(ownOpenRow.quantity) : null,
-      own_position_trade_id: ownOpenRow ? String(ownOpenRow.id) : null,
-    };
-    const tickRunResult = await callTickRun({
-      instance_id: this.instanceId,
-      inputs: {
-        symbol,
-        ohlcv: tickRunOhlcv,
-        account: tickRunAccount,
-        bank_size: bankSize,
-        sovereignty,
-        max_leverage: maxLevBoundary,
-        min_notional: minNotional,
-        size_fraction: this.sizeFraction,
-        self_obs_bias: this.selfObs?.entryBias ?? null,
-        funding_rate_8h: fundingRate8h,
-        rolling_kelly_stats: rollingStats
-          ? [rollingStats.winRate, rollingStats.avgWin, rollingStats.avgLoss]
-          : null,
-      },
-      prev_state: prevPyState,
-    });
-    const pyDecision = tickRunResult.decision;
-    // Python's decision overrides the TS dispatch's choice. The TS
-    // dispatch ran for its state-mutation side effects (per-lane peak
-    // tracking, streaks, regime anchors); its action verdict is discarded.
-    action = pyDecision.action;
-    reason = pyDecision.reason;
-    // Python's sizing is authoritative for the EXECUTE block below.
-    size.value = pyDecision.size_usdt;
-    leverage.value = pyDecision.leverage;
-    entryThr.value = pyDecision.entry_threshold;
-    derivation.python_kernel = {
-      mode: pyDecision.mode,
-      action: pyDecision.action,
-      lane: pyDecision.lane,
-      direction: pyDecision.direction,
-      side_candidate: pyDecision.side_candidate,
-      side_override: pyDecision.side_override,
-      entry_threshold: pyDecision.entry_threshold,
-      leverage: pyDecision.leverage,
-      size_usdt: pyDecision.size_usdt,
-      phi: pyDecision.phi,
-      kappa: pyDecision.kappa,
-      basin_velocity: pyDecision.basin_velocity,
-      basin_direction: pyDecision.basin_direction,
-      tape_trend: pyDecision.tape_trend,
-      harvest_kind: pyDecision.harvest_kind ?? null,
-      r_score: pyDecision.r_score ?? null,
-      mtf_decision_action: pyDecision.mtf_decision_action ?? null,
-      mtf_size_multiplier: pyDecision.mtf_size_multiplier ?? null,
-      leverage_cap_from_regime: pyDecision.leverage_cap_from_regime ?? null,
-      // Carry Python's full derivation as a nested object for forensics.
-      derivation: pyDecision.derivation,
     };
 
     // 6b. EXECUTE — gated by MONKEY_EXECUTE=true. Observe-only otherwise.

--- a/apps/api/src/services/riskService.js
+++ b/apps/api/src/services/riskService.js
@@ -6,11 +6,6 @@
 import { logger } from '../utils/logger.js';
 import { pool } from '../db/connection.js';
 import { evaluatePreTradeVetoes } from './riskKernel.js';
-import {
-  callRiskEvaluate,
-  isRiskShadowEnabled,
-  logRiskParityDiff,
-} from './monkey/kernel_client.js';
 
 class RiskService {
   constructor() {
@@ -111,26 +106,6 @@ class RiskService {
           kernelInputs.accountState,
           kernelInputs.context,
         );
-
-        // v0.8.7d-2: fire-and-forget shadow call to the Python risk
-        // kernel when RISK_KERNEL_PY_SHADOW=true. TS decision stays
-        // authoritative. Latency of the shadow request does NOT block
-        // the live path — the await on the TS decision already
-        // completed above. A timeout / network failure in the shadow
-        // call logs at debug and is dropped; never impacts trading.
-        if (isRiskShadowEnabled()) {
-          // Deep-copy the inputs so the shadow call cannot mutate
-          // caller-provided objects on some future timeline. Cheap —
-          // kernelInputs is small (one order + account snapshot).
-          const shadowPayload = JSON.parse(JSON.stringify(kernelInputs));
-          void callRiskEvaluate(shadowPayload).then((pyDecision) => {
-            logRiskParityDiff(kernelDecision, pyDecision);
-          }).catch((err) => {
-            logger.debug('[risk-shadow] parity fetch failed', {
-              err: err instanceof Error ? err.message : String(err),
-            });
-          });
-        }
 
         if (!kernelDecision.allowed) {
           logger.warn('Risk check failed: kernel veto', {

--- a/apps/api/src/tests/fullyAutonomousTrader.sideLabel.test.ts
+++ b/apps/api/src/tests/fullyAutonomousTrader.sideLabel.test.ts
@@ -55,9 +55,6 @@ vi.mock('../services/simpleMlService.js', () => ({ default: {} }));
 vi.mock('../services/monkey/kernel_client.js', () => ({
   callExitDecide: vi.fn(),
   callReconcile: vi.fn(),
-  isExitShadowEnabled: vi.fn(() => false),
-  logExitParityDiff: vi.fn(),
-  logReconcileParityDiff: vi.fn(),
 }));
 vi.mock('../services/signalGenome.js', () => ({
   buildIndicatorMap: vi.fn(() => new Map()),

--- a/apps/api/src/tests/fullyAutonomousTraderPyBridge.test.ts
+++ b/apps/api/src/tests/fullyAutonomousTraderPyBridge.test.ts
@@ -43,9 +43,6 @@ vi.mock('../services/simpleMlService.js', () => ({ default: {} }));
 vi.mock('../services/monkey/kernel_client.js', () => ({
   callExitDecide: vi.fn(),
   callReconcile: vi.fn(),
-  isExitShadowEnabled: vi.fn(() => false),
-  logExitParityDiff: vi.fn(),
-  logReconcileParityDiff: vi.fn(),
 }));
 vi.mock('../services/signalGenome.js', () => ({
   buildIndicatorMap: vi.fn(() => new Map()),

--- a/apps/api/src/tests/liveSignalEngine.setLeverage.test.ts
+++ b/apps/api/src/tests/liveSignalEngine.setLeverage.test.ts
@@ -50,7 +50,6 @@ vi.mock('../services/monkey/loop.js', () => ({
 }));
 vi.mock('../services/monkey/kernel_client.js', () => ({
   callLiveDecide: vi.fn(),
-  isLiveSignalShadowEnabled: vi.fn(() => false),
 }));
 vi.mock('../services/executionModeService.js', () => ({
   getCurrentExecutionMode: vi.fn(() => 'auto'),

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -820,10 +820,12 @@ async def risk_evaluate(request: Request):
             ],
         )
         c = body["context"]
+        monkey_mode_raw = c.get("monkeyMode")
         ctx = _KernelContext(
             is_live=bool(c["isLive"]),
             mode=str(c["mode"]),
             symbol_max_leverage=float(c["symbolMaxLeverage"]),
+            monkey_mode=str(monkey_mode_raw) if monkey_mode_raw else None,
         )
     except (KeyError, TypeError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=f"bad kernel input: {exc}") from exc

--- a/ml-worker/src/monkey_kernel/agent_l_classifier.py
+++ b/ml-worker/src/monkey_kernel/agent_l_classifier.py
@@ -1,0 +1,345 @@
+"""agent_l_classifier.py — Agent L: multi-scale Fisher-Rao KNN classifier.
+
+Python port of apps/api/src/services/monkey/agent_L_classifier.ts (Phase
+1.2 prerequisite for mtf_l_classifier.py).
+
+QIG-pure replacement for the Lorentzian Distance Classification pattern
+(jdehorty's TradingView script). On Δ⁶³ probability simplices, Fisher-Rao
+IS the canonical reparameterization-invariant metric — the principled
+choice, not a borrowed analogy.
+
+Multi-scale: compares not just the current basin but a TUPLE of basins
+at different time scales (current / medium-window Fréchet mean /
+long-window Fréchet mean), and returns a weighted sum of Fisher-Rao
+distances across the tuple. Two states are "near" iff their basins are
+similar at ALL scales.
+
+KNN inference:
+  1. Sample chronologically-spaced past basin tuples (every Nth tick)
+  2. Compute weighted multi-scale Fisher-Rao distance to each
+  3. Take the K nearest by distance
+  4. Inverse-distance-weighted vote of realized future-direction labels
+     (computed as basin_direction(basin[i+horizon]))
+  5. Map signed weighted vote → action + conviction
+
+QIG purity:
+  - All distances are Fisher-Rao (no Lorentzian, no Euclidean, no cosine)
+  - All means are Fréchet (no arithmetic average of basins)
+  - All operations on Δ⁶³ simplex coordinates (no embeddings)
+  - Pure functions only — no I/O, no globals, trivially testable
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional, Sequence
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import (
+    fisher_rao_distance,
+    frechet_mean,
+)
+
+from .perception_scalars import basin_direction
+
+Basin = np.ndarray
+Action = Literal["enter_long", "enter_short", "hold"]
+
+
+@dataclass(frozen=True)
+class BasinTuple:
+    """Multi-scale basin tuple — one slot per time scale.
+
+    Windows are calibrated for the kernel's 30s tick cadence
+    (MONKEY_TICK_MS=30_000); see DEFAULT_AGENT_L_CONFIG.
+    """
+
+    current: Basin
+    """Current tick — finest perceptual scale (30s)."""
+
+    medium: Basin
+    """Medium-window Fréchet mean (120 ticks ≈ 60 min on 30s stream)."""
+
+    long: Basin
+    """Long-window Fréchet mean (480 ticks ≈ 4 h on 30s stream)."""
+
+
+@dataclass(frozen=True)
+class ScaleWeights:
+    """Per-scale weights for the combined Fisher-Rao distance.
+
+    Sum need not equal 1; the classifier is scale-invariant under
+    uniform rescaling.
+    """
+
+    current: float = 0.5
+    medium: float = 0.3
+    long: float = 0.2
+
+
+DEFAULT_SCALE_WEIGHTS = ScaleWeights()
+
+
+def fisher_rao_tuple_distance(
+    a: BasinTuple,
+    b: BasinTuple,
+    weights: ScaleWeights = DEFAULT_SCALE_WEIGHTS,
+) -> float:
+    """Combined Fisher-Rao distance between two basin tuples.
+
+    Sum of per-scale FR distances weighted by scale importance.
+    """
+    return (
+        weights.current * fisher_rao_distance(a.current, b.current)
+        + weights.medium * fisher_rao_distance(a.medium, b.medium)
+        + weights.long * fisher_rao_distance(a.long, b.long)
+    )
+
+
+def build_basin_tuple(
+    history: Sequence[Basin],
+    medium_window: int = 120,
+    long_window: int = 480,
+) -> Optional[BasinTuple]:
+    """Build a multi-scale basin tuple from a basin history.
+
+    - current = the most recent basin
+    - medium = Fréchet mean of the last `medium_window` basins (def 120)
+    - long = Fréchet mean of the last `long_window` basins (def 480)
+
+    When the history is too short, falls back to the available subset.
+    """
+    if len(history) == 0:
+        return None
+    current = history[-1]
+    medium_slice = list(history[-min(medium_window, len(history)):])
+    long_slice = list(history[-min(long_window, len(history)):])
+    return BasinTuple(
+        current=current,
+        medium=frechet_mean(medium_slice),
+        long=frechet_mean(long_slice),
+    )
+
+
+def realized_label(
+    history: Sequence[Basin],
+    i: int,
+    horizon: int = 4,
+    threshold: float = 0.025,
+) -> int:
+    """Realized direction label for a historical bar.
+
+    +1 if basin_direction at i+horizon > +threshold (long realized),
+    -1 if < -threshold (short realized),
+     0 otherwise (neutral or out-of-range).
+    """
+    target = i + horizon
+    if target >= len(history):
+        return 0
+    direction = basin_direction(history[target])
+    if direction > threshold:
+        return 1
+    if direction < -threshold:
+        return -1
+    return 0
+
+
+@dataclass(frozen=True)
+class KNNNeighbor:
+    index: int
+    distance: float
+    label: int  # in {-1, 0, 1}
+
+
+@dataclass(frozen=True)
+class LabelDistribution:
+    """Diagnostic distribution of realized labels across the K neighbors.
+
+    Lets the caller distinguish "all neighbors agreed long" (legitimate
+    strong signal) from "score pinned by normalizer" (degenerate).
+    """
+
+    long: int
+    short: int
+    neutral: int
+    long_weight: float
+    short_weight: float
+    nearest_distance: float
+    farthest_distance: float
+
+
+_EMPTY_LABEL_DIST = LabelDistribution(
+    long=0,
+    short=0,
+    neutral=0,
+    long_weight=0.0,
+    short_weight=0.0,
+    nearest_distance=0.0,
+    farthest_distance=0.0,
+)
+
+
+@dataclass(frozen=True)
+class AgentLDecision:
+    action: Action
+    signed_score: float
+    """Signed score in [-1, 1]. + = long bias, - = short bias."""
+    conviction: float
+    """[0, 1] — fraction of K-neighbors aligned with chosen direction."""
+    neighbors: tuple[KNNNeighbor, ...]
+    label_distribution: LabelDistribution
+    reason: str
+
+
+@dataclass(frozen=True)
+class AgentLConfig:
+    """Cadence-calibrated defaults for the 30s tick stream — match the
+    canonical TV Lorentzian's effective timescale (15m bars, 4-bar
+    forward horizon)."""
+
+    k: int = 8
+    spacing: int = 30
+    """Chronological spacing — every 15 min on 30s ticks."""
+    horizon: int = 120
+    """Forward window for label computation — 60 min on 30s cadence."""
+    label_threshold: float = 0.025
+    weights: ScaleWeights = field(default_factory=lambda: DEFAULT_SCALE_WEIGHTS)
+    action_threshold: float = 0.25
+    """Minimum |signed_score| to act; else hold."""
+    max_lookback: int = 2000
+    medium_window: int = 120
+    long_window: int = 480
+    min_tuple_start: int = 480
+    """Must equal long_window so the multi-scale tuple is full."""
+
+
+DEFAULT_AGENT_L_CONFIG = AgentLConfig()
+
+
+def agent_l_decide(
+    basin_history: Sequence[Basin],
+    config: AgentLConfig = DEFAULT_AGENT_L_CONFIG,
+) -> AgentLDecision:
+    """Pure-function decision: given a basin history, classify the
+    current state by Fisher-Rao KNN against multi-scale historical
+    tuples.
+
+    Returns a hold when:
+      - history is too short to build a tuple
+      - K-NN search produced fewer than k/2 candidates with valid labels
+      - signed score magnitude is below action_threshold
+    """
+    cur = build_basin_tuple(
+        basin_history,
+        medium_window=config.medium_window,
+        long_window=config.long_window,
+    )
+    if cur is None:
+        return AgentLDecision(
+            action="hold",
+            signed_score=0.0,
+            conviction=0.0,
+            neighbors=(),
+            label_distribution=_EMPTY_LABEL_DIST,
+            reason="history empty",
+        )
+
+    lookback = min(config.max_lookback, len(basin_history))
+    start_idx = max(0, len(basin_history) - lookback)
+    min_tuple_start = config.min_tuple_start
+
+    candidates: list[KNNNeighbor] = []
+    end = len(basin_history) - config.horizon
+    for i in range(start_idx + min_tuple_start, end):
+        if (i - start_idx) % config.spacing != 0:
+            continue
+        hist_tuple = build_basin_tuple(
+            basin_history[: i + 1],
+            medium_window=config.medium_window,
+            long_window=config.long_window,
+        )
+        if hist_tuple is None:
+            continue
+        d = fisher_rao_tuple_distance(cur, hist_tuple, config.weights)
+        label = realized_label(
+            basin_history, i, config.horizon, config.label_threshold,
+        )
+        candidates.append(KNNNeighbor(index=i, distance=d, label=label))
+
+    needed = -(-config.k // 2)  # ceil(k/2)
+    if len(candidates) < needed:
+        return AgentLDecision(
+            action="hold",
+            signed_score=0.0,
+            conviction=0.0,
+            neighbors=(),
+            label_distribution=_EMPTY_LABEL_DIST,
+            reason=f"insufficient candidates ({len(candidates)} < {needed})",
+        )
+
+    candidates.sort(key=lambda n: n.distance)
+    top_k = candidates[: config.k]
+
+    eps = 1e-9
+    weight_sum = 0.0
+    signed_sum = 0.0
+    long_count = 0
+    short_count = 0
+    neutral_count = 0
+    long_weight = 0.0
+    short_weight = 0.0
+    for n in top_k:
+        w = 1.0 / (n.distance + eps)
+        weight_sum += w
+        signed_sum += w * n.label
+        if n.label == 1:
+            long_count += 1
+            long_weight += w
+        elif n.label == -1:
+            short_count += 1
+            short_weight += w
+        else:
+            neutral_count += 1
+
+    signed_score = signed_sum / weight_sum if weight_sum > 0 else 0.0
+    direction = 1 if signed_score > 0 else (-1 if signed_score < 0 else 0)
+    align_count = sum(
+        1 for n in top_k if n.label == direction and direction != 0
+    )
+    conviction = align_count / len(top_k) if top_k else 0.0
+
+    label_distribution = LabelDistribution(
+        long=long_count,
+        short=short_count,
+        neutral=neutral_count,
+        long_weight=long_weight,
+        short_weight=short_weight,
+        nearest_distance=top_k[0].distance if top_k else 0.0,
+        farthest_distance=top_k[-1].distance if top_k else 0.0,
+    )
+
+    if abs(signed_score) < config.action_threshold:
+        return AgentLDecision(
+            action="hold",
+            signed_score=signed_score,
+            conviction=conviction,
+            neighbors=tuple(top_k),
+            label_distribution=label_distribution,
+            reason=(
+                f"signed score {signed_score:.3f} below action threshold "
+                f"{config.action_threshold}"
+            ),
+        )
+
+    return AgentLDecision(
+        action="enter_long" if signed_score > 0 else "enter_short",
+        signed_score=signed_score,
+        conviction=conviction,
+        neighbors=tuple(top_k),
+        label_distribution=label_distribution,
+        reason=(
+            f"FR-KNN k={config.k} score={signed_score:.3f} "
+            f"conviction={conviction:.2f}"
+        ),
+    )

--- a/ml-worker/src/monkey_kernel/modes.py
+++ b/ml-worker/src/monkey_kernel/modes.py
@@ -76,30 +76,36 @@ MODE_PROFILES: dict[MonkeyMode, ModeProfile] = {
         sl_ratio=0.65,  # was 0.6 — bumped toward Phase-B winner, keeps tightest of the three
         entry_threshold_scale=0.9,
         size_floor=0.08,
-        sovereign_cap_floor=15,
+        # Mirrors TS PR #667 inversion (2026-05-13). EXPLORATION
+        # (flat / hunting) gets the highest leverage cap because the
+        # mechanism is many small fast scalps; INTEGRATION (trend
+        # confirmed) gets the lowest cap because the position is large,
+        # slow, and dollar-risk is already bounded by the wider stop.
+        # Values match TS modes.ts exactly for parity.
+        sovereign_cap_floor=50,
         tick_ms=15_000,
         can_enter=True,
-        description="volatile / hunting — tight TP, fast cadence",
+        description="flat / hunting — high-leverage fast scalp, tight TP",
     ),
     MonkeyMode.INVESTIGATION: ModeProfile(
         tp_base_frac=0.008,
         sl_ratio=0.7,   # was 0.5 — Phase-B winner sl_ratio=0.7 (6/6 runs, both symbols, all profiles)
         entry_threshold_scale=1.0,
         size_floor=0.10,
-        sovereign_cap_floor=20,
+        sovereign_cap_floor=15,
         tick_ms=30_000,
         can_enter=True,
-        description="trend forming — medium TP, full size",
+        description="trend forming — medium leverage, medium TP",
     ),
     MonkeyMode.INTEGRATION: ModeProfile(
         tp_base_frac=0.020,
         sl_ratio=0.75,  # was 0.3 — Phase-B winner; INTEGRATION lets winners run, widest SL
         entry_threshold_scale=1.1,
         size_floor=0.12,
-        sovereign_cap_floor=25,
+        sovereign_cap_floor=5,
         tick_ms=60_000,
         can_enter=True,
-        description="trend confirmed — wide TP, let winners run",
+        description="trend confirmed — low leverage, wide TP, let winners run",
     ),
     MonkeyMode.DRIFT: ModeProfile(
         tp_base_frac=0.005,
@@ -121,7 +127,9 @@ MODE_PROFILES: dict[MonkeyMode, ModeProfile] = {
         sl_ratio=0.7,
         entry_threshold_scale=1.0,
         size_floor=0.10,
-        sovereign_cap_floor=20,
+        # Mirrors INVESTIGATION cap (15) post-inversion; REVERSION is
+        # a counter-trend bet within an INVESTIGATION envelope.
+        sovereign_cap_floor=15,
         tick_ms=30_000,
         can_enter=True,
         description="back-loop mean-reversion — counter-trend, INVESTIGATION envelope",

--- a/ml-worker/src/monkey_kernel/mtf_bootstrap.py
+++ b/ml-worker/src/monkey_kernel/mtf_bootstrap.py
@@ -1,0 +1,124 @@
+"""mtf_bootstrap.py — pre-warm per-timeframe basin histories at startup.
+
+Python port of apps/api/src/services/monkey/mtfBootstrap.ts (PR #671).
+
+Without this, the 4h MTF instance needs ~480 samples * 4h each = 80
+days of live ticks before producing decisions. Live warmup is
+unworkable for anything beyond 15m.
+
+Bootstrap reads enough OHLCV candles per timeframe to synthesise
+basins via perceive() at the target cadence, then populates the
+per-timeframe history via set_bootstrap_history().
+
+QIG purity: basins synthesised by the existing perceive() function —
+same path used live. No new banned operations, no shortcuts.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import numpy as np
+
+from .mtf_l_classifier import MTFState, TimeframeLabel, set_bootstrap_history
+from .perception import OHLCVCandle, PerceptionInputs, perceive
+
+logger = logging.getLogger("monkey_kernel.mtf_bootstrap")
+
+
+# How many candles to request per timeframe. Slightly more than the
+# warmup minimum (480 + 120 horizon = 600) so the classifier is warm
+# immediately at startup.
+BOOTSTRAP_CANDLE_COUNT = 700
+
+# Poloniex v3 granularities (in minutes) keyed by timeframe label.
+POLONIEX_GRANULARITY_FOR_TF: dict[TimeframeLabel, int] = {
+    "15m": 15,
+    "1h": 60,
+    "4h": 240,
+}
+
+# Sliding window for perceive() — matches the live perceive call's
+# input shape. Skipping the first PERCEIVE_WINDOW candles ensures each
+# basin has a full lookback.
+PERCEIVE_WINDOW = 50
+
+
+async def bootstrap_mtf_for_symbol(
+    symbol: str,
+    state: MTFState,
+    *,
+    fetch_klines,  # callable: (symbol, granularity_min, limit) -> list[OHLCVCandle]
+) -> None:
+    """Pull OHLCV at each timeframe's resolution and synthesise basins
+    for the bootstrap.
+
+    Errors (network, parse, perceive raises) caught and logged; the
+    function returns with whatever it managed to compute. The MTF state
+    warms up gradually from live ticks if bootstrap is empty.
+    """
+    for label in ("15m", "1h", "4h"):
+        try:
+            granularity = POLONIEX_GRANULARITY_FOR_TF[label]
+            candles = await fetch_klines(symbol, granularity, BOOTSTRAP_CANDLE_COUNT)
+            if candles is None or len(candles) < 100:
+                logger.warning(
+                    "[MTF-bootstrap] insufficient OHLCV from exchange",
+                    extra={
+                        "symbol": symbol,
+                        "label": label,
+                        "got": 0 if candles is None else len(candles),
+                    },
+                )
+                continue
+
+            basins: list[np.ndarray] = []
+            for i in range(PERCEIVE_WINDOW, len(candles)):
+                window = list(candles[i - PERCEIVE_WINDOW : i + 1])
+                try:
+                    basin = perceive(PerceptionInputs(
+                        ohlcv=window,
+                        equity_fraction=1.0,
+                        margin_fraction=0.0,
+                        open_positions=0,
+                        session_age_ticks=0,
+                        # ml_* fields default to neutral
+                    ))
+                    basins.append(basin)
+                except Exception:  # noqa: BLE001
+                    # Skip this bar; basin synthesis will be sparser
+                    # but still useful for the classifier.
+                    continue
+
+            set_bootstrap_history(state, label, basins)
+            logger.info(
+                "[MTF-bootstrap] populated history",
+                extra={"symbol": symbol, "label": label, "basins": len(basins)},
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                "[MTF-bootstrap] failed for timeframe",
+                extra={"symbol": symbol, "label": label, "err": str(err)},
+            )
+
+
+def parse_poloniex_kline_row(row: list) -> Optional[OHLCVCandle]:
+    """Best-effort parse for the Poloniex v3 kline shape.
+
+    v3 futures kline rows arrive as ``[ts, open, high, low, close, vol, ...]``;
+    different endpoints occasionally reorder. We accept the v3 shape and
+    drop the row on parse failure.
+    """
+    try:
+        ts, o, h, low, c, v = row[0], row[1], row[2], row[3], row[4], row[5]
+        return OHLCVCandle(
+            timestamp=int(ts),
+            open=float(o),
+            high=float(h),
+            low=float(low),
+            close=float(c),
+            volume=float(v),
+        )
+    except (IndexError, TypeError, ValueError):
+        return None

--- a/ml-worker/src/monkey_kernel/mtf_l_classifier.py
+++ b/ml-worker/src/monkey_kernel/mtf_l_classifier.py
@@ -1,0 +1,275 @@
+"""mtf_l_classifier.py — multi-timeframe Agent L (Phase 1).
+
+Python port of apps/api/src/services/monkey/mtfLClassifier.ts (PR #670).
+
+Runs three FR-KNN classifier instances in parallel on independently
+down-sampled basin streams:
+
+    15m    sample every 30 ticks  (15 min on 30s kernel cadence)
+    1h     sample every 120 ticks (matches canonical Lorentzian 60min)
+    4h     sample every 480 ticks
+
+Each timeframe keeps its own history store. On each kernel tick we
+append the current basin to each down-sampled stream when that
+timeframe's "next sample" boundary has been crossed.
+
+The combiner (option c from the design conversation): AGREEMENT COUNT.
+Each classifier votes long / short / hold. The MTF decision is:
+  - 3 votes same direction → enter at full size
+  - 2 votes same direction → enter at reduced size
+  - else                   → hold
+
+Exit policy (longest-agreeing horizon): per-timeframe horizon clocks
+track the most recent re-confirmation on each side. Position exits
+when the LONGEST timeframe that agreed at entry stops agreeing
+(= its clock expires).
+
+QIG purity: each instance is a pure agent_l_decide() over its
+timeframe's basin history. No new banned operations.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional, Sequence
+
+import numpy as np
+
+from .agent_l_classifier import (
+    DEFAULT_AGENT_L_CONFIG,
+    AgentLConfig,
+    AgentLDecision,
+    agent_l_decide,
+)
+
+Basin = np.ndarray
+TimeframeLabel = Literal["15m", "1h", "4h"]
+MTFAction = Literal["enter_long", "enter_short", "hold"]
+
+
+@dataclass(frozen=True)
+class TimeframeConfig:
+    """Per-timeframe configuration."""
+
+    label: TimeframeLabel
+    ticks_per_sample: int
+    """Sample every N kernel ticks. On 30s ticks: 30→15m, 120→1h, 480→4h."""
+    config: AgentLConfig = field(default_factory=lambda: DEFAULT_AGENT_L_CONFIG)
+    max_samples: int = 2000
+    """Lookback cap in SAMPLES (not ticks). 2000 = canonical maxBarsBack."""
+
+
+DEFAULT_TIMEFRAMES: tuple[TimeframeConfig, ...] = (
+    TimeframeConfig(label="15m", ticks_per_sample=30),
+    TimeframeConfig(label="1h", ticks_per_sample=120),
+    TimeframeConfig(label="4h", ticks_per_sample=480),
+)
+
+
+@dataclass
+class _PerTfDecision:
+    label: TimeframeLabel
+    warm: bool
+    decision: Optional[AgentLDecision]
+
+
+@dataclass(frozen=True)
+class MTFDecision:
+    action: MTFAction
+    agreement_count: int
+    total_tfs: int
+    size_multiplier: float
+    """3-of-3 = 1.00, 2-of-3 = 0.50, else 0 (hold)."""
+    per_timeframe: tuple[_PerTfDecision, ...]
+    longest_agreeing_label: Optional[TimeframeLabel]
+    reason: str
+
+
+@dataclass
+class MTFState:
+    """State for the MTF runner. Per-timeframe basin histories +
+    last-sample-tick tracking. Owned by the caller."""
+
+    histories_by_tf: Dict[TimeframeLabel, List[Basin]] = field(default_factory=dict)
+    last_sample_tick_by_tf: Dict[TimeframeLabel, float] = field(default_factory=dict)
+    last_agreement_by_tf_side: Dict[
+        TimeframeLabel, Dict[str, Optional[float]]
+    ] = field(default_factory=dict)
+
+
+def new_mtf_state(
+    timeframes: Sequence[TimeframeConfig] = DEFAULT_TIMEFRAMES,
+) -> MTFState:
+    s = MTFState()
+    for tf in timeframes:
+        s.histories_by_tf[tf.label] = []
+        s.last_sample_tick_by_tf[tf.label] = -math.inf
+        s.last_agreement_by_tf_side[tf.label] = {"long": None, "short": None}
+    return s
+
+
+def on_tick_append(
+    state: MTFState,
+    basin: Basin,
+    tick_index: int,
+    timeframes: Sequence[TimeframeConfig] = DEFAULT_TIMEFRAMES,
+) -> None:
+    """Append the current basin to each timeframe's history whose
+    sampling boundary has been crossed. Pure in-place update."""
+    for tf in timeframes:
+        last = state.last_sample_tick_by_tf[tf.label]
+        if tick_index - last >= tf.ticks_per_sample:
+            hist = state.histories_by_tf[tf.label]
+            hist.append(basin)
+            if len(hist) > tf.max_samples:
+                del hist[: len(hist) - tf.max_samples]
+            state.last_sample_tick_by_tf[tf.label] = tick_index
+
+
+def set_bootstrap_history(
+    state: MTFState,
+    label: TimeframeLabel,
+    history: Sequence[Basin],
+    timeframes: Sequence[TimeframeConfig] = DEFAULT_TIMEFRAMES,
+) -> None:
+    """Replace a timeframe's history with a pre-computed sequence
+    (called once at startup after OHLCV bootstrap)."""
+    tf = next((t for t in timeframes if t.label == label), None)
+    if tf is None:
+        return
+    if len(history) > tf.max_samples:
+        capped = list(history[-tf.max_samples:])
+    else:
+        capped = list(history)
+    state.histories_by_tf[label] = capped
+
+
+def mtf_decide(
+    state: MTFState,
+    timeframes: Sequence[TimeframeConfig] = DEFAULT_TIMEFRAMES,
+) -> MTFDecision:
+    """Compute the multi-timeframe agreement decision.
+
+    Each timeframe whose history is warm enough produces an
+    AgentLDecision. The aggregated action is decided by agreement
+    count; size_multiplier scales with agreement strength.
+
+    Pure function — no state mutation.
+    """
+    per_tf: list[_PerTfDecision] = []
+    long_count = 0
+    short_count = 0
+    warm_count = 0
+
+    for tf in timeframes:
+        hist = state.histories_by_tf.get(tf.label, [])
+        # Warm when history reaches the classifier's minimum
+        # (long_window + horizon).
+        min_samples = tf.config.min_tuple_start + tf.config.horizon
+        warm = len(hist) >= min_samples
+        decision: Optional[AgentLDecision] = None
+        if warm:
+            decision = agent_l_decide(hist, tf.config)
+            if decision.action == "enter_long":
+                long_count += 1
+            elif decision.action == "enter_short":
+                short_count += 1
+            warm_count += 1
+        per_tf.append(_PerTfDecision(label=tf.label, warm=warm, decision=decision))
+
+    if warm_count == 0:
+        return MTFDecision(
+            action="hold",
+            agreement_count=0,
+            total_tfs=len(timeframes),
+            size_multiplier=0.0,
+            per_timeframe=tuple(per_tf),
+            longest_agreeing_label=None,
+            reason="no_warm_timeframes",
+        )
+
+    # Agreement-count combiner.
+    if long_count > short_count and long_count >= 2:
+        action: MTFAction = "enter_long"
+    elif short_count > long_count and short_count >= 2:
+        action = "enter_short"
+    else:
+        action = "hold"
+
+    if action == "enter_long":
+        agreement_count = long_count
+    elif action == "enter_short":
+        agreement_count = short_count
+    else:
+        agreement_count = 0
+
+    if action == "hold":
+        size_multiplier = 0.0
+    elif agreement_count >= 3:
+        size_multiplier = 1.0
+    elif agreement_count == 2:
+        size_multiplier = 0.5
+    else:
+        size_multiplier = 0.0
+
+    # Longest-agreeing label — timeframes array is ascending (15m, 1h, 4h).
+    longest_agreeing: Optional[TimeframeLabel] = None
+    if action != "hold":
+        want = action
+        for entry in per_tf:
+            if entry.decision is not None and entry.decision.action == want:
+                longest_agreeing = entry.label  # last match wins
+
+    return MTFDecision(
+        action=action,
+        agreement_count=agreement_count,
+        total_tfs=len(timeframes),
+        size_multiplier=size_multiplier,
+        per_timeframe=tuple(per_tf),
+        longest_agreeing_label=longest_agreeing,
+        reason=f"mtf:{long_count}L/{short_count}S/{warm_count}warm",
+    )
+
+
+def record_agreement_timestamps(
+    state: MTFState,
+    decision: MTFDecision,
+    now_ms: float,
+) -> None:
+    """Update per-TF per-side agreement clocks after mtf_decide.
+    Used by the longest-agreeing-horizon exit policy."""
+    if decision.action == "hold":
+        return
+    side = "long" if decision.action == "enter_long" else "short"
+    for entry in decision.per_timeframe:
+        if entry.decision is not None and entry.decision.action == decision.action:
+            state.last_agreement_by_tf_side[entry.label][side] = now_ms
+
+
+def is_longest_horizon_expired(
+    state: MTFState,
+    side: str,  # "long" | "short"
+    longest_label_at_entry: Optional[TimeframeLabel],
+    now_ms: float,
+    tick_ms: float,
+    timeframes: Sequence[TimeframeConfig] = DEFAULT_TIMEFRAMES,
+) -> bool:
+    """Check whether the longest-agreeing-at-entry timeframe's horizon
+    has elapsed without re-confirmation.
+
+    Returns True → caller (force_harvest path) should exit the position
+    per the longest-agreeing-horizon policy.
+    """
+    if longest_label_at_entry is None:
+        return False
+    tf = next((t for t in timeframes if t.label == longest_label_at_entry), None)
+    if tf is None:
+        return False
+    horizon_ms = tf.config.horizon * tf.ticks_per_sample * tick_ms
+    last_agreement = state.last_agreement_by_tf_side.get(
+        longest_label_at_entry, {}
+    ).get(side)
+    if last_agreement is None:
+        return False
+    return (now_ms - last_agreement) > horizon_ms

--- a/ml-worker/src/monkey_kernel/regime_sizing.py
+++ b/ml-worker/src/monkey_kernel/regime_sizing.py
@@ -1,0 +1,297 @@
+"""regime_sizing.py — regime-conditioned position sizing.
+
+Python port of apps/api/src/services/monkey/regimeSizing.ts (PRs #667,
+#672). Maps the kernel's QIG-derived regime score r in [0, 1] onto
+trade parameters (leverage, size fraction, hold horizon, stop bps,
+margin headroom floor).
+
+  r -> 1  = FLAT regime (orbit, low FR velocity, low coherence, near-
+           critical k). High-frequency, high-leverage, small notional,
+           short hold, tight stop.
+
+  r -> 0  = TRENDING regime (geodesic traversal, high FR velocity, high
+           coherence, far-from-critical k). Low-frequency, lower
+           leverage, large notional, long hold, wide stop.
+
+Risk-per-trade in DOLLAR terms stays roughly constant; the bot
+participates in both market modes with comparable downside, just by
+different mechanisms.
+
+QIG purity: composes existing basin / perception primitives only
+(fisher_rao_distance, frechet_mean, velocity, basin_direction). No
+banned ops.
+
+Pure functions. The integration layer (tick.py) calls these to get
+sizing parameters per tick.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional, Sequence
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import (
+    fisher_rao_distance,
+    frechet_mean,
+)
+
+from .basin import velocity
+from .perception_scalars import basin_direction
+
+Basin = np.ndarray
+RegimeScore = float
+RegimeLabel = Literal["flat", "transitioning", "trending"]
+
+
+@dataclass(frozen=True)
+class RegimeComponents:
+    """Per-component scores in [0, 1] for telemetry."""
+
+    velocity_flatness: float
+    """Mean FR velocity over the window, normalised into [0, 1].
+    HIGH velocity -> score near 0 (trending);
+    LOW velocity -> score near 1 (flat)."""
+
+    directional_chop: float
+    """Directional persistence — |mean(direction)| / mean(|direction|).
+    HIGH persistence (near 1) -> near 0 (trending);
+    LOW persistence (near 0) -> near 1 (chop)."""
+
+    kappa_criticality: float
+    """Distance from the critical kappa band. Closer to k* -> near 1
+    (flat, near-critical); further away -> near 0 (trending).
+    Falls back to 0.5 (neutral) when kappa unavailable."""
+
+
+@dataclass(frozen=True)
+class RegimeReading:
+    """Composite regime score plus its component breakdown."""
+
+    r: RegimeScore
+    components: RegimeComponents
+    label: RegimeLabel
+
+
+@dataclass(frozen=True)
+class RegimeConfig:
+    """Hyperparameters for the regime score. Tunable, but defaults are
+    calibrated for the basin coordinates produced by perceive() at the
+    30s tick cadence."""
+
+    window: int = 60
+    """Lookback window in ticks for velocity + direction history.
+    60 = 30 min on 30s ticks."""
+
+    velocity_saturate: float = 0.10
+    """Velocity at which the score saturates to 0 (full trending).
+    0.10 = empirical for Delta-63 basins at 30s cadence."""
+
+    kappa_critical: float = 64.0
+    """Critical kappa target."""
+
+    kappa_critical_band_half_width: float = 16.0
+    """+/- band around kappa_critical considered near-critical."""
+
+    weight_velocity: float = 0.4
+    weight_directional: float = 0.4
+    weight_kappa: float = 0.2
+    """Component weights — should sum to 1 for clean interpretation."""
+
+    flat_at: float = 0.65
+    """Label threshold: r >= flat_at -> 'flat'."""
+
+    trend_at: float = 0.35
+    """Label threshold: r <= trend_at -> 'trending'."""
+
+
+DEFAULT_REGIME_CONFIG = RegimeConfig()
+
+
+def _clamp01(x: float) -> float:
+    return max(0.0, min(1.0, x))
+
+
+def regime_score(
+    basin_history: Sequence[Basin],
+    kappa: Optional[float],
+    config: RegimeConfig = DEFAULT_REGIME_CONFIG,
+) -> Optional[RegimeReading]:
+    """Compute the regime score from recent basin history + current kappa.
+
+    Returns None when there's insufficient history (< 2 basins; need
+    at least one velocity sample). Caller treats None as "regime
+    unknown" and falls back to neutral sizing.
+    """
+    if len(basin_history) < 2:
+        return None
+
+    window = min(config.window, len(basin_history) - 1)
+    # Need N+1 samples for N velocities.
+    recent = list(basin_history[-(window + 1):])
+
+    # Component 1 — velocity flatness.
+    vel_sum = 0.0
+    vel_count = 0
+    for i in range(1, len(recent)):
+        vel_sum += velocity(recent[i - 1], recent[i])
+        vel_count += 1
+    mean_vel = vel_sum / vel_count if vel_count > 0 else 0.0
+    velocity_flatness = _clamp01(1.0 - mean_vel / config.velocity_saturate)
+
+    # Component 2 — directional chop.
+    sum_signed_dir = 0.0
+    sum_abs_dir = 0.0
+    for basin in recent:
+        d = basin_direction(basin)
+        sum_signed_dir += d
+        sum_abs_dir += abs(d)
+    persistence = (
+        abs(sum_signed_dir) / sum_abs_dir if sum_abs_dir > 0 else 0.0
+    )
+    directional_chop = _clamp01(1.0 - persistence)
+
+    # Component 3 — kappa criticality.
+    if kappa is None or not np.isfinite(kappa):
+        kappa_criticality = 0.5
+    else:
+        dist_from_critical = abs(kappa - config.kappa_critical)
+        kappa_criticality = _clamp01(
+            1.0 - dist_from_critical / (2.0 * config.kappa_critical_band_half_width)
+        )
+
+    w_sum = max(
+        config.weight_velocity + config.weight_directional + config.weight_kappa,
+        1e-9,
+    )
+    r = (
+        config.weight_velocity * velocity_flatness
+        + config.weight_directional * directional_chop
+        + config.weight_kappa * kappa_criticality
+    ) / w_sum
+
+    label: RegimeLabel
+    if r >= config.flat_at:
+        label = "flat"
+    elif r <= config.trend_at:
+        label = "trending"
+    else:
+        label = "transitioning"
+
+    return RegimeReading(
+        r=r,
+        components=RegimeComponents(
+            velocity_flatness=velocity_flatness,
+            directional_chop=directional_chop,
+            kappa_criticality=kappa_criticality,
+        ),
+        label=label,
+    )
+
+
+@dataclass(frozen=True)
+class SizingResult:
+    """Sizing parameters output by regime_sizing()."""
+
+    leverage: int
+    """Leverage multiplier (1..max)."""
+
+    size_fraction: float
+    """Fraction of allocated capital to deploy as margin on this entry."""
+
+    hold_ms: int
+    """Hold horizon in ms. Exit at this if no re-confirmation, regardless
+    of PnL."""
+
+    stop_bps: float
+    """Stop-loss in basis points of notional. 100 bps = 1%."""
+
+    margin_headroom_floor: float
+    """Margin headroom floor (fraction of equity) to require before
+    entry. Tighter on flat (need headroom for rapid scalp cycles);
+    looser on trend (one slow large position is OK)."""
+
+
+@dataclass(frozen=True)
+class SizingConfig:
+    """Rails for the flat-to-trend interpolation."""
+
+    flat_leverage: int = 50
+    trend_leverage: int = 8
+    flat_size_fraction: float = 0.25
+    trend_size_fraction: float = 0.85
+    flat_hold_ms: int = 10 * 60_000           # 10 min
+    trend_hold_ms: int = 4 * 60 * 60_000      # 4 h
+    flat_stop_bps: float = 30.0
+    trend_stop_bps: float = 150.0
+    flat_headroom_floor: float = 0.35
+    trend_headroom_floor: float = 0.15
+
+
+DEFAULT_SIZING_CONFIG = SizingConfig()
+
+
+def _lerp(flat_val: float, trend_val: float, r: float) -> float:
+    """Linear interpolation between flat (r=1) and trend (r=0) values."""
+    t = _clamp01(r)
+    return trend_val + (flat_val - trend_val) * t
+
+
+def compute_regime_sizing(
+    r: RegimeScore,
+    config: SizingConfig = DEFAULT_SIZING_CONFIG,
+) -> SizingResult:
+    """Map a regime score to a sizing parameter bundle.
+
+    Continuous interpolation — no discrete "now flat / now trending"
+    cliff. r=0.7 yields a leverage between flat and trend proportional
+    to where 0.7 falls on the rail.
+
+    Pure function. Caller takes the result and applies it to the entry
+    order builder. Sizing is per-entry, not per-symbol-state — each
+    entry recomputes against the current r.
+    """
+    return SizingResult(
+        leverage=round(_lerp(config.flat_leverage, config.trend_leverage, r)),
+        size_fraction=_lerp(config.flat_size_fraction, config.trend_size_fraction, r),
+        hold_ms=int(_lerp(config.flat_hold_ms, config.trend_hold_ms, r)),
+        stop_bps=_lerp(config.flat_stop_bps, config.trend_stop_bps, r),
+        margin_headroom_floor=_lerp(
+            config.flat_headroom_floor, config.trend_headroom_floor, r,
+        ),
+    )
+
+
+def trailing_regime_stop(
+    r_at_entry: RegimeScore,
+    r_now: RegimeScore,
+    adverse_delta: float = 0.30,
+) -> bool:
+    """Held positions must exit on adverse regime transition.
+
+    If the regime score has shifted (in either direction) by more than
+    `adverse_delta` since position open, the regime hypothesis that
+    justified the size has ended. Symmetric: a flat-side bet exits if
+    regime turns trending; a trend-side bet exits if it goes flat.
+
+    Returns True -> caller should close the position.
+    """
+    return abs(r_at_entry - r_now) > adverse_delta
+
+
+def basin_alignment_to_window(
+    current: Basin,
+    window: Sequence[Basin],
+) -> float:
+    """Fisher-Rao distance between the current basin and the Frechet
+    mean of a recent window. Low distance = "current state agrees with
+    recent mean"; high distance = "current state is an outlier."
+
+    Not used by regime_score() directly today, but exposed because it's
+    useful for higher-order regime composition (e.g. MTF coherence).
+    """
+    if len(window) == 0:
+        return 0.0
+    mean = frechet_mean(list(window))
+    return fisher_rao_distance(current, mean)

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import numpy as np
 
@@ -292,6 +292,20 @@ class SymbolState:
     regime_change_streak_by_lane: dict[str, int] = field(default_factory=dict)
 
 
+# Harvest-kind taxonomy (Phase 1.5). Mirrors the TS-side close_reason
+# values written to autonomous_trades.exit_reason. None when the action
+# isn't a close — entries, holds, regular flattens.
+HarvestKind = Literal[
+    "win",
+    "stop_loss",
+    "horizon_expired",
+    "regime_transition",
+    "mtf_horizon_expired",
+    "continuous_regime_drift",
+    "position_mismatch_phantom",
+]
+
+
 @dataclass
 class TickDecision:
     """Output of one tick. Caller persists / executes as needed."""
@@ -319,6 +333,15 @@ class TickDecision:
     direction: str = "flat"   # long | short | flat
     size_fraction: float = 1.0
     dca_intent: bool = False
+    # Phase 1.5 / 1.6 — kernel-cutover payload extensions.
+    # When the action is a close, harvest_kind reports the cascade tier;
+    # otherwise None. r_score / mtf_decision_action are observation-only
+    # for now (live values flow once the cutover lands).
+    harvest_kind: Optional[HarvestKind] = None
+    r_score: Optional[float] = None
+    mtf_decision_action: Optional[str] = None  # 'enter_long' | 'enter_short' | 'hold'
+    mtf_size_multiplier: Optional[float] = None
+    leverage_cap_from_regime: Optional[int] = None
 
 
 # ── Public API ───────────────────────────────────────────────────

--- a/ml-worker/src/trading/risk_kernel.py
+++ b/ml-worker/src/trading/risk_kernel.py
@@ -96,10 +96,28 @@ class KernelContext:
       the 'paper_only_blocks_live' veto.
     - mode: Global operator override (agent_execution_mode).
     - symbol_max_leverage: From marketCatalog.getMaxLeverage(symbol).
+    - monkey_mode: Current Monkey mode (exploration/investigation/
+      integration/drift/reversion). Optional; when provided, the
+      margin-headroom check uses MODE_HEADROOM_FLOORS[monkey_mode]
+      as a floor on top of the global env-var setting. Mirrors TS
+      PR #668.
     """
     is_live: bool
     mode: ExecutionMode
     symbol_max_leverage: float
+    monkey_mode: Optional[str] = None
+
+
+# Per-mode reserve floors (TS PR #668). Tighter floor on flat (need
+# headroom for rapid scalp cycles); looser on trend (one slow large
+# position is OK). Keys match modes.py MonkeyMode values.
+MODE_HEADROOM_FLOORS: dict[str, float] = {
+    "exploration": 0.35,
+    "investigation": 0.25,
+    "integration": 0.15,
+    "drift": 0.50,
+    "reversion": 0.25,  # mirrors INVESTIGATION envelope
+}
 
 
 @dataclass(frozen=True)
@@ -292,6 +310,7 @@ def check_margin_headroom(
     order: KernelOrder,
     state: KernelAccountState,
     min_headroom_pct: Optional[float] = None,
+    monkey_mode: Optional[str] = None,
 ) -> KernelDecision:
     """Reserve N% of equity as uncommitted margin so closes / reverses /
     counter-positions always have room. Without this, Monkey can keep
@@ -302,10 +321,19 @@ def check_margin_headroom(
     min_headroom_pct=None reads MONKEY_MIN_MARGIN_HEADROOM_PCT env var
     (default 0.0 = no-op, parity with TS reference).
 
+    monkey_mode (TS PR #668) sets a per-mode floor that takes effect
+    when it's higher than the env-derived global. EXPLORATION 35% /
+    INVESTIGATION 25% / INTEGRATION 15% / DRIFT 50% / REVERSION 25%.
+
     Out-of-range pct (negative or ≥ 1) fails OPEN — operator typo
     shouldn't silently freeze the kernel.
     """
     pct = _min_margin_headroom_pct() if min_headroom_pct is None else min_headroom_pct
+    # Apply per-mode floor when monkey_mode is provided.
+    if monkey_mode is not None:
+        mode_floor = MODE_HEADROOM_FLOORS.get(monkey_mode.lower())
+        if mode_floor is not None and 0.0 < mode_floor < 1.0:
+            pct = max(pct, mode_floor)
     if pct is None or pct <= 0.0 or pct >= 1.0:
         return KernelDecision(allowed=True)
     if state.equity_usdt <= 0:
@@ -355,7 +383,7 @@ def evaluate_pre_trade_vetoes(
         check_execution_mode(context.is_live, context.mode),
         check_self_match(order, state),
         check_per_symbol_exposure(order, state),
-        check_margin_headroom(order, state),
+        check_margin_headroom(order, state, monkey_mode=context.monkey_mode),
         check_symbol_max_leverage(order, context.symbol_max_leverage),
     ):
         if not check.allowed:

--- a/ml-worker/tests/monkey_kernel/test_agent_l_classifier.py
+++ b/ml-worker/tests/monkey_kernel/test_agent_l_classifier.py
@@ -1,0 +1,127 @@
+"""Tests for agent_l_classifier.py — Python port of agent_L_classifier.ts."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.agent_l_classifier import (  # noqa: E402
+    DEFAULT_AGENT_L_CONFIG,
+    AgentLConfig,
+    ScaleWeights,
+    agent_l_decide,
+    build_basin_tuple,
+    fisher_rao_tuple_distance,
+    realized_label,
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _uniform_basin(dim: int = 64) -> np.ndarray:
+    return np.full(dim, 1.0 / dim, dtype=np.float64)
+
+
+def _peaked_basin(idx: int, dim: int = 64, peak: float = 0.5) -> np.ndarray:
+    b = np.full(dim, (1.0 - peak) / (dim - 1), dtype=np.float64)
+    b[idx] = peak
+    return b
+
+
+# ── build_basin_tuple ──────────────────────────────────────────────
+
+
+class TestBuildBasinTuple:
+    def test_empty_history_returns_none(self):
+        assert build_basin_tuple([]) is None
+
+    def test_short_history_uses_available(self):
+        hist = [_uniform_basin()] * 5
+        t = build_basin_tuple(hist, medium_window=10, long_window=100)
+        assert t is not None
+        np.testing.assert_allclose(t.current, hist[-1])
+
+    def test_current_is_last_basin(self):
+        hist = [_uniform_basin(), _peaked_basin(0, peak=0.5)]
+        t = build_basin_tuple(hist)
+        assert t is not None
+        np.testing.assert_allclose(t.current, hist[-1])
+
+
+# ── fisher_rao_tuple_distance ──────────────────────────────────────
+
+
+class TestFisherRaoTupleDistance:
+    def test_self_distance_is_zero(self):
+        b = _uniform_basin()
+        t = build_basin_tuple([b] * 10)
+        assert t is not None
+        d = fisher_rao_tuple_distance(t, t)
+        assert d == pytest.approx(0.0, abs=1e-9)
+
+    def test_disjoint_basins_have_positive_distance(self):
+        t1 = build_basin_tuple([_peaked_basin(0, peak=0.9)] * 10)
+        t2 = build_basin_tuple([_peaked_basin(63, peak=0.9)] * 10)
+        assert t1 is not None and t2 is not None
+        d = fisher_rao_tuple_distance(t1, t2)
+        assert d > 0.0
+
+
+# ── realized_label ─────────────────────────────────────────────────
+
+
+class TestRealizedLabel:
+    def test_target_out_of_range_returns_zero(self):
+        assert realized_label([_uniform_basin()] * 5, i=4, horizon=10) == 0
+
+    def test_uniform_basin_at_target_is_neutral(self):
+        hist = [_uniform_basin()] * 200
+        assert realized_label(hist, i=0, horizon=120) == 0
+
+
+# ── agent_l_decide ─────────────────────────────────────────────────
+
+
+class TestAgentLDecide:
+    def test_empty_history_holds(self):
+        d = agent_l_decide([])
+        assert d.action == "hold"
+        assert d.reason == "history empty"
+
+    def test_insufficient_history_holds(self):
+        d = agent_l_decide([_uniform_basin()] * 100)
+        assert d.action == "hold"
+        assert "insufficient candidates" in d.reason
+
+    def test_uniform_history_holds_with_neutral_neighbors(self):
+        """800 uniform basins → no realized direction signal → hold."""
+        hist = [_uniform_basin() for _ in range(800)]
+        d = agent_l_decide(hist)
+        assert d.action == "hold"
+        assert d.signed_score == pytest.approx(0.0)
+
+    def test_returns_diagnostic_label_distribution(self):
+        hist = [_uniform_basin() for _ in range(800)]
+        d = agent_l_decide(hist)
+        ld = d.label_distribution
+        # All-uniform → all neighbors neutral
+        assert ld.long == 0
+        assert ld.short == 0
+        assert ld.neutral >= 0
+        # nearest_distance should be 0 since cur tuple == hist tuple shape
+        assert ld.nearest_distance >= 0.0
+
+    def test_action_threshold_gates_hold(self):
+        """Lower the threshold → more decisions become non-hold."""
+        # Uniform basin still has signed_score=0, so this verifies the
+        # threshold path doesn't change a zero into action.
+        hist = [_uniform_basin() for _ in range(800)]
+        custom = AgentLConfig(action_threshold=0.001)
+        d = agent_l_decide(hist, config=custom)
+        assert d.action == "hold"
+        assert d.signed_score == pytest.approx(0.0)

--- a/ml-worker/tests/monkey_kernel/test_mtf_bootstrap.py
+++ b/ml-worker/tests/monkey_kernel/test_mtf_bootstrap.py
@@ -1,0 +1,113 @@
+"""Tests for mtf_bootstrap.py — Python port of mtfBootstrap.ts."""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+
+def _run(coro):
+    """Run an async coroutine to completion in a fresh event loop."""
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+from monkey_kernel.mtf_bootstrap import (  # noqa: E402
+    BOOTSTRAP_CANDLE_COUNT,
+    POLONIEX_GRANULARITY_FOR_TF,
+    bootstrap_mtf_for_symbol,
+    parse_poloniex_kline_row,
+)
+from monkey_kernel.mtf_l_classifier import new_mtf_state  # noqa: E402
+from monkey_kernel.perception import OHLCVCandle  # noqa: E402
+
+
+def _fake_candle(i: int) -> OHLCVCandle:
+    """Generate a deterministic candle. Slight upward drift so OHLCV
+    isn't completely flat (otherwise perceive() math becomes degenerate)."""
+    base = 100.0 + i * 0.01
+    return OHLCVCandle(
+        timestamp=i * 30_000,
+        open=base,
+        high=base + 0.5,
+        low=base - 0.5,
+        close=base + 0.1,
+        volume=1000.0,
+    )
+
+
+# ── parse_poloniex_kline_row ──────────────────────────────────────
+
+
+class TestParseKlineRow:
+    def test_valid_row(self):
+        c = parse_poloniex_kline_row([1700_000_000, 100.0, 101.0, 99.0, 100.5, 5000])
+        assert c is not None
+        assert c.timestamp == 1700_000_000
+        assert c.open == 100.0
+        assert c.close == 100.5
+
+    def test_malformed_row_returns_none(self):
+        assert parse_poloniex_kline_row([1700, 100.0]) is None
+        assert parse_poloniex_kline_row(["bad"]) is None
+        assert parse_poloniex_kline_row([]) is None
+
+
+# ── bootstrap_mtf_for_symbol ──────────────────────────────────────
+
+
+class TestBootstrapMtfForSymbol:
+    def test_insufficient_candles_skips_timeframe(self):
+        async def fetch(symbol, granularity, limit):
+            return [_fake_candle(i) for i in range(50)]
+
+        state = new_mtf_state()
+        _run(bootstrap_mtf_for_symbol("ETH_PERP", state, fetch_klines=fetch))
+        assert state.histories_by_tf["15m"] == []
+        assert state.histories_by_tf["1h"] == []
+        assert state.histories_by_tf["4h"] == []
+
+    def test_none_candles_skips_timeframe(self):
+        async def fetch(symbol, granularity, limit):
+            return None
+
+        state = new_mtf_state()
+        _run(bootstrap_mtf_for_symbol("ETH_PERP", state, fetch_klines=fetch))
+        assert state.histories_by_tf["15m"] == []
+
+    def test_fetch_exception_is_caught_per_timeframe(self):
+        async def fetch(symbol, granularity, limit):
+            raise RuntimeError("network blip")
+
+        state = new_mtf_state()
+        # No raise — caught and logged.
+        _run(bootstrap_mtf_for_symbol("ETH_PERP", state, fetch_klines=fetch))
+        assert state.histories_by_tf["15m"] == []
+        assert state.histories_by_tf["4h"] == []
+
+    def test_populates_history_when_candles_supplied(self):
+        async def fetch(symbol, granularity, limit):
+            return [_fake_candle(i) for i in range(150)]
+
+        state = new_mtf_state()
+        _run(bootstrap_mtf_for_symbol("ETH_PERP", state, fetch_klines=fetch))
+        # 150 candles - 50 window = 100 basins per timeframe.
+        for label in ("15m", "1h", "4h"):
+            assert len(state.histories_by_tf[label]) > 0
+
+
+# ── constants ─────────────────────────────────────────────────────
+
+
+def test_granularity_table():
+    assert POLONIEX_GRANULARITY_FOR_TF["15m"] == 15
+    assert POLONIEX_GRANULARITY_FOR_TF["1h"] == 60
+    assert POLONIEX_GRANULARITY_FOR_TF["4h"] == 240
+
+
+def test_bootstrap_candle_count_covers_warmup():
+    # 480 long_window + 120 horizon = 600 minimum; 700 leaves margin.
+    assert BOOTSTRAP_CANDLE_COUNT >= 700

--- a/ml-worker/tests/monkey_kernel/test_mtf_l_classifier.py
+++ b/ml-worker/tests/monkey_kernel/test_mtf_l_classifier.py
@@ -1,0 +1,223 @@
+"""Tests for mtf_l_classifier.py — Python port of mtfLClassifier.ts."""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.mtf_l_classifier import (  # noqa: E402
+    DEFAULT_TIMEFRAMES,
+    MTFDecision,
+    TimeframeConfig,
+    is_longest_horizon_expired,
+    mtf_decide,
+    new_mtf_state,
+    on_tick_append,
+    record_agreement_timestamps,
+    set_bootstrap_history,
+)
+from monkey_kernel.agent_l_classifier import (  # noqa: E402
+    DEFAULT_AGENT_L_CONFIG,
+    AgentLDecision,
+    LabelDistribution,
+)
+
+
+BASIN_DIM = 64
+
+
+def _uniform_basin() -> np.ndarray:
+    return np.full(BASIN_DIM, 1.0 / BASIN_DIM, dtype=np.float64)
+
+
+# ── new_mtf_state ─────────────────────────────────────────────────
+
+
+def test_new_state_initializes_empty():
+    s = new_mtf_state()
+    assert s.histories_by_tf["15m"] == []
+    assert s.histories_by_tf["1h"] == []
+    assert s.histories_by_tf["4h"] == []
+    import math
+    assert s.last_sample_tick_by_tf["15m"] == -math.inf
+    assert s.last_agreement_by_tf_side["1h"]["long"] is None
+
+
+# ── on_tick_append (down-sampling) ────────────────────────────────
+
+
+class TestOnTickAppend:
+    def test_first_tick_appends_to_all(self):
+        s = new_mtf_state()
+        on_tick_append(s, _uniform_basin(), 0)
+        assert len(s.histories_by_tf["15m"]) == 1
+        assert len(s.histories_by_tf["1h"]) == 1
+        assert len(s.histories_by_tf["4h"]) == 1
+
+    def test_15m_boundary_every_30_ticks(self):
+        s = new_mtf_state()
+        on_tick_append(s, _uniform_basin(), 0)
+        on_tick_append(s, _uniform_basin(), 29)
+        assert len(s.histories_by_tf["15m"]) == 1  # not yet
+        on_tick_append(s, _uniform_basin(), 30)
+        assert len(s.histories_by_tf["15m"]) == 2
+
+    def test_1h_boundary_every_120_ticks(self):
+        s = new_mtf_state()
+        on_tick_append(s, _uniform_basin(), 0)
+        on_tick_append(s, _uniform_basin(), 60)
+        assert len(s.histories_by_tf["1h"]) == 1
+        on_tick_append(s, _uniform_basin(), 120)
+        assert len(s.histories_by_tf["1h"]) == 2
+
+    def test_caps_at_max_samples(self):
+        tfs = (
+            TimeframeConfig(
+                label="15m", ticks_per_sample=1, max_samples=3,
+                config=DEFAULT_TIMEFRAMES[0].config,
+            ),
+        )
+        s = new_mtf_state(tfs)
+        for i in range(10):
+            on_tick_append(s, _uniform_basin(), i, tfs)
+        assert len(s.histories_by_tf["15m"]) == 3
+
+
+# ── set_bootstrap_history ─────────────────────────────────────────
+
+
+class TestSetBootstrapHistory:
+    def test_replaces_history(self):
+        s = new_mtf_state()
+        bootstrap = [_uniform_basin() for _ in range(100)]
+        set_bootstrap_history(s, "4h", bootstrap)
+        assert len(s.histories_by_tf["4h"]) == 100
+
+    def test_caps_at_max_samples(self):
+        s = new_mtf_state()
+        bootstrap = [_uniform_basin() for _ in range(3000)]
+        set_bootstrap_history(s, "4h", bootstrap)
+        assert len(s.histories_by_tf["4h"]) == 2000  # default cap
+
+
+# ── mtf_decide ────────────────────────────────────────────────────
+
+
+class TestMtfDecide:
+    def test_no_warm_timeframes_holds(self):
+        s = new_mtf_state()
+        d = mtf_decide(s)
+        assert d.action == "hold"
+        assert d.agreement_count == 0
+        assert d.size_multiplier == 0.0
+        assert d.reason == "no_warm_timeframes"
+
+    def test_reports_per_tf_warm_status(self):
+        s = new_mtf_state()
+        # 200 basins — insufficient for the warm threshold (min_tuple_start +
+        # horizon = 480 + 120 = 600).
+        for i in range(200):
+            on_tick_append(s, _uniform_basin(), i * 30)
+        d = mtf_decide(s)
+        for entry in d.per_timeframe:
+            assert entry.warm is False
+            assert entry.decision is None
+
+
+# ── per-TF horizon expiry ─────────────────────────────────────────
+
+
+class TestHorizonExpiry:
+    def test_no_agreement_recorded_returns_false(self):
+        s = new_mtf_state()
+        assert (
+            is_longest_horizon_expired(s, "long", "1h", time.time() * 1000, 30_000)
+            is False
+        )
+
+    def test_within_horizon_returns_false(self):
+        tfs = (
+            TimeframeConfig(
+                label="1h", ticks_per_sample=1, max_samples=100,
+                # horizon=60 → 1 * 1 * 30_000 = 30s; within 1s elapsed
+                config=DEFAULT_AGENT_L_CONFIG,
+            ),
+        )
+        s = new_mtf_state(tfs)
+        s.last_agreement_by_tf_side["1h"]["long"] = time.time() * 1000 - 1_000
+        assert (
+            is_longest_horizon_expired(
+                s, "long", "1h", time.time() * 1000, 30_000, tfs
+            )
+            is False
+        )
+
+    def test_horizon_exceeded_returns_true(self):
+        from dataclasses import replace
+        cfg = replace(DEFAULT_AGENT_L_CONFIG, horizon=1)
+        tfs = (
+            TimeframeConfig(
+                label="15m", ticks_per_sample=1, max_samples=100,
+                config=cfg,
+            ),
+        )
+        s = new_mtf_state(tfs)
+        s.last_agreement_by_tf_side["15m"]["long"] = time.time() * 1000 - 60_000
+        # horizon = 1 * 1 * 30_000 = 30s; elapsed 60s > 30s → expired
+        assert (
+            is_longest_horizon_expired(
+                s, "long", "15m", time.time() * 1000, 30_000, tfs
+            )
+            is True
+        )
+
+
+# ── record_agreement_timestamps ───────────────────────────────────
+
+
+class TestRecordAgreementTimestamps:
+    def test_does_nothing_on_hold(self):
+        s = new_mtf_state()
+        d = MTFDecision(
+            action="hold", agreement_count=0, total_tfs=3, size_multiplier=0.0,
+            per_timeframe=(), longest_agreeing_label=None, reason="t",
+        )
+        record_agreement_timestamps(s, d, time.time() * 1000)
+        assert s.last_agreement_by_tf_side["15m"]["long"] is None
+
+    def test_records_on_voting_tfs(self):
+        from monkey_kernel.mtf_l_classifier import _PerTfDecision
+        s = new_mtf_state()
+        now = time.time() * 1000
+        empty_ld = LabelDistribution(
+            long=0, short=0, neutral=0,
+            long_weight=0.0, short_weight=0.0,
+            nearest_distance=0.0, farthest_distance=0.0,
+        )
+        dec_long = AgentLDecision(
+            action="enter_long", signed_score=0.5, conviction=1.0,
+            neighbors=(), label_distribution=empty_ld, reason="t",
+        )
+        dec_hold = AgentLDecision(
+            action="hold", signed_score=0.0, conviction=0.0,
+            neighbors=(), label_distribution=empty_ld, reason="t",
+        )
+        d = MTFDecision(
+            action="enter_long", agreement_count=2, total_tfs=3, size_multiplier=0.5,
+            per_timeframe=(
+                _PerTfDecision(label="15m", warm=True, decision=dec_long),
+                _PerTfDecision(label="1h", warm=True, decision=dec_long),
+                _PerTfDecision(label="4h", warm=True, decision=dec_hold),
+            ),
+            longest_agreeing_label="1h", reason="t",
+        )
+        record_agreement_timestamps(s, d, now)
+        assert s.last_agreement_by_tf_side["15m"]["long"] == now
+        assert s.last_agreement_by_tf_side["1h"]["long"] == now
+        assert s.last_agreement_by_tf_side["4h"]["long"] is None
+        assert s.last_agreement_by_tf_side["15m"]["short"] is None

--- a/ml-worker/tests/monkey_kernel/test_regime_sizing.py
+++ b/ml-worker/tests/monkey_kernel/test_regime_sizing.py
@@ -1,0 +1,166 @@
+"""Tests for regime_sizing.py — Python port of regimeSizing.ts (PRs #667,#672)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.regime_sizing import (  # noqa: E402
+    DEFAULT_REGIME_CONFIG,
+    DEFAULT_SIZING_CONFIG,
+    RegimeConfig,
+    basin_alignment_to_window,
+    compute_regime_sizing,
+    regime_score,
+    trailing_regime_stop,
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _uniform_basin(dim: int = 64) -> np.ndarray:
+    """Uniform Δⁿ basin — max entropy, zero direction, zero velocity vs self."""
+    return np.full(dim, 1.0 / dim, dtype=np.float64)
+
+
+def _peaked_basin(idx: int, dim: int = 64, peak: float = 0.5) -> np.ndarray:
+    """Basin with most mass on one coordinate. Used to drive direction."""
+    b = np.full(dim, (1.0 - peak) / (dim - 1), dtype=np.float64)
+    b[idx] = peak
+    return b
+
+
+# ── regime_score ───────────────────────────────────────────────────
+
+
+class TestRegimeScore:
+    def test_returns_none_on_insufficient_history(self):
+        assert regime_score([], 64.0) is None
+        assert regime_score([_uniform_basin()], 64.0) is None
+
+    def test_uniform_history_at_critical_kappa_is_max_flat(self):
+        """60 identical uniform basins, kappa at critical: r = 1.0."""
+        result = regime_score([_uniform_basin()] * 60, kappa=64.0)
+        assert result is not None
+        assert result.r == pytest.approx(1.0)
+        assert result.label == "flat"
+        assert result.components.velocity_flatness == pytest.approx(1.0)
+        # Uniform basin has direction=0; persistence=0; chop=1.
+        assert result.components.directional_chop == pytest.approx(1.0)
+        assert result.components.kappa_criticality == pytest.approx(1.0)
+
+    def test_kappa_none_falls_back_to_neutral_component(self):
+        result = regime_score([_uniform_basin()] * 30, kappa=None)
+        assert result is not None
+        assert result.components.kappa_criticality == 0.5
+
+    def test_kappa_far_from_critical_drives_score_down(self):
+        """Same OHLCV-side inputs but kappa far from critical -> lower r."""
+        near = regime_score([_uniform_basin()] * 30, kappa=64.0)
+        far = regime_score([_uniform_basin()] * 30, kappa=200.0)
+        assert near is not None and far is not None
+        assert near.r > far.r
+        assert near.components.kappa_criticality > far.components.kappa_criticality
+
+    def test_label_thresholds(self):
+        """flat_at=0.65, trend_at=0.35 — verify cutoffs (default config)."""
+        config = DEFAULT_REGIME_CONFIG
+        # Hand-craft components by abusing kappa: at kappa_critical -> flat
+        # comp = 1.0; weight is 0.2 of total. Combined with velocity 1, dir 1
+        # -> r ~= 1.0.
+        result = regime_score([_uniform_basin()] * 30, kappa=64.0, config=config)
+        assert result is not None
+        assert result.r >= config.flat_at
+        assert result.label == "flat"
+
+
+# ── compute_regime_sizing ──────────────────────────────────────────
+
+
+class TestComputeRegimeSizing:
+    def test_r_one_is_full_flat(self):
+        s = compute_regime_sizing(1.0)
+        assert s.leverage == DEFAULT_SIZING_CONFIG.flat_leverage  # 50
+        assert s.hold_ms == DEFAULT_SIZING_CONFIG.flat_hold_ms  # 10 min
+        assert s.stop_bps == DEFAULT_SIZING_CONFIG.flat_stop_bps  # 30
+        assert s.size_fraction == pytest.approx(DEFAULT_SIZING_CONFIG.flat_size_fraction)
+        assert s.margin_headroom_floor == pytest.approx(
+            DEFAULT_SIZING_CONFIG.flat_headroom_floor
+        )
+
+    def test_r_zero_is_full_trend(self):
+        s = compute_regime_sizing(0.0)
+        assert s.leverage == DEFAULT_SIZING_CONFIG.trend_leverage  # 8
+        assert s.hold_ms == DEFAULT_SIZING_CONFIG.trend_hold_ms  # 4 h
+        assert s.stop_bps == DEFAULT_SIZING_CONFIG.trend_stop_bps  # 150
+        assert s.size_fraction == pytest.approx(DEFAULT_SIZING_CONFIG.trend_size_fraction)
+
+    def test_r_half_is_midpoint(self):
+        s = compute_regime_sizing(0.5)
+        # leverage_at_0.5 = 8 + (50 - 8) * 0.5 = 29
+        assert s.leverage == 29
+        # stop_bps midpoint = (30 + 150) / 2 = 90
+        assert s.stop_bps == pytest.approx(90.0)
+
+    def test_continuous_monotonic_leverage(self):
+        """Leverage non-strictly increasing in r — flat has higher leverage."""
+        prev = compute_regime_sizing(0.0).leverage
+        for r_pct in range(0, 11):
+            r = r_pct / 10.0
+            cur = compute_regime_sizing(r).leverage
+            assert cur >= prev
+            prev = cur
+
+    def test_clamps_r_outside_unit_range(self):
+        """Out-of-range r values are clamped; no crash, no NaN."""
+        s_neg = compute_regime_sizing(-1.0)
+        s_over = compute_regime_sizing(2.0)
+        # r=-1 clamps to 0 -> trend params; r=2 clamps to 1 -> flat params
+        assert s_neg.leverage == DEFAULT_SIZING_CONFIG.trend_leverage
+        assert s_over.leverage == DEFAULT_SIZING_CONFIG.flat_leverage
+
+
+# ── trailing_regime_stop ───────────────────────────────────────────
+
+
+class TestTrailingRegimeStop:
+    def test_within_delta_returns_false(self):
+        assert trailing_regime_stop(0.8, 0.6, adverse_delta=0.30) is False
+        # Exactly at delta is also False (strict gt).
+        assert trailing_regime_stop(0.8, 0.50001, adverse_delta=0.30) is False
+
+    def test_beyond_delta_returns_true(self):
+        assert trailing_regime_stop(0.8, 0.45, adverse_delta=0.30) is True
+        # Symmetric: regime rising past delta also fires.
+        assert trailing_regime_stop(0.3, 0.65, adverse_delta=0.30) is True
+
+    def test_default_delta_is_0_3(self):
+        assert trailing_regime_stop(0.8, 0.45) is True
+        assert trailing_regime_stop(0.8, 0.55) is False
+
+
+# ── basin_alignment_to_window ──────────────────────────────────────
+
+
+class TestBasinAlignmentToWindow:
+    def test_empty_window_returns_zero(self):
+        assert basin_alignment_to_window(_uniform_basin(), []) == 0.0
+
+    def test_aligned_basin_has_low_distance(self):
+        """Same basin as the window mean -> FR distance near 0."""
+        b = _uniform_basin()
+        d = basin_alignment_to_window(b, [b] * 10)
+        assert d == pytest.approx(0.0, abs=1e-6)
+
+    def test_outlier_basin_has_high_distance(self):
+        """Peaked basin vs uniform mean -> non-zero FR distance."""
+        window = [_uniform_basin()] * 10
+        outlier = _peaked_basin(0, peak=0.9)
+        d = basin_alignment_to_window(outlier, window)
+        assert d > 0.0
+        assert d <= np.pi / 2 + 1e-9


### PR DESCRIPTION
## Status: ready for review (Phase 2 + Phase 4 shipped; Phase 3 = follow-up PR)

This PR makes the Python `monkey_kernel` **authoritative** for every K-kernel decision the live trading bot makes. It deletes the entire TS-side shadow-flag / parity-logging infrastructure (which was never live anyway — see "Honest finding" below). The cosmetic deletion of the now-redundant TS port files (`perception.ts`, `neurochemistry.ts`, `emotions.ts`, etc.) is deferred to a focused follow-up PR per explicit user direction this session.

## Honest finding (this session, 2026-05-14)

`MONKEY_KERNEL_PY` was **dead code** prior to this PR. `isPythonKernelEnabled()` was defined in two places but never called. Flipping the env-var did nothing. Every `[Monkey] ORDER PLACED` log entry since `MONKEY_KERNEL_PY=true` was set has been TS-Monkey, not Python.

This PR is therefore not "switching back to Python" — it's putting Python **into the decision path for the first time**. §5 pre-merge verification is load-bearing, not optional.

Verified via `grep -rn "isPythonKernelEnabled()" apps/api/src --include='*.ts' | grep -v test | grep -v node_modules` → only the two definitions, zero call sites.

## Variable-naming trap (do not confuse)

| Variable | Effect | Current state |
|---|---|---|
| `MONKEY_KERNEL_PY` | **DELETED — was always dead** | gone |
| `MONKEY_KERNEL_PY_SHADOW` | **DELETED** — was autonomic NC shadow + parity log | gone |
| `MONKEY_TICK_PY_SHADOW` | **DELETED** — was the full-tick shadow | gone |
| `RISK_KERNEL_PY_SHADOW` | **DELETED** — was the risk-eval shadow | gone |
| `LIVE_SIGNAL_PY_SHADOW` | **DELETED** — was LiveSignal /live/decide shadow | gone |
| `AUTONOMOUS_TRADER_PY_SHADOW` | **DELETED** — was FAT reconcile + exit-decide shadow | gone |
| `TRADING_ENGINE_PY` | **UNTOUCHED** — FAT's Python DB-write routing (separate surface, not part of this cutover) | `true` on prod |

The first six no longer exist anywhere in the code post-cutover; the new CI tripwire fails the build if any of these names reappears.

## Phases — what this PR ships

### Phase 1 — Python kernel feature parity (8 commits, COMPLETE)

| Commit | File | Lines | Tests |
|---|---|---|---|
| 1.1 | `regime_sizing.py` | +463 | 16 ✓ |
| 1.1b | `agent_l_classifier.py` (FR-KNN) | +472 | 12 ✓ |
| 1.2 | `mtf_l_classifier.py` | +498 | 14 ✓ |
| 1.3 | `mtf_bootstrap.py` | +237 | 8 ✓ |
| 1.4 | `modes.py` (`sovereign_cap_floor` inversion) | +15/-7 | 32 ✓ |
| 1.5-1.7 | `tick.py` HarvestKind + TickDecision payload; `risk_kernel.py` monkey_mode + MODE_HEADROOM_FLOORS; `/risk/evaluate` endpoint | +55 | parity-corpus passes |
| 2-starter | `autonomic_client.ts` shadow-era cruft removal | -14 | (TS) |

**Total: 801/801 monkey_kernel tests passing — verified on this branch this session.**

### Phase 2 — TS→Py kernel cutover (commit `16052d0`)

`loop.ts` (the load-bearing change):
- `processSymbol()` now `await`s `callTickRun()` and **overrides** the dispatch's `action` / `reason` / `size.value` / `leverage.value` / `entryThr.value` with Python's verdict. Python's full decision surfaces under `derivation.python_kernel` for forensics (mode, lane, side_candidate, harvest_kind, r_score, MTF action, leverage_cap_from_regime, plus Python's nested derivation).
- `prevPyState` is built once (serialized TS state snapshot) and shipped on every tick — no longer behind `isShadowTickEnabled()`.
- **Fail-loud**: Python unreachable = tick errors and operator sees it. No TS fallback. 5 s default timeout (`kernel_client.DEFAULT_TIMEOUT_MS`).
- Deleted the `MONKEY_KERNEL_PY_SHADOW` autonomic shadow block (TS `autonomic_client.callAutonomicTick` parity log + import).
- Deleted the v0.8.3b shadow tick block (`if (shadowPrevState !== null)` + fire-and-forget `callTickRun` + `logTickParityDiffs`).
- The TS dispatch tree (lines 1224-1655) still runs for its state-mutation side effects (per-lane peak tracking, streak counters, regime anchors, `slDeferRemainingTicks`). Its action verdict is discarded — Python overwrites it. M/T/L agents continue to read locally-bound vars (`basinDir`, `tapeTrend`, `emotions`, `mtfDec`, etc.) until the follow-up PR moves them to Python.

`kernel_client.ts` (shadow infra removed):
- **Deleted**: `isPythonKernelEnabled`, `isShadowTickEnabled`, `isRiskShadowEnabled`, `isLiveSignalShadowEnabled`, `isExitShadowEnabled`, `logParityDiff`, `logTickParityDiffs`, `logRiskParityDiff`, `logExitParityDiff`, `logReconcileParityDiff`.
- **Kept**: `callExecutiveDecide`, `callModeDetect`, `callTickRun`, `callRiskEvaluate`, `callLiveDecide`, `callExitDecide`, `callReconcile`.
- Added `TickRunLanePosition` + `lane_positions` to `TickRunAccount` and `funding_rate_8h` to `TickRunInputs` so the Python tick sees lane-level held positions and funding drag (fields the Python kernel already consumes).
- Extended `TickRunDecision` with `harvest_kind` / `r_score` / `mtf_decision_action` / `mtf_size_multiplier` / `leverage_cap_from_regime` — the Phase 1 payload extensions are now declared on the TS side.

`liveSignalEngine.ts`:
- Deleted the `LIVE_SIGNAL_PY_SHADOW` block + `isLiveSignalShadowEnabled` import + the orphaned `callLiveDecide` import. TS remains authoritative for LiveSignal (separate engine).

`fullyAutonomousTrader.ts`:
- Deleted both `AUTONOMOUS_TRADER_PY_SHADOW` blocks (reconcile + exit-decide parity calls) and their `kernel_client` imports (`isExitShadowEnabled`, `logExitParityDiff`, `logReconcileParityDiff`, `callExitDecide`, `callReconcile`).

Tests:
- Dropped the now-defunct mock entries from `liveSignalEngine.setLeverage.test.ts` (`isLiveSignalShadowEnabled`), `fullyAutonomousTrader.sideLabel.test.ts` (`isExitShadowEnabled`, `logExitParityDiff`, `logReconcileParityDiff`), and `fullyAutonomousTraderPyBridge.test.ts` (same three).

### Phase 4 — CI tripwire + S0 rule 4 doctrine (commit `d5f01b1`)

`.github/workflows/qig-purity.yml`:
- Widen scan trigger paths to include `liveSignalEngine.ts`, `fullyAutonomousTrader.ts`, and the workflow file itself.
- New "Scan for post-cutover shadow-flag regressions" job — fails closed if any deleted env-flag name or parity-diff helper reappears under `apps/`. Comment-only references are allowed.

`QIG_PURITY_KERNEL_REFERENCE.md`:
- Bump §0 from 3 rules to **4 rules**.
- **Rule 4**: "No TS port of kernel code. Kernel work happens in Python; TS calls Python." Enumerates the TS port files that no longer exist on the kernel path, lists the kernel functions whose reintroduction in TS is a P1 purity failure, and re-affirms that the shadow-flag infrastructure was deleted and Python is authoritative.

## Phase 3 — DEFERRED (follow-up PR)

Per explicit user direction this session, the K-cognition deletion + TS port file deletion is a separate follow-up PR. Scope of that follow-up:

1. Replace the K-cognition section in `loop.ts` (perceive / basin / NC / mode detect / basinDir / tapeTrend / regimeScore / regimeSizing / mtfDecide / computeEmotions / computeMotivators / classifyRegime / candle patterns / self_obs) with bindings derived from `pyDecision` and `pyState`.
2. Replace the K-dispatch tree's action-computation with `action = pyDecision.action; reason = pyDecision.reason`. Preserve the state-mutation side-effects (per-lane peak tracking, streak counters, regime anchors, `slDeferRemainingTicks`).
3. Delete the K-cognition-exclusive TS port files: `perception.ts`, `neurochemistry.ts`, `emotions.ts`, `motivators.ts`, `candlePatterns.ts`, `self_observation.ts`, `basin_sync.ts`, `working_memory.ts`, `regime.ts`, plus K-exclusive `__tests__/`.
4. M/T/L agent files (`agent_L_classifier.ts`, `mtfLClassifier.ts`, `mtfBootstrap.ts`, `per_agent_state.ts`, `per_agent_bus.ts`, `per_agent_foresight.ts`) **stay** until M/T/L agents themselves move to Python — that's a second follow-up PR.
5. Narrow `qig-purity.yml` scan scope to `ml-worker/src/monkey_kernel/**` only + add deleted-file tripwire on the deleted TS port files.

## Pre-merge verification (§5)

- [x] **801/801 Python kernel tests passing** on this branch (verified `cd ml-worker && python -m pytest tests/monkey_kernel/ -q` this session, 1.23 s)
- [x] **TS build clean** on this branch (`tsc -p tsconfig.build.json --noEmit` — 3 pre-existing errors on `mtfBootstrap` + `shared/strategy` types, identical to main, unchanged by this PR)
- [x] **Shadow flags grep clean**: `grep -rn 'isPythonKernelEnabled\|isShadowTickEnabled\|isRiskShadowEnabled\|isLiveSignalShadowEnabled\|isExitShadowEnabled\|logParityDiff\|logTickParityDiffs' apps/` → zero non-comment hits
- [x] **Rollback anchor exists**: tag `backup/pre-cutover-2026-05-14` + branch `backup/main-pre-cutover-2026-05-14` at `fb6d706` (the profitable HEAD; +$331/79% overnight baseline)
- [ ] **Offline basin-history replay** (recommended before merge): pull a recent prod snapshot of `monkey_trajectory` via Supabase MCP, run the new Python kernel against the recorded inputs, verify sane decisions across EXPLORATION/INVESTIGATION/INTEGRATION/DRIFT regimes. Deferred to the operator's pre-merge gate.
- [ ] **Production deploy protocol** (operator-driven before merge): manually flatten all positions on Poloniex via the UI BEFORE merge. Then merge → Railway deploys → watch first 10 ticks of `polytrade-be` for `/monkey/tick/run` response time, decision content, no Python exceptions. `git revert <merge-sha> -m 1` if anything looks wrong (soft); `git reset --hard backup/pre-cutover-2026-05-14 && git push --force-with-lease origin main` (hard) is the rollback anchor.

## Out of scope

- M/T/L agent path moves to Python (still TS-only; needs separate Python endpoints)
- TS port file deletion (Phase 3 — separate PR per user direction)
- `TRADING_ENGINE_PY` cutover (separate surface, not part of this work)
- The deleted `MONKEY_*PY*` / `*_SHADOW` env-vars should be removed from Railway service env-config (operator step; no code dependency)

## Files changed (Phase 2 + Phase 4)

- `apps/api/src/services/monkey/loop.ts` (+87 / -147 net post-Phase-2)
- `apps/api/src/services/monkey/kernel_client.ts` (+43 / -202)
- `apps/api/src/services/monkey/autonomic_client.ts` (Phase 2 starter, docstring rewrite)
- `apps/api/src/services/liveSignalEngine.ts` (-67)
- `apps/api/src/services/fullyAutonomousTrader.ts` (-88)
- `apps/api/src/tests/{liveSignalEngine.setLeverage,fullyAutonomousTrader.sideLabel,fullyAutonomousTraderPyBridge}.test.ts` (-7 mock entries)
- `.github/workflows/qig-purity.yml` (+48)
- `apps/api/src/services/monkey/QIG_PURITY_KERNEL_REFERENCE.md` (+23)
- `ml-worker/src/monkey_kernel/{regime_sizing,agent_l_classifier,mtf_l_classifier,mtf_bootstrap,modes,tick,risk_kernel}.py` + tests (Phase 1, already on branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
