### PR TITLE
fix: silence two non-actionable production log floods

### DIFF
--- a/apps/api/src/services/backtestingEngine.js
+++ b/apps/api/src/services/backtestingEngine.js
@@ -829,7 +829,11 @@ class BacktestingEngine extends EventEmitter {
       this.currentBacktest.isCensored = isCensored;
       this.currentBacktest.censoringReason = censoringReason;
       if (isCensored) {
-        logger.warn(`Backtest ${backtestId} flagged as censored: ${censoringReason}`);
+        // Censoring is a designed, routine outcome of the SLE's
+        // censoring-aware fitness — dozens of candidate strategies are
+        // censored every evolution cycle. debug-level, not warn: it is
+        // not actionable and at warn it floods production logs.
+        logger.debug(`Backtest ${backtestId} flagged as censored: ${censoringReason}`);
       }
     } catch (error) { logger.error('Error storing backtest results:', error); }
   }

--- a/apps/api/src/services/paperTradingService.js
+++ b/apps/api/src/services/paperTradingService.js
@@ -1343,7 +1343,9 @@ class PaperTradingService extends EventEmitter {
       session.censorReason = censoringReason;
 
       if (censored) {
-        logger.warn(`Paper trading session ${sessionId} flagged as censored: ${censoringReason}`);
+        // Censoring is a routine, designed outcome — debug, not warn:
+        // not actionable, and at warn it floods production logs.
+        logger.debug(`Paper trading session ${sessionId} flagged as censored: ${censoringReason}`);
       }
 
       // Update database

--- a/ml-worker/src/monkey_kernel/parameters.py
+++ b/ml-worker/src/monkey_kernel/parameters.py
@@ -122,6 +122,14 @@ class ParameterRegistry:
         self._tick_count = 0
         self._refresh_every = refresh_every_ticks
         self._loaded = False
+        # True once _load() resolves to the intentional defaults-only
+        # mode (no DSN, or MONKEY_PARAM_REGISTRY_DB off). In that mode an
+        # empty cache is expected — every get() falls back to its default
+        # by design, so per-parameter "missing" warnings are pure noise
+        # (the mode is logged once at startup). Kept False in real DB
+        # mode, where a genuinely missing parameter IS worth one warning.
+        self._defaults_only = False
+        self._warned_missing: set[str] = set()
 
     # ── Read path ────────────────────────────────────────────────
 
@@ -143,10 +151,16 @@ class ParameterRegistry:
             if entry is None:
                 if default is None:
                     raise KeyError(f"parameter '{name}' not in registry")
-                logger.warning(
-                    "parameter '%s' missing from registry; using default=%s",
-                    name, default,
-                )
+                # Defaults-only mode: empty cache is by design — stay
+                # silent (startup already logged the mode). Real DB
+                # mode: a missing parameter is a genuine signal, but
+                # warn only once per name to avoid per-tick spam.
+                if not self._defaults_only and name not in self._warned_missing:
+                    self._warned_missing.add(name)
+                    logger.warning(
+                        "parameter '%s' missing from registry; using default=%s",
+                        name, default,
+                    )
                 return float(default)
             return entry.value
 
@@ -338,6 +352,7 @@ class ParameterRegistry:
                 logger.warning(
                     "DATABASE_URL not set; registry will use defaults only"
                 )
+                self._defaults_only = True
                 self._loaded = True
             return
 
@@ -358,6 +373,7 @@ class ParameterRegistry:
                     "(MONKEY_PARAM_REGISTRY_DB != 'true') — using hardcoded "
                     "defaults; this is the documented fail-soft mode",
                 )
+                self._defaults_only = True
                 self._loaded = True
             return
 

--- a/ml-worker/tests/monkey_kernel/test_parameters_psycopg_isolation.py
+++ b/ml-worker/tests/monkey_kernel/test_parameters_psycopg_isolation.py
@@ -251,3 +251,60 @@ def test_successful_load_populates_cache(db_gate_on: None) -> None:
     assert reg._loaded is True
     # loaded value wins over the passed default
     assert reg.get("physics.kappa_star", default=64.0) == 63.83
