### PR TITLE
fix(monkey): MTF L bootstrap audibility + per-agent neurochemistry re…

### DIFF
--- a/apps/api/src/services/monkey/__tests__/mtfBootstrap.test.ts
+++ b/apps/api/src/services/monkey/__tests__/mtfBootstrap.test.ts
@@ -49,17 +49,19 @@ describe('bootstrapMTFForSymbol — status reporting', () => {
     expect(status.perTimeframe.every((p) => p.basinsPopulated > 0)).toBe(true);
   });
 
-  it('reports insufficient_candles when exchange returns < 100', async () => {
+  it('reports insufficient_candles when exchange returns below warm threshold', async () => {
     vi.doMock('../../poloniexFuturesService.js', () => ({
-      default: { getHistoricalData: vi.fn().mockResolvedValue(repeatCandles(50)) },
+      default: { getHistoricalData: vi.fn().mockResolvedValue(repeatCandles(200)) },
     }));
-    const { bootstrapMTFForSymbol } = await import('../mtfBootstrap.js');
+    const { bootstrapMTFForSymbol, bootstrapMinCandlesNeeded } = await import('../mtfBootstrap.js');
     const { newMTFState } = await import('../mtfLClassifier.js');
     const state = newMTFState();
     const status = await bootstrapMTFForSymbol('BTC_USDT_PERP', state);
+    const need15m = bootstrapMinCandlesNeeded('15m');
     expect(status.allSucceeded).toBe(false);
     expect(status.perTimeframe.every((p) => p.status === 'insufficient_candles')).toBe(true);
-    expect(status.perTimeframe[0]!.errorMessage).toContain('got 50 candles');
+    expect(status.perTimeframe[0]!.errorMessage).toContain('got 200 candles');
+    expect(status.perTimeframe[0]!.errorMessage).toContain(`need ≥ ${need15m}`);
   });
 
   it('reports fetch_failed when getHistoricalData throws', async () => {
@@ -109,5 +111,21 @@ describe('bootstrapMTFForSymbol — status reporting', () => {
     expect(status.startedAtMs).toBeGreaterThanOrEqual(before);
     expect(status.finishedAtMs).toBeLessThanOrEqual(after);
     expect(status.finishedAtMs).toBeGreaterThanOrEqual(status.startedAtMs);
+  });
+
+  it('bootstraps only requested timeframes when labels filter is provided', async () => {
+    const stub = vi.fn().mockResolvedValue(repeatCandles(700));
+    vi.doMock('../../poloniexFuturesService.js', () => ({
+      default: { getHistoricalData: stub },
+    }));
+    const { bootstrapMTFForSymbol } = await import('../mtfBootstrap.js');
+    const { newMTFState } = await import('../mtfLClassifier.js');
+    const state = newMTFState();
+    const status = await bootstrapMTFForSymbol('BTC_USDT_PERP', state, ['1h']);
+    expect(status.perTimeframe).toHaveLength(1);
+    expect(status.perTimeframe[0]!.label).toBe('1h');
+    expect(status.perTimeframe[0]!.status).toBe('success');
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(stub).toHaveBeenCalledWith('BTC_USDT_PERP', '1h', 700);
   });
 });

--- a/apps/api/src/services/monkey/__tests__/mtfBootstrap.test.ts
+++ b/apps/api/src/services/monkey/__tests__/mtfBootstrap.test.ts
@@ -1,0 +1,113 @@
+/**
+ * mtfBootstrap.test.ts — MTF L bootstrap status reporting.
+ *
+ * Pre-2026-05-16 the bootstrap was fire-and-forget at the caller and
+ * swallowed silent failures (live logs showed `[MTF-L] decision
+ * agreement: 0/3, perTf: cold,cold,cold` across whole sessions). The
+ * fix returns a per-TF status report so the caller can retry the
+ * cold timeframes on a later tick.
+ *
+ * These tests use a stub poloniexFuturesService via vi.doMock so we
+ * exercise the status-reporting paths without an exchange round-trip.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const STUB_CANDLE_RAW = {
+  open: '100',
+  high: '101',
+  low: '99',
+  close: '100.5',
+  volume: '10',
+};
+
+function repeatCandles(n: number, start = 0): Array<typeof STUB_CANDLE_RAW & { timestamp: number }> {
+  return Array.from({ length: n }, (_, i) => ({
+    ...STUB_CANDLE_RAW,
+    timestamp: 1_700_000_000_000 + (start + i) * 60_000,
+  }));
+}
+
+describe('bootstrapMTFForSymbol — status reporting', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.doUnmock('../../poloniexFuturesService.js');
+  });
+
+  it('reports success for all three TFs when candles are sufficient', async () => {
+    vi.doMock('../../poloniexFuturesService.js', () => ({
+      default: { getHistoricalData: vi.fn().mockResolvedValue(repeatCandles(700)) },
+    }));
+    const { bootstrapMTFForSymbol } = await import('../mtfBootstrap.js');
+    const { newMTFState } = await import('../mtfLClassifier.js');
+    const state = newMTFState();
+    const status = await bootstrapMTFForSymbol('BTC_USDT_PERP', state);
+    expect(status.allSucceeded).toBe(true);
+    expect(status.perTimeframe.map((p) => p.label)).toEqual(['15m', '1h', '4h']);
+    expect(status.perTimeframe.every((p) => p.status === 'success')).toBe(true);
+    expect(status.perTimeframe.every((p) => p.basinsPopulated > 0)).toBe(true);
+  });
+
+  it('reports insufficient_candles when exchange returns < 100', async () => {
+    vi.doMock('../../poloniexFuturesService.js', () => ({
+      default: { getHistoricalData: vi.fn().mockResolvedValue(repeatCandles(50)) },
+    }));
+    const { bootstrapMTFForSymbol } = await import('../mtfBootstrap.js');
+    const { newMTFState } = await import('../mtfLClassifier.js');
+    const state = newMTFState();
+    const status = await bootstrapMTFForSymbol('BTC_USDT_PERP', state);
+    expect(status.allSucceeded).toBe(false);
+    expect(status.perTimeframe.every((p) => p.status === 'insufficient_candles')).toBe(true);
+    expect(status.perTimeframe[0]!.errorMessage).toContain('got 50 candles');
+  });
+
+  it('reports fetch_failed when getHistoricalData throws', async () => {
+    vi.doMock('../../poloniexFuturesService.js', () => ({
+      default: { getHistoricalData: vi.fn().mockRejectedValue(new Error('429 rate limited')) },
+    }));
+    const { bootstrapMTFForSymbol } = await import('../mtfBootstrap.js');
+    const { newMTFState } = await import('../mtfLClassifier.js');
+    const state = newMTFState();
+    const status = await bootstrapMTFForSymbol('BTC_USDT_PERP', state);
+    expect(status.allSucceeded).toBe(false);
+    expect(status.perTimeframe.every((p) => p.status === 'fetch_failed')).toBe(true);
+    expect(status.perTimeframe[0]!.errorMessage).toContain('429');
+  });
+
+  it('reports partial state — one TF success, others fetch_failed', async () => {
+    const stub = vi.fn();
+    // 15m succeeds; 1h + 4h throw.
+    stub.mockResolvedValueOnce(repeatCandles(700));
+    stub.mockRejectedValueOnce(new Error('1h unavailable'));
+    stub.mockRejectedValueOnce(new Error('4h unavailable'));
+    vi.doMock('../../poloniexFuturesService.js', () => ({
+      default: { getHistoricalData: stub },
+    }));
+    const { bootstrapMTFForSymbol } = await import('../mtfBootstrap.js');
+    const { newMTFState } = await import('../mtfLClassifier.js');
+    const state = newMTFState();
+    const status = await bootstrapMTFForSymbol('BTC_USDT_PERP', state);
+    expect(status.allSucceeded).toBe(false);
+    expect(status.perTimeframe[0]!.status).toBe('success');
+    expect(status.perTimeframe[1]!.status).toBe('fetch_failed');
+    expect(status.perTimeframe[2]!.status).toBe('fetch_failed');
+    expect(status.perTimeframe[0]!.basinsPopulated).toBeGreaterThan(0);
+    expect(status.perTimeframe[1]!.basinsPopulated).toBe(0);
+  });
+
+  it('startedAtMs and finishedAtMs bracket the call', async () => {
+    vi.doMock('../../poloniexFuturesService.js', () => ({
+      default: { getHistoricalData: vi.fn().mockResolvedValue(repeatCandles(700)) },
+    }));
+    const { bootstrapMTFForSymbol } = await import('../mtfBootstrap.js');
+    const { newMTFState } = await import('../mtfLClassifier.js');
+    const state = newMTFState();
+    const before = Date.now();
+    const status = await bootstrapMTFForSymbol('BTC_USDT_PERP', state);
+    const after = Date.now();
+    expect(status.startedAtMs).toBeGreaterThanOrEqual(before);
+    expect(status.finishedAtMs).toBeLessThanOrEqual(after);
+    expect(status.finishedAtMs).toBeGreaterThanOrEqual(status.startedAtMs);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -503,6 +503,11 @@ export class MonkeyKernel extends EventEmitter {
    *  failed bootstrap. Backs off 60s → 120s → 240s → 480s capped, so
    *  a flaky exchange endpoint doesn't hammer on every tick. */
   private mtfBootstrapRetryAtMs: Map<string, number> = new Map();
+  /** Per-symbol last-applied backoff delay (ms). Doubled on each
+   *  failed retry to compute the next backoff; stored explicitly
+   *  rather than reconstructed from (retryAt − startedAtMs) which
+   *  mixed unrelated timestamps and produced bogus delays. */
+  private mtfBootstrapLastDelayMs: Map<string, number> = new Map();
   private static readonly MTF_BOOTSTRAP_INITIAL_RETRY_MS = 60_000;
   private static readonly MTF_BOOTSTRAP_MAX_RETRY_MS = 480_000;
   /** Basin-sync instance — per-kernel, so sub-kernels appear as peers. */
@@ -742,18 +747,18 @@ export class MonkeyKernel extends EventEmitter {
               symbol: sym,
               cold: cold.map((p) => `${p.label}:${p.status}`).join(','),
             });
-            this.mtfBootstrapRetryAtMs.set(
+            this.scheduleMTFBootstrapRetry(
               sym,
-              Date.now() + MonkeyKernel.MTF_BOOTSTRAP_INITIAL_RETRY_MS,
+              MonkeyKernel.MTF_BOOTSTRAP_INITIAL_RETRY_MS,
             );
           }
         } catch (err) {
           logger.warn('[MTF-bootstrap] failed for symbol', {
             symbol: sym, err: err instanceof Error ? err.message : String(err),
           });
-          this.mtfBootstrapRetryAtMs.set(
+          this.scheduleMTFBootstrapRetry(
             sym,
-            Date.now() + MonkeyKernel.MTF_BOOTSTRAP_INITIAL_RETRY_MS,
+            MonkeyKernel.MTF_BOOTSTRAP_INITIAL_RETRY_MS,
           );
         }
       }),
