### PR TITLE
fix(ml-worker): isolate registry psycopg connect off the event loop (segfault)

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -497,8 +497,34 @@ def _handle_predict_ensemble(payload: dict) -> dict:
 # FastAPI app
 # ---------------------------------------------------------------------------
 
+async def _prewarm_parameter_registry() -> None:
+    """Trigger the one-time parameter-registry DB load at startup, on a
+    worker thread (NOT the event loop).
+
+    2026-05-14 fix: without this, the registry's lazy _load() first
+    runs inside the `/monkey/tick/run` request handler chain
+    (Ocean.__init__ → parameters.get() → _load()). _load() now isolates
+    its psycopg work to a dedicated thread, but pre-warming here means
+    request handlers only ever hit the in-memory cache — the DB connect
+    happens exactly once, at startup, off the event loop. Fail-soft:
+    parameters.get() falls back to its hardcoded defaults if the load
+    fails, so a registry-unreachable startup must not abort boot.
+    """
+    try:
+        from monkey_kernel.parameters import get_registry
+
+        await asyncio.to_thread(get_registry().refresh)
+        logger.info("parameter registry pre-warmed at startup")
+    except Exception as exc:  # noqa: BLE001 — never block boot on this
+        logger.warning(
+            "parameter registry pre-warm failed (defaults will be used): %s",
+            exc,
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    await _prewarm_parameter_registry()
     _start_redis_listener()
     _start_trade_outcome_listener()
     logger.info("ML worker started")

--- a/ml-worker/src/monkey_kernel/parameters.py
+++ b/ml-worker/src/monkey_kernel/parameters.py
@@ -29,6 +29,7 @@ and audit-logged by the DB trigger in migration 034.
 
 from __future__ import annotations
 
+import concurrent.futures
 import logging
 import os
 import threading
@@ -37,6 +38,29 @@ from enum import Enum
 from typing import Any, Optional
 
 logger = logging.getLogger("monkey.parameters")
+
+# ── psycopg isolation executor ───────────────────────────────────
+#
+# 2026-05-14 fix: psycopg's synchronous connect() must NEVER run on
+# the asyncio event-loop thread. ml-worker is a FastAPI/uvloop process
+# with heavy native extensions (TensorFlow, scipy, sklearn, h5py); when
+# psycopg3's sync `wait_conn` machinery runs on the event-loop thread
+# in that environment it segfaults / aborts the whole process — and a
+# native crash is NOT catchable by the try/except in _load(). Observed
+# in production: every `/monkey/tick/run` request crashed ml-worker via
+# Ocean.__init__ → parameters.get() → _load() → psycopg.connect().
+#
+# Routing every _load() through this single-worker executor guarantees
+# the native connect always runs on a dedicated OS thread that is never
+# the event loop — the supported way to use sync psycopg from async
+# code. Single worker (max_workers=1) because registry loads are rare
+# (startup + every refresh_every_ticks) and must not race each other.
+_DB_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="param-registry-db",
+)
+# Hard ceiling on a single registry load — a hung connect must not
+# wedge the executor forever. The caller falls back to cache/defaults.
+_LOAD_TIMEOUT_S = 15.0
 
 
 class VariableCategory(Enum):
@@ -239,8 +263,62 @@ class ParameterRegistry:
 
     # ── Internal ─────────────────────────────────────────────────
 
