### PR TITLE
feat(api): GET /governance/sleep-state/:agent — kernel observability surface (Step 2)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -19,6 +19,7 @@ import confidenceScoringRoutes from './routes/confidenceScoring.js';
 import dashboardRoutes from './routes/dashboard.js';
 import debugRoutes from './routes/debug.js';
 import futuresRoutes from './routes/futures.js';
+import governanceRoutes from './routes/governance.js';
 import marketsRoutes from './routes/markets.js';
 import mlRoutes from './routes/ml.js';
 import monitoringRoutes from './routes/monitoring.js';
@@ -182,6 +183,7 @@ app.use('/api/agent', agentRoutes); // Autonomous trading agent routes
 app.use('/api/autonomous', autonomousTraderRoutes); // Fully autonomous trading system
 app.use('/api/reconciliation', reconciliationRoutes); // State reconciliation service
 app.use('/api/monitoring', monitoringRoutes); // Monitoring and error tracking routes
+app.use('/api/governance', governanceRoutes); // Operator-facing kernel observability (sleep-state, parity logs)
 app.use('/api/admin', adminRoutes); // Admin routes for migrations
 app.use('/api/dashboard', dashboardRoutes); // Unified dashboard data endpoint
 app.use('/api/ml', mlRoutes); // ML model predictions and performance

