### PR TITLE
fix(reconciler): side-aware mismatch detection (phantom-row 21002 spam)

### DIFF
--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -1232,7 +1232,19 @@ class FullyAutonomousTrader extends EventEmitter {
 
   /**
    * Reconcile DB position state with actual exchange positions.
-   * Logs drift but does not auto-close — lets the human investigate.
+   *
+   * 2026-05-14 fix: now side-aware. The legacy implementation only
+   * checked symbol-level presence (``new Set(exchangePositions.map(symbol))``)
+   * which silently skipped the case where the DB had a LONG row but the
+   * exchange had a same-symbol SHORT — both "contain BTC" so the
+   * symbol-only set diff yielded an empty mismatch list. Net effect on
+   * 2026-05-14: 3 BTC LONG rows in DB sat as phantoms for 50+ minutes
+   * after Poloniex netted them against a SHORT, and Monkey's
+   * stale_bleed gate spun every 30 s firing close orders that returned
+   * code=21002 "Position not enough". This implementation builds a
+   * per-symbol set of OPEN exchange sides (HEDGE-aware via ``posSide``,
+   * ONE_WAY fallback via ``Math.sign(qty)``) and closes any DB row
+   * whose ``(symbol, side)`` pair is not represented on the exchange.
    */
   private async reconcilePositions(userId: string): Promise<void> {
     try {
@@ -1241,22 +1253,54 @@ class FullyAutonomousTrader extends EventEmitter {
 
       // Get actual positions from Poloniex
       const exchangePositions = await poloniexFuturesService.getPositions(credentials);
-      const openSymbols = new Set(
-        (exchangePositions || [])
-          .filter((p: Record<string, unknown>) => Number(p.qty || p.currentQty || 0) !== 0)
-          .map((p: Record<string, unknown>) => String(p.symbol))
-      );
 
-      // Get DB open trades (non-paper)
+      // Build per-symbol set of OPEN exchange sides ('long' | 'short').
+      // HEDGE-aware: posSide=LONG → 'long', posSide=SHORT → 'short';
+      // ONE_WAY fallback: Math.sign(qty) decides side. Same resolution
+      // order used by managePositions's [FAT] side-label fix.
+      const exchangeSidesBySymbol = new Map<string, Set<'long' | 'short'>>();
+      for (const raw of (exchangePositions || []) as unknown[]) {
+        const p = raw as Record<string, unknown>;
+        const qty = Number(p.qty ?? p.currentQty ?? 0);
+        if (qty === 0) continue;
+        const symbol = String(p.symbol ?? '');
+        if (!symbol) continue;
+        const posSide = String(p.posSide ?? '').toUpperCase();
+        const side: 'long' | 'short' =
+          posSide === 'SHORT' || (posSide !== 'LONG' && qty < 0) ? 'short' : 'long';
+        if (!exchangeSidesBySymbol.has(symbol)) {
+          exchangeSidesBySymbol.set(symbol, new Set());
+        }
+        exchangeSidesBySymbol.get(symbol)!.add(side);
+      }
+      const openSymbols = new Set(exchangeSidesBySymbol.keys());
+
+      // Get DB open trades (non-paper). Fetches the row id + side so the
+      // side-aware mismatch check below can target specific rows.
       const dbResult = await pool.query(
-        `SELECT symbol, order_id FROM autonomous_trades
+        `SELECT id, symbol, side, order_id FROM autonomous_trades
          WHERE user_id = $1 AND status = 'open' AND paper_trade = false`,
         [userId]
       );
-      const dbSymbols = new Set(dbResult.rows.map((r: { symbol: string }) => r.symbol));
+      const dbRows = dbResult.rows as Array<{
+        id: string;
+        symbol: string;
+        side: string;
+        order_id?: string;
+      }>;
+      const dbSymbols = new Set(dbRows.map(r => r.symbol));
 
-      // Drift detection
-      const inDbNotExchange = [...dbSymbols].filter(s => !openSymbols.has(s));
+      // Side-aware phantom detection: a row is phantom when the exchange
+      // either has NO position on that symbol, OR has a position but on
+      // the OPPOSITE side. The latter is the 2026-05-14 trigger case.
+      const sideMismatchedRows = dbRows.filter(r => {
+        const sideRaw = String(r.side).toLowerCase();
+        const sideNorm: 'long' | 'short' =
+          sideRaw === 'sell' || sideRaw === 'short' ? 'short' : 'long';
+        const exchSides = exchangeSidesBySymbol.get(r.symbol);
+        return !exchSides || !exchSides.has(sideNorm);
+      });
+      const inDbNotExchange = [...new Set(sideMismatchedRows.map(r => r.symbol))];
       const inExchangeNotDb = ([...openSymbols] as string[]).filter(s => !dbSymbols.has(s));
 
       // v0.8.7d-4: fire-and-forget shadow call to /live/reconcile. TS
@@ -1292,19 +1336,31 @@ class FullyAutonomousTrader extends EventEmitter {
         });
       }
 
-      if (inDbNotExchange.length > 0) {
+      if (sideMismatchedRows.length > 0) {
         logger.warn(
-          `[RECONCILE] DB shows open positions not on exchange: ${inDbNotExchange.join(', ')} — ` +
-          `marking as closed`
+          `[RECONCILE] DB rows open but exchange has no matching side: ` +
+          `${sideMismatchedRows.length} row(s) on symbols ${inDbNotExchange.join(', ')} — ` +
+          `marking as closed`,
+          {
+            rows: sideMismatchedRows.map(r => ({
+              id: r.id, symbol: r.symbol, side: r.side,
+            })),
+            exchangeSidesBySymbol: Object.fromEntries(
+              [...exchangeSidesBySymbol.entries()].map(([k, v]) => [k, [...v]]),
+            ),
+          },
         );
-        for (const symbol of inDbNotExchange) {
-          await pool.query(
-            `UPDATE autonomous_trades SET status = 'closed', exit_time = NOW(),
-             exit_reason = 'reconciliation: position not found on exchange'
-             WHERE user_id = $1 AND symbol = $2 AND status = 'open' AND paper_trade = false`,
-            [userId, symbol]
-          );
-        }
+        // Close the specific phantom rows by id. Using ANY($1::uuid[])
+        // targets only the mismatched rows, NOT all open rows for the
+        // symbol — important because a same-symbol opposite-side row
+        // CAN legitimately coexist (e.g., HEDGE-mode lane-isolated
+        // positions), and bulk-closing by symbol would over-reach.
+        await pool.query(
+          `UPDATE autonomous_trades SET status = 'closed', exit_time = NOW(),
+           exit_reason = 'reconciliation: side mismatch with exchange'
+           WHERE id = ANY($1::uuid[])`,
+          [sideMismatchedRows.map(r => r.id)],
+        );
       }
 
       if (inExchangeNotDb.length > 0) {

--- a/apps/api/src/tests/fullyAutonomousTrader.reconcilerSideMismatch.test.ts
+++ b/apps/api/src/tests/fullyAutonomousTrader.reconcilerSideMismatch.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the FAT reconciler side-aware-mismatch fix (2026-05-14).
+ *
+ * Background:
+ *   Production incident 2026-05-14T03:24Z onward: 3 BTC LONG DB rows
+ *   sat as phantoms for 50+ minutes after Poloniex netted them against
+ *   an external SHORT. The legacy reconciler did a symbol-level diff —
+ *   ``Set<string>`` of DB symbols vs ``Set<string>`` of exchange
+ *   symbols — which evaluated "BTC in DB" ∧ "BTC on exchange" =
+ *   match, NOT mismatched. So no UPDATE ran. Monkey's stale_bleed gate
+ *   then spun every 30 s, firing close orders that came back with
+ *   ``code=21002 Position not enough`` because the exchange's BTC was
+ *   actually a SHORT, not the LONG the DB row was trying to close.
+ *
+ *   Root cause: symbol-only set difference. Fix: build a per-symbol
+ *   ``Set<'long' | 'short'>`` from exchangePositions and require each
+ *   DB row's ``(symbol, side)`` to be in that set; close the rows
+ *   that aren't, by id (NOT by symbol — same-symbol opposite-side
+ *   rows can coexist in HEDGE-mode lane isolation).
+ *
+ * Coverage:
+ *   1. DB long, exchange long (ONE_WAY shape) — no UPDATE.
+ *   2. DB long, exchange short (the 2026-05-14 failure shape) — UPDATE
+ *      fires and closes the specific id with reason='reconciliation:
+ *      side mismatch with exchange'.
+ *   3. DB short, exchange long (mirror of #2) — same behavior.
+ *   4. DB short, exchange long+short HEDGE-mode (both sides open) —
+ *      no UPDATE: the short DB row matches the exchange's short side.
+ *   5. DB row, exchange has no position on the symbol at all — UPDATE
+ *      fires (legacy "symbol entirely missing" case still handled).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../db/connection.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) }
+}));
+vi.mock('../services/poloniexFuturesService.js', () => ({
+  default: {
+    getPositions: vi.fn(),
+    closePosition: vi.fn().mockResolvedValue({}),
+    normalizeSymbol: vi.fn((s: string) => s),
+    getAccountBalance: vi.fn().mockResolvedValue({ eq: '10000' }),
+  }
+}));
+vi.mock('../services/riskService.js', () => ({ default: {} }));
+vi.mock('../services/mlPredictionService.js', () => ({ default: {} }));
+vi.mock('../services/apiCredentialsService.js', () => ({
+  apiCredentialsService: { getCredentials: vi.fn() }
+}));
+vi.mock('../utils/marketDataValidator.js', () => ({ validateMarketData: vi.fn() }));
+vi.mock('../services/marketCatalog.js', () => ({ getPrecisions: vi.fn() }));
+vi.mock('../services/monitoringService.js', () => ({
+  monitoringService: { recordPipelineHeartbeat: vi.fn(), recordTradeEvent: vi.fn() }
+}));
+vi.mock('../utils/engineVersion.js', () => ({ getEngineVersion: () => 'v-test' }));
+vi.mock('../services/backtestingEngine.js', () => ({ default: {} }));
+vi.mock('../services/simpleMlService.js', () => ({ default: {} }));
+vi.mock('../services/monkey/kernel_client.js', () => ({
+  callExitDecide: vi.fn(),
+  callReconcile: vi.fn(),
+  isExitShadowEnabled: vi.fn(() => false),
+  logExitParityDiff: vi.fn(),
+  logReconcileParityDiff: vi.fn(),
+}));
+vi.mock('../services/signalGenome.js', () => ({
+  buildIndicatorMap: vi.fn(() => new Map()),
+  evaluateGenomeEntry: vi.fn(() => ({ action: 'HOLD', score: 0 })),
+}));
+
+import { FullyAutonomousTrader } from '../services/fullyAutonomousTrader.js';
+import { pool } from '../db/connection.js';
+import poloniexFuturesService from '../services/poloniexFuturesService.js';
+import { apiCredentialsService } from '../services/apiCredentialsService.js';
+
+function priv(t: FullyAutonomousTrader) {
+  return t as unknown as {
+    reconcilePositions: (userId: string) => Promise<void>;
+  };
+}
+
+const USER = 'test-user-reconcile';
+
+/**
+ * Stub pool.query with SQL-pattern matching. The FAT constructor's
+ * loadConfigs() also calls pool.query, so a naive ``mockResolvedValueOnce``
+ * gets consumed before reconcilePositions runs. Discriminating on the
+ * SQL text lets us return the test's DB rows ONLY for the reconciler's
+ * SELECT and ``{ rows: [] }`` for everything else (loadConfigs, the
+ * logAgentEvent INSERT into agent_events, etc.).
+ */
+function stubReconcilerQueries(rows: Array<{ id: string; symbol: string; side: string }>) {
+  vi.mocked(pool.query).mockReset();
+  vi.mocked(pool.query).mockImplementation((async (sql: unknown) => {
+    const sqlStr = typeof sql === 'string' ? sql : '';
+    if (sqlStr.includes('SELECT id, symbol, side, order_id')) {
+      return { rows } as never;
+    }
+    return { rows: [] } as never;
+  }) as never);
+}
+
+/** Find the FIRST pool.query call whose SQL contains the given substring. */
+function findCallContaining(substr: string): { args: unknown[] } | null {
+  const calls = (pool.query as ReturnType<typeof vi.fn>).mock.calls;
+  for (const c of calls) {
+    const sql = typeof c[0] === 'string' ? c[0] : '';
+    if (sql.includes(substr)) return { args: c as unknown[] };
+  }
+  return null;
+}
+
+beforeEach(() => {
+  vi.mocked(apiCredentialsService.getCredentials).mockResolvedValue({
+    apiKey: 'k', apiSecret: 's',
+  } as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('FAT reconcilePositions — side-aware mismatch (#11011/phantom-row fix)', () => {
+  // ────────────────────────────────────────────────────────────────────────
+  // 1. ONE_WAY long match — no UPDATE fires.
+  // ────────────────────────────────────────────────────────────────────────
+  it('ONE_WAY long DB + long exchange (positive qty) → no UPDATE', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      { symbol: 'BTC_USDT_PERP', qty: '0.027' },  // long: positive qty, no posSide
+    ] as never);
+    stubReconcilerQueries([
+      { id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', symbol: 'BTC_USDT_PERP', side: 'buy' },
+    ]);
+    const trader = new FullyAutonomousTrader();
+
+    await priv(trader).reconcilePositions(USER);
+
+    // The reconciler's SELECT fires; no UPDATE-autonomous-trades call.
+    expect(findCallContaining('SELECT id, symbol, side, order_id')).not.toBeNull();
+    expect(findCallContaining('UPDATE autonomous_trades')).toBeNull();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // 2. The 2026-05-14 failure shape: DB long, exchange short — UPDATE fires.
+  // ────────────────────────────────────────────────────────────────────────
+  it('DB long + exchange SHORT (HEDGE posSide) → UPDATE closes the DB row by id', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      { symbol: 'BTC_USDT_PERP', qty: '0.137', posSide: 'SHORT' },  // exchange has SHORT
+    ] as never);
+    stubReconcilerQueries([
+      { id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', symbol: 'BTC_USDT_PERP', side: 'buy' },
+    ]);
+    const trader = new FullyAutonomousTrader();
+
+    await priv(trader).reconcilePositions(USER);
+
+    const upd = findCallContaining('UPDATE autonomous_trades');
+    expect(upd).not.toBeNull();
+    const [updateSql, updateParams] = upd!.args as [string, unknown[]];
+    expect(updateSql).toContain("status = 'closed'");
+    expect(updateSql).toContain("exit_reason = 'reconciliation: side mismatch with exchange'");
+    expect(updateSql).toContain('id = ANY($1::uuid[])');
+    expect(updateParams[0]).toEqual(['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa']);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // 3. Mirror: DB short + exchange long.
+  // ────────────────────────────────────────────────────────────────────────
+  it('DB short + exchange LONG (positive qty, no posSide) → UPDATE fires', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      { symbol: 'ETH_USDT_PERP', qty: '0.1' },  // ONE_WAY long
+    ] as never);
+    stubReconcilerQueries([
+      { id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', symbol: 'ETH_USDT_PERP', side: 'sell' },
+    ]);
+    const trader = new FullyAutonomousTrader();
+
+    await priv(trader).reconcilePositions(USER);
+
+    const upd = findCallContaining('UPDATE autonomous_trades');
+    expect(upd).not.toBeNull();
+    const [, updateParams] = upd!.args as [string, unknown[]];
+    expect(updateParams[0]).toEqual(['bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb']);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // 4. HEDGE both-sides open — same-symbol opposite-side rows coexist.
+  // ────────────────────────────────────────────────────────────────────────
+  it('HEDGE mode: DB short + exchange has both long AND short → no UPDATE for short row', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      { symbol: 'BTC_USDT_PERP', qty: '0.01', posSide: 'LONG' },
+      { symbol: 'BTC_USDT_PERP', qty: '0.02', posSide: 'SHORT' },
+    ] as never);
+    stubReconcilerQueries([
+      { id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', symbol: 'BTC_USDT_PERP', side: 'sell' },
+    ]);
+    const trader = new FullyAutonomousTrader();
+
+    await priv(trader).reconcilePositions(USER);
+
+    // DB short matches exchange short — no UPDATE.
+    expect(findCallContaining('UPDATE autonomous_trades')).toBeNull();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // 5. Symbol entirely missing on exchange — legacy case still covered.
+  // ────────────────────────────────────────────────────────────────────────
+  it('symbol entirely absent from exchange → UPDATE closes the orphan row', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([] as never);
+    stubReconcilerQueries([
+      { id: 'dddddddd-dddd-dddd-dddd-dddddddddddd', symbol: 'ETH_USDT_PERP', side: 'buy' },
+    ]);
+    const trader = new FullyAutonomousTrader();
+
+    await priv(trader).reconcilePositions(USER);
+
+    const upd = findCallContaining('UPDATE autonomous_trades');
+    expect(upd).not.toBeNull();
+    const [, updateParams] = upd!.args as [string, unknown[]];
+    expect(updateParams[0]).toEqual(['dddddddd-dddd-dddd-dddd-dddddddddddd']);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // 6. Multi-row mismatch — only the side-mismatched ones get closed.
+  // ────────────────────────────────────────────────────────────────────────
+  it('multi-row: closes only the side-mismatched ids, leaves matching rows alone', async () => {
+    vi.mocked(poloniexFuturesService.getPositions).mockResolvedValue([
+      { symbol: 'BTC_USDT_PERP', qty: '0.137', posSide: 'SHORT' },  // exchange BTC short
+      { symbol: 'ETH_USDT_PERP', qty: '0.1', posSide: 'LONG' },     // exchange ETH long
+    ] as never);
+    stubReconcilerQueries([
+      // Phantom: DB BTC long but exchange BTC is short.
+      { id: '11111111-1111-1111-1111-111111111111', symbol: 'BTC_USDT_PERP', side: 'buy' },
+      // Real: DB ETH long matches exchange ETH long.
+      { id: '22222222-2222-2222-2222-222222222222', symbol: 'ETH_USDT_PERP', side: 'buy' },
+      // Phantom: DB BTC long #2 (same side as #1, both miss the short).
+      { id: '33333333-3333-3333-3333-333333333333', symbol: 'BTC_USDT_PERP', side: 'buy' },
+    ]);
+    const trader = new FullyAutonomousTrader();
+
+    await priv(trader).reconcilePositions(USER);
+
+    const upd = findCallContaining('UPDATE autonomous_trades');
+    expect(upd).not.toBeNull();
+    const [, updateParams] = upd!.args as [string, unknown[]];
+    // The two phantom BTC longs get closed; the real ETH long is left alone.
+    expect(updateParams[0]).toEqual([
+      '11111111-1111-1111-1111-111111111111',
+      '33333333-3333-3333-3333-333333333333',
+    ]);
+  });
+});


### PR DESCRIPTION
## Production incident — 50 min phantom-row spam

From 2026-05-14T03:24Z onward, the polytrade-be production log carried a sustained 30-second cycle of:

```
ERROR Poloniex /v3/trade/order returned code=21002: Position not enough
[Monkey] BTC_USDT_PERP [investigation] scalp_exit ... stale_bleed: held 2069s ≥ 1800s at ROI -2.75% ≤ -1.00% | close: close_exchange_rejected: ... code=21002
```

3 BTC LONG DB rows were "open" in `autonomous_trades` but the exchange's BTC position was actually a SHORT (Poloniex netted the LONGs to zero when an external SHORT order arrived). Monkey's stale_bleed gate kept firing close orders for the phantom LONGs every 30 s.

## Root cause

[`fullyAutonomousTrader.ts:1252`](apps/api/src/services/fullyAutonomousTrader.ts#L1252) (pre-fix):

```typescript
const inDbNotExchange = [...dbSymbols].filter(s => !openSymbols.has(s));
```

The reconciler built two `Set<string>` — one of DB symbols, one of exchange symbols — and did a set difference. When the DB has a BTC LONG row AND the exchange has a BTC SHORT position, **both sets contain `"BTC_USDT_PERP"`**, the difference is empty, no UPDATE fires. The reconciler was symbol-aware but not side-aware.

## Fix

Build a `Map<symbol, Set<'long' | 'short'>>` from `exchangePositions`:
- HEDGE-aware: `posSide=LONG` / `posSide=SHORT` resolved first
- ONE_WAY fallback: `Math.sign(qty)` decides side (same resolution order as the existing `[FAT]` side-label fix in `managePositions`)

Then iterate DB open rows and close any whose `(symbol, side)` pair isn't represented on the exchange. Close by `id = ANY($1::uuid[])` to target the specific phantom rows — **NOT** `WHERE symbol = $1` which would over-reach on HEDGE-mode lane-isolated positions where same-symbol opposite-side rows legitimately coexist.

```typescript
const sideMismatchedRows = dbRows.filter(r => {
  const sideRaw = String(r.side).toLowerCase();
  const sideNorm: 'long' | 'short' =
    sideRaw === 'sell' || sideRaw === 'short' ? 'short' : 'long';
  const exchSides = exchangeSidesBySymbol.get(r.symbol);
  return !exchSides || !exchSides.has(sideNorm);
});
```

## Audit cleanup already applied

The 3 phantom DB rows were manually closed via Railway `DATABASE_PUBLIC_URL` with `exit_reason='manual_reconcile_phantom_2026_05_14_post_hotfix'` once the bug was identified. **The 21002 spam stopped within 30 s of that UPDATE; bot recovered to clean ticks by 04:34Z.** The fix in this PR prevents recurrence.

## Regression coverage

6 new tests in [`fullyAutonomousTrader.reconcilerSideMismatch.test.ts`](apps/api/src/tests/fullyAutonomousTrader.reconcilerSideMismatch.test.ts) covering:

1. **ONE_WAY long-match**: DB long + exchange long → no UPDATE
2. **The 2026-05-14 failure shape**: DB long + exchange SHORT (HEDGE `posSide`) → UPDATE fires, closes by id
3. **Mirror**: DB short + exchange LONG (ONE_WAY positive qty) → UPDATE fires
4. **HEDGE both-sides-open**: DB short + exchange long+short coexist → no UPDATE (legitimate)
5. **Legacy missing-symbol**: DB row exists, exchange has nothing → UPDATE fires
6. **Multi-row mixed**: 3 DB rows, 2 phantom + 1 real → only the 2 phantoms close

All 6 pass. `tsc -p tsconfig.json --noEmit` clean.

## Follow-ups (separate PRs)

- Monkey's K-path close handler should also ghost on Poloniex `21002` (the L path already does this; the K path retries the same row 30 s later until the reconciler catches up).
- **Profit-capture-and-reverse**: when conviction flips while position is green, harvest then immediately open the new side. (The user surfaced a +$50 → -$30 give-back during the chop window.)

## Test plan

- [x] `yarn vitest run src/tests/fullyAutonomousTrader.reconcilerSideMismatch.test.ts` — 6/6 passing
- [x] `tsc -p tsconfig.json --noEmit` clean (no new errors)
- [x] 3 phantom DB rows manually closed; 21002 spam stopped; bot recovered
- [ ] Post-merge: watch for the next side-mismatch scenario to confirm reconciler self-heals (no manual UPDATE needed next time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