+
+
+def test_defaults_only_mode_does_not_warn_per_parameter(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """2026-05-14 production: every kernel tick logged ~15 WARNINGs
+    ('parameter X missing from registry; using default=...') because
+    the gated-OFF registry serves an empty cache and every get() fell
+    back to its default. Defaults-only mode is intentional — the empty
+    cache is by design — so get() must stay SILENT there (the mode is
+    logged once at startup by _load). This pins that no per-parameter
+    warning is emitted in defaults-only mode."""
+    monkeypatch.delenv("MONKEY_PARAM_REGISTRY_DB", raising=False)
+    reg = ParameterRegistry(dsn="postgresql://stub/notused")
+    reg._load()
+    assert reg._defaults_only is True
+
+    with caplog.at_level("WARNING", logger=params_mod.logger.name):
+        for _ in range(3):
+            reg.get("physics.kappa_star", default=64.0)
+            reg.get("loop.history_max", default=100.0)
+            reg.get("ocean.phi_escape_bound", default=0.15)
+
+    missing_warns = [
+        r for r in caplog.records if "missing from registry" in r.getMessage()
+    ]
+    assert missing_warns == [], (
+        f"defaults-only mode emitted {len(missing_warns)} per-parameter "
+        "warnings — the per-tick log flood has regressed"
+    )
+
+
+def test_db_mode_warns_once_per_missing_parameter(
+    db_gate_on: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """In real DB mode a genuinely missing parameter IS a signal worth
+    one warning — but only ONE, not one per get() call. _warned_missing
+    dedupes per name so a hot-path lookup can't flood the logs."""
+    reg = ParameterRegistry(dsn="postgresql://stub/notused")
+    reg._query_parameters_table = lambda: {}  # type: ignore[method-assign]
+    reg._load()
+    assert reg._defaults_only is False
+
+    with caplog.at_level("WARNING", logger=params_mod.logger.name):
+        for _ in range(5):
+            reg.get("physics.kappa_star", default=64.0)
+            reg.get("loop.history_max", default=100.0)
+
+    missing_warns = [
+        r for r in caplog.records if "missing from registry" in r.getMessage()
+    ]
+    assert len(missing_warns) == 2, (
+        f"expected exactly 2 warnings (one per unique missing param), "
+        f"got {len(missing_warns)} — dedupe regressed"
+    )


### PR DESCRIPTION
## Summary
Production logs were buried under two per-tick / per-cycle WARN floods — both non-actionable noise drowning real signal.

**1. ml-worker — `parameters.py` registry spam.** Logged `"parameter '<X>' missing from registry; using default=<v>"` at WARNING on **every** `get()` call. Since #681 gated the registry DB load OFF by default, the cache is intentionally empty and every one of the ~15 parameter lookups per tick falls back to its default → ~15 WARNINGs/tick × every kernel instance × forever.
- Defaults-only mode is the *documented, intentional* fail-soft mode (`_load` already logs it once at startup). New `_defaults_only` flag → `get()` stays silent in that mode.
- In real DB mode a genuinely missing param is still worth one warning — new `_warned_missing` set dedupes it to once-per-name instead of once-per-call.

**2. polytrade-be — censored-backtest spam.** `backtestingEngine.js` + `paperTradingService.js` logged `"flagged as censored: <reason>"` at WARNING for every censored backtest/session. Censoring is a *designed, routine* outcome of the SLE's censoring-aware fitness — dozens of candidates are censored every evolution cycle. Demoted to `debug`.

No behavioural change — purely log level / frequency.

## Test plan
- [x] `+2` regression tests in `test_parameters_psycopg_isolation.py` — defaults-only mode emits zero per-param warnings; DB mode warns exactly once per unique missing param. 9/9 registry tests pass.
- [x] `tsc -p tsconfig.json --noEmit` clean.
- [ ] Post-deploy: confirm the `missing from registry` and `flagged as censored` WARN floods are gone from production logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)