+    def _query_parameters_table(self) -> dict[str, ParamValue]:
+        """Open a psycopg connection and read the whole parameters table.
+
+        Runs ONLY inside the _DB_EXECUTOR worker thread (see _load) — it
+        must never execute on the asyncio event-loop thread. Pure
+        synchronous psycopg; raises on any DB/parse failure for _load to
+        catch.
+        """
+        import psycopg
+
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT name, category, value, bounds_low, bounds_high,
+                           justification, version
+                      FROM monkey_parameters
+                    """
+                )
+                new_cache: dict[str, ParamValue] = {}
+                for row in cur.fetchall():
+                    (name, category_str, value, b_low, b_high,
+                     justification, version) = row
+                    try:
+                        cat = VariableCategory(category_str)
+                    except ValueError:
+                        logger.warning(
+                            "registry row '%s' has unknown category '%s'; "
+                            "skipping",
+                            name, category_str,
+                        )
+                        continue
+                    new_cache[name] = ParamValue(
+                        name=name,
+                        category=cat,
+                        value=float(value),
+                        bounds_low=float(b_low) if b_low is not None else None,
+                        bounds_high=float(b_high) if b_high is not None else None,
+                        justification=justification,
+                        version=int(version),
+                    )
+        return new_cache
+
     def _load(self) -> None:
-        """Reload the entire parameters table into the cache."""
+        """Reload the entire parameters table into the cache.
+
+        The actual psycopg connect + query runs on the dedicated
+        _DB_EXECUTOR thread — NEVER on the calling thread. This is
+        load-bearing: if _load is reached from an async request handler
+        (Ocean.__init__ → parameters.get() → _load), running sync
+        psycopg on the uvloop event-loop thread segfaults the process
+        (2026-05-14 production incident). Submitting to the executor and
+        blocking on .result() keeps the native connect off the event
+        loop; the brief block is acceptable (registry loads are rare and
+        the startup pre-warm means request handlers hit the cache).
+        """
         if self._dsn is None:
             if not self._loaded:
                 logger.warning(
@@ -250,44 +328,15 @@ class ParameterRegistry:
             return
 
         try:
-            import psycopg
-
-            with psycopg.connect(self._dsn) as conn:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        """
-                        SELECT name, category, value, bounds_low, bounds_high,
-                               justification, version
-                          FROM monkey_parameters
-                        """
-                    )
-                    new_cache: dict[str, ParamValue] = {}
-                    for row in cur.fetchall():
-                        (name, category_str, value, b_low, b_high,
-                         justification, version) = row
-                        try:
-                            cat = VariableCategory(category_str)
-                        except ValueError:
-                            logger.warning(
-                                "registry row '%s' has unknown category '%s'; "
-                                "skipping",
-                                name, category_str,
-                            )
-                            continue
-                        new_cache[name] = ParamValue(
-                            name=name,
-                            category=cat,
-                            value=float(value),
-                            bounds_low=float(b_low) if b_low is not None else None,
-                            bounds_high=float(b_high) if b_high is not None else None,
-                            justification=justification,
-                            version=int(version),
-                        )
+            future = _DB_EXECUTOR.submit(self._query_parameters_table)
+            new_cache = future.result(timeout=_LOAD_TIMEOUT_S)
             self._cache = new_cache
             self._loaded = True
             logger.debug("parameter registry loaded: %d entries", len(new_cache))
         except Exception as exc:
-            # Fail-soft: keep serving from existing cache.
+            # Fail-soft: keep serving from existing cache / defaults.
+            # Covers DB-unreachable, query errors, AND the executor
+            # timeout — the process stays up either way.
             logger.warning("parameter registry load failed: %s", exc)
             if not self._loaded:
                 self._loaded = True  # don't retry every .get() call

--- a/ml-worker/tests/monkey_kernel/test_parameters_psycopg_isolation.py
+++ b/ml-worker/tests/monkey_kernel/test_parameters_psycopg_isolation.py
@@ -1,0 +1,173 @@
+"""test_parameters_psycopg_isolation.py — registry psycopg thread isolation.
+
+2026-05-14 production incident: ml-worker crashed with
+``Fatal Python error: Aborted`` / ``Segmentation fault`` every time
+``/monkey/tick/run`` was invoked. The crash chain was:
+
+    monkey_tick_run (async, uvloop event-loop thread)
+      → _get_ocean() → Ocean.__init__
+        → parameters.get() → ParameterRegistry._load()
+          → psycopg.connect()  ← sync connect ON the event-loop thread
+            → SEGFAULT (psycopg3 sync wait_conn + uvloop + heavy native
+              extensions: TensorFlow / scipy / sklearn / h5py)
+
+A native crash is NOT catchable by the try/except in _load() — the
+process dies.
+
+Fix: _load() submits the actual psycopg connect+query
+(_query_parameters_table) to a dedicated single-worker
+ThreadPoolExecutor (_DB_EXECUTOR). The native connect therefore always
+runs on a ``param-registry-db`` thread, never the caller's thread —
+the supported way to use sync psycopg from async code.
+
+These tests lock:
+  1. The psycopg work runs on a _DB_EXECUTOR thread, not the caller.
+  2. _load() stays fail-soft (DB error → defaults, no raise).
+  3. _load() stays fail-soft on executor timeout.
+  4. No-DSN path is unchanged (defaults only, no DB attempt).
+"""
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel import parameters as params_mod  # noqa: E402
+from monkey_kernel.parameters import (  # noqa: E402
+    ParameterRegistry,
+    VariableCategory,
+)
+
+
+def test_query_runs_on_db_executor_thread_not_caller() -> None:
+    """The psycopg connect+query must execute on a _DB_EXECUTOR worker
+    thread — never the thread that called _load(). This is the
+    load-bearing property: on the real server _load() is reached from
+    the uvloop event-loop thread, and sync psycopg there segfaults."""
+    caller_thread = threading.current_thread().name
+    seen: dict[str, str] = {}
+
+    reg = ParameterRegistry(dsn="postgresql://stub/notused")
+
+    def fake_query() -> dict:
+        seen["thread"] = threading.current_thread().name
+        return {}
+
+    reg._query_parameters_table = fake_query  # type: ignore[method-assign]
+    reg._load()
+
+    assert "thread" in seen, "_query_parameters_table was never invoked"
+    assert seen["thread"] != caller_thread, (
+        f"psycopg work ran on the CALLER thread ({caller_thread}) — "
+        "this is the segfault path"
+    )
+    assert seen["thread"].startswith("param-registry-db"), (
+        f"expected a _DB_EXECUTOR thread, got {seen['thread']!r}"
+    )
+    assert reg._loaded is True
+
+
+def test_load_is_failsoft_on_db_error() -> None:
+    """A DB/connect failure inside the executor must NOT propagate —
+    _load() catches it, marks _loaded so it stops retrying, and the
+    registry serves hardcoded defaults via get()."""
+    reg = ParameterRegistry(dsn="postgresql://stub/notused")
+
+    def boom() -> dict:
+        raise ConnectionError("simulated DB unreachable")
+
+    reg._query_parameters_table = boom  # type: ignore[method-assign]
+    reg._load()  # must not raise
+
+    assert reg._loaded is True
+    # get() with a default still works — fail-soft to the default.
+    assert reg.get("physics.kappa_star", default=64.0) == 64.0
+
+
+def test_load_is_failsoft_on_executor_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the connect hangs past _LOAD_TIMEOUT_S, _load() catches the
+    TimeoutError and stays up serving defaults — a wedged connect must
+    not wedge the kernel. The module-level timeout is monkeypatched to
+    a small value so the test is fast; the production default (15 s)
+    behaves identically, just slower."""
+    monkeypatch.setattr(params_mod, "_LOAD_TIMEOUT_S", 0.5)
+    reg = ParameterRegistry(dsn="postgresql://stub/notused")
+
+    # Interruptible "hang": waits on an Event the test releases at the
+    # end, so the shared single-worker _DB_EXECUTOR isn't left occupied
+    # for subsequent tests.
+    release = threading.Event()
+
+    def hang() -> dict:
+        release.wait(timeout=5.0)  # past the patched 0.5 s _load timeout
+        return {}
+
+    reg._query_parameters_table = hang  # type: ignore[method-assign]
+    started = time.monotonic()
+    try:
+        reg._load()  # must not raise, must not block past the timeout
+        elapsed = time.monotonic() - started
+
+        assert reg._loaded is True
+        assert elapsed < 2.0, (
+            f"_load blocked {elapsed:.1f}s — should bail at ~0.5 s"
+        )
+        assert reg.get("loop.history_max", default=100.0) == 100.0
+    finally:
+        release.set()  # free the executor worker
+
+
+def test_no_dsn_path_unchanged() -> None:
+    """With no DATABASE_URL, _load() short-circuits before ever touching
+    the executor — defaults-only, no DB attempt."""
+    reg = ParameterRegistry(dsn=None)
+    called = {"n": 0}
+
+    def should_not_run() -> dict:
+        called["n"] += 1
+        return {}
+
+    reg._query_parameters_table = should_not_run  # type: ignore[method-assign]
+    reg._load()
+
+    assert called["n"] == 0, "_query_parameters_table ran despite no DSN"
+    assert reg._loaded is True
+    assert reg.get("executive.green_turn_reversal.min_roi", default=0.003) == 0.003
+
+
+def test_successful_load_populates_cache() -> None:
+    """Happy path: the executor returns a parameter map and _load()
+    installs it as the cache; get() then returns the loaded value, not
+    the default."""
+    reg = ParameterRegistry(dsn="postgresql://stub/notused")
+
+    from monkey_kernel.parameters import ParamValue
+
+    def good_query() -> dict:
+        return {
+            "physics.kappa_star": ParamValue(
+                name="physics.kappa_star",
+                category=VariableCategory.SAFETY_BOUND
+                if hasattr(VariableCategory, "SAFETY_BOUND")
+                else list(VariableCategory)[0],
+                value=63.83,
+                bounds_low=None,
+                bounds_high=None,
+                justification="measured",
+                version=1,
+            ),
+        }
+
+    reg._query_parameters_table = good_query  # type: ignore[method-assign]
+    reg._load()
+
+    assert reg._loaded is True
+    # loaded value wins over the passed default
+    assert reg.get("physics.kappa_star", default=64.0) == 63.83


