### PR TITLE
fix(ml-worker): gate registry DB-load OFF by default (psycopg connect segfault)

### DIFF
--- a/ml-worker/src/monkey_kernel/parameters.py
+++ b/ml-worker/src/monkey_kernel/parameters.py
@@ -270,10 +270,24 @@ class ParameterRegistry:
         must never execute on the asyncio event-loop thread. Pure
         synchronous psycopg; raises on any DB/parse failure for _load to
         catch.
+
+        sslmode=disable: the Railway internal network
+        (postgres.railway.internal) is already private — SSL adds
+        nothing — and psycopg[binary]'s bundled libpq+openssl can
+        SEGFAULT during the TLS handshake when its openssl symbols
+        collide with the other native extensions loaded in the
+        ml-worker process (TensorFlow, scipy, sklearn, h5py). Skipping
+        the handshake avoids that crash path. Only appended when the
+        DSN doesn't already pin sslmode.
         """
         import psycopg
 
-        with psycopg.connect(self._dsn) as conn:
+        dsn = self._dsn
+        if dsn and "sslmode=" not in dsn:
+            sep = "&" if "?" in dsn else "?"
+            dsn = f"{dsn}{sep}sslmode=disable"
+
+        with psycopg.connect(dsn) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
@@ -323,6 +337,26 @@ class ParameterRegistry:
             if not self._loaded:
                 logger.warning(
                     "DATABASE_URL not set; registry will use defaults only"
+                )
+                self._loaded = True
+            return
+
+        # 2026-05-14: the live DB load is GATED OFF by default. psycopg's
+        # binary wheel bundles libpq+openssl; in the ml-worker process
+        # (TensorFlow / scipy / sklearn / h5py also loaded) the connect()
+        # path SEGFAULTS the whole process — an uncatchable native crash
+        # that restart-loops the service. Until the connect path is
+        # proven safe in that environment (sslmode=disable + a clean
+        # endpoint smoke-test), the registry runs on its hardcoded
+        # defaults — its documented fail-soft mode, and per migration
+        # 047 equal to the current DB values anyway. Flip
+        # MONKEY_PARAM_REGISTRY_DB=true to re-enable once verified.
+        if os.environ.get("MONKEY_PARAM_REGISTRY_DB", "").lower() != "true":
+            if not self._loaded:
+                logger.info(
+                    "parameter registry DB load disabled "
+                    "(MONKEY_PARAM_REGISTRY_DB != 'true') — using hardcoded "
+                    "defaults; this is the documented fail-soft mode",
                 )
                 self._loaded = True
             return

--- a/ml-worker/tests/monkey_kernel/test_parameters_psycopg_isolation.py
+++ b/ml-worker/tests/monkey_kernel/test_parameters_psycopg_isolation.py
@@ -44,7 +44,86 @@ from monkey_kernel.parameters import (  # noqa: E402
 )
 
 
-def test_query_runs_on_db_executor_thread_not_caller() -> None:
+@pytest.fixture
+def db_gate_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable the live DB-load path. _load() is GATED OFF by default
+    (MONKEY_PARAM_REGISTRY_DB != 'true' → defaults-only) because
+    psycopg's binary wheel segfaults the ml-worker process during
+    connect. The DB-path tests below opt in via this fixture so they
+    actually reach _query_parameters_table / the executor."""
+    monkeypatch.setenv("MONKEY_PARAM_REGISTRY_DB", "true")
+
+
+def test_db_load_gated_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The load-bearing safety property: with MONKEY_PARAM_REGISTRY_DB
+    unset, _load() must NOT touch psycopg at all — it short-circuits to
+    defaults-only. This is what keeps ml-worker from segfaulting: no
+    psycopg.connect() call = no native crash."""
+    monkeypatch.delenv("MONKEY_PARAM_REGISTRY_DB", raising=False)
+    reg = ParameterRegistry(dsn="postgresql://stub/notused")
+    called = {"n": 0}
+
+    def must_not_run() -> dict:
+        called["n"] += 1
+        return {}
+
+    reg._query_parameters_table = must_not_run  # type: ignore[method-assign]
+    reg._load()
+
+    assert called["n"] == 0, (
+        "_query_parameters_table ran despite the DB gate being OFF — "
+        "this re-opens the segfault path"
+    )
+    assert reg._loaded is True
+    # get() still works — defaults-only fail-soft mode.
+    assert reg.get("physics.kappa_star", default=64.0) == 64.0
+
+
+def test_query_appends_sslmode_disable() -> None:
+    """_query_parameters_table appends sslmode=disable when the DSN
+    doesn't pin it — the Railway internal network is private (SSL adds
+    nothing) and psycopg[binary]'s bundled openssl is the crash path."""
+    seen: dict[str, str] = {}
+    reg = ParameterRegistry(dsn="postgresql://u:p@postgres.railway.internal:5432/railway")
+
+    class _FakeConn:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def cursor(self):
+            class _Cur:
+                def __enter__(self_): return self_
+                def __exit__(self_, *a): return False
+                def execute(self_, *a): pass
+                def fetchall(self_): return []
+            return _Cur()
+
+    import monkey_kernel.parameters as pm
+
+    class _FakePsycopg:
+        @staticmethod
+        def connect(dsn: str):
+            seen["dsn"] = dsn
+            return _FakeConn()
+
+    # _query_parameters_table does `import psycopg` locally; patch sys.modules.
+    sys.modules["psycopg"] = _FakePsycopg  # type: ignore[assignment]
+    try:
+        reg._query_parameters_table()
+    finally:
+        del sys.modules["psycopg"]
+
+    assert "sslmode=disable" in seen["dsn"], seen["dsn"]
+    # already had a query-string, so the separator must be '&'
+    reg2 = ParameterRegistry(dsn="postgresql://h/db?connect_timeout=5")
+    sys.modules["psycopg"] = _FakePsycopg  # type: ignore[assignment]
+    try:
+        reg2._query_parameters_table()
+    finally:
+        del sys.modules["psycopg"]
+    assert "?connect_timeout=5&sslmode=disable" in seen["dsn"], seen["dsn"]
+
+
+def test_query_runs_on_db_executor_thread_not_caller(db_gate_on: None) -> None:
     """The psycopg connect+query must execute on a _DB_EXECUTOR worker
     thread — never the thread that called _load(). This is the
     load-bearing property: on the real server _load() is reached from
@@ -72,7 +151,7 @@ def test_query_runs_on_db_executor_thread_not_caller() -> None:
     assert reg._loaded is True
 
 
-def test_load_is_failsoft_on_db_error() -> None:
+def test_load_is_failsoft_on_db_error(db_gate_on: None) -> None:
     """A DB/connect failure inside the executor must NOT propagate —
     _load() catches it, marks _loaded so it stops retrying, and the
     registry serves hardcoded defaults via get()."""
@@ -90,6 +169,7 @@ def test_load_is_failsoft_on_db_error() -> None:
 
 
 def test_load_is_failsoft_on_executor_timeout(
+    db_gate_on: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If the connect hangs past _LOAD_TIMEOUT_S, _load() catches the
@@ -142,7 +222,7 @@ def test_no_dsn_path_unchanged() -> None:
     assert reg.get("executive.green_turn_reversal.min_roi", default=0.003) == 0.003
 
 
-def test_successful_load_populates_cache() -> None:
+def test_successful_load_populates_cache(db_gate_on: None) -> None:
     """Happy path: the executor returns a parameter map and _load()
     installs it as the cache; get() then returns the loaded value, not
     the default."""


### PR DESCRIPTION
## ml-worker still crash-looping — #680 did not fix it

PR #680's thread-isolation **did not work**. A native segfault inside psycopg's `connect()` kills the **whole process** regardless of thread — moving the connect to a `_DB_EXECUTOR` worker just relocated the crash. ml-worker is still restart-looping in production.

**Honest correction:** #680 was shipped on unit-test evidence (the executor-isolation logic) without live-testing against the actual production segfault. The segfault is a native-environment crash no Python unit test reproduces. This PR is the corrected fix.

## Root cause

ml-worker installs `psycopg[binary]` — the wheel bundles libpq + openssl. The process also loads TensorFlow, scipy, sklearn, h5py, statsmodels — each with native libs. `DATABASE_URL` is `postgresql://…@postgres.railway.internal:5432/railway` with **no `sslmode` pinned**, so psycopg defaults to `sslmode=prefer` and attempts a TLS handshake. The bundled-openssl symbols collide with the other extensions' openssl during the handshake → **SIGSEGV / SIGABRT**. Uncatchable — the `try/except` in `_load()` never runs.

Latent on `main` (nothing calls `/monkey/tick/run` on a cadence pre-cutover); **hard blocker for PR #674** (post-cutover every tick calls it).

## Fix — guaranteed + targeted

**1. GUARANTEED** — `_load()` is gated behind `MONKEY_PARAM_REGISTRY_DB`, **default OFF**. When off, `_load()` short-circuits to the same defaults-only path as the no-DSN case. **No `psycopg.connect()` call → the segfault in `psycopg.connect()` is a logical impossibility, not a hope.** The registry runs on hardcoded defaults — its documented fail-soft mode (every `.get()` passes a default), and per migration 047 the DB values currently *equal* the code defaults, so **no behavioural delta**.

**2. TARGETED** — `_query_parameters_table()` appends `sslmode=disable` to the DSN when not already pinned. The Railway internal network is private (SSL adds nothing); skipping the handshake avoids the openssl-collision crash path. Staged for when `MONKEY_PARAM_REGISTRY_DB` is flipped on *after* a clean endpoint smoke-test.

#680's executor isolation + startup pre-warm are **kept** — harmless no-ops while the gate is off, real defense-in-depth once the DB load is re-enabled.

## Tests

7 total in `test_parameters_psycopg_isolation.py` (+2 this PR):
- `test_db_load_gated_off_by_default` — the load-bearing safety property: gate OFF → `_query_parameters_table` is **never** invoked
- `test_query_appends_sslmode_disable` — `sslmode=disable` appended with correct `?`/`&` separator
- the 5 prior tests opt into the DB path via a `db_gate_on` fixture

`758/758 monkey_kernel tests passing`.

## Operator note

To re-enable the live registry DB load later: set `MONKEY_PARAM_REGISTRY_DB=true` on ml-worker **and first confirm** via a `/monkey/tick/run` smoke-test that `connect()` with `sslmode=disable` doesn't crash in that process. Until then, defaults-only is correct and safe.

## Test plan
- [x] `pytest tests/monkey_kernel/test_parameters_psycopg_isolation.py` — 7/7
- [x] `pytest tests/monkey_kernel/` — 758/758
- [ ] **Post-deploy (the real verification):** ml-worker boots and STAYS UP — no `Fatal Python error`, no restart loop; log shows `parameter registry DB load disabled … using hardcoded defaults`
- [ ] Post-deploy: polytrade-be `ML worker unavailable` errors stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)