### PR TITLE
fix(ui): UI corrections — timeframe selector, status badge, fees aggregation, baseline reset, stale 404 cleanup

### DIFF
--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -67,6 +67,20 @@ const AutonomousAgentDashboard: React.FC = () => {
   const [agentStatus, setAgentStatus] = useState<AgentStatus | null>(null);
   const [activity, setActivity] = useState<AgentActivity[]>([]);
   const [strategies, setStrategies] = useState<AgentStrategy[]>([]);
+  // C6/C7 — surface real LIVE-vs-PAPER state and detect stale baseline.
+  //  • /api/autonomous/status returns { enabled, config.paperTrading,
+  //    config.initialCapital } — drives the status badge AND the
+  //    baseline-divergence banner.
+  //  • /api/dashboard/balance returns { data.totalBalance } — compared
+  //    against initialCapital to detect drift > 20% which makes the
+  //    totalPnlPercent display absurd (e.g. 777% on a stale $440 baseline
+  //    while current equity is $91).
+  const [autonomousStatus, setAutonomousStatus] = useState<{
+    enabled: boolean;
+    paperTrading: boolean;
+    initialCapital: number | null;
+  } | null>(null);
+  const [currentBalance, setCurrentBalance] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastPolled, setLastPolled] = useState<Date | null>(null);
@@ -209,6 +223,8 @@ const AutonomousAgentDashboard: React.FC = () => {
     fetchStrategies();
     fetchHealth();
     fetchCapabilities();
+    fetchAutonomousStatus();
+    fetchCurrentBalance();
 
     // WebSocket real-time updates
     let socket: { on: (event: string, cb: (data: any) => void) => void; disconnect: () => void } | null = null;
@@ -261,6 +277,8 @@ const AutonomousAgentDashboard: React.FC = () => {
 
     const interval = setInterval(() => {
       fetchAgentStatus();
+      fetchAutonomousStatus();
+      fetchCurrentBalance();
       if (agentStatusRef.current === 'running') {
         fetchActivity();
         fetchStrategies();
@@ -284,7 +302,7 @@ const AutonomousAgentDashboard: React.FC = () => {
       const response = await axios.get(`${API_BASE_URL}/api/agent/status`, {
         headers: getAuthHeaders()
       });
-      
+
       if (response.data.success) {
         setAgentStatus(response.data.status);
         consecutiveErrorsRef.current = 0; // Reset on success
@@ -293,6 +311,45 @@ const AutonomousAgentDashboard: React.FC = () => {
     } catch (_err: unknown) {
       consecutiveErrorsRef.current = Math.min(consecutiveErrorsRef.current + 1, MAX_CONSECUTIVE_ERRORS);
       setLastPolled(new Date());
+    }
+  };
+
+  // C6 — pull the authoritative LIVE/PAPER flag and the stored baseline
+  // from /api/autonomous/status. The /api/agent/status payload exposes
+  // status.trader.paperTrading but the autonomous endpoint also returns
+  // config.initialCapital (needed for the C7 divergence check), so we
+  // hit it once on mount + on poll ticks for a consistent snapshot.
+  const fetchAutonomousStatus = async () => {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/api/autonomous/status`, {
+        headers: getAuthHeaders()
+      });
+      if (response.data.success) {
+        setAutonomousStatus({
+          enabled: !!response.data.enabled,
+          paperTrading: !!response.data.config?.paperTrading,
+          initialCapital:
+            typeof response.data.config?.initialCapital === 'number'
+              ? response.data.config.initialCapital
+              : null,
+        });
+      }
+    } catch {
+      // Non-critical — badge/banner just won't render.
+    }
+  };
+
+  // C7 — current futures equity for baseline-divergence detection.
+  const fetchCurrentBalance = async () => {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/api/dashboard/balance`, {
+        headers: getAuthHeaders()
+      });
+      if (response.data.success && typeof response.data.data?.totalBalance === 'number') {
+        setCurrentBalance(response.data.data.totalBalance);
+      }
+    } catch {
+      // Non-critical.
     }
   };
 
@@ -528,6 +585,45 @@ const AutonomousAgentDashboard: React.FC = () => {
             <p className="mt-2 opacity-90">
               AI-powered autonomous trading system using Claude Sonnet 4.5
             </p>
+            {/* C6 — capital-mode badge. Renders against the actual
+                {enabled, paperTrading} state pulled from
+                /api/autonomous/status, NOT the localStorage execution-mode
+                preference (which can disagree with the kernel's truth). */}
+            {autonomousStatus && (
+              (() => {
+                if (!autonomousStatus.enabled) {
+                  return (
+                    <span
+                      role="status"
+                      aria-label="Autonomous trading stopped"
+                      className="mt-3 inline-flex items-center gap-2 px-3 py-1 rounded-md bg-gray-800/60 text-gray-100 text-sm font-semibold border border-gray-500/40"
+                    >
+                      <span aria-hidden>⚫</span> STOPPED
+                    </span>
+                  );
+                }
+                if (autonomousStatus.paperTrading) {
+                  return (
+                    <span
+                      role="status"
+                      aria-label="Paper trading mode — simulated capital"
+                      className="mt-3 inline-flex items-center gap-2 px-3 py-1 rounded-md bg-yellow-100 text-yellow-900 text-sm font-semibold border border-yellow-300"
+                    >
+                      <span aria-hidden>🟡</span> PAPER — Simulated capital
+                    </span>
+                  );
+                }
+                return (
+                  <span
+                    role="status"
+                    aria-label="Live trading active — real capital at risk"
+                    className="mt-3 inline-flex items-center gap-2 px-3 py-1 rounded-md bg-red-600 text-white text-sm font-bold border-2 border-red-300 shadow-md animate-pulse"
+                  >
+                    <span aria-hidden>🔴</span> LIVE — REAL CAPITAL
+                  </span>
+                );
+              })()
+            )}
           </div>
 
           <div className="flex items-center gap-3">
@@ -566,6 +662,57 @@ const AutonomousAgentDashboard: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {/* C7 — Baseline-divergence banner.
+          totalPnlPercent on this dashboard is computed against the
+          stored autonomous_trading_configs.initial_capital. If that
+          baseline is more than 20% off the current futures equity,
+          the % display goes nonsensical (e.g. 777% when $440 baseline
+          vs $91 actual). Surface a warning + the suggested reset
+          value so the user can fix it via the config endpoint.
+
+          NOTE: there is no BE reset endpoint today — this banner is
+          informational only. Once /api/autonomous/config (or similar)
+          accepts a PATCH for initial_capital, wire the CTA to it. */}
+      {autonomousStatus?.initialCapital !== undefined
+        && autonomousStatus?.initialCapital !== null
+        && autonomousStatus.initialCapital > 0
+        && currentBalance !== null
+        && currentBalance > 0
+        && (() => {
+          const drift = Math.abs(currentBalance - autonomousStatus.initialCapital!)
+            / autonomousStatus.initialCapital!;
+          if (drift <= 0.2) return null;
+          const direction = currentBalance > autonomousStatus.initialCapital! ? 'above' : 'below';
+          return (
+            <div
+              className="bg-amber-50 border border-amber-300 rounded-lg p-4 flex items-start gap-3"
+              role="alert"
+              aria-label="Stale baseline warning"
+            >
+              <AlertCircle className="w-6 h-6 text-amber-600 flex-shrink-0 mt-0.5" />
+              <div className="flex-1">
+                <h3 className="text-amber-800 font-semibold">Stale baseline detected</h3>
+                <p className="text-amber-700 text-sm mt-1">
+                  Stored baseline is{' '}
+                  <strong>${autonomousStatus.initialCapital!.toFixed(2)}</strong>
+                  {' '}but current equity is{' '}
+                  <strong>${safeNum(currentBalance).toFixed(2)}</strong>
+                  {' '}— a {safeNum(drift * 100).toFixed(0)}% drift {direction} the baseline.
+                  The Total P&amp;L % shown on this dashboard is computed against
+                  the stored baseline and will read as nonsense until the baseline
+                  is reset to the current equity.
+                </p>
+                <p className="text-amber-700 text-xs mt-2">
+                  TODO: wire a backend PATCH endpoint (e.g.
+                  <code className="px-1 mx-1 bg-amber-100 rounded">PATCH /api/autonomous/config</code>
+                  with <code className="px-1 bg-amber-100 rounded">{`{ initialCapital: ${safeNum(currentBalance).toFixed(2)} }`}</code>)
+                  to reset baseline from the UI.
+                </p>
+              </div>
+            </div>
+          );
+        })()}
 
       {/* Existing Session Banner */}
       {existingSession && (

--- a/apps/web/src/components/agent/PerformanceAnalytics.tsx
+++ b/apps/web/src/components/agent/PerformanceAnalytics.tsx
@@ -28,7 +28,10 @@ interface PerformanceData {
 
 interface PerformanceAnalyticsProps {
   agentStatus?: string;
-  timeRange?: '24h' | '7d' | '30d' | 'all';
+  // Backend /api/agent/performance accepts ?range=24h|7d|30d|90d|1y.
+  // 'all' was a legacy value that the new backend treats as invalid —
+  // selector below now offers 90d / 1y instead.
+  timeRange?: '24h' | '7d' | '30d' | '90d' | '1y';
   /**
    * Execution-mode filter from the parent's Performance Mode tabs.
    * The backend accepts 'paper' | 'live' (derived from order_id prefix)
@@ -350,17 +353,17 @@ const PerformanceAnalytics: React.FC<PerformanceAnalyticsProps> = ({
             Performance Analytics
           </h3>
           <div className="flex gap-2">
-            {['24h', '7d', '30d', 'all'].map((range) => (
+            {(['24h', '7d', '30d', '90d', '1y'] as const).map((range) => (
               <button
                 key={range}
-                onClick={() => setSelectedRange(range as any)}
+                onClick={() => setSelectedRange(range)}
                 className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
                   selectedRange === range
                     ? 'bg-blue-600 text-white'
                     : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
                 }`}
               >
-                {range === '24h' ? '24 Hours' : range === '7d' ? '7 Days' : range === '30d' ? '30 Days' : 'All Time'}
+                {range === '24h' ? '24 Hours' : range === '7d' ? '7 Days' : range === '30d' ? '30 Days' : range === '90d' ? '90 Days' : '1 Year'}
               </button>
             ))}
           </div>

--- a/apps/web/src/pages/TradeHistory.tsx
+++ b/apps/web/src/pages/TradeHistory.tsx
@@ -120,6 +120,12 @@ const TradeHistory: React.FC = () => {
               amount: t.quantity || 0,
               price: t.entryPrice || 0,
               total: (t.quantity || 0) * (t.entryPrice || 0),
+              // TODO(BE): /api/autonomous/trades does not surface the
+              // per-trade fee column from autonomous_trades. Result:
+              // the Total Fees summary card on this page always reads
+              // $0.00 for the bot-trade portion. Add `fee` + `feeCurrency`
+              // to the autonomous trades payload (or join from the
+              // exchange-fill ledger) so this aggregation is correct.
               fee: 0,
               feeCurrency: 'USDT',
               pnl: t.pnl ?? undefined,
@@ -348,10 +354,15 @@ const TradeHistory: React.FC = () => {
         </p>
       </div>
 
-      {/* Trade Source Tabs */}
+      {/* Trade Source Tabs.
+          'All' shows the deduplicated union (exchange fills already
+          accounted for by a bot row are filtered out — see
+          dedupedExchangeTrades above), so the header count must use
+          the deduped length, not the raw sum. Previously displayed
+          e.g. "All Trades (200)" while the rendered list held ~105 rows. */}
       <div className="flex border-b border-border-subtle mb-6">
         {([
-          { key: 'all', label: 'All Trades', count: exchangeTrades.length + botTrades.length },
+          { key: 'all', label: 'All Trades', count: dedupedExchangeTrades.length + botTrades.length },
           { key: 'exchange', label: 'Exchange History', count: exchangeTrades.length },
           { key: 'bot', label: 'Bot Trades', count: botTrades.length }
         ] as const).map(tab => (

--- a/apps/web/src/services/autonomousTradingAPI.ts
+++ b/apps/web/src/services/autonomousTradingAPI.ts
@@ -355,8 +355,9 @@ class AutonomousTradingAPIService {
   async getStrategyPerformance(strategyId: string, timeframe: string = '24h'): Promise<any> {
         try {
                 const api = createAuthenticatedAxios();
-                // GET /api/agent/performance (overall performance)
-          const response = await api.get('/performance', { params: { timeframe } });
+                // GET /api/agent/performance accepts ?range=24h|7d|30d|90d|1y
+                // (param renamed from `timeframe` 2026-05-16; backend reads `range`).
+          const response = await api.get('/performance', { params: { range: timeframe } });
                 return response.data;
         } catch (error) {
                 this.handleError(error);
@@ -442,8 +443,9 @@ class AutonomousTradingAPIService {
   async getPerformanceAnalytics(timeframe: string = '24h'): Promise<PerformanceAnalytics> {
         try {
                 const api = createAuthenticatedAxios();
-                // GET /api/agent/performance
-          const response = await api.get('/performance', { params: { timeframe } });
+                // GET /api/agent/performance accepts ?range=24h|7d|30d|90d|1y
+                // (param renamed from `timeframe` 2026-05-16; backend reads `range`).
+          const response = await api.get('/performance', { params: { range: timeframe } });
                 const perf = response.data.performance || {};
                 return {
                           totalProfit: perf.totalPnl || 0,


### PR DESCRIPTION
## Summary

FE-side companion to `fix/ui-data-integrity-backend` (which renames the
`/api/agent/performance` query param to `range` and adds a `timeframe`
alias to `/api/autonomous/performance`). This PR delivers five UI
corrections — no new features, no refactors, no scope bleed.

### C4 — Timeframe selector sends the right param name
- `apps/web/src/services/autonomousTradingAPI.ts` — rename `timeframe`
  → `range` on both `getStrategyPerformance` and
  `getPerformanceAnalytics`. Backend reads `req.query.range`, not
  `req.query.timeframe`.
- `apps/web/src/components/agent/PerformanceAnalytics.tsx` — replace
  the legacy `'all'` selector value (no longer accepted on the new BE)
  with `'90d'` and `'1y'` to match the BE's `24h|7d|30d|90d|1y`
  contract.

### C5 — TradeHistory tab count uses the deduplicated 'All' total
- `apps/web/src/pages/TradeHistory.tsx` — the "All Trades" tab renders
  `dedupedExchangeTrades + botTrades` (exchange fills already accounted
  for in a bot row get filtered) but the header count summed the RAW
  lists, so users saw `All Trades (200)` while the table held ~105 rows.
- Add a TODO on the bot-trade fee mapping: `/api/autonomous/trades`
  does not return a `fee` column, so the Total Fees aggregation card
  always reads `$0.00` for the bot-trade portion. Surface as a BE TODO
  rather than fix here (scope discipline).

### C6 — Status badge reflects actual paperTrading state
- `apps/web/src/components/agent/AutonomousAgentDashboard.tsx` — pull
  `{enabled, config.paperTrading, config.initialCapital}` from
  `/api/autonomous/status` and render in the page header:
  - 🔴 LIVE — REAL CAPITAL (red, pulsing, bordered)
  - 🟡 PAPER — Simulated capital
  - ⚫ STOPPED
- Previously the only mode hint was the Tailwind execution-mode tab
  which could disagree with the kernel's actual `paperTrading` flag,
  so users could think they were in paper while real orders flowed.

### C7 — Baseline divergence banner
- Same file. Compare stored `config.initialCapital` against
  `/api/dashboard/balance.totalBalance`. When |drift| > 20%, surface
  an amber banner explaining the dashboard's `totalPnlPercent` is
  computed against a stale baseline (e.g. 777% when baseline=$440 but
  equity=$91). Shows the suggested correct baseline + a TODO for the
  missing BE reset endpoint.

### C8 — Stale 404 cleanup
- Searched `apps/web/src/` for `/api/autonomous-trader/*`,
  `/api/trades/recent`, `/api/trades/summary` — zero callsites. The
  console 404s must be coming from a deployed bundle that predates an
  earlier cleanup. Nothing to remove in source.

## Discipline
- Do NOT touch the files the main session owns
  (`apps/api/src/routes/agent.ts`, `apps/api/src/routes/autonomousTrader.ts`,
  `apps/api/src/services/monkey/mtfBootstrap.ts`, migration 050) — only
  `apps/web/`.
- Each item is a separate commit for clean history.

## Test plan
- [ ] After backend PR merges: open `/autonomous-agent` while
      `paperTrading=false, enabled=true` — verify red LIVE badge.
- [ ] Set `paperTrading=true` — verify yellow PAPER badge.
- [ ] Disable agent — verify gray STOPPED badge.
- [ ] Trigger baseline drift > 20% — verify amber baseline banner with
      suggested correct value.
- [ ] Open `/history` — verify "All Trades" count matches the rendered
      table length.
- [ ] Open `PerformanceAnalytics` — click 24h / 7d / 30d / 90d / 1y
      and verify the request to `/api/agent/performance?range=…` is
      made (and that the backend honors it after the backend PR ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align autonomous trading UI with updated backend performance and status APIs and surface data integrity issues to users.

Bug Fixes:
- Ensure performance analytics requests use the updated range query parameter and supported time ranges.
- Fix the All Trades tab count to match the deduplicated list of rendered trades.

Enhancements:
- Display an explicit LIVE, PAPER, or STOPPED status badge based on the authoritative autonomous status endpoint.
- Show a baseline divergence warning banner when initial capital and current equity differ significantly, indicating misleading P&L percentages.
- Document missing backend fee data for autonomous trades to explain zeroed fee aggregation in the trade history UI.