### PR TITLE
fix(api): UI data-integrity — engine_type column + range/timeframe filters

### DIFF
--- a/apps/api/database/migrations/050_autonomous_trades_engine_type.sql
+++ b/apps/api/database/migrations/050_autonomous_trades_engine_type.sql
@@ -1,0 +1,49 @@
+-- 050_autonomous_trades_engine_type.sql
+--
+-- Add engine_type discriminator to autonomous_trades so /api/agent/performance
+-- can cleanly filter live vs paper vs backtest rows. Today the handler at
+-- apps/api/src/routes/agent.ts:332 uses a leaky `order_id LIKE 'paper_%'`
+-- heuristic that includes any NULL-order_id rows as "live" — conflates
+-- ghost rows, manual entries, and real live trades.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, backfill WHERE IS NULL only,
+-- index uses IF NOT EXISTS. Re-applying on prod is a no-op.
+--
+-- Backfill rules (most specific first):
+--   order_id LIKE 'paper_%'                     -> 'paper'
+--   order_id LIKE 'paper-%'                     -> 'paper' (alt prefix used by paperExchangeSimulator PR #699)
+--   order_id ~ '^[0-9]+$' (numeric, real polo)  -> 'live'
+--   order_id IS NULL                            -> 'unknown' (likely ghost)
+--   otherwise                                   -> 'unknown'
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'autonomous_trades'
+      AND column_name = 'engine_type'
+  ) THEN
+    ALTER TABLE autonomous_trades ADD COLUMN engine_type VARCHAR(20);
+  END IF;
+
+  -- Backfill any rows where engine_type is NULL (initial population or
+  -- newly-added rows from older code paths). Safe to re-run: WHERE
+  -- engine_type IS NULL filter keeps it idempotent.
+  UPDATE autonomous_trades
+     SET engine_type = CASE
+       WHEN order_id LIKE 'paper_%'    THEN 'paper'
+       WHEN order_id LIKE 'paper-%'    THEN 'paper'
+       WHEN order_id ~ '^[0-9]+$'      THEN 'live'
+       WHEN order_id IS NULL           THEN 'unknown'
+       ELSE                                  'unknown'
+     END
+   WHERE engine_type IS NULL;
+END $$;
+
+-- Partial index on the hot read path: per-engine recent-closed trades.
+-- Existing dashboard queries ORDER BY exit_time DESC and filter by engine_type
+-- after the agent.ts handler change ships.
+CREATE INDEX IF NOT EXISTS idx_autonomous_trades_engine_exit
+  ON autonomous_trades(engine_type, exit_time DESC)
+  WHERE exit_time IS NOT NULL;