### PR DESCRIPTION
## Production incident — ml-worker crash-looping

From ~2026-05-14T05:02Z, ml-worker **CRASHED** (restart-looping) with alternating `Fatal Python error: Aborted` / `Segmentation fault` every time `/monkey/tick/run` was invoked. polytrade-be has been logging `ML worker unavailable via HTTP and Redis` every ~10s since.

Crash chain:
```
monkey_tick_run        (async — runs on the uvloop event-loop thread)
  → _get_ocean() → Ocean.__init__
    → parameters.get() → ParameterRegistry._load()
      → psycopg.connect()         ← SYNC connect ON the event-loop thread
        → SEGFAULT / ABORT
```

## Root cause

psycopg3's synchronous `connect()` drives a native `wait_conn` generator. Running that **on the uvloop event-loop thread**, in a process already loaded with heavy native extensions (TensorFlow oneDNN, scipy, sklearn, h5py, statsmodels), corrupts the FD/signal machinery and aborts the process. **A native crash is not catchable** — the existing `try/except` in `_load()` never runs; the whole process dies and Railway restart-loops it.

**Latent on `main`** — nothing calls `/monkey/tick/run` on a cadence pre-cutover (`MONKEY_TICK_PY_SHADOW=false`). **Hard blocker for PR #674** — post-cutover *every* Monkey tick calls `/monkey/tick/run`, so every tick would crash ml-worker and the fail-loud kernel would stop trading entirely.

