### PR TITLE
cherry-pick from backup: forward-port live tiebreaker hotfixes + demote warmup log noise

### DIFF
--- a/apps/api/src/services/mlPredictionService.js
+++ b/apps/api/src/services/mlPredictionService.js
@@ -305,18 +305,16 @@ class MLPredictionService {
       const isWarmup =
         result?.signal === 'HOLD' &&
         result?.reason === 'Insufficient data for regime detection';
+      const logMessage = `ML trading signal for ${symbol}:`;
+      const logPayload = {
+        signal: result.signal,
+        strength: result.strength,
+        reason: result.reason,
+      };
       if (isWarmup) {
-        logger.debug(`ML trading signal for ${symbol}:`, {
-          signal: result.signal,
-          strength: result.strength,
-          reason: result.reason,
-        });
+        logger.debug(logMessage, logPayload);
       } else {
-        logger.info(`ML trading signal for ${symbol}:`, {
-          signal: result.signal,
-          strength: result.strength,
-          reason: result.reason,
-        });
+        logger.info(logMessage, logPayload);
       }
       return result;
     } catch (error) {

--- a/apps/api/src/services/mlPredictionService.js
+++ b/apps/api/src/services/mlPredictionService.js
@@ -289,7 +289,26 @@ class MLPredictionService {
   async getTradingSignal(symbol, ohlcvData, currentPrice) {
     try {
       const result = await this._callWorker({ action: 'signal', symbol, data: ohlcvData, current_price: currentPrice });
-      logger.info(`ML trading signal for ${symbol}:`, {
+      // Warmup responses ("Insufficient data for regime detection") are
+      // a HOLD@0.30 with no conviction — emitted by the ml-worker
+      // strategyloop backend (ROUTE_VERSION=v0.8) when its
+      // RegimeDetector hasn't seen enough candles to classify yet.
+      // Production logs show one of our callers polls every ~60s
+      // with too few candles per symbol; that caller will be fixed
+      // in a follow-up, but until then the per-tick INFO line floods
+      // production logs without adding signal (12+ lines/minute on
+      // 3 symbols across both polling cadences). Demote those to
+      // debug; everything else — including HOLDs with real reason
+      // strings like "regime=creator strategy=breakout dir=neutral"
+      // — stays at info so genuine signal transitions and conviction
+      // shifts remain visible.
+      const isWarmup =
+        result?.signal === 'HOLD' &&
+        result?.reason === 'Insufficient data for regime detection';
+      const logFn = isWarmup
+        ? logger.debug.bind(logger)
+        : logger.info.bind(logger);
+      logFn(`ML trading signal for ${symbol}:`, {
         signal: result.signal,
         strength: result.strength,
         reason: result.reason,

--- a/apps/api/src/services/mlPredictionService.js
+++ b/apps/api/src/services/mlPredictionService.js
@@ -305,14 +305,19 @@ class MLPredictionService {
       const isWarmup =
         result?.signal === 'HOLD' &&
         result?.reason === 'Insufficient data for regime detection';
-      const logFn = isWarmup
-        ? logger.debug.bind(logger)
-        : logger.info.bind(logger);
-      logFn(`ML trading signal for ${symbol}:`, {
-        signal: result.signal,
-        strength: result.strength,
-        reason: result.reason,
-      });
+      if (isWarmup) {
+        logger.debug(`ML trading signal for ${symbol}:`, {
+          signal: result.signal,
+          strength: result.strength,
+          reason: result.reason,
+        });
+      } else {
+        logger.info(`ML trading signal for ${symbol}:`, {
+          signal: result.signal,
+          strength: result.strength,
+          reason: result.reason,
+        });
+      }
       return result;
     } catch (error) {
       if (error?.code !== ML_WORKER_NOT_CONFIGURED_CODE) {


### PR DESCRIPTION
## What this brings to `main`

Two commits already proven on the backup branch (currently the production target on Railway). Cherry-picking them to `main` so a future Railway cut-over is safe.

### Commits

1. **`157dcbe`** — `fix(ml-worker): forward-port live tiebreaker hotfixes (6ec4185 + 1266156 + caa3a9d)`

   Squashed forward-port of the three live tiebreaker iterations from the original backup chain. Without these, `main`'s `_regime_to_direction` returns `BULLISH` unconditionally on `creator + trend_strength > 0.1` even when the multi-window probe sees a fresh breakdown — the original "BUY on a clear downtrend" bug class. The earlier `1ee713bc` (direction-aware `_strategy_to_signal`) is already on `main` via PR #688 as `f055304`, so this is the remaining delta.

   - `6ec4185` — regime-direction dead-zone tiebreaker (`recent_change_pct` parameter)
   - `1266156` — multi-window probe `_strongest_recent_change` (3/5/10/15 bar, per-window floors 0.5% / 0.5% / 0.7% / 1.0%)
   - `caa3a9d` — probe pre-empts regime-class early returns when decisive

2. **`076a803`** — `demote "Insufficient data for regime detection" log to debug`

   Production-log noise fix. One of our `/ml/predict` callers polls roughly every 60s with too few candles per symbol for ml-worker's `RegimeDetector` to classify, so the worker correctly returns `HOLD@0.30 / reason="Insufficient data for regime detection"`. `mlPredictionService::getTradingSignal` logged every response at INFO, flooding logs with 12+ lines/minute across 3 symbols and masking genuine signal transitions. Surgical single-file change: when signal is HOLD AND reason matches the exact worker string, route the log through `logger.debug`; everything else (including HOLDs with real reasons like `regime=creator strategy=breakout dir=neutral`) stays at INFO. No behaviour change — same response shape, return value, error path.

   The underlying caller bug (polling with insufficient candles) is being tracked separately under the multi-caller-architecture issue family.

## Why this PR exists

Production is running on `backup/main-pre-cutover-2026-05-14`. `main` was rolled back to `b7af600` via PR #688 (Path B), which kept the bug fixes but reverted the TS→Py cutover and intentionally did NOT include the three tiebreaker iterations. Those iterations are validated on the live tape and `main` is strictly worse without them at calling SELL on breakdowns. This PR closes that gap and adds the log-noise fix, so `main` becomes a safe cut-over target.

## Verification

- `076a8039` — single-file change in `apps/api/src/services/mlPredictionService.js`. Defensive (optional chaining). `tsc --noEmit` expected clean.
- `157dcbe3` — Python only, py_compile clean on backup. Parent is `b7af600` (= `main` HEAD), so this cherry-picks with zero conflicts by construction.
- Backup branch carrying both commits has been running in production with these signals visible in logs (`dir=bullish` / `dir=bearish` / `dir=neutral` consistently align with tape direction in live ticks 09:29–09:34Z).

## Cut-over sequence (after this merges)

1. Confirm CI green on `main` post-merge
2. One-tick live verification on Railway preview/staging if available
3. Cut Railway from `backup/main-pre-cutover-2026-05-14` → `main`
4. Watch one full tick cycle on production-from-main
5. **Backup branch stays untouched as fallback** — permanent safety net per standing policy

## Not in scope

- The multi-caller architecture issue (different `/ml/predict` callers sending different OHLCV → different signals on same tick) — separate fix
- The actual heartbeat-aligned caller that's polling with insufficient candles — separate fix
- Wiring `qig-warp` / `qig-compute` into the live trading path — tracked under #695

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Forward-port validated live regime/tiebreaker logic from the backup branch and quieten noisy warmup logging to make main a safe production cut-over target.

Bug Fixes:
- Correct live trading regime and direction selection by incorporating the multi-window tiebreaker and probe logic already running on the backup branch.
- Reduce production log noise by logging warmup "Insufficient data for regime detection" HOLD signals at debug level while keeping other signals at info.