### PR TITLE
feat(ml-worker): #695 shadow-mode qig_warp regime classifier (no live impact)

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -681,6 +681,7 @@ async def root():
             "ingest": "/run/ingest (POST)",
             "governance_status": "/governance/status (GET)",
             "governance_ml_parity": "/governance/ml-predict-parity (GET)",
+            "governance_regime_parity": "/governance/regime-parity (GET) — issue #695 shadow",
             "monkey_tick": "/monkey/tick/run (POST)",
             "monkey_autonomic_tick": "/monkey/autonomic/tick (POST)",
             "monkey_executive_decide": "/monkey/executive/decide (POST)",
@@ -835,6 +836,55 @@ async def governance_ml_predict_parity(limit: int = 200):
         "sample_count": len(rows),
         "signal_disagreements": diffs,
         "disagreement_ratio": (diffs / len(rows)) if rows else 0.0,
+        "rows": rows,
+    }
+
+
+@app.get("/governance/regime-parity")
+async def governance_regime_parity(limit: int = 200):
+    """Parity-diff ring buffer for issue #695 — qig_warp shadow regime.
+
+    Populated every time StrategyLoop.tick runs (i.e. every /ml/predict
+    call on the v0.8 path). Each row carries the live MarketRegime
+    (creator/preserver/dissolver) alongside the published
+    qig_warp.classify_regime output (CRITICAL/DISORDERED/ORDERED) and
+    the (h, J) inputs that drove the shadow call. The live trading
+    path is unaffected — this is read-only telemetry.
+
+    Promotion gate (per #689 discipline): the cutover PR that
+    replaces RegimeDetector with qig_warp.classify_regime ships only
+    after the parity-log accumulates a representative tape window and
+    the shadow/live mapping stabilises (or the mapping is re-calibrated
+    based on the observed diff distribution).
+    """
+    from proprietary_core.regime_shadow import (
+        get_regime_parity_log,
+        SHADOW_EQUIVALENCE_GUESS,
+    )
+    rows = get_regime_parity_log()
+    rows = rows[-max(1, min(limit, 2000)):]
+    # Tally diffs against the v0 first-order equivalence guess so the
+    # operator can eyeball mapping accuracy at a glance.
+    matches = 0
+    diffs = 0
+    errors = 0
+    for r in rows:
+        if r.get("shadow_error"):
+            errors += 1
+            continue
+        guess = SHADOW_EQUIVALENCE_GUESS.get(r.get("live_regime", ""))
+        if r.get("shadow_regime") == guess:
+            matches += 1
+        else:
+            diffs += 1
+    return {
+        "available": True,
+        "sample_count": len(rows),
+        "shadow_errors": errors,
+        "matches_v0_guess": matches,
+        "diffs_v0_guess": diffs,
+        "match_ratio": (matches / (matches + diffs)) if (matches + diffs) else 0.0,
+        "equivalence_guess_v0": SHADOW_EQUIVALENCE_GUESS,
         "rows": rows,
     }
 

