### PR TITLE
fix(logger): handle BigInt + guarantee safeStringify never throws

### DIFF
--- a/apps/api/src/utils/__tests__/logger.circular.test.ts
+++ b/apps/api/src/utils/__tests__/logger.circular.test.ts
@@ -37,4 +37,13 @@ describe('logger circular-structure safety', () => {
   it('still logs plain metadata correctly', () => {
     expect(() => logger.info('plain metadata', { endpoint: '/market/candles', status: 200 })).not.toThrow();
   });
+
+  it('does not throw when metadata contains a BigInt (JSON.stringify rejects it)', () => {
+    expect(() => logger.warn('bigint metadata', { qty: 9007199254740993n })).not.toThrow();
+  });
+
+  it('does not throw when a nested getter throws during serialization', () => {
+    const hostile = { get bad() { throw new Error('getter exploded'); } };
+    expect(() => logger.error('hostile metadata', { hostile })).not.toThrow();
+  });
 });

--- a/apps/api/src/utils/logger.js
+++ b/apps/api/src/utils/logger.js
@@ -14,15 +14,23 @@ const EXCLUDED_METADATA_KEYS = ['level', 'message', 'timestamp'];
 // `logger.error(msg, axiosErr)` would make JSON.stringify throw
 // "Converting circular structure to JSON" — and that throw replaces
 // the original error, turning a recoverable 429 into a failed tick.
+// The replacer handles circular refs and BigInt (JSON.stringify
+// rejects BigInt outright); the try/catch is the final guarantee —
+// whatever else is in the metadata, this returns a string, never throws.
 const safeStringify = (obj) => {
   const seen = new WeakSet();
-  return JSON.stringify(obj, (_key, value) => {
-    if (typeof value === 'object' && value !== null) {
-      if (seen.has(value)) return '[Circular]';
-      seen.add(value);
-    }
-    return value;
-  });
+  try {
+    return JSON.stringify(obj, (_key, value) => {
+      if (typeof value === 'bigint') return `${value}n`;
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) return '[Circular]';
+        seen.add(value);
+      }
+      return value;
+    });
+  } catch (err) {
+    return `[unserializable metadata: ${err instanceof Error ? err.message : String(err)}]`;
+  }
 };
 
 const logFormat = winston.format.combine(


### PR DESCRIPTION
## Summary
Follow-up to #682, addressing the Sourcery review comment on that PR.

- Sourcery flagged that the circular-safe `safeStringify` could **still throw**: `JSON.stringify` rejects `BigInt` outright, so `logger.error(msg, { qty: 123n })` would still crash the caller — the exact failure mode #682 set out to eliminate.
- Replacer now coerces `BigInt → "<n>n"` string.
- The whole stringify is wrapped in `try/catch` with an `[unserializable metadata: ...]` fallback — whatever else lands in the metadata (a `.toJSON` that throws, an exotic host object), the logger returns a string and **never throws on its caller**.

## Test plan
- [x] `+2` regression tests in `logger.circular.test.ts` — BigInt metadata, and a nested getter that throws during serialization. 5/5 pass.
- [x] `tsc -p tsconfig.json --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)