### PR TITLE
feat(monkey-kernel): green-turn reversal — capture the win + ride the swing

### DIFF
--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -1099,6 +1099,7 @@ def run_tick(
             held_side=held_side,
             side_candidate=side_candidate,
             side_override=side_override,
+            direction=direction,
             entry_thr_val=entry_thr_d["value"],
             size_val=size_d["value"],
             leverage_val=leverage_d["value"],
@@ -1420,6 +1421,7 @@ def _decide_with_position(
     emotions: Any = None,
     mode_value: str = "investigation",
     regime_confidence: float = 1.0,
+    direction: str = "flat",
 ) -> tuple[str, str, bool, bool]:
     """v0.6.1 exit gate order: profit harvest → scalp TP/SL → Loop 2 exit.
     v0.7.1 override-reverse. v0.6.2 DCA. Proposal #10: per-lane peak +
@@ -1624,6 +1626,88 @@ def _decide_with_position(
             )
             return "scalp_exit", reason, False, False
     derivation["rejustification"] = rejust
+
+    # ── Green-turn reversal ───────────────────────────────────────
+    # When the position is GREEN and the kernel's geometric direction
+    # has flipped against the held side WITH tape confirmation, close
+    # the winner AND immediately open the new side — capture the
+    # realized gain + ride the reversal swing in one decision.
+    #
+    # Without this gate the kernel relies on should_profit_harvest
+    # (close-only, trailing retrace) followed by a hoped-for re-entry
+    # on some future tick. In a sharp chop reversal the re-entry is
+    # often margin-gated or cooldown-blocked, so the +50 → -30
+    # give-back observed 2026-05-14 was the position bleeding back
+    # through break-even before any re-entry fired.
+    #
+    # Distinct from:
+    #   * REVERSION-mode side_override reversal below (counter-trend
+    #     stud-topology flip) — that fires on flat/red too.
+    #   * should_profit_harvest — trailing retrace, close-only.
+    # This is a trend-FOLLOWING capture: the trend the position rode
+    # has turned, so flip with it while still green.
+    #
+    # Placement: AFTER rejustification (a contradicted position must
+    # exit, not reverse — rejustification's checks aren't PnL-aware
+    # and a flip signal can be noise) and BEFORE trailing-harvest
+    # (when both would fire, reverse strictly dominates harvest —
+    # same capture, plus the new-side entry).
+    green_turn_min_roi = float(_registry.get(
+        "executive.green_turn_reversal.min_roi", default=0.003,
+    ))
+    green_turn_tape_threshold = float(_registry.get(
+        "executive.green_turn_reversal.tape_threshold", default=0.25,
+    ))
+    position_roi = (
+        unrealized_pnl / (position_notional / max(1, leverage_val))
+        if position_notional > 0 else 0.0
+    )
+    tape_opposes_held = (
+        (held_side == "long" and tape_trend < -green_turn_tape_threshold)
+        or (held_side == "short" and tape_trend > green_turn_tape_threshold)
+    )
+    # direction must be a genuine non-flat read on the opposite side —
+    # side_candidate alone is insufficient (it defaults to 'long' when
+    # direction is flat, which would false-trigger on a held short).
+    direction_flipped = direction != "flat" and direction != held_side
+    emo_for_reverse = basin_state.emotions
+    green_turn_reversal_eligible = (
+        position_roi >= green_turn_min_roi
+        and tape_opposes_held
+        and direction_flipped
+        and MODE_PROFILES[mode_enum].can_enter
+        and emo_for_reverse is not None
+        and kernel_should_enter(emotions=emo_for_reverse)
+        and size_val > 0
+    )
+    derivation["green_turn_reversal"] = {
+        "eligible": green_turn_reversal_eligible,
+        "position_roi": position_roi,
+        "min_roi": green_turn_min_roi,
+        "tape_trend": tape_trend,
+        "tape_threshold": green_turn_tape_threshold,
+        "tape_opposes_held": tape_opposes_held,
+        "direction": direction,
+        "direction_flipped": direction_flipped,
+        "unrealized_pnl": unrealized_pnl,
+    }
+    if green_turn_reversal_eligible:
+        action = (
+            "reverse_long" if side_candidate == "long" else "reverse_short"
+        )
+        reason = (
+            f"GREEN_TURN_REVERSAL[{held_side}→{side_candidate}] "
+            f"roi={position_roi:.3%} tape={tape_trend:.2f} "
+            f"capture +{unrealized_pnl:.2f} then open {side_candidate} "
+            f"margin={size_val:.2f} lev={leverage_val}x"
+        )
+        derivation["scalp"] = {
+            "exit_type_bit": 4,  # green-turn-reversal capture leg
+            "unrealized_pnl": unrealized_pnl,
+            "mark_price": last_price,
+            "trade_id": trade_id,
+        }
+        return action, reason, False, True  # is_reverse=True
 
     # ── Trailing-harvest (existing) ───────────────────────────────
     harvest = should_profit_harvest(

--- a/ml-worker/tests/monkey_kernel/test_green_turn_reversal.py
+++ b/ml-worker/tests/monkey_kernel/test_green_turn_reversal.py
@@ -1,0 +1,322 @@
+"""test_green_turn_reversal.py — green-turn reversal gate.
+
+When a position is GREEN and the kernel's geometric direction has
+flipped against the held side WITH tape confirmation, _decide_with_position
+returns reverse_long / reverse_short (is_reverse=True) — capture the
+realized gain AND open the new side in one decision, instead of the
+plain trailing-harvest which only closes.
+
+Motivation (2026-05-14): a +$50 combined-short position bled back to
+-$30 in a sharp chop reversal because should_profit_harvest closed
+nothing in time and re-entry on the new side never fired (margin-gated
+/ cooldown-blocked). The green-turn reversal captures the turn while
+still green.
+
+Gate conditions (ALL must hold):
+  1. position_roi >= executive.green_turn_reversal.min_roi (default 0.003)
+  2. tape opposes held side by >= green_turn_reversal.tape_threshold (0.25)
+  3. direction != "flat" AND direction != held_side
+  4. MODE_PROFILES[mode].can_enter
+  5. emotions present AND kernel_should_enter(emotions)
+  6. size_val > 0
+
+Placement: AFTER rejustification (a contradicted position must exit,
+not reverse) and BEFORE trailing-harvest (reverse dominates harvest
+when both would fire).
+
+These tests exercise _decide_with_position directly.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.basin import uniform_basin  # noqa: E402
+from monkey_kernel.executive import ExecBasinState  # noqa: E402
+from monkey_kernel.modes import MonkeyMode  # noqa: E402
+from monkey_kernel.state import NeurochemicalState  # noqa: E402
+from monkey_kernel.tick import (  # noqa: E402
+    AccountContext,
+    SymbolState,
+    TickInputs,
+    _decide_with_position,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@dataclass
+class _Emotions:
+    """Minimal Emotions stand-in — kernel_should_enter + the
+    rejustification conviction check read these fields. Defaults give
+    a confident, low-anxiety state so kernel_should_enter passes."""
+    confidence: float = 0.8
+    anxiety: float = 0.05
+    confusion: float = 0.05
+    wonder: float = 0.1
+    frustration: float = 0.0
+    satisfaction: float = 0.0
+    clarity: float = 0.0
+    boredom: float = 0.0
+    flow: float = 0.0
+
+
+def _nc() -> NeurochemicalState:
+    return NeurochemicalState(
+        acetylcholine=0.5, dopamine=0.5, serotonin=0.5,
+        norepinephrine=0.5, gaba=0.5, endorphins=0.5,
+    )
+
+
+def _basin_state(*, phi: float = 0.27, emotions: _Emotions | None = None) -> ExecBasinState:
+    basin = uniform_basin(64)
+    return ExecBasinState(
+        basin=basin,
+        identity_basin=basin,
+        phi=phi,
+        kappa=64.0,
+        regime_weights={"quantum": 0.34, "efficient": 0.33, "equilibrium": 0.33},
+        sovereignty=0.5,
+        basin_velocity=0.05,
+        neurochemistry=_nc(),
+        emotions=emotions or _Emotions(),  # type: ignore[arg-type]
+    )
+
+
+def _fresh_state() -> SymbolState:
+    """A SymbolState with NO rejustification anchors — so the
+    rejustification gate is skipped and execution reaches the
+    green-turn-reversal gate."""
+    return SymbolState(
+        symbol="BTC_USDT_PERP",
+        identity_basin=uniform_basin(64),
+    )
+
+
+def _inputs(*, entry_price: float, qty: float, held_side: str) -> TickInputs:
+    return TickInputs(
+        symbol="BTC_USDT_PERP",
+        ohlcv=[],  # _decide_with_position does not read ohlcv
+        account=AccountContext(
+            equity_fraction=0.05,
+            margin_fraction=0.03,
+            open_positions=1,
+            available_equity=1000.0,
+            exchange_held_side=held_side,
+            own_position_entry_price=entry_price,
+            own_position_quantity=qty,
+            own_position_trade_id="trade-gtr-1",
+        ),
+        bank_size=10,
+        sovereignty=0.5,
+        max_leverage=20,
+        min_notional=10.0,
+    )
+
+
+def _call(
+    *,
+    held_side: str,
+    entry_price: float,
+    last_price: float,
+    qty: float = 0.1,
+    tape_trend: float,
+    direction: str,
+    side_candidate: str,
+    mode: MonkeyMode = MonkeyMode.INVESTIGATION,
+    size_val: float = 10.0,
+    leverage_val: int = 5,
+    emotions: _Emotions | None = None,
+) -> tuple[str, str, bool, bool, dict[str, Any]]:
+    """Drive _decide_with_position through the green-turn-reversal path."""
+    derivation: dict[str, Any] = {}
+    bs = _basin_state(emotions=emotions)
+    action, reason, is_dca, is_reverse = _decide_with_position(
+        inputs=_inputs(entry_price=entry_price, qty=qty, held_side=held_side),
+        state=_fresh_state(),
+        basin=uniform_basin(64),
+        basin_state=bs,
+        mode_enum=mode,
+        last_price=last_price,
+        tape_trend=tape_trend,
+        held_side=held_side,
+        side_candidate=side_candidate,
+        side_override=False,
+        direction=direction,
+        entry_thr_val=0.5,
+        size_val=size_val,
+        leverage_val=leverage_val,
+        derivation=derivation,
+        position_lane="swing",
+        phi=0.27,
+        emotions=bs.emotions,
+        mode_value=mode.value,
+        regime_confidence=1.0,
+    )
+    return action, reason, is_dca, is_reverse, derivation
+
+
+# ── Positive: the gate fires ──────────────────────────────────────
+
+
+class TestGreenTurnReversalFires:
+    def test_green_long_bearish_tape_flip_reverses_to_short(self) -> None:
+        # Held LONG at 100, now 102 → green. Tape strongly bearish,
+        # direction flipped to short → reverse_short.
+        action, reason, is_dca, is_reverse, derivation = _call(
+            held_side="long",
+            entry_price=100.0,
+            last_price=102.0,
+            tape_trend=-0.40,
+            direction="short",
+            side_candidate="short",
+        )
+        assert action == "reverse_short"
+        assert is_reverse is True
+        assert is_dca is False
+        assert reason.startswith("GREEN_TURN_REVERSAL[long→short]")
+        gtr = derivation["green_turn_reversal"]
+        assert gtr["eligible"] is True
+        assert gtr["position_roi"] > 0.003
+        assert gtr["tape_opposes_held"] is True
+        assert gtr["direction_flipped"] is True
+        # capture leg tagged on derivation.scalp for the executor
+        assert derivation["scalp"]["exit_type_bit"] == 4
+
+    def test_green_short_bullish_tape_flip_reverses_to_long(self) -> None:
+        # Held SHORT at 100, now 98 → green. Tape strongly bullish,
+        # direction flipped to long → reverse_long.
+        action, reason, is_dca, is_reverse, derivation = _call(
+            held_side="short",
+            entry_price=100.0,
+            last_price=98.0,
+            tape_trend=0.40,
+            direction="long",
+            side_candidate="long",
+        )
+        assert action == "reverse_long"
+        assert is_reverse is True
+        assert reason.startswith("GREEN_TURN_REVERSAL[short→long]")
+        assert derivation["green_turn_reversal"]["eligible"] is True
+
+
+# ── Negative: the gate does NOT fire ──────────────────────────────
+
+
+class TestGreenTurnReversalDoesNotFire:
+    def test_red_position_does_not_reverse(self) -> None:
+        # Held LONG at 100, now 98 → RED. Even with a bearish tape +
+        # direction flip, a losing position is NOT a green-turn capture
+        # — it falls through to the existing exit gates.
+        action, _reason, _is_dca, is_reverse, derivation = _call(
+            held_side="long",
+            entry_price=100.0,
+            last_price=98.0,
+            tape_trend=-0.40,
+            direction="short",
+            side_candidate="short",
+        )
+        assert action != "reverse_short"
+        assert is_reverse is False
+        assert derivation["green_turn_reversal"]["eligible"] is False
+        assert derivation["green_turn_reversal"]["position_roi"] < 0
+
+    def test_weak_tape_does_not_reverse(self) -> None:
+        # Green long, direction flipped, but tape only -0.10 — below
+        # the 0.25 opposition threshold. Not a confirmed turn.
+        action, _reason, _is_dca, is_reverse, derivation = _call(
+            held_side="long",
+            entry_price=100.0,
+            last_price=102.0,
+            tape_trend=-0.10,
+            direction="short",
+            side_candidate="short",
+        )
+        assert action != "reverse_short"
+        assert is_reverse is False
+        gtr = derivation["green_turn_reversal"]
+        assert gtr["eligible"] is False
+        assert gtr["tape_opposes_held"] is False
+
+    def test_flat_direction_does_not_reverse(self) -> None:
+        # Green short, tape bullish — but direction is flat (no genuine
+        # opposite-side read). side_candidate defaults to 'long' when
+        # direction is flat; the direction_flipped guard must reject it.
+        action, _reason, _is_dca, is_reverse, derivation = _call(
+            held_side="short",
+            entry_price=100.0,
+            last_price=98.0,
+            tape_trend=0.40,
+            direction="flat",
+            side_candidate="long",
+        )
+        assert action != "reverse_long"
+        assert is_reverse is False
+        gtr = derivation["green_turn_reversal"]
+        assert gtr["eligible"] is False
+        assert gtr["direction_flipped"] is False
+
+    def test_tiny_green_below_min_roi_does_not_reverse(self) -> None:
+        # Held LONG at 100.000, now 100.001 — green but ROI far below
+        # the 0.3% min_roi floor. A sub-noise gain is not worth the
+        # round-trip fees + slippage of a reverse.
+        action, _reason, _is_dca, is_reverse, derivation = _call(
+            held_side="long",
+            entry_price=100.0,
+            last_price=100.001,
+            tape_trend=-0.40,
+            direction="short",
+            side_candidate="short",
+            leverage_val=1,  # ROI = pnl / (notional / 1) — smallest ROI
+        )
+        assert action != "reverse_short"
+        assert is_reverse is False
+        gtr = derivation["green_turn_reversal"]
+        assert gtr["eligible"] is False
+        assert gtr["position_roi"] < 0.003
+
+    def test_same_direction_does_not_reverse(self) -> None:
+        # Green long, tape still bullish, direction still long — no turn.
+        action, _reason, _is_dca, is_reverse, derivation = _call(
+            held_side="long",
+            entry_price=100.0,
+            last_price=102.0,
+            tape_trend=0.40,
+            direction="long",
+            side_candidate="long",
+        )
+        assert action != "reverse_long"
+        assert action != "reverse_short"
+        assert is_reverse is False
+        assert derivation["green_turn_reversal"]["eligible"] is False
+
+
+# ── Derivation telemetry is always present ────────────────────────
+
+
+class TestGreenTurnReversalTelemetry:
+    def test_derivation_block_always_emitted(self) -> None:
+        # Even on a no-fire tick the derivation carries the gate's
+        # inputs so the decision is auditable from monkey_decisions.
+        _action, _reason, _is_dca, _is_reverse, derivation = _call(
+            held_side="long",
+            entry_price=100.0,
+            last_price=100.5,
+            tape_trend=0.0,
+            direction="long",
+            side_candidate="long",
+        )
+        gtr = derivation["green_turn_reversal"]
+        for key in (
+            "eligible", "position_roi", "min_roi", "tape_trend",
+            "tape_threshold", "tape_opposes_held", "direction",
+            "direction_flipped", "unrealized_pnl",
+        ):
+            assert key in gtr, f"missing telemetry key: {key}"


### PR DESCRIPTION
## Summary

Adds a **green-turn reversal** gate to the Python kernel: when a position is GREEN and the kernel's geometric direction has flipped against the held side **with tape confirmation**, `_decide_with_position` returns `reverse_long` / `reverse_short` — closing the winner AND opening the new side in one decision.

> **Stacked on `cutover/python-authoritative-kernel` (PR #674).** Base branch is the cutover branch, not `main` — this feature needs the Phase 1.5-1.7 `TickDecision` payload extensions + the latest `tick.py`. Merges into the cutover branch; carried to `main` via #674.

## Motivation

User-surfaced 2026-05-14: a **+$50 combined-short position bled back to −$30** in a sharp chop reversal. `should_profit_harvest` (trailing retrace, close-only) didn't catch the turn in time, and re-entry on the new side never fired — margin-gated by LiveSignal's open positions + harvest cooldown. The result was a round-trip through break-even.

The kernel **saw** the turn — tape flipped from −0.4 to +0.25 within minutes — but had no decision path that both captured the gain and rode the reversal. This adds that path.

## The gate

New block in `tick.py:_decide_with_position`. Fires `reverse_*` when ALL hold:

| # | Condition | Default |
|---|---|---|
| 1 | `position_roi >= executive.green_turn_reversal.min_roi` | `0.003` (0.3% ROI on margin — a sub-noise gain isn't worth the round-trip fees) |
| 2 | tape opposes held side by `>= green_turn_reversal.tape_threshold` | `0.25` (a confirmed turn, not a flicker) |
| 3 | `direction != "flat" AND direction != held_side` | — (a genuine opposite-side read; `side_candidate` alone is insufficient — it defaults to `'long'` when direction is flat) |
| 4 | `MODE_PROFILES[mode].can_enter` | — |
| 5 | `emotions` present AND `kernel_should_enter(emotions)` | — (same conviction gate a fresh entry passes) |
| 6 | `size_val > 0` | — |

## Placement

**AFTER** held-position rejustification — a *contradicted* position must exit, not reverse (rejustification's regime/phi/conviction checks aren't PnL-aware, and a flip signal can be noise).

**BEFORE** trailing-harvest — when both would fire, reverse strictly dominates: same capture, plus the new-side entry.

## Distinct from existing paths

- **REVERSION-mode `side_override` reversal** — counter-trend stud-topology flip; fires on flat/red too. Green-turn is trend-*following* and gated on green + confirmed turn.
- **`should_profit_harvest`** — trailing retrace, close-only, no re-entry.

## Executor impact: none

The executor's existing `reverse_long` / `reverse_short` path (flatten-then-reopen) handles the action unchanged — green-turn-reversal slots into the exact path REVERSION-mode already uses. The executor doesn't distinguish *why* it's a reverse. The capture leg is tagged `derivation.scalp.exit_type_bit=4` for telemetry.

## Other changes

- `direction` is now threaded into `_decide_with_position` (was only `side_candidate`, which loses the flat/non-flat distinction).
- `derivation.green_turn_reversal` carries the full gate inputs every tick (`eligible` flag + `position_roi` + `tape_trend` + `direction` + thresholds) so the decision is auditable from `monkey_decisions` even on no-fire ticks.

## Tests

+8 in `test_green_turn_reversal.py`:
- **Fires**: green long → reverse_short (bearish tape flip); green short → reverse_long (bullish tape flip)
- **Does NOT fire**: red position; weak tape (−0.10 < 0.25 threshold); flat direction; sub-min-ROI tiny green; same direction (no turn)
- **Telemetry**: derivation block always emitted with all gate-input keys

`809/809 monkey_kernel tests passing` (801 prior + 8 new). `tick.py` parses + imports clean.

## Test plan

- [x] `python -m pytest tests/monkey_kernel/test_green_turn_reversal.py -q` — 8/8
- [x] `python -m pytest tests/monkey_kernel/ -q` — 809/809
- [ ] Post-merge: offline replay should show `GREEN_TURN_REVERSAL[...]` reasons appearing on chop-reversal ticks where the old kernel only logged `scalp_exit: trailing_harvest` (or nothing)
- [ ] Post-deploy: watch first reversal events for clean flatten-then-reopen execution (no `21002`, no orphaned legs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