--- a/ml-worker/src/proprietary_core/regime_shadow.py
+++ b/ml-worker/src/proprietary_core/regime_shadow.py
@@ -1,0 +1,143 @@
+"""regime_shadow.py — shadow-mode parity probe for issue #695.
+
+The bespoke ``RegimeDetector`` in ``regime.py`` produces a
+``MarketRegime`` (CREATOR / PRESERVER / DISSOLVER) from Shannon entropy
++ trend strength. The published ``qig_warp.classify_regime(h, J, dim)``
+produces a physics ``Regime`` (CRITICAL / DISORDERED / ORDERED) from
+lattice transverse field ``h`` + coupling ``J``.
+
+This module runs the published classifier in parallel with the live
+one and logs the diff so the operator has evidence to promote (or
+reject) the swap. The live trading path is unaffected — every call
+here is fire-and-forget with broad exception handling, and the live
+``MarketRegime`` continues to drive ``_regime_to_direction``.
+
+Shadow only. Per the #689 discipline (translation-only PRs, parity
+gating before cutover), the swap itself ships in a separate PR once
+the parity-log accumulates a representative tape window.
+
+Market → physics mapping (calibration v0, deliberately first-order
+so the parity-log surfaces calibration error as a measurable signal):
+
+  h  ← regime_state.entropy            (Shannon entropy of return distribution
+                                        — analogue of disorder pressure)
+  J  ← regime_state.trend_strength     (|mean / std| of returns
+                                        — analogue of coupling strength)
+  dim = 2                              (futures order-book is effectively 2D
+                                        — bid + ask depth; matches the
+                                        2D critical_ratio in qig_warp)
+
+The mapping is intentionally a 1:1 metric-to-metric port; if it turns
+out h or J need a scale factor (e.g. h × C_h, J × C_J) to land in the
+range where qig_warp's CRITICAL_RATIO_2D is meaningful, the parity-log
+distribution will show DISORDERED-only or ORDERED-only outputs, and
+the cutover PR re-calibrates from there.
+
+This module never raises. Any failure path returns ``None`` and is
+recorded as a parity row with ``shadow_error`` populated.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from .regime import MarketRegime, RegimeState
+
+logger = logging.getLogger(__name__)
+
+# Module-local parity log. Same ring-buffer pattern as main.py's
+# _PARITY_LOG / _record_parity but scoped to regime-shadow rows so
+# the existing /governance/ml-predict-parity log isn't polluted.
+_REGIME_PARITY_LOG: list[dict[str, Any]] = []
+_REGIME_PARITY_LOG_MAX = 2_000
+_REGIME_PARITY_LOG_LOCK = threading.Lock()
+
+
+def _record_regime_parity(row: dict[str, Any]) -> None:
+    """Append a parity-comparison row. Bounded ring buffer (FIFO eviction
+    when full — drops the oldest 10% in one shot to amortise cost)."""
+    with _REGIME_PARITY_LOG_LOCK:
+        _REGIME_PARITY_LOG.append(row)
+        if len(_REGIME_PARITY_LOG) > _REGIME_PARITY_LOG_MAX:
+            del _REGIME_PARITY_LOG[: _REGIME_PARITY_LOG_MAX // 10]
+
+
+def get_regime_parity_log() -> list[dict[str, Any]]:
+    """Snapshot copy of the current parity log. Safe to call from any
+    thread; returns a list copy, not the underlying buffer."""
+    with _REGIME_PARITY_LOG_LOCK:
+        return list(_REGIME_PARITY_LOG)
+
+
+def shadow_classify(
+    regime_state: Optional[RegimeState],
+    symbol: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """Run ``qig_warp.classify_regime`` against the live ``RegimeState``
+    and emit a parity row. Returns the row (also recorded internally)
+    or ``None`` when no live state is available.
+
+    Never raises. Any error path returns a row with ``shadow_error``
+    populated; the caller still gets a structured log entry.
+
+    Cheap: a single function call into qig_warp + one ring-buffer
+    insert. The live ``RegimeDetector.update`` already computed every
+    quantity this function consumes — no recomputation of price-series
+    statistics.
+    """
+    if regime_state is None:
+        return None
+
+    started = time.monotonic()
+    live_regime_value = regime_state.regime.value
+    h = float(regime_state.entropy)
+    j = float(regime_state.trend_strength)
+
+    shadow_regime: Optional[str] = None
+    shadow_error: Optional[str] = None
+    try:
+        from qig_warp import classify_regime  # type: ignore[import-not-found]
+        warp_regime = classify_regime(h=h, J=j, dim=2)
+        # WarpRegime is an enum; .value (or .name) gives a stable string.
+        shadow_regime = getattr(warp_regime, "value", None) or getattr(warp_regime, "name", str(warp_regime))
+    except ImportError as exc:
+        shadow_error = f"ImportError: {exc}"
+    except Exception as exc:  # noqa: BLE001 — shadow must never break live
+        shadow_error = f"{type(exc).__name__}: {exc}"
+
+    row: dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "symbol": symbol,
+        "live_regime": live_regime_value,
+        "shadow_regime": shadow_regime,
+        "shadow_error": shadow_error,
+        "h": h,
+        "J": j,
+        "dim": 2,
+        # Live-side ancillary metrics — useful when post-hoc analysis
+        # wants to see WHICH price-series shape produced a given diff.
+        "live_confidence": float(regime_state.confidence),
+        "live_volatility": float(regime_state.volatility),
+        "live_fisher_info": float(regime_state.fisher_info),
+        "live_is_transition": bool(regime_state.is_transition),
+        "shadow_latency_ms": round((time.monotonic() - started) * 1000.0, 3),
+    }
+    _record_regime_parity(row)
+    return row
+
+
+# Compact equivalence map used by post-hoc analysis tooling. Not used
+# at runtime — both regimes are logged raw so the operator can re-map.
+# Conjectured first-order alignment (to be validated by the live tape):
+#   CREATOR    ↔ DISORDERED  (high entropy → disorder)
+#   PRESERVER  ↔ ORDERED     (trend present → coupling → order)
+#   DISSOLVER  ↔ CRITICAL    (low entropy + no trend → near-critical edge)
+SHADOW_EQUIVALENCE_GUESS: dict[str, str] = {
+    MarketRegime.CREATOR.value: "DISORDERED",
+    MarketRegime.PRESERVER.value: "ORDERED",
+    MarketRegime.DISSOLVER.value: "CRITICAL",
+}

--- a/ml-worker/src/proprietary_core/strategy_loop.py
+++ b/ml-worker/src/proprietary_core/strategy_loop.py
@@ -146,6 +146,19 @@ class StrategyLoop:
         # === FEEL: Regime detection ===
         self._last_regime = self._regime.update(price)
 
+        # === SHADOW: qig_warp.classify_regime parity probe (issue #695) ===
+        # Fire-and-forget — the shadow function never raises and the
+        # live MarketRegime drives the live decision below regardless.
+        # Diff lands in proprietary_core.regime_shadow._REGIME_PARITY_LOG
+        # and is exposed via /governance/regime-parity for post-hoc
+        # analysis. Per #689 discipline this stays shadow until the
+        # parity-log accumulates a representative window.
+        try:
+            from .regime_shadow import shadow_classify
+            shadow_classify(self._last_regime, symbol=self.symbol)
+        except Exception:  # noqa: BLE001 — shadow MUST NOT affect live
+            pass
+
         # === FEEL: Coupling update (if signal/pnl provided) ===
         if signal_value is not None and pnl_value is not None:
             self._last_coupling = self._coupling.update(signal_value, pnl_value)

--- a/ml-worker/tests/test_regime_shadow.py
+++ b/ml-worker/tests/test_regime_shadow.py
@@ -1,0 +1,145 @@
+"""Tests for proprietary_core.regime_shadow (issue #695).
+
+The qig_warp call itself isn't exercised here (the test environment
+may or may not have qig_warp installed). What IS tested:
+  - shadow_classify always returns a row, even when qig_warp raises
+    or is missing — the live path must never see an exception
+  - the row schema is stable (live_regime, shadow_regime,
+    shadow_error, h, J, dim, timing fields)
+  - the parity log is a bounded ring buffer (FIFO eviction)
+  - None input is a no-op (no row appended, returns None)
+
+A separate parity-log integration test would run the live tape
+through StrategyLoop and verify rows accumulate; that's better
+exercised on Railway, not in unit tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make the `src/` package layout importable when pytest is run from
+# the ml-worker/ root (no pyproject.toml / conftest yet).
+_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from proprietary_core.regime import MarketRegime, RegimeState  # noqa: E402
+from proprietary_core.regime_shadow import (  # noqa: E402
+    SHADOW_EQUIVALENCE_GUESS,
+    _REGIME_PARITY_LOG,
+    _REGIME_PARITY_LOG_MAX,
+    get_regime_parity_log,
+    shadow_classify,
+)
+
+
+def _make_state(regime: MarketRegime = MarketRegime.CREATOR) -> RegimeState:
+    return RegimeState(
+        regime=regime,
+        entropy=2.7,
+        fisher_info=0.5,
+        trend_strength=0.18,
+        volatility=0.012,
+        confidence=0.6,
+        is_transition=False,
+        pillar1_gate=True,
+    )
+
+
+def _reset_log() -> None:
+    _REGIME_PARITY_LOG.clear()
+
+
+class TestShadowClassify:
+    def test_none_input_returns_none_no_row(self):
+        _reset_log()
+        row = shadow_classify(None, symbol="BTC")
+        assert row is None
+        assert get_regime_parity_log() == []
+
+    def test_returns_row_with_stable_schema(self):
+        _reset_log()
+        state = _make_state(MarketRegime.PRESERVER)
+        row = shadow_classify(state, symbol="ETH_USDT_PERP")
+        assert row is not None
+        for key in (
+            "timestamp",
+            "symbol",
+            "live_regime",
+            "shadow_regime",
+            "shadow_error",
+            "h",
+            "J",
+            "dim",
+            "live_confidence",
+            "live_volatility",
+            "live_fisher_info",
+            "live_is_transition",
+            "shadow_latency_ms",
+        ):
+            assert key in row, f"missing key in parity row: {key}"
+        assert row["symbol"] == "ETH_USDT_PERP"
+        assert row["live_regime"] == "preserver"
+        assert row["h"] == 2.7
+        assert row["J"] == 0.18
+        assert row["dim"] == 2
+        # One of shadow_regime / shadow_error MUST be populated.
+        assert (row["shadow_regime"] is not None) or (row["shadow_error"] is not None)
+
+    def test_appends_to_parity_log(self):
+        _reset_log()
+        shadow_classify(_make_state(), symbol="BTC")
+        shadow_classify(_make_state(MarketRegime.DISSOLVER), symbol="ETH")
+        rows = get_regime_parity_log()
+        assert len(rows) == 2
+        assert rows[0]["symbol"] == "BTC"
+        assert rows[1]["symbol"] == "ETH"
+        assert rows[1]["live_regime"] == "dissolver"
+
+    def test_never_raises_on_qig_warp_failure(self, monkeypatch):
+        # Force the qig_warp import inside shadow_classify to fail.
+        import importlib
+        real_import = importlib.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "qig_warp":
+                raise RuntimeError("simulated qig_warp explosion")
+            return real_import(name, *args, **kwargs)
+
+        # Patch builtins.__import__ so the in-function `from qig_warp
+        # import classify_regime` goes through our fake.
+        monkeypatch.setattr("builtins.__import__", fake_import)
+
+        _reset_log()
+        row = shadow_classify(_make_state(), symbol="BTC")
+        assert row is not None
+        assert row["shadow_regime"] is None
+        assert row["shadow_error"] is not None
+        assert "RuntimeError" in row["shadow_error"]
+
+    def test_parity_log_is_bounded(self):
+        _reset_log()
+        # Push more than _REGIME_PARITY_LOG_MAX rows; ring buffer must
+        # cap at MAX (with a 10% FIFO eviction when full).
+        for _ in range(_REGIME_PARITY_LOG_MAX + 250):
+            shadow_classify(_make_state(), symbol="BTC")
+        assert len(get_regime_parity_log()) <= _REGIME_PARITY_LOG_MAX
+
+
+class TestEquivalenceGuess:
+    """The SHADOW_EQUIVALENCE_GUESS is used by /governance/regime-parity
+    to surface mapping accuracy at-a-glance. It's a guess; the parity
+    log itself is the authority. These tests just pin the guess
+    contract so a refactor doesn't silently re-shape it."""
+
+    def test_guess_covers_all_market_regimes(self):
+        for mr in MarketRegime:
+            assert mr.value in SHADOW_EQUIVALENCE_GUESS
+
+    def test_guess_values_are_qig_warp_regime_names(self):
+        # qig_warp.Regime members: CRITICAL, DISORDERED, ORDERED.
+        valid = {"CRITICAL", "DISORDERED", "ORDERED"}
+        for v in SHADOW_EQUIVALENCE_GUESS.values():
+            assert v in valid, f"{v} is not a qig_warp.Regime member"


