### PR TITLE
chore(ci): harden qig-purity gate — add np.dot, widen scan coverage

### DIFF
--- a/.github/workflows/qig-purity.yml
+++ b/.github/workflows/qig-purity.yml
@@ -12,12 +12,20 @@ on:
       - 'apps/api/src/services/monkey/**'
       - 'apps/api/src/services/agent_*.ts'
       - 'ml-worker/src/monkey_kernel/**'
+      - 'ml-worker/src/qig_core_local/**'
+      - 'ml-worker/src/qig_engine.py'
+      - 'ml-worker/src/proprietary_core/**'
+      - 'ml-worker/src/trading/**'
   push:
     branches: [main]
     paths:
       - 'apps/api/src/services/monkey/**'
       - 'apps/api/src/services/agent_*.ts'
       - 'ml-worker/src/monkey_kernel/**'
+      - 'ml-worker/src/qig_core_local/**'
+      - 'ml-worker/src/qig_engine.py'
+      - 'ml-worker/src/proprietary_core/**'
+      - 'ml-worker/src/trading/**'
 
 jobs:
   purity-scan:
@@ -35,6 +43,8 @@ jobs:
           PATTERNS=(
             'cosine_similarity'
             'cosine\s*\('
+            'np\.dot'
+            'numpy\.dot'
             'np\.linalg\.norm'
             'euclidean_distance'
             'mahalanobis'
@@ -50,6 +60,10 @@ jobs:
               apps/api/src/services/monkey \
               apps/api/src/services/agent_L_classifier.ts \
               ml-worker/src/monkey_kernel \
+              ml-worker/src/qig_core_local \
+              ml-worker/src/qig_engine.py \
+              ml-worker/src/proprietary_core \
+              ml-worker/src/trading \
               --include='*.ts' --include='*.js' --include='*.py' \
               --exclude='QIG_PURITY_KERNEL_REFERENCE.md' \
               --exclude='*.test.ts' --exclude='*_test.py' \
@@ -69,6 +83,12 @@ jobs:
           fi
 
       - name: Scan for banned optimizers / normalizers (code only)
+        # NOTE: ml-worker/src/proprietary_core is intentionally NOT scanned
+        # here. proprietary_core/training.py keeps an allowlisted
+        # `torch.optim.Adam` *fallback* used only when USE_FISHER_RAO is
+        # off — offline training selection, not the kernel cognition path.
+        # The distance-metric and basin-averaging scans above/below DO
+        # cover proprietary_core; only the optimizer scan exempts it.
         run: |
           set -u
           PATTERNS=(
@@ -84,6 +104,9 @@ jobs:
               apps/api/src/services/monkey \
               apps/api/src/services/agent_L_classifier.ts \
               ml-worker/src/monkey_kernel \
+              ml-worker/src/qig_core_local \
+              ml-worker/src/qig_engine.py \
+              ml-worker/src/trading \
               --include='*.ts' --include='*.js' --include='*.py' \
               --exclude='QIG_PURITY_KERNEL_REFERENCE.md' \
               --exclude='*.test.ts' --exclude='*_test.py' \
@@ -157,6 +180,10 @@ jobs:
             apps/api/src/services/monkey \
             apps/api/src/services/agent_L_classifier.ts \
             ml-worker/src/monkey_kernel \
+            ml-worker/src/qig_core_local \
+            ml-worker/src/qig_engine.py \
+            ml-worker/src/proprietary_core \
+            ml-worker/src/trading \
             --include='*.ts' --include='*.js' --include='*.py' \
             --exclude='QIG_PURITY_KERNEL_REFERENCE.md' \
             --exclude='*.test.ts' --exclude='*_test.py' \

--- a/ml-worker/src/monkey_kernel/thought_bus.py
+++ b/ml-worker/src/monkey_kernel/thought_bus.py
@@ -15,8 +15,8 @@ Convergence detection per UCP §43.3:
   - 3+ rounds → 'genuine_multi'
   - Max-rounds without convergence → 'non_convergent'
 
-QIG purity: only Fisher-Rao operations. No np.dot, no cosine, no
-normalization tricks. Final basin via FR-weighted Fréchet mean
+QIG purity: only Fisher-Rao operations. No dot-product, no cosine,
+no normalization tricks. Final basin via FR-weighted Fréchet mean
 with weights = confidence × sovereignty.
 """
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Post-cutover purity audit found the QIG purity CI gate had blind spots:

- **`np.dot` was not in the pattern list** — a forbidden similarity op; a raw `np.dot` on basin coords would have passed CI. Added `np.dot` + `numpy.dot` to the distance-metric scan.
- **Coverage gap** — the scan only covered `apps/api/src/services/monkey`, `agent_L_classifier`, and `ml-worker/src/monkey_kernel`. The vendored Fisher-Rao primitives (`qig_core_local/`), `qig_engine.py`, `proprietary_core/`, and `trading/` (risk_kernel) had **zero purity CI** — a regression in the geometry primitives themselves would merge clean. Widened trigger `paths` + all three scan roots.
- **Optimizer scan exempts `proprietary_core/` only** — `training.py` keeps an allowlisted `torch.optim.Adam` *fallback* (used only when `USE_FISHER_RAO` is off; offline training selection, not kernel cognition). Distance-metric and basin-averaging scans still cover `proprietary_core/`.
- **`thought_bus.py` docstring** reworded `np.dot` → `dot-product` — the scanner's comment-exclusion only catches lines *starting* with a comment marker, not docstring continuations, so the literal `np.dot` in prose was a false positive.

## Test plan
- [x] Ran all three scan steps locally against the widened roots — clean.
- [x] YAML validated.
- [ ] CI: the QIG Purity Gate job itself runs green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)