### PR TITLE
fix(livesignal): forward posSide to placeOrder on HEDGE accounts (#11011)

### DIFF
--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -1272,15 +1272,29 @@ export class LiveSignalEngine extends EventEmitter {
     }
 
     // 2. Market order — this is the point of no return.
+    //
+    // 2026-05-14 fix: forward ``posSide`` (computed above from
+    // ``positionDirectionMode``) via the third-arg opts so the request
+    // body carries ``posSide: LONG | SHORT`` on HEDGE accounts. Without
+    // it, ``poloniexFuturesService.placeOrder`` defaults the body to
+    // ``posSide: BOTH``, which Poloniex v3 rejects on HEDGE accounts
+    // with code=11011 "Position mode and posSide do not match" — the
+    // exact failure observed since ~2026-05-14T00:53Z on prod. setLeverage
+    // already forwards posSide just above (line 1192) so the leverage
+    // call succeeded while the order itself failed every tick.
     let orderId: string | undefined;
     try {
-      const exchangeOrder = await poloniexFuturesService.placeOrder(credentials, {
-        symbol: order.symbol,
-        side: exchangeSide,
-        type: 'market',
-        size: formattedSize,
-        lotSize: symbolLotSize,
-      });
+      const exchangeOrder = await poloniexFuturesService.placeOrder(
+        credentials,
+        {
+          symbol: order.symbol,
+          side: exchangeSide,
+          type: 'market',
+          size: formattedSize,
+          lotSize: symbolLotSize,
+        },
+        posSide ? { posSide } : {},
+      );
       // Poloniex v3 futures returns the exchange order id as `ordId`.
       // Keep `orderId`/`id` fallbacks so mocked tests + any future
       // adapter variants still work without changing this line.

--- a/apps/api/src/tests/liveSignalEngine.setLeverage.test.ts
+++ b/apps/api/src/tests/liveSignalEngine.setLeverage.test.ts
@@ -158,3 +158,62 @@ describe('LiveSignalEngine.submitOrder — HEDGE-mode setLeverage posSide', () =
     expect(priv(engine).positionDirectionMode).toBe('HEDGE');
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 2026-05-14 hotfix regression cover — placeOrder posSide on HEDGE.
+//
+// On 2026-05-14T00:53Z prod started emitting code=11011 "Position mode and
+// posSide do not match" on every LiveSignal tick. Root cause: submitOrder
+// forwarded posSide to setLeverage but NOT to placeOrder, so the order body
+// defaulted to posSide=BOTH and HEDGE accounts rejected it. setLeverage's
+// posSide plumbing is locked by the suite above; this suite locks the
+// matching placeOrder plumbing so a future refactor can't regress it.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('LiveSignalEngine.submitOrder — HEDGE-mode placeOrder posSide (#11011 hotfix)', () => {
+  let engine: LiveSignalEngine;
+
+  beforeEach(() => {
+    engine = new LiveSignalEngine();
+    vi.mocked(poloniexFuturesService.setLeverage).mockClear();
+    vi.mocked(poloniexFuturesService.placeOrder).mockClear().mockResolvedValue({ ordId: 'mock-order-id' } as never);
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockReset();
+  });
+
+  it('HEDGE + long order → placeOrder receives opts = { posSide: \'LONG\' }', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'HEDGE' } as never);
+
+    const order = { symbol: 'BTC_USDT_PERP', side: 'long' as const, notional: 50, leverage: 10, price: 50000 };
+    await priv(engine).submitOrder(order, SIGNAL, 100, 'user-1', CREDS);
+
+    expect(poloniexFuturesService.placeOrder).toHaveBeenCalledTimes(1);
+    const [, orderData, opts] = vi.mocked(poloniexFuturesService.placeOrder).mock.calls[0];
+    expect(orderData).toEqual(
+      expect.objectContaining({ symbol: 'BTC_USDT_PERP', side: 'buy', type: 'market' }),
+    );
+    expect(opts).toEqual({ posSide: 'LONG' });
+  });
+
+  it('HEDGE + short order → placeOrder receives opts = { posSide: \'SHORT\' }', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'HEDGE' } as never);
+
+    const order = { symbol: 'ETH_USDT_PERP', side: 'short' as const, notional: 50, leverage: 20, price: 2250 };
+    await priv(engine).submitOrder(order, SIGNAL, 100, 'user-1', CREDS);
+
+    expect(poloniexFuturesService.placeOrder).toHaveBeenCalledTimes(1);
+    const [, , opts] = vi.mocked(poloniexFuturesService.placeOrder).mock.calls[0];
+    expect(opts).toEqual({ posSide: 'SHORT' });
+  });
+
+  it('ONE_WAY mode → placeOrder receives opts = {} (posSide omitted)', async () => {
+    vi.mocked(poloniexFuturesService.getPositionDirectionMode).mockResolvedValue({ posMode: 'ONE_WAY' } as never);
+
+    const order = { symbol: 'BTC_USDT_PERP', side: 'long' as const, notional: 50, leverage: 10, price: 50000 };
+    await priv(engine).submitOrder(order, SIGNAL, 100, 'user-1', CREDS);
+
+    expect(poloniexFuturesService.placeOrder).toHaveBeenCalledTimes(1);
+    const [, , opts] = vi.mocked(poloniexFuturesService.placeOrder).mock.calls[0];
+    expect(opts).toEqual({});
+    expect(opts).not.toHaveProperty('posSide');
+  });
+});