### PR DESCRIPTION
**Shadow only. Do NOT merge until the parity log stabilises** — this PR exists to accumulate evidence per the #689 TS→Py migration discipline. The cutover that actually swaps `proprietary_core.regime.RegimeDetector` for `qig_warp.classify_regime` ships as a separate PR.

Refs #695, #689.

## What ships

A single fire-and-forget call inside `StrategyLoop.tick` runs `qig_warp.classify_regime(h, J, dim=2)` alongside the live `RegimeDetector.update(price)`. The live `MarketRegime` continues to drive every live decision (`signal_mapping.regime_to_direction`, strategy selection, sizing). The shadow output is logged to a bounded ring buffer and exposed at `GET /governance/regime-parity` for post-hoc analysis.

## Market → physics mapping (v0)

`qig_warp.classify_regime` is a physics classifier — `h` (transverse field) + `J` (coupling) → `Regime{CRITICAL, DISORDERED, ORDERED}`. The v0 adapter:

| qig_warp arg | source | rationale |
|---|---|---|
| `h` | `regime_state.entropy` | Shannon entropy of return distribution ≈ disorder pressure |
| `J` | `regime_state.trend_strength` | `\|mean/std\|` of returns ≈ coupling strength |
| `dim` | `2` | Futures order book is effectively 2D (bid+ask depth) — matches `qig_warp.CRITICAL_RATIO_2D` |