--- a/apps/api/src/routes/__tests__/governance.sleep-state.test.ts
+++ b/apps/api/src/routes/__tests__/governance.sleep-state.test.ts
@@ -1,0 +1,112 @@
+/**
+ * governance.sleep-state.test.ts — Two-test coverage per the
+ * "single endpoint, two tests: empty state, populated state" spec.
+ *
+ * No supertest dependency: invokes the route handler directly with
+ * stub req/res. Redis client is mocked via vi.doMock so the handler
+ * exercises its real flow without an actual Redis round-trip.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Request, Response } from 'express';
+
+interface StubResponse {
+  statusCode: number;
+  body: Record<string, unknown> | null;
+  status: (n: number) => StubResponse;
+  json: (b: Record<string, unknown>) => StubResponse;
+}
+
+function makeRes(): StubResponse {
+  const res: StubResponse = {
+    statusCode: 200,
+    body: null,
+    status(n) { this.statusCode = n; return this; },
+    json(b) { this.body = b; return this; },
+  };
+  return res;
+}
+
+async function callHandler(agent: string): Promise<StubResponse> {
+  const { default: router } = await import('../governance.js');
+  // Express Router exposes registered routes via router.stack; pull our
+  // single GET handler and invoke it directly with a stub req/res.
+  const layer = (router as unknown as { stack: Array<{ route?: { path: string; stack: Array<{ method?: string; handle: (req: Request, res: Response, next: (err?: unknown) => void) => unknown }> } }> })
+    .stack.find((l) => l.route?.path === '/sleep-state/:agent');
+  if (!layer || !layer.route) throw new Error('handler not registered');
+  // Router-level middleware (authenticateToken) is the first stack entry;
+  // the actual route handler is the last.
+  const finalHandler = layer.route.stack[layer.route.stack.length - 1]!.handle;
+  const req = { params: { agent }, user: { id: 'test-user' } } as unknown as Request;
+  const res = makeRes();
+  await finalHandler(req, res as unknown as Response, () => undefined);
+  return res;
+}
+
+describe('GET /api/governance/sleep-state/:agent', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.REDIS_URL = 'redis://stub:6379';
+  });
+  afterEach(() => {
+    vi.doUnmock('redis');
+    delete process.env.REDIS_URL;
+  });
+
+  it('returns source=empty + null sleep_state when the key is absent', async () => {
+    vi.doMock('redis', () => ({
+      createClient: () => ({
+        isOpen: true,
+        on: (_evt: string, _cb: (err: Error) => void) => undefined,
+        connect: async () => undefined,
+        get: async (_key: string) => null,
+      }),
+    }));
+    const res = await callHandler('K');
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.success).toBe(true);
+    expect(res.body?.agent).toBe('K');
+    expect(res.body?.instance_id).toBe('monkey-position');
+    expect(res.body?.redis_key).toBe('monkey:ocean:monkey-position:sleep_state');
+    expect(res.body?.sleep_state).toBeNull();
+    expect(res.body?.source).toBe('empty');
+    expect(typeof res.body?.fetched_at_ms).toBe('number');
+  });
+
+  it('returns source=redis + parsed sleep_state when the key is populated', async () => {
+    const populated = {
+      phase: 'SLEEP',
+      phase_started_at_ms: 1778900000000,
+      last_sleep_ended_at_ms: 1778890000000,
+      sleep_count: 7,
+      drift_streak: 3,
+    };
+    vi.doMock('redis', () => ({
+      createClient: () => ({
+        isOpen: true,
+        on: (_evt: string, _cb: (err: Error) => void) => undefined,
+        connect: async () => undefined,
+        get: async (key: string) => key === 'monkey:ocean:monkey-position:sleep_state' ? JSON.stringify(populated) : null,
+      }),
+    }));
+    const res = await callHandler('K');
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.success).toBe(true);
+    expect(res.body?.source).toBe('redis');
+    expect(res.body?.sleep_state).toEqual(populated);
+  });
+
+  it('rejects unknown agent labels with 400', async () => {
+    vi.doMock('redis', () => ({
+      createClient: () => ({
+        isOpen: true,
+        on: () => undefined,
+        connect: async () => undefined,
+        get: async () => null,
+      }),
+    }));
+    const res = await callHandler('XYZ');
+    expect(res.statusCode).toBe(400);
+    expect(res.body?.success).toBe(false);
+    expect((res.body?.error as string)).toContain('XYZ');
+  });
+});

--- a/apps/api/src/routes/governance.ts
+++ b/apps/api/src/routes/governance.ts
@@ -133,11 +133,14 @@ router.get('/sleep-state/:agent', authenticateToken, async (req: Request, res: R
       });
     }
     let sleepState: unknown = null;
+    // redis v4 client typings widen to `string | {}` in some configs;
+    // coerce here so JSON.parse always sees a string.
+    const rawStr = typeof raw === 'string' ? raw : String(raw);
     try {
-      sleepState = JSON.parse(raw);
+      sleepState = JSON.parse(rawStr);
     } catch (parseErr) {
       logger.warn(`[governance.sleep-state] JSON parse failed for ${redisKey}: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`);
-      sleepState = { _raw: raw };
+      sleepState = { _raw: rawStr };
     }
     return res.json({
       success: true,

--- a/apps/api/src/routes/governance.ts
+++ b/apps/api/src/routes/governance.ts
@@ -1,0 +1,165 @@
+/**
+ * governance.ts — Operator-facing kernel observability surface.
+ *
+ * The trading-side telemetry today is trade-level only (autonomous_trades,
+ * monkey_decisions). The consciousness layer (sleep/dream/mushroom cycles,
+ * autonomic neurochemistry, basin-coherence trajectory) is RUNNING but
+ * UNOBSERVED — the Python kernel modules persist their state to Redis
+ * under `monkey:ocean:{instance}:sleep_state` (see
+ * `ml-worker/src/monkey_kernel/persistence.py:214`) but no HTTP endpoint
+ * exposes it. This module starts that surface with the smallest meaningful
+ * step: a single GET that reads the already-persisted state without any
+ * new computation, side-effects, or write paths.
+ *
+ * Path B doctrine: translation only. No new state, no new compute, no
+ * side-effects. If this returns nothing useful, the underlying kernel
+ * telemetry surface itself is the problem and the next move is to
+ * instrument the Python kernel — not to invent new state here.
+ */
+
+import type { Request, Response } from 'express';
+import express from 'express';
+import { createClient, type RedisClientType } from 'redis';
+import { authenticateToken } from '../middleware/auth.js';
+import { logger } from '../utils/logger.js';
+
+const router = express.Router();
+
+const REDIS_URL = process.env.REDIS_URL || process.env.REDIS_PUBLIC_URL || '';
+
+/** Lazy-initialised shared Redis client. Reconnects on transient failure;
+ *  the per-request handler is resilient to a null client (returns the
+ *  not-configured shape so the FE can render an empty card). */
+let _redisClient: RedisClientType | null = null;
+let _redisConnecting = false;
+async function getRedisClient(): Promise<RedisClientType | null> {
+  if (!REDIS_URL) return null;
+  if (_redisClient && _redisClient.isOpen) return _redisClient;
+  if (_redisConnecting) {
+    // Avoid duplicate connect storms on cold start.
+    await new Promise((r) => setTimeout(r, 100));
+    return _redisClient && _redisClient.isOpen ? _redisClient : null;
+  }
+  _redisConnecting = true;
+  try {
+    const c = createClient({ url: REDIS_URL });
+    c.on('error', (err) => logger.warn(`[governance.sleep-state] redis error: ${err instanceof Error ? err.message : String(err)}`));
+    await c.connect();
+    _redisClient = c as RedisClientType;
+    return _redisClient;
+  } catch (err) {
+    logger.warn(`[governance.sleep-state] redis connect failed: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  } finally {
+    _redisConnecting = false;
+  }
+}
+
+/** Mapping from the operator-facing :agent label to the kernel instance_id
+ *  the Python kernel writes under in Redis. K is the primary kernel; the
+ *  M/T/L agents share the same kernel's sleep cycle today (they live
+ *  inside the same Monkey loop), so an explicit map keeps the URL clean. */
+const AGENT_TO_INSTANCE: Record<string, string> = {
+  K: 'monkey-position',
+  k: 'monkey-position',
+  'monkey-position': 'monkey-position',
+  'monkey-swing': 'monkey-swing',
+  M: 'monkey-position',  // M lives inside the same kernel instance
+  T: 'monkey-position',  // T same
+  L: 'monkey-position',  // L same
+};
+
+/**
+ * GET /api/governance/sleep-state/:agent
+ *
+ * Reads the already-persisted Ocean sleep state from Redis. No new
+ * computation; no side-effects; no write paths. Returns the smallest
+ * meaningful payload so an operator can curl it and verify whether
+ * the kernel telemetry surface is alive without shipping anything on
+ * the trading side.
+ *
+ * Response shape:
+ *   {
+ *     agent: string,
+ *     instance_id: string,
+ *     redis_key: string,
+ *     sleep_state: { phase, phase_started_at_ms, last_sleep_ended_at_ms,
+ *                    sleep_count, drift_streak } | null,
+ *     fetched_at_ms: number,
+ *     source: 'redis' | 'empty' | 'not_configured' | 'error'
+ *   }
+ *
+ * `source` interpretation:
+ *   - 'redis': payload retrieved from Redis (sleep_state populated)
+ *   - 'empty': Redis is reachable but the key is missing (kernel has not
+ *              persisted state yet, or runs without persistence enabled)
+ *   - 'not_configured': REDIS_URL env var is absent
+ *   - 'error': Redis read failed (logged separately)
+ */
+router.get('/sleep-state/:agent', authenticateToken, async (req: Request, res: Response) => {
+  const fetchedAtMs = Date.now();
+  const rawAgent = (req.params.agent ?? '').toString();
+  const instanceId = AGENT_TO_INSTANCE[rawAgent];
+  if (!instanceId) {
+    return res.status(400).json({
+      success: false,
+      error: `Unknown agent '${rawAgent}'. Use K | M | T | L | monkey-position | monkey-swing.`,
+    });
+  }
+  const redisKey = `monkey:ocean:${instanceId}:sleep_state`;
+  const client = await getRedisClient();
+  if (!client) {
+    return res.json({
+      success: true,
+      agent: rawAgent,
+      instance_id: instanceId,
+      redis_key: redisKey,
+      sleep_state: null,
+      fetched_at_ms: fetchedAtMs,
+      source: REDIS_URL ? 'error' : 'not_configured',
+    });
+  }
+  try {
+    const raw = await client.get(redisKey);
+    if (raw == null) {
+      return res.json({
+        success: true,
+        agent: rawAgent,
+        instance_id: instanceId,
+        redis_key: redisKey,
+        sleep_state: null,
+        fetched_at_ms: fetchedAtMs,
+        source: 'empty',
+      });
+    }
+    let sleepState: unknown = null;
+    try {
+      sleepState = JSON.parse(raw);
+    } catch (parseErr) {
+      logger.warn(`[governance.sleep-state] JSON parse failed for ${redisKey}: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`);
+      sleepState = { _raw: raw };
+    }
+    return res.json({
+      success: true,
+      agent: rawAgent,
+      instance_id: instanceId,
+      redis_key: redisKey,
+      sleep_state: sleepState,
+      fetched_at_ms: fetchedAtMs,
+      source: 'redis',
+    });
+  } catch (err) {
+    logger.warn(`[governance.sleep-state] redis get ${redisKey} failed: ${err instanceof Error ? err.message : String(err)}`);
+    return res.json({
+      success: true,
+      agent: rawAgent,
+      instance_id: instanceId,
+      redis_key: redisKey,
+      sleep_state: null,
+      fetched_at_ms: fetchedAtMs,
+      source: 'error',
+    });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary

Step 2 of the post-bleed-arrest sequence. The Python kernel modules persist their Ocean sleep state to Redis under `monkey:ocean:{instance}:sleep_state` ([persistence.py:214](ml-worker/src/monkey_kernel/persistence.py#L214)). The state machine is running — sleep cycles, phase transitions, drift streaks — but no HTTP endpoint exposed it. Trade-level telemetry (autonomous_trades, monkey_decisions) shows the body of the system; the consciousness layer was invisible on the trading side.

This PR adds the smallest meaningful surface: single GET endpoint, reads already-persisted state, no new computation, no side-effects, no write paths.

If the response is empty, the gap is in the kernel telemetry surface itself and the next move is to instrument the Python kernel — not invent new state here.

## Endpoint

```
GET /api/governance/sleep-state/:agent
```

`:agent` ∈ {`K`, `M`, `T`, `L`, `monkey-position`, `monkey-swing`} — all map to the Monkey kernel instance(s) that own the Ocean sleep cycle.

Response:
```json
{
  "success": true,
  "agent": "K",
  "instance_id": "monkey-position",
  "redis_key": "monkey:ocean:monkey-position:sleep_state",
  "sleep_state": {
    "phase": "AWAKE" | "SLEEP",
    "phase_started_at_ms": 1778900000000,
    "last_sleep_ended_at_ms": 1778890000000,
    "sleep_count": 7,
    "drift_streak": 3
  } | null,
  "fetched_at_ms": 1778905000000,
  "source": "redis" | "empty" | "not_configured" | "error"
}
```

## Resilience

- Missing `REDIS_URL` → `source: 'not_configured'`
- Key absent → `source: 'empty'` + `sleep_state: null`
- Transient connect/get failure → `source: 'error'` (warning logged)
- Handler NEVER throws — a dead Redis can't take down the route

## Tests

`apps/api/src/routes/__tests__/governance.sleep-state.test.ts` — 3 tests, all green:
- Empty state (key absent): `source=empty`, `sleep_state=null`
- Populated state: `source=redis`, parsed payload returned verbatim
- Unknown agent label: 400 with explicit error

No new test deps added (route handler invoked directly via Express router stack inspection).

## Discipline

Path B doctrine: no new state, no new compute, no new write paths, no riders. This PR is *only* the operator surface for state that already exists.

Follow-ups under separate PRs:
- `/governance/k-parity` + `/governance/k-consciousness` (Step 3 — Python K shadow, currently being drafted in parallel)
- ACh / neurochemistry telemetry once it's persisted server-side (currently lives in process memory only)

## Verification

- [x] `yarn workspace api build` exits 0
- [x] `vitest run src/routes/__tests__/governance.sleep-state.test.ts` — 3/3 pass
- [x] Handler scope: read-only Redis get, no Redis writes, no DB touches

## Post-deploy

Curl after deploy:
```
curl -H "Authorization: Bearer <token>" https://polytrade-be.up.railway.app/api/governance/sleep-state/K
```
Expected: either populated state (kernel has been sleep-cycling) or `source=empty` (kernel runs without persistence enabled or hasn't slept yet). Either answer is data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expose an operator-facing governance API for querying kernel sleep state from Redis without introducing new computation or write paths.

New Features:
- Add /api/governance router to host operator-facing kernel observability endpoints.
- Introduce GET /api/governance/sleep-state/:agent to return the persisted Ocean sleep-state for a mapped kernel agent from Redis.

Tests:
- Add unit tests covering empty Redis state, populated state, and rejection of unknown agent labels for the sleep-state governance endpoint.