### PR DESCRIPTION
## Production incident

polytrade-be has been failing every LiveSignal order since **2026-05-14T00:53Z** with:

\`\`\`
Poloniex /v3/trade/order returned code=11011: Position mode and posSide do not match
\`\`\`

Every minute, every tick. ~90 minutes of bleeding before detection. Sample from Railway logs:

\`\`\`
2026-05-14T00:53:17.626Z [ERROR]: Poloniex v3 futures API request error: ... code=11011 ...
2026-05-14T00:53:17.626Z [ERROR]: [LiveSignal] exchange placeOrder failed { err: ... }
\`\`\`

## Root cause

[\`liveSignalEngine.submitOrder()\`](apps/api/src/services/liveSignalEngine.ts) computes a HEDGE-aware \`posSide\` at lines 1191-1194 from the cached \`positionDirectionMode\`, then forwards it to \`setLeverage\` (line 1199). The *very next* call — \`placeOrder\` at line 1210 — was constructed **without that opts argument**, so [\`poloniexFuturesService.placeOrder\`](apps/api/src/services/poloniexFuturesService.js#L648) defaulted the request body to \`posSide: 'BOTH'\`. On a HEDGE-mode account, Poloniex v3 rejects \`BOTH\` with **code=11011**.

\`setLeverage\` succeeded every tick (posSide forwarded). \`placeOrder\` failed every tick (posSide dropped). The leverage call's success masked the failure mode in observability dashboards — the order rejection only surfaced in the structured error log.

The Monkey kernel's [\`executeEntry\`](apps/api/src/services/monkey/loop.ts#L4192-L4194) already does this correctly (\`placeOrder(creds, body, posSide ? { posSide } : {})\`), which is why Monkey orders kept landing through the same window.

## Fix

Thread the same \`posSide ? { posSide } : {}\` opts through LiveSignal's \`placeOrder\` call so the body carries \`posSide: LONG | SHORT\` on HEDGE accounts and stays \`BOTH\` on ONE_WAY.

Single 9-line change in [\`liveSignalEngine.ts\`](apps/api/src/services/liveSignalEngine.ts):

\`\`\`diff
- const exchangeOrder = await poloniexFuturesService.placeOrder(credentials, {
-   symbol: order.symbol,
-   side: exchangeSide,
-   type: 'market',
-   size: formattedSize,
-   lotSize: symbolLotSize,
- });
+ const exchangeOrder = await poloniexFuturesService.placeOrder(
+   credentials,
+   {
+     symbol: order.symbol,
+     side: exchangeSide,
+     type: 'market',
+     size: formattedSize,
+     lotSize: symbolLotSize,
+   },
+   posSide ? { posSide } : {},
+ );
\`\`\`

## Regression coverage

3 new tests in [\`liveSignalEngine.setLeverage.test.ts\`](apps/api/src/tests/liveSignalEngine.setLeverage.test.ts) under describe \`"HEDGE-mode placeOrder posSide (#11011 hotfix)"\`:

- HEDGE + long → \`opts = { posSide: 'LONG' }\`
- HEDGE + short → \`opts = { posSide: 'SHORT' }\`
- ONE_WAY → \`opts = {}\` (posSide omitted)

All 7 tests in the file pass (4 setLeverage + caching + 3 new placeOrder). tsc clean.

## Deploy plan

Standard merge → Railway auto-deploys polytrade-be. The next LiveSignal tick after deploy should print \`[LiveSignal] exchange order placed\` instead of the 11011 error.

## Test plan
- [x] All 7 tests pass in \`liveSignalEngine.setLeverage.test.ts\`
- [x] All 6 tests pass in \`poloniexFuturesService.placeOrder.hedge.test.js\`
- [x] \`tsc -p tsconfig.build.json --noEmit\` clean (no new errors)
- [ ] Post-merge: watch first 5 LiveSignal ticks for \`exchange order placed\` log lines (no 11011)
- [ ] Post-merge: verify Monkey unaffected (its placeOrder was always correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure LiveSignal futures orders pass the correct position side to Poloniex in HEDGE mode to prevent code=11011 rejections and add regression coverage for this behavior.

Bug Fixes:
- Forward the computed HEDGE-mode posSide through LiveSignalEngine.submitOrder to poloniexFuturesService.placeOrder so HEDGE accounts no longer receive code=11011 "Position mode and posSide do not match" errors.

Tests:
- Add regression tests verifying that submitOrder sends posSide=LONG/SHORT on HEDGE accounts and omits posSide on ONE_WAY accounts when calling placeOrder.