## Fix — defense in depth

**1. `parameters.py`** — `_load()` now submits the psycopg connect+query (extracted into `_query_parameters_table`) to a dedicated single-worker `ThreadPoolExecutor` (`_DB_EXECUTOR`, thread name `param-registry-db`). The native connect **always** runs on a real OS worker thread, never the caller's — the supported way to use sync psycopg from async code. `_load()` blocks on `.result(timeout=15s)`; a hung connect fails soft to cache/defaults instead of wedging the kernel.

**2. `main.py`** — `lifespan` startup pre-warms the registry via `await asyncio.to_thread(get_registry().refresh)`. The one-time DB load happens at boot, off the event loop, **before any request handler runs** — so handlers only ever hit the in-memory cache. Fail-soft: a registry-unreachable startup logs a warning and boots anyway.

Either layer alone fixes the crash; together they also cover the refresh-every-N-ticks path and any future lazy `_load()` caller.

## Tests

+5 in `test_parameters_psycopg_isolation.py`:
1. psycopg work runs on a `_DB_EXECUTOR` thread, **not** the caller thread (the load-bearing property)
2. `_load` stays fail-soft on DB error
3. `_load` stays fail-soft on executor timeout (monkeypatched short timeout — fast test)
4. no-DSN path unchanged (defaults only, no DB attempt)
5. successful load populates the cache

`756/756 monkey_kernel tests passing`. Both files parse clean.

## Relationship to PR #674

**This must land + ml-worker must be confirmed healthy under `/monkey/tick/run` load before the cutover merges.** The §5 verification's "smoke test on the endpoint" step is exactly what would have caught this — the 801-test kernel-logic suite doesn't exercise the FastAPI/uvloop/psycopg interaction. After this merges, the cutover branch picks it up via the next main→cutover merge.

## Test plan
- [x] `pytest tests/monkey_kernel/test_parameters_psycopg_isolation.py` — 5/5
- [x] `pytest tests/monkey_kernel/` — 756/756
- [ ] Post-deploy: ml-worker stays UP; hit `/monkey/tick/run` (or wait for a real call) — no `Fatal Python error`; `parameter registry pre-warmed at startup` in logs
- [ ] Post-deploy: polytrade-be `ML worker unavailable` errors stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)