### PR TITLE
fix(monkey): MTF 1h bootstrap uses '1h' not '60m'

### DIFF
--- a/apps/api/src/services/monkey/mtfBootstrap.ts
+++ b/apps/api/src/services/monkey/mtfBootstrap.ts
@@ -47,7 +47,7 @@ const BOOTSTRAP_CANDLE_COUNT = 700;
  *  encodes the perceptual scale via perceive(). */
 const POLONIEX_INTERVAL_FOR_TF: Record<TimeframeLabel, string> = {
   '15m': '15m',
-  '1h': '60m',
+  '1h': '1h',
   '4h': '4h',
 };
 


### PR DESCRIPTION
## Summary

One-line typo fix in [mtfBootstrap.ts:50](apps/api/src/services/monkey/mtfBootstrap.ts#L50). Poloniex v3 kline endpoint rejects \`60m\` as a granularity — valid set is \`1m/5m/15m/30m/1h/2h/4h/12h/1d\`.

PR #671 introduced the typo, so the 1h MTF instance has been failing bootstrap since merge:

\`\`\`
ERROR: Error: Invalid interval: 60m. Use 1m, 5m, 15m, 30m, 1h, 2h, 4h, 12h, or 1d
\`\`\`

15m and 4h timeframes bootstrap fine. Impact: 1h MTF warms from live ticks instead of OHLCV — slower MTF strength for hours post-restart, no other regression. Bot has been trading normally through this — verified in tonight's logs (BTC/ETH shorts at 16× placing fine, mode transitions firing).

## Test plan

- [x] yarn build passes locally
- [ ] CI type-check + purity gate green
- [ ] Railway redeploy succeeds; next ml-worker restart shows successful 1h bootstrap log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix 1h MTF bootstrap failures caused by using an unsupported '60m' Poloniex granularity.