@@ -772,6 +777,7 @@ export class MonkeyKernel extends EventEmitter {
     const state = this.symbolStates.get(symbol);
     if (!state) {
       this.mtfBootstrapRetryAtMs.delete(symbol);
+      this.mtfBootstrapLastDelayMs.delete(symbol);
       return;
     }
     try {
@@ -781,9 +787,15 @@ export class MonkeyKernel extends EventEmitter {
       if (status.allSucceeded) {
         logger.info('[MTF-bootstrap] retry success', { symbol });
         this.mtfBootstrapRetryAtMs.delete(symbol);
+        this.mtfBootstrapLastDelayMs.delete(symbol);
       } else {
-        // Still partial — double the backoff for next attempt.
-        const prevDelay = retryAt - (this.mtfBootstrapStatus.get(symbol)?.startedAtMs ?? Date.now());
+        // Still partial — double the previous backoff for next attempt.
+        // Tracked explicitly in mtfBootstrapLastDelayMs (per Sourcery
+        // review on PR #700: reconstructing it from
+        // retryAt − startedAtMs mixed unrelated timestamps and
+        // produced bogus delays).
+        const prevDelay = this.mtfBootstrapLastDelayMs.get(symbol)
+          ?? MonkeyKernel.MTF_BOOTSTRAP_INITIAL_RETRY_MS;
         const nextDelay = Math.min(
           MonkeyKernel.MTF_BOOTSTRAP_MAX_RETRY_MS,
           Math.max(MonkeyKernel.MTF_BOOTSTRAP_INITIAL_RETRY_MS, prevDelay * 2),
@@ -794,17 +806,26 @@ export class MonkeyKernel extends EventEmitter {
           cold: cold.map((p) => `${p.label}:${p.status}`).join(','),
           nextRetryInMs: nextDelay,
         });
-        this.mtfBootstrapRetryAtMs.set(symbol, Date.now() + nextDelay);
+        this.scheduleMTFBootstrapRetry(symbol, nextDelay);
       }
     } catch (err) {
       logger.warn('[MTF-bootstrap] retry threw', {
         symbol, err: err instanceof Error ? err.message : String(err),
       });
-      this.mtfBootstrapRetryAtMs.set(
+      this.scheduleMTFBootstrapRetry(
         symbol,
-        Date.now() + MonkeyKernel.MTF_BOOTSTRAP_MAX_RETRY_MS,
+        MonkeyKernel.MTF_BOOTSTRAP_MAX_RETRY_MS,
       );
     }
+  }
+
+  /** Schedule the next bootstrap retry attempt for ``symbol``.
+   *  Stores both the absolute retry time AND the delay used so the
+   *  next backoff can correctly double from the actual previous delay
+   *  (not a derived value from unrelated timestamps). */
+  private scheduleMTFBootstrapRetry(symbol: string, delayMs: number): void {
+    this.mtfBootstrapRetryAtMs.set(symbol, Date.now() + delayMs);
+    this.mtfBootstrapLastDelayMs.set(symbol, delayMs);
   }
 
   private newSymbolState(): SymbolState {
@@ -1926,10 +1947,14 @@ export class MonkeyKernel extends EventEmitter {
     // own dopamine derives from K-only rewards (decayedRewardSums('K')),
     // but per-agent telemetry surfaces what M/T/L's "shadow" chemistry
     // would look like if they had brains. Useful for the dashboard's
-    // "which agent is in flow" indicator.
+    // "which agent is in flow" indicator. Snapshot `now` once so all
+    // four agents see the same decay reference within this tick (per
+    // Sourcery review on PR #700: separate Date.now() calls per agent
+    // produced slightly different decay snapshots in the same tick).
+    const ncSnapshotMs = Date.now();
     const ncWindowsByAgent: Record<string, { dop: number; ser: number; endo: number }> = {};
     for (const agent of ['K', 'M', 'T', 'L'] as const) {
-      const r = this.decayedRewardSums(Date.now(), agent);
+      const r = this.decayedRewardSums(ncSnapshotMs, agent);
       ncWindowsByAgent[agent] = {
         dop: r.dopamine,
         ser: r.serotonin,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -489,10 +489,14 @@ export class MonkeyKernel extends EventEmitter {
   /**
    * Per-symbol MTF bootstrap status — keyed by symbol, valued by the
    * last attempt's per-TF outcome. The retry hook in processSymbol
-   * re-runs only the timeframes that didn't succeed. Without this,
-   * silent fetch / synthesis failures left MTF L cold for the entire
-   * session and the agreement filter (the loudest noise-suppression
-   * in the stack) never fired.
+   * uses this status to detect partial / failed bootstrap attempts and
+   * schedule another bootstrap for the symbol. This tracks which TFs
+   * were cold or failed, even though the current bootstrap path
+   * re-runs the symbol-level bootstrap rather than selectively
+   * fetching only failed timeframes. Without this status, silent
+   * fetch / synthesis failures left MTF L cold for the entire session
+   * and the agreement filter (the loudest noise-suppression in the
+   * stack) never fired.
    *
    * 2026-05-16: live tape showed `[MTF-L] decision agreement: 0/3,
    * perTf: 15m:cold, 1h:cold, 4h:cold` across whole sessions.

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -774,6 +774,17 @@ export class MonkeyKernel extends EventEmitter {
     const retryAt = this.mtfBootstrapRetryAtMs.get(symbol);
     if (retryAt === undefined) return;          // never bootstrapped — handled by run-on-startup
     if (Date.now() < retryAt) return;            // backoff still running
+    const previousStatus = this.mtfBootstrapStatus.get(symbol);
+    const labelsToRetry = previousStatus
+      ? previousStatus.perTimeframe
+          .filter((p) => p.status !== 'success')
+          .map((p) => p.label)
+      : undefined;
+    if (labelsToRetry && labelsToRetry.length === 0) {
+      this.mtfBootstrapRetryAtMs.delete(symbol);
+      this.mtfBootstrapLastDelayMs.delete(symbol);
+      return;
+    }
     const state = this.symbolStates.get(symbol);
     if (!state) {
       this.mtfBootstrapRetryAtMs.delete(symbol);
@@ -782,7 +793,8 @@ export class MonkeyKernel extends EventEmitter {
     }
     try {
       const { bootstrapMTFForSymbol } = await import('./mtfBootstrap.js');
-      const status = await bootstrapMTFForSymbol(symbol, state.mtfState);
+      const retryStatus = await bootstrapMTFForSymbol(symbol, state.mtfState, labelsToRetry);
+      const status = this.mergeMTFBootstrapStatus(previousStatus, retryStatus);
       this.mtfBootstrapStatus.set(symbol, status);
       if (status.allSucceeded) {
         logger.info('[MTF-bootstrap] retry success', { symbol });
@@ -817,6 +829,40 @@ export class MonkeyKernel extends EventEmitter {
         MonkeyKernel.MTF_BOOTSTRAP_MAX_RETRY_MS,
       );
     }
+  }
+
+  /** Merge a subset retry result into prior full per-TF status. */
+  private mergeMTFBootstrapStatus(
+    previous: import('./mtfBootstrap.js').BootstrapSymbolStatus | undefined,
+    retry: import('./mtfBootstrap.js').BootstrapSymbolStatus,
+  ): import('./mtfBootstrap.js').BootstrapSymbolStatus {
+    if (!previous) return retry;
+    const orderedLabels: Array<import('./mtfLClassifier.js').TimeframeLabel> = [];
+    const mergedByLabel = new Map<
+      import('./mtfLClassifier.js').TimeframeLabel,
+      import('./mtfBootstrap.js').BootstrapTimeframeStatus
+    >();
+    for (const p of previous.perTimeframe) {
+      orderedLabels.push(p.label);
+      mergedByLabel.set(p.label, p);
+    }
+    for (const p of retry.perTimeframe) {
+      if (!orderedLabels.includes(p.label)) {
+        orderedLabels.push(p.label);
+      }
+      mergedByLabel.set(p.label, p);
+    }
+    // Safe non-null assertion: orderedLabels is populated from keys that
+    // are always inserted into mergedByLabel in the loops above.
+    const perTimeframe = orderedLabels.map((label) => mergedByLabel.get(label)!);
+    const allSucceeded = perTimeframe.length > 0 && perTimeframe.every((p) => p.status === 'success');
+    return {
+      symbol: retry.symbol,
+      startedAtMs: retry.startedAtMs,
+      finishedAtMs: retry.finishedAtMs,
+      perTimeframe,
+      allSucceeded,
+    };
   }
 
   /** Schedule the next bootstrap retry attempt for ``symbol``.

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -191,10 +191,19 @@ const HISTORY_MAX = 100;
  * Preserves P5 Autonomy + P14 Variable Separation: rewards are STATE
  * events; neurotransmitters are derived VIEWS; nothing externally
  * writes the chemical levels.
+ *
+ * Per-agent rewards (2026-05-16): tag every push with the agent that
+ * generated the outcome. The kernel runs ONE neurochemistry (K's brain);
+ * when it reads the reward queue to derive K's dopamine, it filters to
+ * K's rewards only. M/T/L wins/losses no longer dilute K's chemical
+ * state — they live in the queue for arbiter / cross-agent telemetry
+ * but don't pull K's dopamine sideways. Legacy callsites default to
+ * 'K' agent so back-compat behaviour is preserved on the K path.
  */
 interface ActivityReward {
   source: string;           // 'trade_close' | 'witnessed_liveSignal' | ...
   symbol?: string;
+  agent: AgentLabel;        // K | M | T | L — which agent generated the outcome
   dopamineDelta: number;    // reward magnitude for dopamine boost
   serotoninDelta: number;   // mood/stability boost (calm-close reward)
   endorphinDelta: number;   // peak-state reward (win-in-high-coupling regime)
@@ -477,6 +486,25 @@ export class MonkeyKernel extends EventEmitter {
    */
   private witnessExitDedup: Map<string, number> = new Map();
   private static readonly WITNESS_DEDUP_WINDOW_MS = 60_000;
+  /**
+   * Per-symbol MTF bootstrap status — keyed by symbol, valued by the
+   * last attempt's per-TF outcome. The retry hook in processSymbol
+   * re-runs only the timeframes that didn't succeed. Without this,
+   * silent fetch / synthesis failures left MTF L cold for the entire
+   * session and the agreement filter (the loudest noise-suppression
+   * in the stack) never fired.
+   *
+   * 2026-05-16: live tape showed `[MTF-L] decision agreement: 0/3,
+   * perTf: 15m:cold, 1h:cold, 4h:cold` across whole sessions.
+   * Without the agreement filter, single-tick noise drives entries.
+   */
+  private mtfBootstrapStatus: Map<string, import('./mtfBootstrap.js').BootstrapSymbolStatus> = new Map();
+  /** Per-symbol countdown of ticks to wait before retrying a partial /
+   *  failed bootstrap. Backs off 60s → 120s → 240s → 480s capped, so
+   *  a flaky exchange endpoint doesn't hammer on every tick. */
+  private mtfBootstrapRetryAtMs: Map<string, number> = new Map();
+  private static readonly MTF_BOOTSTRAP_INITIAL_RETRY_MS = 60_000;
+  private static readonly MTF_BOOTSTRAP_MAX_RETRY_MS = 480_000;
   /** Basin-sync instance — per-kernel, so sub-kernels appear as peers. */
   private readonly basinSync: BasinSync;
   /** Kernel bus — pub/sub for inter-kernel comms (v0.6a). */
@@ -562,25 +590,15 @@ export class MonkeyKernel extends EventEmitter {
     // need 80 days of live ticks to warm up. Async + fail-soft;
     // failures (network, parse) leave the bootstrap empty and the
     // MTF state warms up gradually from live ticks instead.
+    //
+    // 2026-05-16: per-symbol bootstrap status tracking + self-healing
+    // retry. The prior fire-and-forget swallowed silent failures (live
+    // logs showed `[MTF-L] decision agreement: 0/3, perTf:cold,cold,cold`
+    // for entire sessions). Now we await per-symbol bootstrap, retain
+    // the per-TF status, and ``maybeRetryMTFBootstrap`` re-runs cold
+    // timeframes on a later tick.
     if (process.env.MONKEY_MTF_BOOTSTRAP !== 'false') {
-      try {
-        const { bootstrapMTFForSymbol } = await import('./mtfBootstrap.js');
-        for (const sym of this.symbols) {
-          const state = this.symbolStates.get(sym);
-          if (state) {
-            // Fire-and-forget — each symbol's bootstrap is independent.
-            void bootstrapMTFForSymbol(sym, state.mtfState).catch((err) => {
-              logger.warn('[MTF-bootstrap] failed for symbol', {
-                symbol: sym, err: err instanceof Error ? err.message : String(err),
-              });
-            });
-          }
-        }
-      } catch (importErr) {
-        logger.warn('[MTF-bootstrap] import failed (non-fatal)', {
-          err: importErr instanceof Error ? importErr.message : String(importErr),
-        });
-      }
+      void this.runInitialMTFBootstrap();
     }
 
     // v0.8.8 cross-agent observation — subscribe to the bus and append
@@ -691,6 +709,102 @@ export class MonkeyKernel extends EventEmitter {
     computedAtMs: number;
   } | null {
     return this.symbolStates.get(symbol)?.latestBasinSnapshot ?? null;
+  }
+
+  /** Initial MTF bootstrap pass. Awaits per-symbol, records the
+   *  per-TF status, and schedules a retry for any symbol with at
+   *  least one cold TF. Called once at startup. */
+  private async runInitialMTFBootstrap(): Promise<void> {
+    let bootstrapMod: typeof import('./mtfBootstrap.js');
+    try {
+      bootstrapMod = await import('./mtfBootstrap.js');
+    } catch (importErr) {
+      logger.warn('[MTF-bootstrap] import failed (non-fatal)', {
+        err: importErr instanceof Error ? importErr.message : String(importErr),
+      });
+      return;
+    }
+    await Promise.all(
+      this.symbols.map(async (sym) => {
+        const state = this.symbolStates.get(sym);
+        if (!state) return;
+        try {
+          const status = await bootstrapMod.bootstrapMTFForSymbol(sym, state.mtfState);
+          this.mtfBootstrapStatus.set(sym, status);
+          if (status.allSucceeded) {
+            logger.info('[MTF-bootstrap] symbol ready', {
+              symbol: sym,
+              perTf: status.perTimeframe.map((p) => `${p.label}:${p.basinsPopulated}`).join(','),
+            });
+          } else {
+            const cold = status.perTimeframe.filter((p) => p.status !== 'success');
+            logger.warn('[MTF-bootstrap] partial — retry scheduled', {
+              symbol: sym,
+              cold: cold.map((p) => `${p.label}:${p.status}`).join(','),
+            });
+            this.mtfBootstrapRetryAtMs.set(
+              sym,
+              Date.now() + MonkeyKernel.MTF_BOOTSTRAP_INITIAL_RETRY_MS,
+            );
+          }
+        } catch (err) {
+          logger.warn('[MTF-bootstrap] failed for symbol', {
+            symbol: sym, err: err instanceof Error ? err.message : String(err),
+          });
+          this.mtfBootstrapRetryAtMs.set(
+            sym,
+            Date.now() + MonkeyKernel.MTF_BOOTSTRAP_INITIAL_RETRY_MS,
+          );
+        }
+      }),
+    );
+  }
+
+  /** Per-tick check: if a symbol has pending MTF bootstrap and the
+   *  retry timer has elapsed, re-run bootstrap for it. Backoff doubles
+   *  on each failed attempt, capped at MTF_BOOTSTRAP_MAX_RETRY_MS.
+   *  Called from processSymbol before the MTF L decision is read so
+   *  a successful retry warms the state in time for the same tick. */
+  private async maybeRetryMTFBootstrap(symbol: string): Promise<void> {
+    const retryAt = this.mtfBootstrapRetryAtMs.get(symbol);
+    if (retryAt === undefined) return;          // never bootstrapped — handled by run-on-startup
+    if (Date.now() < retryAt) return;            // backoff still running
+    const state = this.symbolStates.get(symbol);
+    if (!state) {
+      this.mtfBootstrapRetryAtMs.delete(symbol);
+      return;
+    }
+    try {
+      const { bootstrapMTFForSymbol } = await import('./mtfBootstrap.js');
+      const status = await bootstrapMTFForSymbol(symbol, state.mtfState);
+      this.mtfBootstrapStatus.set(symbol, status);
+      if (status.allSucceeded) {
+        logger.info('[MTF-bootstrap] retry success', { symbol });
+        this.mtfBootstrapRetryAtMs.delete(symbol);
+      } else {
+        // Still partial — double the backoff for next attempt.
+        const prevDelay = retryAt - (this.mtfBootstrapStatus.get(symbol)?.startedAtMs ?? Date.now());
+        const nextDelay = Math.min(
+          MonkeyKernel.MTF_BOOTSTRAP_MAX_RETRY_MS,
+          Math.max(MonkeyKernel.MTF_BOOTSTRAP_INITIAL_RETRY_MS, prevDelay * 2),
+        );
+        const cold = status.perTimeframe.filter((p) => p.status !== 'success');
+        logger.warn('[MTF-bootstrap] retry partial', {
+          symbol,
+          cold: cold.map((p) => `${p.label}:${p.status}`).join(','),
+          nextRetryInMs: nextDelay,
+        });
+        this.mtfBootstrapRetryAtMs.set(symbol, Date.now() + nextDelay);
+      }
+    } catch (err) {
+      logger.warn('[MTF-bootstrap] retry threw', {
+        symbol, err: err instanceof Error ? err.message : String(err),
+      });
+      this.mtfBootstrapRetryAtMs.set(
+        symbol,
+        Date.now() + MonkeyKernel.MTF_BOOTSTRAP_MAX_RETRY_MS,
+      );
+    }
   }
 
   private newSymbolState(): SymbolState {
@@ -931,7 +1045,14 @@ export class MonkeyKernel extends EventEmitter {
     // v0.6.7: consume the decayed reward queue as a neurochemistry input.
     // Nothing externally writes dopamine — the chemical is derived each
     // tick from (Φ gradient + decayed lived-outcome stream).
-    const rewardDeltas = this.decayedRewardSums();
+    //
+    // 2026-05-16: filtered to K's rewards only. The kernel running here
+    // IS K's brain — its neurochemistry should reinforce on K's wins,
+    // not on M/T/L outcomes that flow through the same queue for
+    // arbiter / telemetry. M/T/L are control arms with their own
+    // sizing/exit logic; their wins go to the arbiter (recordSettled)
+    // and bump their capital share, but K's dopamine is K's only.
+    const rewardDeltas = this.decayedRewardSums(Date.now(), 'K');
     const nc: NeurochemicalState = computeNeurochemicals({
       isAwake: true,
       phiDelta,
@@ -1048,6 +1169,12 @@ export class MonkeyKernel extends EventEmitter {
     // (15m / 1h / 4h) and compute agreement-count decision. Phase 2
     // wires the result into L's entry sizing + harvest exit policy
     // below; the per-tick log keeps observability.
+    //
+    // 2026-05-16: if MTF bootstrap previously failed for this symbol,
+    // retry now (backoff-gated). Awaited so a successful retry warms
+    // the state in time for this tick's mtfDecide read; on the
+    // retry-still-pending path it's a no-op resolved by the next tick.
+    await this.maybeRetryMTFBootstrap(symbol);
     mtfOnTickAppend(state.mtfState, basin, state.sessionTicks);
     const mtfDec = mtfDecide(state.mtfState);
     if (mtfDec.action !== 'hold') {
@@ -1785,7 +1912,47 @@ export class MonkeyKernel extends EventEmitter {
       tPnlWindowTotal: arbiterSnapshotMany.T?.pnlWindowTotal ?? 0,
       tTradesInWindow: arbiterSnapshotMany.T?.tradesInWindow ?? 0,
       tAllocatedUsdt: arbiterAllocationMany.T ?? 0,
+      // L-specific telemetry — added 2026-05-16 to surface the
+      // FR-KNN classifier's share alongside K/M/T. Without this the
+      // dashboard can't tell whether L is starved by the arbiter or
+      // by its own warmup floor.
+      lEligible,
+      lShare: arbiterSnapshotMany.L?.share ?? 0,
+      lPnlWindowTotal: arbiterSnapshotMany.L?.pnlWindowTotal ?? 0,
+      lTradesInWindow: arbiterSnapshotMany.L?.tradesInWindow ?? 0,
+      lAllocatedUsdt: arbiterAllocationMany.L ?? 0,
     };
+    // Per-agent neurochemistry windows — added 2026-05-16. The kernel's
+    // own dopamine derives from K-only rewards (decayedRewardSums('K')),
+    // but per-agent telemetry surfaces what M/T/L's "shadow" chemistry
+    // would look like if they had brains. Useful for the dashboard's
+    // "which agent is in flow" indicator.
+    const ncWindowsByAgent: Record<string, { dop: number; ser: number; endo: number }> = {};
+    for (const agent of ['K', 'M', 'T', 'L'] as const) {
+      const r = this.decayedRewardSums(Date.now(), agent);
+      ncWindowsByAgent[agent] = {
+        dop: r.dopamine,
+        ser: r.serotonin,
+        endo: r.endorphin,
+      };
+    }
+    derivation.ncByAgent = ncWindowsByAgent;
+    // MTF bootstrap status surface — 2026-05-16. Cold timeframes mean
+    // the agreement filter (the strongest noise filter in the stack)
+    // can't fire. Surfacing this in derivation makes silent failures
+    // visible in /monkey/snapshot.
+    const mtfStatus = this.mtfBootstrapStatus.get(symbol);
+    derivation.mtfBootstrap = mtfStatus
+      ? {
+          allSucceeded: mtfStatus.allSucceeded,
+          perTimeframe: mtfStatus.perTimeframe.map((p) => ({
+            label: p.label,
+            status: p.status,
+            basins: p.basinsPopulated,
+          })),
+          retryAtMs: this.mtfBootstrapRetryAtMs.get(symbol) ?? null,
+        }
+      : { allSucceeded: false, perTimeframe: [], retryAtMs: null };
 
     let executed = false;
     let monkeyOrderId: string | null = null;
@@ -4056,6 +4223,11 @@ export class MonkeyKernel extends EventEmitter {
     // (she has only one kernel state; we use one of her symbol states
     // for κ). Pushed as an EVENT; computeNeurochemicals derives the
     // actual dopamine lift next tick.
+    //
+    // K-tagged: closeHeldPosition is the K-kernel's own close path
+    // (M/T/L use their own execution paths that call recordSettled
+    // separately). Tagging the reward 'K' means K's brain gets the
+    // dopamine on K's wins.
     const symState = this.symbolStates.get(symbol);
     try {
       const totalQtyForMargin = exchangeQty || 0.01;
@@ -4067,6 +4239,7 @@ export class MonkeyKernel extends EventEmitter {
         realizedPnlUsdt: pnlAtDecision,
         marginUsdt: margin,
         kappaAtExit: symState?.kappa,
+        agent: 'K',
       });
     } catch { /* non-fatal */ }
     return { executed: true, orderId, reason: 'closed' };
@@ -4556,7 +4729,11 @@ export class MonkeyKernel extends EventEmitter {
     realizedPnlUsdt: number;
     marginUsdt: number;
     kappaAtExit?: number;
+    /** Which agent generated the outcome. Defaults to 'K' for
+     *  back-compat with pre-2026-05-16 callsites that didn't pass it. */
+    agent?: AgentLabel;
   }): void {
+    const agent: AgentLabel = input.agent ?? 'K';
     const pnlFrac = input.marginUsdt > 0
       ? input.realizedPnlUsdt / input.marginUsdt
       : 0;
@@ -4577,6 +4754,7 @@ export class MonkeyKernel extends EventEmitter {
     this.pendingRewards.push({
       source: input.source,
       symbol: input.symbol,
+      agent,
       dopamineDelta: dop,
       serotoninDelta: ser,
       endorphinDelta: endo,
@@ -4590,6 +4768,7 @@ export class MonkeyKernel extends EventEmitter {
     logger.info(`[${this.label}] reward pushed`, {
       source: input.source,
       symbol: input.symbol,
+      agent,
       pnl: input.realizedPnlUsdt.toFixed(4),
       pnlFrac: (pnlFrac * 100).toFixed(2) + '%',
       dop: dop.toFixed(3),
@@ -4603,14 +4782,24 @@ export class MonkeyKernel extends EventEmitter {
    * processSymbol to build the NeurochemicalInputs reward deltas.
    * Half-life = REWARD_HALF_LIFE_MS (20 min default). Old rewards decay
    * naturally; queue also FIFO-evicts at REWARD_QUEUE_MAX.
+   *
+   * `agentFilter` (added 2026-05-16) selects only the rewards generated
+   * by that agent. The kernel runs ONE neurochemistry (K's brain), so
+   * processSymbol passes 'K' — K's wins reinforce K's dopamine, M/T/L
+   * outcomes no longer dilute it. Omit the filter to get the legacy
+   * shared-pool behaviour (useful for cross-agent telemetry).
    */
-  private decayedRewardSums(nowMs: number = Date.now()): {
+  private decayedRewardSums(
+    nowMs: number = Date.now(),
+    agentFilter?: AgentLabel,
+  ): {
     dopamine: number;
     serotonin: number;
     endorphin: number;
   } {
     let dop = 0, ser = 0, endo = 0;
     for (const r of this.pendingRewards) {
+      if (agentFilter !== undefined && r.agent !== agentFilter) continue;
       const ageMs = nowMs - r.atMs;
       const decay = Math.pow(0.5, ageMs / REWARD_HALF_LIFE_MS);
       if (decay < 0.01) continue;  // negligible, skip
@@ -4807,12 +4996,14 @@ export class MonkeyKernel extends EventEmitter {
         // events — her bank learned from them, so her NC should too.
         // Dampen the reward magnitude since it wasn't her trade (she
         // just observed). Estimate margin from typical liveSignal
-        // position (~$5 at 16x).
+        // position (~$5 at 16x). Tagged 'K' because witnessExit feeds
+        // K's bank — observation belongs to K's cognitive stream.
         this.pushReward({
           source: 'witnessed_liveSignal',
           symbol,
           realizedPnlUsdt: realizedPnl * 0.5,  // half-weight (witnessed, not her own)
           marginUsdt: 5,
+          agent: 'K',
         });
       }
     } catch (err) {

--- a/apps/api/src/services/monkey/mtfBootstrap.ts
+++ b/apps/api/src/services/monkey/mtfBootstrap.ts
@@ -51,18 +51,49 @@ const POLONIEX_INTERVAL_FOR_TF: Record<TimeframeLabel, string> = {
   '4h': '4h',
 };
 
+/** Per-(symbol, timeframe) bootstrap outcome. Returned by
+ *  ``bootstrapMTFForSymbol`` so the caller can track which timeframes
+ *  are warm vs need retry. Added 2026-05-16 — the previous fire-and-
+ *  forget call ``void bootstrapMTFForSymbol(...)`` silently lost
+ *  failures, leaving MTF L cold for the whole session. */
+export type BootstrapTimeframeStatusCode =
+  | 'success'
+  | 'insufficient_candles'
+  | 'fetch_failed'
+  | 'synthesis_empty';
+
+export interface BootstrapTimeframeStatus {
+  label: TimeframeLabel;
+  status: BootstrapTimeframeStatusCode;
+  basinsPopulated: number;
+  errorMessage?: string;
+}
+
+export interface BootstrapSymbolStatus {
+  symbol: string;
+  startedAtMs: number;
+  finishedAtMs: number;
+  perTimeframe: BootstrapTimeframeStatus[];
+  /** True iff every TF reached ``success``. */
+  allSucceeded: boolean;
+}
+
 /** Pull OHLCV at the timeframe's resolution and synthesise basins
  *  for the bootstrap. Each candle becomes one basin via the same
  *  perceive() the live loop uses; the sliding-window context for
  *  perceive is the trailing N candles ending at each step.
  *
  *  Errors (network, parse, perceive throw) caught and logged; the
- *  function returns with whatever it managed to compute. The MTF
- *  state warms up gradually from live ticks if bootstrap is empty. */
+ *  function returns a per-TF status report. The MTF state warms up
+ *  gradually from live ticks if bootstrap is empty — but per-TF
+ *  status now surfaces silent failures so the caller can retry the
+ *  cold timeframes on a later tick. */
 export async function bootstrapMTFForSymbol(
   symbol: string,
   state: MTFState,
-): Promise<void> {
+): Promise<BootstrapSymbolStatus> {
+  const startedAtMs = Date.now();
+  const perTimeframe: BootstrapTimeframeStatus[] = [];
   for (const label of ['15m', '1h', '4h'] as const) {
     try {
       const interval = POLONIEX_INTERVAL_FOR_TF[label];
@@ -74,6 +105,12 @@ export async function bootstrapMTFForSymbol(
       if (!Array.isArray(candles) || candles.length < 100) {
         logger.warn('[MTF-bootstrap] insufficient OHLCV from exchange', {
           symbol, label, got: candles?.length ?? 0,
+        });
+        perTimeframe.push({
+          label,
+          status: 'insufficient_candles',
+          basinsPopulated: 0,
+          errorMessage: `got ${candles?.length ?? 0} candles (need ≥ 100)`,
         });
         continue;
       }
@@ -112,14 +149,44 @@ export async function bootstrapMTFForSymbol(
           // still useful for the classifier.
         }
       }
+      if (basins.length === 0) {
+        logger.warn('[MTF-bootstrap] synthesis empty', { symbol, label });
+        perTimeframe.push({
+          label,
+          status: 'synthesis_empty',
+          basinsPopulated: 0,
+          errorMessage: 'perceive() failed on every candle',
+        });
+        continue;
+      }
       setBootstrapHistory(state, label, basins);
       logger.info('[MTF-bootstrap] populated history', {
         symbol, label, basins: basins.length,
       });
+      perTimeframe.push({
+        label,
+        status: 'success',
+        basinsPopulated: basins.length,
+      });
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       logger.warn('[MTF-bootstrap] failed for timeframe', {
-        symbol, label, err: err instanceof Error ? err.message : String(err),
+        symbol, label, err: message,
+      });
+      perTimeframe.push({
+        label,
+        status: 'fetch_failed',
+        basinsPopulated: 0,
+        errorMessage: message,
       });
     }
   }
+  const allSucceeded = perTimeframe.every((p) => p.status === 'success');
+  return {
+    symbol,
+    startedAtMs,
+    finishedAtMs: Date.now(),
+    perTimeframe,
+    allSucceeded,
+  };
 }

--- a/apps/api/src/services/monkey/mtfBootstrap.ts
+++ b/apps/api/src/services/monkey/mtfBootstrap.ts
@@ -17,7 +17,13 @@
  * Pure compute given OHLCV inputs; one I/O call (Poloniex public
  * candles endpoint) at the top.
  */
-import { setBootstrapHistory, type MTFState, type TimeframeLabel } from './mtfLClassifier.js';
+import {
+  DEFAULT_TIMEFRAMES,
+  setBootstrapHistory,
+  type MTFState,
+  type TimeframeConfig,
+  type TimeframeLabel,
+} from './mtfLClassifier.js';
 import { perceive } from './perception.js';
 import poloniexFuturesService from '../poloniexFuturesService.js';
 import { logger } from '../../utils/logger.js';
@@ -40,6 +46,7 @@ interface OHLCVCandle {
  *  the warmup minimum (480 + 120 horizon = 600) so the classifier
  *  is warm immediately at startup. */
 const BOOTSTRAP_CANDLE_COUNT = 700;
+const PERCEIVE_WINDOW = 50;
 
 /** Poloniex candle resolution strings keyed by our timeframe label.
  *  These map to the granularity the exchange provides; we DO NOT
@@ -78,6 +85,29 @@ export interface BootstrapSymbolStatus {
   allSucceeded: boolean;
 }
 
+/** Keep bootstrap warm-threshold logic aligned with mtfLClassifier's
+ *  warm gate (hist.length >= 480 + horizon). */
+function minBasinsNeededForTf(
+  label: TimeframeLabel,
+  timeframes: readonly TimeframeConfig[] = DEFAULT_TIMEFRAMES,
+): number {
+  const tf = timeframes.find((t) => t.label === label);
+  if (!tf) {
+    logger.warn('[MTF-bootstrap] timeframe config missing; using fallback horizon', {
+      label, fallbackHorizon: 120,
+    });
+  }
+  return 480 + (tf?.config.horizon ?? 120);
+}
+
+/** Raw candles needed so synthesised basins can meet warm threshold. */
+export function bootstrapMinCandlesNeeded(
+  label: TimeframeLabel,
+  timeframes: readonly TimeframeConfig[] = DEFAULT_TIMEFRAMES,
+): number {
+  return PERCEIVE_WINDOW + minBasinsNeededForTf(label, timeframes);
+}
+
 /** Pull OHLCV at the timeframe's resolution and synthesise basins
  *  for the bootstrap. Each candle becomes one basin via the same
  *  perceive() the live loop uses; the sliding-window context for
@@ -91,26 +121,28 @@ export interface BootstrapSymbolStatus {
 export async function bootstrapMTFForSymbol(
   symbol: string,
   state: MTFState,
+  labels: readonly TimeframeLabel[] = ['15m', '1h', '4h'],
 ): Promise<BootstrapSymbolStatus> {
   const startedAtMs = Date.now();
   const perTimeframe: BootstrapTimeframeStatus[] = [];
-  for (const label of ['15m', '1h', '4h'] as const) {
+  for (const label of labels) {
     try {
       const interval = POLONIEX_INTERVAL_FOR_TF[label];
+      const minCandlesNeeded = bootstrapMinCandlesNeeded(label);
       const candles = (await poloniexFuturesService.getHistoricalData(
         symbol,
         interval,
         BOOTSTRAP_CANDLE_COUNT,
       )) as OHLCVCandle[];
-      if (!Array.isArray(candles) || candles.length < 100) {
+      if (!Array.isArray(candles) || candles.length < minCandlesNeeded) {
         logger.warn('[MTF-bootstrap] insufficient OHLCV from exchange', {
-          symbol, label, got: candles?.length ?? 0,
+          symbol, label, got: candles?.length ?? 0, need: minCandlesNeeded,
         });
         perTimeframe.push({
           label,
           status: 'insufficient_candles',
           basinsPopulated: 0,
-          errorMessage: `got ${candles?.length ?? 0} candles (need ≥ 100)`,
+          errorMessage: `got ${candles?.length ?? 0} candles (need ≥ ${minCandlesNeeded})`,
         });
         continue;
       }
@@ -118,7 +150,6 @@ export async function bootstrapMTFForSymbol(
       // (matches the live perceive call's input shape). Skip the
       // first 50 candles since they don't have a full lookback.
       const basins: import('./basin.js').Basin[] = [];
-      const PERCEIVE_WINDOW = 50;
       for (let i = PERCEIVE_WINDOW; i < candles.length; i++) {
         const window = candles.slice(i - PERCEIVE_WINDOW, i + 1);
         try {
@@ -156,6 +187,19 @@ export async function bootstrapMTFForSymbol(
           status: 'synthesis_empty',
           basinsPopulated: 0,
           errorMessage: 'perceive() failed on every candle',
+        });
+        continue;
+      }
+      const minBasinsNeeded = minBasinsNeededForTf(label);
+      if (basins.length < minBasinsNeeded) {
+        logger.warn('[MTF-bootstrap] insufficient synthesized basins', {
+          symbol, label, got: basins.length, need: minBasinsNeeded,
+        });
+        perTimeframe.push({
+          label,
+          status: 'insufficient_candles',
+          basinsPopulated: basins.length,
+          errorMessage: `synthesized ${basins.length} basins (need ≥ ${minBasinsNeeded})`,
         });
         continue;
       }


### PR DESCRIPTION
…wards

Two diagnostic findings from the 2026-05-15/16 trade tape combined into one commit because they share the same root cause: the system was running with its strongest noise filter (MTF L 3-of-3 agreement) silently disabled and its reward chemistry diluted across all agents instead of reinforcing the winner (Agent K).

## 1. MTF L bootstrap silent-failure (mtfBootstrap.ts + loop.ts)

The live logs showed `[MTF-L] decision agreement: 0/3, perTf: 15m:cold, 1h:cold, 4h:cold` across full sessions. Root cause: the bootstrap was `void bootstrapMTFForSymbol(...)` fire-and-forget at startup, swallowing exchange fetch failures (429s, network blips) and insufficient-candle returns. Once cold, MTF L stayed cold for the session because:
  - 15m needs ~600 samples × 30-tick sample period = 5 hours of live runtime to warm (vs ~instant with bootstrap)
  - 1h needs ~25 days
  - 4h needs ~80 days

Without the 3-of-3 agreement filter, single-tick noise drives entries.

Fix:
- `bootstrapMTFForSymbol` now returns `BootstrapSymbolStatus` with per-TF result codes (success | insufficient_candles | fetch_failed | synthesis_empty) and basins-populated counts
- Startup bootstrap awaited per-symbol; status retained on `MonkeyKernel.mtfBootstrapStatus`
- New `maybeRetryMTFBootstrap` runs at the start of every tick — if the symbol's bootstrap is still partial AND the backoff timer has elapsed, re-runs the bootstrap. Backoff doubles 60s → 120s → ... → 480s capped, so a flaky exchange endpoint doesn't hammer per tick
- Status surfaced in `derivation.mtfBootstrap` so silent failures are visible in `/monkey/snapshot`

5 new vitest tests in `__tests__/mtfBootstrap.test.ts` covering success / insufficient / fetch_failed / partial / timing.

## 2. Per-agent neurochemistry rewards (loop.ts)

The autonomic reward queue `pendingRewards` was shared across all agents (K, M, T, L). Every closed trade — wins on K, losses on T, mixed on L — pooled into the same dopamine/serotonin/endorphin sum. K's wins were diluted by other agents' losses; K's brain never got the chemical reinforcement signal it earned.

Fix:
- `ActivityReward.agent` field added, populated on every push
- `pushReward` accepts `agent` param (defaults to 'K' for back-compat)
- `decayedRewardSums(now, agentFilter?)` filters when given an agent
- The kernel's tick loop (which IS K's brain) now passes 'K' as the filter — K's neurochemistry derives only from K's outcomes
- M/T/L rewards still flow into the queue for telemetry but don't pull K's dopamine sideways
- Per-agent decayed reward windows surfaced in `derivation.ncByAgent` so the dashboard can show "which agent is in flow"

The two existing K-tagged push paths (`closeHeldPosition` / `witnessExit`) now explicitly tag `agent: 'K'`. Other agent close paths are unchanged — they already use `recordSettled(label, pnl)` correctly for the arbiter and don't pushReward (so no pollution).

## Why both at once

The MTF L bootstrap is THE strongest noise filter; the reward routing is what makes the kernel internalize K's wins. The combination — MTF L active + K-specific dopamine — is what makes the kernel "feel" K's success and reinforce K's decision patterns. Either alone is insufficient.

## Verification

- Python suite: 783 monkey_kernel + utils tests passing (unchanged)
- QIG purity: 40 files clean (Python untouched)
- TS tests added: 5 new vitest tests for mtfBootstrap status reporting

The arbiter (capital allocator) is already correctly per-agent — it's been routing PnL through `recordSettled(label, pnl)` per agent and SLERP-allocates capital toward the winning agent (see arbiter.ts + qig-verification#47). No changes needed there; it's working as designed and K's wins do shift K's share up. The neurochemistry was the missing reward channel; that's what this commit fixes.

https://claude.ai/code/session_01HNGnUYFgphxnNfvRL45Gq3

## Summary by Sourcery

Ensure MTF L bootstrap robustness and audibility while making neurochemistry rewards agent-specific.

New Features:
- Add per-agent tagging and filtering of neurochemistry rewards so K’s brain derives chemicals only from K’s outcomes.
- Expose per-agent decayed neurochemistry windows and MTF bootstrap status in the monkey snapshot derivation for dashboard observability.

Bug Fixes:
- Prevent silent MTF L bootstrap failures by tracking per-symbol, per-timeframe bootstrap status and retrying with exponential backoff when needed.
- Stop cross-agent dilution of K’s rewards by segregating reward contributions by agent instead of pooling all agents into a shared queue.

Enhancements:
- Refactor MTF bootstrap to return structured per-timeframe status codes and timing metadata instead of fire-and-forget void behaviour.
- Improve logging around MTF bootstrap attempts and retries for clearer diagnosis of partial or failed warmups.

Tests:
- Add vitest coverage for mtfBootstrap status reporting across success, insufficient data, fetch failure, partial success, and timing metadata scenarios.