### PR TITLE
fix(reconciler): stateReconciliationService HEDGE posSide — stop create/close churn

### DIFF
--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -144,14 +144,32 @@ class StateReconciliationService {
       const normalizeDbSide = (s: string): 'long' | 'short' =>
         s === 'buy' || s === 'long' ? 'long' : 'short';
 
+      // Resolve an EXCHANGE position's side. 2026-05-14 fix: HEDGE-mode
+      // Poloniex v3 positions carry a POSITIVE ``qty`` magnitude and the
+      // real side in ``posSide`` — so the legacy ``parseFloat(qty) > 0``
+      // test mislabels every HEDGE short as 'long'. After the side-aware
+      // FAT reconciler (PR #677) started closing side-mismatched rows,
+      // this mislabel produced a 1-minute create/close churn loop:
+      // orphan-detection inserted a 'long' row for a SHORT exchange
+      // position, the FAT reconciler closed it as a side mismatch, and
+      // the next reconciler tick re-inserted it. posSide-first resolution
+      // (same order as the #676/#677 fixes), Math.sign(qty) fallback for
+      // ONE_WAY accounts.
+      const resolveExchangeSide = (exPos: Record<string, unknown>): 'long' | 'short' => {
+        const posSide = String(exPos.posSide ?? '').toUpperCase();
+        const qtyNum = parseFloat(String(exPos.qty ?? exPos.availQty ?? '0'));
+        return posSide === 'SHORT' || (posSide !== 'LONG' && qtyNum < 0)
+          ? 'short'
+          : 'long';
+      };
+
       // ── 5. Orphan detection: on exchange but not in DB ───────────────────────
       for (const exPos of exchangePositions) {
         const symbol: string = exPos.symbol ?? exPos.instId ?? '';
         const size: number = Math.abs(parseFloat(exPos.qty ?? exPos.availQty ?? '0'));
         if (!symbol || size === 0) continue;
 
-        const side: string =
-          parseFloat(exPos.qty ?? '0') > 0 ? 'long' : 'short';
+        const side: 'long' | 'short' = resolveExchangeSide(exPos);
 
         // Check if this exchange symbol+side is already in the DB.
         // DB side may be 'buy'/'sell' (liveSignal) or 'long'/'short'
@@ -256,7 +274,7 @@ class StateReconciliationService {
         if (!exSymbol) continue;
         const exQty = Math.abs(parseFloat(exPos.qty ?? exPos.availQty ?? '0')) || 0;
         if (exQty === 0) continue;
-        const exSide = parseFloat(exPos.qty ?? '0') > 0 ? 'long' : 'short';
+        const exSide = resolveExchangeSide(exPos);
         const key = `${exSymbol}|${exSide}`;
         exchangeQtyByKey.set(key, (exchangeQtyByKey.get(key) ?? 0) + exQty);
       }


### PR DESCRIPTION
## Summary

Third occurrence of the HEDGE `posSide` bug class (after [#676](https://github.com/GaryOcean428/poloniex-trading-platform/pull/676) `placeOrder` and [#677](https://github.com/GaryOcean428/poloniex-trading-platform/pull/677) FAT reconciler). `stateReconciliationService` derived exchange-position side from `parseFloat(exPos.qty) > 0 ? 'long' : 'short'` at two call sites. On HEDGE-mode Poloniex v3 accounts `qty` is a **positive magnitude** and the real side is in `posSide` — so every HEDGE SHORT was mislabelled `long`.

## How it surfaced

Latent until #677 made the FAT reconciler side-aware. After #677 deployed (`6e6c25f`, 04:42Z), production fell into a **1-minute create/close churn loop**:

```
04:51:23 [RECONCILE] DB rows open but exchange has no matching side: 2 row(s) BTC/ETH — marking as closed
04:51:25 [RECONCILE] Tracked user-opened position: BTC_USDT_PERP long qty=137 @0
04:52:23 [RECONCILE] DB rows open but exchange has no matching side ...   ← #677 closes the mislabelled row
04:52:25 [RECONCILE] Tracked user-opened position: BTC_USDT_PERP long qty=137 @0   ← this service re-inserts it
... every minute, fresh row ids ...
```

`stateReconciliationService` orphan-detection inserted a `long` `autonomous_trades` row for a **SHORT** exchange position. The side-aware FAT reconciler (#677) correctly closed it as a side mismatch. The next `stateReconciliation` tick re-inserted it. Repeat.

**Not money-bleeding** — no `code=21002`, the mislabelled rows never drove a close order — but it churned mislabelled rows + `agent_events` every minute and could mis-feed PnL accounting.

## Fix

A single `resolveExchangeSide(exPos)` helper — `posSide`-first (`posSide === 'SHORT'`), `Math.sign(qty)` fallback for ONE_WAY — applied at both call sites:
- orphan-detection (line ~154)
- ghost qty-map (line ~259)

Same resolution order as the #676/#677 fixes and the **already-correct** `posSide`-aware path at line ~394 of this same file.

## Coverage

The resolution logic is the exact pattern locked by the 6 tests in `fullyAutonomousTrader.reconcilerSideMismatch.test.ts` (#677). `resolveExchangeSide` is a local closure inside the 600-line reconcile method — extracting a testable seam would be scope creep for a 3-line logic mirror of an already-tested pattern. `tsc -p tsconfig.json --noEmit` clean.

## Pattern note

**Any code deriving position side from qty-sign is a HEDGE-account bug.** Canonical resolution everywhere: `posSide` first, `Math.sign(qty)` fallback. This is the 3rd instance fixed in 2 hours — worth a lint rule or shared util in a follow-up.

## Test plan
- [x] `tsc -p tsconfig.json --noEmit` clean
- [ ] Post-deploy: `[RECONCILE] Tracked user-opened position` should show `short` for the BTC/ETH short positions (not `long`), and the create/close churn loop should stop — no more `DB rows open but exchange has no matching side` every minute for the same symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct position side resolution in state reconciliation to prevent mislabelled HEDGE positions and the resulting create/close churn.

Bug Fixes:
- Fix HEDGE-mode position side detection by preferring posSide with qty-sign fallback instead of relying solely on qty sign in state reconciliation.

Enhancements:
- Introduce a shared resolveExchangeSide helper to consistently determine exchange position side across reconciliation logic.