### PR TITLE
fix(monkey): MTF L bootstrap must paginate past Poloniex 500-per-call cap

### DIFF
--- a/apps/api/src/services/monkey/__tests__/mtfBootstrap.test.ts
+++ b/apps/api/src/services/monkey/__tests__/mtfBootstrap.test.ts
@@ -126,6 +126,50 @@ describe('bootstrapMTFForSymbol — status reporting', () => {
     expect(status.perTimeframe[0]!.label).toBe('1h');
     expect(status.perTimeframe[0]!.status).toBe('success');
     expect(stub).toHaveBeenCalledTimes(1);
-    expect(stub).toHaveBeenCalledWith('BTC_USDT_PERP', '1h', 700);
+    // 4th arg is the opts object containing startTime so the service's
+    // chunked-loop pagination actually returns the requested count
+    // (otherwise the 500-per-call cap silently truncates → MTF L cold).
+    expect(stub).toHaveBeenCalledWith(
+      'BTC_USDT_PERP',
+      '1h',
+      700,
+      expect.objectContaining({ startTime: expect.any(Number) }),
+    );
+  });
+
+  it('passes a startTime opt so getHistoricalData paginates past the 500-per-call cap', async () => {
+    // Regression for the 2026-05-16 scalp-spiral root cause: bootstrap
+    // demanded 700 candles, exchange capped each single-call response at
+    // 500, mtfBootstrap was NOT supplying opts.startTime so the service
+    // never engaged its loop → 500 returned < 650 bootstrapMinCandlesNeeded
+    // ('15m') → marked insufficient_candles → MTF L permanently cold →
+    // no 3-of-3 agreement gate on K's entries → scalp-spiral.
+    const stub = vi.fn().mockResolvedValue(repeatCandles(700));
+    vi.doMock('../../poloniexFuturesService.js', () => ({
+      default: { getHistoricalData: stub },
+    }));
+    const { bootstrapMTFForSymbol } = await import('../mtfBootstrap.js');
+    const { newMTFState } = await import('../mtfLClassifier.js');
+    const state = newMTFState();
+    const beforeMs = Date.now();
+    await bootstrapMTFForSymbol('BTC_USDT_PERP', state, ['15m', '1h', '4h']);
+    // 15m: 700 candles × 15min = ~7.3 days back
+    const callFor = (label: '15m' | '1h' | '4h') => {
+      const expectedIntervalMs = label === '15m' ? 900_000 : label === '1h' ? 3_600_000 : 14_400_000;
+      const c = stub.mock.calls.find((args) => args[1] === label);
+      expect(c, `expected one call for ${label}`).toBeTruthy();
+      const opts = c![3] as { startTime: number };
+      expect(opts).toBeDefined();
+      expect(typeof opts.startTime).toBe('number');
+      // startTime must be back by approximately BOOTSTRAP_CANDLE_COUNT (700)
+      // × intervalMs from "now" — tolerate small drift from the test
+      // setup wall-clock.
+      const expectedStart = beforeMs - expectedIntervalMs * 700;
+      expect(opts.startTime).toBeGreaterThan(expectedStart - 60_000);
+      expect(opts.startTime).toBeLessThan(expectedStart + 60_000);
+    };
+    callFor('15m');
+    callFor('1h');
+    callFor('4h');
   });
 });

