### PR TITLE
fix(logger): circular-safe winston formatter — stop 429s failing ticks

### DIFF
--- a/apps/api/src/utils/__tests__/logger.circular.test.ts
+++ b/apps/api/src/utils/__tests__/logger.circular.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression: a logger must never throw on its caller.
+ *
+ * 2026-05-14 production: post-cutover, every Poloniex 429 produced
+ * `[Monkey] <sym> tick failed {"err":"Converting circular structure
+ * to JSON ... TLSSocket"}`. Root cause: winston's printf formatter did
+ * `JSON.stringify(metadata)`; an axios error spread into metadata
+ * carries `.request → .socket` (a circular TLSSocket), so the stringify
+ * threw — and that throw replaced the original 429, failing the tick.
+ *
+ * The formatter is now circular-safe. These tests pin that a
+ * `logger.error(msg, <object-with-a-cycle>)` call completes normally.
+ */
+import { describe, it, expect } from 'vitest';
+import { logger } from '../logger.js';
+
+describe('logger circular-structure safety', () => {
+  it('does not throw when metadata contains a direct cycle', () => {
+    const cyclic: Record<string, unknown> = { a: 1 };
+    cyclic.self = cyclic;
+    expect(() => logger.error('cyclic metadata', cyclic)).not.toThrow();
+  });
+
+  it('does not throw on an axios-shaped error (request → socket → request)', () => {
+    // Mirrors the real failure: an axios error whose .request.socket
+    // points back up the graph.
+    const socket: Record<string, unknown> = { constructor: { name: 'TLSSocket' } };
+    const request: Record<string, unknown> = { socket };
+    socket.parser = { socket };
+    const axiosLikeError = Object.assign(new Error('Request failed with status code 429'), {
+      request,
+      response: { status: 429, data: '' },
+    });
+    expect(() => logger.error('Error fetching historical data for BTC:', axiosLikeError)).not.toThrow();
+  });
+
+  it('still logs plain metadata correctly', () => {
+    expect(() => logger.info('plain metadata', { endpoint: '/market/candles', status: 200 })).not.toThrow();
+  });
+});

--- a/apps/api/src/utils/logger.js
+++ b/apps/api/src/utils/logger.js
@@ -8,12 +8,29 @@ const __dirname = path.dirname(__filename);
 // Keys to exclude from metadata logging
 const EXCLUDED_METADATA_KEYS = ['level', 'message', 'timestamp'];
 
+// A logger must never throw on its caller. Axios errors carry
+// .request → .socket (a circular TLSSocket); winston spreads an
+// error's own-properties into metadata, so a raw
+// `logger.error(msg, axiosErr)` would make JSON.stringify throw
+// "Converting circular structure to JSON" — and that throw replaces
+// the original error, turning a recoverable 429 into a failed tick.
+const safeStringify = (obj) => {
+  const seen = new WeakSet();
+  return JSON.stringify(obj, (_key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) return '[Circular]';
+      seen.add(value);
+    }
+    return value;
+  });
+};
+
 const logFormat = winston.format.combine(
   winston.format.timestamp(),
   winston.format.errors({ stack: true }),
   winston.format.printf(({ timestamp, level, message, stack, ...metadata }) => {
     let logMessage = `${timestamp} [${level.toUpperCase()}]: ${stack || message}`;
-    
+
     // Add metadata if present (for structured logging)
     const metadataKeys = Object.keys(metadata);
     if (metadataKeys.length > 0 && metadataKeys.some(key => !EXCLUDED_METADATA_KEYS.includes(key))) {
@@ -21,10 +38,10 @@ const logFormat = winston.format.combine(
         Object.entries(metadata).filter(([key]) => !EXCLUDED_METADATA_KEYS.includes(key))
       );
       if (Object.keys(cleanMetadata).length > 0) {
-        logMessage += ` ${JSON.stringify(cleanMetadata)}`;
+        logMessage += ` ${safeStringify(cleanMetadata)}`;
       }
     }
-    
+
     return logMessage;
   })
 );


### PR DESCRIPTION
## Summary
- Post-cutover production: every Poloniex 429 produced `[Monkey] <sym> tick failed {"err":"Converting circular structure to JSON ... TLSSocket"}`.
- Root cause: the winston printf formatter did `JSON.stringify(metadata)`. A raw `logger.error(msg, axiosError)` spreads the axios error's own-props into metadata; the axios error carries `.request → .socket` (a circular TLSSocket). The stringify threw a `TypeError` *inside* `logger.error()`, so the throw propagated out and **replaced** the original 429 — turning a recoverable rate-limit into a failed Monkey tick.
- Fix: a circular-safe `safeStringify` (WeakSet `[Circular]` replacer) used by the formatter. One change at the root — protects every `logger.error(msg, obj)` site, not just the candles path. A logger must never throw on its caller.

## Test plan
- [x] `+3` regression tests in `logger.circular.test.ts` — direct cycle, axios-shaped `request→socket→request` cycle, plain-metadata unchanged. All pass.
- [x] `tsc -p tsconfig.json --noEmit` clean.
- [ ] Post-deploy: confirm Poloniex 429s log cleanly and no longer surface as `tick failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make logger formatting robust against circular metadata so logging cannot throw and interfere with request handling.

Bug Fixes:
- Prevent logger from throwing when logging errors or metadata containing circular references, avoiding masked upstream errors such as 429 rate limits being treated as failures.

Tests:
- Add regression tests covering circular reference handling and axios-style request/socket cycles in logger metadata, as well as non-circular metadata behavior.