--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -329,7 +329,36 @@ router.get('/performance', authenticateToken, async (req: Request, res: Response
     if (!traderStatus.enabled && !traderStatus.metrics) return res.json({ success: true, performance: defaultPerformance });
     try {
       const mode = req.query.mode as string | undefined;
-      const modeFilter = mode === 'paper' ? " AND order_id LIKE 'paper_%'" : mode === 'live' ? " AND (order_id IS NULL OR order_id NOT LIKE 'paper_%')" : '';
+      // Per-engine filter uses the `engine_type` column populated by
+      // migration 050. The prior `order_id LIKE 'paper_%'` heuristic at
+      // this site conflated NULL-order_id ghost rows with live trades
+      // (so mode='live' was identical to mode='all'). engine_type makes
+      // live / paper / backtest cleanly separable. NULL engine_type
+      // (rows pre-050 with order_ids that didn't match any pattern) is
+      // treated as 'unknown' and excluded from per-mode filtered views;
+      // mode='all' (or absent) still includes everything.
+      const modeFilter =
+        mode === 'paper'    ? " AND engine_type = 'paper'"
+        : mode === 'live'     ? " AND engine_type = 'live'"
+        : mode === 'backtest' ? " AND engine_type = 'backtest'"
+        :                       '';
+      // Range filter — 24h / 7d / 30d / 90d / 1y / all. Previously
+      // absent: the UI timeframe selector re-fetched with each value
+      // but the backend returned identical data for every range. Now
+      // every aggregate query (trades stats, returns, daily, per-agent,
+      // per-symbol) honors the same window.
+      const range = req.query.range as string | undefined;
+      const rangeInterval =
+        range === '24h' ? '24 hours'
+        : range === '7d'  ? '7 days'
+        : range === '30d' ? '30 days'
+        : range === '90d' ? '90 days'
+        : range === '1y'  ? '1 year'
+        :                   null;
+      const rangeFilter = rangeInterval
+        ? ` AND created_at > NOW() - INTERVAL '${rangeInterval}'`
+        : '';
+      const filters = `${modeFilter}${rangeFilter}`;
       const tradesResult = await pool.query(
         `SELECT
             COUNT(*) AS total_trades,
@@ -342,13 +371,13 @@ router.get('/performance', authenticateToken, async (req: Request, res: Response
             MIN(pnl) AS worst_trade,
             SUM(CASE WHEN pnl > 0 THEN pnl ELSE 0 END) AS gross_wins,
             SUM(CASE WHEN pnl < 0 THEN ABS(pnl) ELSE 0 END) AS gross_losses
-         FROM autonomous_trades WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter}`,
+         FROM autonomous_trades WHERE user_id = $1 AND pnl IS NOT NULL${filters}`,
         [userId],
       );
       const metrics = tradesResult.rows[0];
       let sharpeRatio = 0; let maxDrawdown = 0;
       try {
-        const returnsResult = await pool.query(`SELECT pnl FROM autonomous_trades WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter} ORDER BY created_at ASC`, [userId]);
+        const returnsResult = await pool.query(`SELECT pnl FROM autonomous_trades WHERE user_id = $1 AND pnl IS NOT NULL${filters} ORDER BY created_at ASC`, [userId]);
         const pnls = returnsResult.rows.map((r: { pnl: string }) => parseFloat(r.pnl));
         if (pnls.length > 1) {
           const mean = pnls.reduce((a: number, b: number) => a + b, 0) / pnls.length;
@@ -361,7 +390,7 @@ router.get('/performance', authenticateToken, async (req: Request, res: Response
       } catch { /* keep defaults */ }
       let dailyPerformance: Array<{ date: string; pnl: number; cumulativePnL: number; trades: number }> = [];
       try {
-        const dailyResult = await pool.query(`SELECT DATE(created_at) AS trade_date, SUM(pnl) AS daily_pnl, COUNT(*) AS daily_trades FROM autonomous_trades WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter} GROUP BY DATE(created_at) ORDER BY trade_date ASC`, [userId]);
+        const dailyResult = await pool.query(`SELECT DATE(created_at) AS trade_date, SUM(pnl) AS daily_pnl, COUNT(*) AS daily_trades FROM autonomous_trades WHERE user_id = $1 AND pnl IS NOT NULL${filters} GROUP BY DATE(created_at) ORDER BY trade_date ASC`, [userId]);
         let cumPnl = 0;
         dailyPerformance = dailyResult.rows.map((r: { trade_date: string; daily_pnl: string; daily_trades: string }) => {
           const dayPnl = parseFloat(r.daily_pnl) || 0;
@@ -386,7 +415,7 @@ router.get('/performance', authenticateToken, async (req: Request, res: Response
                     THEN (SUM(CASE WHEN pnl > 0 THEN 1 ELSE 0 END)::float * 100.0 / COUNT(*))
                     ELSE 0 END AS win_rate
              FROM autonomous_trades
-            WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter}
+            WHERE user_id = $1 AND pnl IS NOT NULL${filters}
             GROUP BY agent
             ORDER BY pnl DESC NULLS LAST`,
           [userId],
@@ -409,7 +438,7 @@ router.get('/performance', authenticateToken, async (req: Request, res: Response
                     THEN (SUM(CASE WHEN pnl > 0 THEN 1 ELSE 0 END)::float * 100.0 / COUNT(*))
                     ELSE 0 END AS win_rate
              FROM autonomous_trades
-            WHERE user_id = $1 AND pnl IS NOT NULL${modeFilter}
+            WHERE user_id = $1 AND pnl IS NOT NULL${filters}
             GROUP BY symbol
             ORDER BY pnl DESC NULLS LAST`,
           [userId],

--- a/apps/api/src/routes/autonomousTrader.ts
+++ b/apps/api/src/routes/autonomousTrader.ts
@@ -146,7 +146,24 @@ router.get('/status', authenticateToken, async (req: Request, res: Response) => 
 router.get('/performance', authenticateToken, async (req: Request, res: Response) => {
   try {
     const userId = String(req.user.id);
-    const days = parseInt(req.query.days as string, 10) || 30;
+    // Accept both `days` (raw integer) and `timeframe` (semantic alias the
+    // FE timeframe-pill component sends — '24h' / '7d' / '30d' / '90d' / '1y').
+    // Before this alias the handler silently fell through to the 30-day default
+    // for every timeframe selection because `parseInt('7d', 10)` returns 7 but
+    // `parseInt('24h', 10)` returns 24 (24 days, not 24 hours) — and other
+    // values like '90d' coincidentally worked while '24h' was unintentionally
+    // a 24-day window. Explicit mapping below removes the ambiguity.
+    const timeframe = req.query.timeframe as string | undefined;
+    const timeframeToDays: Record<string, number> = {
+      '24h': 1,
+      '7d': 7,
+      '30d': 30,
+      '90d': 90,
+      '1y': 365,
+    };
+    const days = timeframe && timeframeToDays[timeframe] != null
+      ? timeframeToDays[timeframe]
+      : (parseInt(req.query.days as string, 10) || 30);
 
     // Get performance history
     const performanceResult = await pool.query(


### PR DESCRIPTION
## Summary

Three coordinated backend fixes for the UI surfaces that were showing wrong numbers regardless of operator filter selection:

1. **Migration `050_autonomous_trades_engine_type.sql`** — adds `engine_type` column to `autonomous_trades` + backfills from existing `order_id` pattern. Idempotent DO-block + partial index on `(engine_type, exit_time)`.

2. **`agent.ts:306` `/api/agent/performance`** —
   - Honors `?range=24h|7d|30d|90d|1y` via `created_at NOW() - INTERVAL` filter on every aggregate query (trades stats, returns, daily, per-agent, per-symbol). Before: timeframe selector returned identical data for every range.
   - Per-engine filter uses the new `engine_type` column. Before: `mode=live` matched NULL ghosts → effectively identical to `mode=all`. `mode=backtest` had no SQL branch at all.

3. **`autonomousTrader.ts:146` `/api/autonomous/performance`** — accepts `?timeframe=` as semantic alias for `?days=`, with explicit map (`24h→1, 7d→7, 30d→30, 90d→90, 1y→365`). Before: `parseInt('24h', 10)` silently returned `24` → 24-day window instead of 24h.

## No behaviour change when params absent

- `?range` missing → no time filter (same as today)
- `?mode` missing → all engines (same as today)
- `?timeframe` missing → falls back to `?days` then to default 30 (same as today)

So this PR can ship before the FE PR without breaking anything.

## Verification

- [x] `yarn workspace api build` — exits 0
- [x] Migration idempotency reviewed against 048/049 patterns
- [x] `engine_type` backfill rules cover the three known order_id shapes (`paper_%`, `paper-%` from PR #699 simulator, numeric Poloniex IDs)

## Companion FE PR (in flight, parallel branch)

`fix/ui-data-integrity-fe` — timeframe selector wires to the correct param per endpoint, status badge reflects actual paperTrading state, `/history` fees aggregation, baseline-reset CTA when balance ÷ initial diverges, stale 404 cleanup. Will arrive as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add engine_type tracking for autonomous trades and update performance endpoints to correctly honor engine mode and timeframe filters.

Bug Fixes:
- Correct agent performance mode filtering by using a dedicated engine_type column instead of order_id heuristics, ensuring live, paper, and backtest stats are separated accurately.
- Apply a consistent created_at-based range filter to all agent performance aggregates so UI timeframe selections (24h–1y) return distinct, correct data.
- Fix autonomous performance timeframe handling by mapping semantic timeframe values (24h, 7d, 30d, 90d, 1y) to explicit day windows instead of relying on parseInt fallthroughs.

Enhancements:
- Introduce an engine_type discriminator column on autonomous_trades, including backfill logic and an index optimized for per-engine recent trade queries.