--- a/apps/api/src/services/monkey/mtfBootstrap.ts
+++ b/apps/api/src/services/monkey/mtfBootstrap.ts
@@ -129,10 +129,20 @@ export async function bootstrapMTFForSymbol(
     try {
       const interval = POLONIEX_INTERVAL_FOR_TF[label];
       const minCandlesNeeded = bootstrapMinCandlesNeeded(label);
+      // poloniexFuturesService.getHistoricalData caps at POLONIEX_MAX_PER_CALL
+      // (500) per single call. Without an explicit `startTime` opt the service
+      // does NOT loop, so a `limit=700` request silently returns 500 — well
+      // below the 480 + horizon warm threshold, leaving MTF L permanently
+      // cold (root cause of the 2026-05-15 scalp-spiral). Pass a startTime
+      // that spans BOOTSTRAP_CANDLE_COUNT intervals so the service's chunked
+      // loop activates and actually returns the count we asked for.
+      const intervalMs = label === '15m' ? 900_000 : label === '1h' ? 3_600_000 : 14_400_000;
+      const startTime = Date.now() - intervalMs * BOOTSTRAP_CANDLE_COUNT;
       const candles = (await poloniexFuturesService.getHistoricalData(
         symbol,
         interval,
         BOOTSTRAP_CANDLE_COUNT,
+        { startTime },
       )) as OHLCVCandle[];
       if (!Array.isArray(candles) || candles.length < minCandlesNeeded) {
         logger.warn('[MTF-bootstrap] insufficient OHLCV from exchange', {

--- a/apps/api/src/services/monkey/mtfBootstrap.ts
+++ b/apps/api/src/services/monkey/mtfBootstrap.ts
@@ -48,14 +48,17 @@ interface OHLCVCandle {
 const BOOTSTRAP_CANDLE_COUNT = 700;
 const PERCEIVE_WINDOW = 50;
 
-/** Poloniex candle resolution strings keyed by our timeframe label.
- *  These map to the granularity the exchange provides; we DO NOT
- *  do further down-sampling because the basin synthesis already
- *  encodes the perceptual scale via perceive(). */
-const POLONIEX_INTERVAL_FOR_TF: Record<TimeframeLabel, string> = {
-  '15m': '15m',
-  '1h': '1h',
-  '4h': '4h',
+/** Poloniex candle resolution per timeframe label. The `format` field is
+ *  the granularity string the exchange API expects; `intervalMs` is the
+ *  duration of one candle at that resolution. Both are colocated so a
+ *  future TF addition or rename updates a single record — addresses the
+ *  Sourcery review note about a duplicated 15m/1h/4h ms mapping inside
+ *  the bootstrap loop. We DO NOT do further down-sampling because the
+ *  basin synthesis already encodes the perceptual scale via perceive(). */
+const POLONIEX_TF_CONFIG: Record<TimeframeLabel, { format: string; intervalMs: number }> = {
+  '15m': { format: '15m', intervalMs: 15 * 60 * 1000 },
+  '1h':  { format: '1h',  intervalMs: 60 * 60 * 1000 },
+  '4h':  { format: '4h',  intervalMs: 4 * 60 * 60 * 1000 },
 };
 
 /** Per-(symbol, timeframe) bootstrap outcome. Returned by
@@ -123,11 +126,16 @@ export async function bootstrapMTFForSymbol(
   state: MTFState,
   labels: readonly TimeframeLabel[] = ['15m', '1h', '4h'],
 ): Promise<BootstrapSymbolStatus> {
+  // Single `nowMs` captured outside the per-TF loop so the three startTime
+  // values are deterministically separated by exact integer multiples of
+  // each timeframe's intervalMs — no per-TF wall-clock drift. Also enables
+  // test injection of a fixed clock if needed later.
   const startedAtMs = Date.now();
+  const nowMs = startedAtMs;
   const perTimeframe: BootstrapTimeframeStatus[] = [];
   for (const label of labels) {
     try {
-      const interval = POLONIEX_INTERVAL_FOR_TF[label];
+      const { format: interval, intervalMs } = POLONIEX_TF_CONFIG[label];
       const minCandlesNeeded = bootstrapMinCandlesNeeded(label);
       // poloniexFuturesService.getHistoricalData caps at POLONIEX_MAX_PER_CALL
       // (500) per single call. Without an explicit `startTime` opt the service
@@ -136,8 +144,7 @@ export async function bootstrapMTFForSymbol(
       // cold (root cause of the 2026-05-15 scalp-spiral). Pass a startTime
       // that spans BOOTSTRAP_CANDLE_COUNT intervals so the service's chunked
       // loop activates and actually returns the count we asked for.
-      const intervalMs = label === '15m' ? 900_000 : label === '1h' ? 3_600_000 : 14_400_000;
-      const startTime = Date.now() - intervalMs * BOOTSTRAP_CANDLE_COUNT;
+      const startTime = nowMs - intervalMs * BOOTSTRAP_CANDLE_COUNT;
       const candles = (await poloniexFuturesService.getHistoricalData(
         symbol,
         interval,


### PR DESCRIPTION
## Summary

Root cause fix for the 2026-05-15 / 2026-05-16 scalp-spiral.

`poloniexFuturesService.getHistoricalData()` caps at `POLONIEX_MAX_PER_CALL=500` per single call. Without an explicit `opts.startTime`, the service does NOT engage its chunked-loop pagination — so a `limit=700` request silently returns 500.

500 < `bootstrapMinCandlesNeeded('15m') = 50 + 480 + 120 = 650`, so the bootstrap marks every TF `insufficient_candles`, MTF L stays cold forever, the 3-of-3 agreement noise gate is permanently 0/3, single-tick basinDir/tape disagreements turn into entries, and K over-trades while L (the actual profit engine at 76.4% WR) gets starved.

Live confirmation from production logs across multiple deploys:
```
[MTF-L] decision {agreement:"0/3", perTf:"15m:cold,1h:cold,4h:cold"}
```

This PR passes `opts.startTime` computed from `BOOTSTRAP_CANDLE_COUNT × intervalMs` so the service's loop fires and returns the count actually needed for the warm threshold.

PR #700's bootstrap-retry mechanism is intact — this just fixes the silent truncation each retry was hitting.

## Tests

- Existing call-shape assertion updated for the new 4th arg
- New regression test pins the boundary: 500-per-call cap requires `opts.startTime` so the loop returns the requested count

## Verification

- [x] `yarn workspace api build` — exits 0
- [x] `vitest mtfBootstrap.test.ts` — 7/7 pass (including new boundary test)
- [x] No behaviour change when the exchange returns >= warm threshold in a single call

## Post-deploy verification (operator)

After deploy completes, watch prod logs for `[MTF-L] decision {agreement:"X/3"}` with `X >= 1` on at least one symbol within 30 minutes of warm. If still `0/3`, escalate to Stage 3 (HEDGE per-symbol per-agent tick lock).

## Companion operator action (already done)

`MONKEY_TRADING_PAUSED=true` + `LIVE_SIGNAL_EXECUTE=false` + `LIVE_LEVERAGE=5` flipped on prod env to arrest the bleed while this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure MTF bootstrap requests sufficient historical candles from Poloniex by time-bounding queries so pagination can exceed the 500-per-call cap.

Bug Fixes:
- Prevent MTF L from remaining permanently cold by avoiding silent truncation of bootstrap candle requests at the exchange’s 500-per-call limit.

Tests:
- Extend mtfBootstrap tests to assert the new startTime option is passed and to cover the 500-per-call pagination boundary behavior.