The mapping is deliberately first-order so the parity log surfaces calibration error as a measurable signal — e.g. all-DISORDERED rows would mean `h` needs a scale factor. The cutover PR re-calibrates from the observed distribution.

## Files

- `ml-worker/src/proprietary_core/regime_shadow.py` (new, 143 lines) — `shadow_classify`, ring buffer, `SHADOW_EQUIVALENCE_GUESS` (v0 first-order map: CREATOR↔DISORDERED, PRESERVER↔ORDERED, DISSOLVER↔CRITICAL).
- `ml-worker/src/proprietary_core/strategy_loop.py` (+13) — single fire-and-forget call after `RegimeDetector.update`. Wrapped in `try/except Exception` so the live path is never affected.
- `ml-worker/main.py` (+50) — `GET /governance/regime-parity?limit=N` endpoint; root listing updated.
- `ml-worker/tests/test_regime_shadow.py` (new, 7 tests) — None input, schema, ring-buffer bounds, never-raises-on-qig_warp-failure regression guard, equivalence-guess contract.

## Safety properties

1. `shadow_classify` never raises — all error paths populate `shadow_error` and still return a structured row.
2. The strategy-loop integration wraps the call in `try/except` as belt-and-braces.
3. No live decision reads `shadow_regime`; the live `MarketRegime` is the only authority.
4. Parity log is bounded (max 2000 rows, 10% FIFO eviction) — fixed memory.

## Verification

- ml-worker pytest: **804 passed / 0 failed** (was 797; +7 new tests). No regressions.
- py_compile clean on the three touched files.
- Inspect on deploy: `GET https://ml-worker-production.up.railway.app/governance/regime-parity` — should return rows with both `live_regime` and `shadow_regime` populated within seconds of a live `/ml/predict` call landing on the v0.8 StrategyLoop path.

## Promotion gate (per #689)

This PR does NOT promote. The cutover PR (separate) ships once:

1. The parity log accumulates a representative tape window (eyeball threshold: ≥ 500 rows across both BTC and ETH symbols and at least one full regime cycle).
2. Either the v0 mapping holds (≥ 80% match against the equivalence guess) OR the diff distribution motivates a calibrated re-map (specific `h` / `J` scale factors documented from the observed values).
3. The cutover PR's diff is a single-line swap (`signal_mapping.regime_to_direction` consumes `shadow_regime` instead of `live_regime`) gated behind a flag for one final shadow window.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Add a shadow-mode quantum-inspired regime classifier alongside the existing market regime detector and expose its parity telemetry via a new governance endpoint, with corresponding tests.

New Features:
- Introduce a regime_shadow module that runs qig_warp.classify_regime in parallel with the existing MarketRegime detector and records parity rows in a bounded in-memory log.
- Expose a new GET /governance/regime-parity endpoint that surfaces live vs shadow regime classifications, error counts, and basic match statistics for operator analysis.

Tests:
- Add unit tests covering shadow_classify behaviour, parity log ring-buffer bounds, error handling when qig_warp fails or is missing, and the equivalence-guess mapping contract.