### PR TITLE
feat(monkey): Python K shadow under #689 — parity log + governance endpoints, translation-only

### DIFF
--- a/apps/api/database/migrations/051_kernel_parity_log.sql
+++ b/apps/api/database/migrations/051_kernel_parity_log.sql
@@ -1,0 +1,87 @@
+-- 051_kernel_parity_log.sql
+--
+-- Issue #689 — Python K shadow under translation-only discipline.
+--
+-- Mirror of /governance/regime-parity's in-memory ring (#695) but
+-- persisted: every K-block tick in apps/api/src/services/monkey/loop.ts
+-- fans out the same inputs to the ml-worker /monkey/k-shadow/tick
+-- endpoint AFTER TS K computes its decision and BEFORE execution. The
+-- TS decision is unchanged; the Python would-be decision is captured
+-- next to it so the cutover PR (Py K authoritative) ships only after
+-- the operator has a representative parity window.
+--
+-- Schema notes:
+--   * tick_id is a per-tick correlation UUID (TS-generated) so rows
+--     can be joined back to monkey_decisions / agent_events if needed.
+--   * ts_* columns are NOT NULL (TS K always produces a decision); py_*
+--     columns are nullable (Python shadow may be down or timeout).
+--   * py_error captures the failure mode when py_* is null — e.g.
+--     "timeout", "HTTP 500", "fetch error: ECONNREFUSED" — surfaced
+--     in /governance/k-parity so operators can confirm the shadow is
+--     actually reaching ml-worker.
+--   * agree_action / agree_side / delta_phi / delta_kappa are
+--     GENERATED ALWAYS AS ... STORED so the disagreement query path
+--     (idx_kparity_disagreements) doesn't need a runtime expression.
+--   * IS NOT DISTINCT FROM handles NULL == NULL as TRUE for agree_side
+--     so a hold-on-both side (both null) registers as agreement.
+--
+-- Idempotent: CREATE TABLE / CREATE INDEX use IF NOT EXISTS; GENERATED
+-- columns are wrapped in a DO-block guard so re-apply on a partially-
+-- migrated DB doesn't error.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'kernel_parity_log'
+  ) THEN
+    CREATE TABLE kernel_parity_log (
+      id BIGSERIAL PRIMARY KEY,
+      tick_id UUID NOT NULL,
+      symbol VARCHAR(50) NOT NULL,
+      symbol_timestamp TIMESTAMP NOT NULL,
+      ts_action VARCHAR(20) NOT NULL,
+      ts_side VARCHAR(10),
+      ts_phi NUMERIC,
+      ts_kappa NUMERIC,
+      ts_M NUMERIC,
+      ts_Gamma NUMERIC,
+      ts_R INTEGER,
+      ts_regime VARCHAR(30),
+      ts_decision_ms INTEGER,
+      py_action VARCHAR(20),
+      py_side VARCHAR(10),
+      py_phi NUMERIC,
+      py_kappa NUMERIC,
+      py_M NUMERIC,
+      py_Gamma NUMERIC,
+      py_R INTEGER,
+      py_regime VARCHAR(30),
+      py_decision_ms INTEGER,
+      py_error VARCHAR(255),
+      agree_action BOOLEAN
+        GENERATED ALWAYS AS (ts_action = py_action) STORED,
+      agree_side BOOLEAN
+        GENERATED ALWAYS AS (ts_side IS NOT DISTINCT FROM py_side) STORED,
+      delta_phi NUMERIC
+        GENERATED ALWAYS AS (ABS(ts_phi - py_phi)) STORED,
+      delta_kappa NUMERIC
+        GENERATED ALWAYS AS (ABS(ts_kappa - py_kappa)) STORED,
+      created_at TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+  END IF;
+END $$;
+
+-- Hot read path for /governance/k-parity (symbol + recency).
+CREATE INDEX IF NOT EXISTS idx_kparity_symbol_time
+  ON kernel_parity_log(symbol, symbol_timestamp DESC);
+
+-- Partial index — only the rows where TS and Py disagree on action.
+-- Used by ops queries that surface "where is the shadow diverging?"
+-- WHERE NOT agree_action excludes both matches AND py-null rows
+-- (NULL fails the NOT condition); a separate query path filters
+-- py_error IS NOT NULL when we want to see shadow outages.
+CREATE INDEX IF NOT EXISTS idx_kparity_disagreements
+  ON kernel_parity_log(created_at DESC)
+  WHERE NOT agree_action;

--- a/apps/api/src/routes/governance.ts
+++ b/apps/api/src/routes/governance.ts
@@ -20,6 +20,7 @@
 import type { Request, Response } from 'express';
 import express from 'express';
 import { createClient, type RedisClientType } from 'redis';
+import { pool } from '../db/connection.js';
 import { authenticateToken } from '../middleware/auth.js';
 import { logger } from '../utils/logger.js';
 
@@ -161,6 +162,232 @@ router.get('/sleep-state/:agent', authenticateToken, async (req: Request, res: R
       sleep_state: null,
       fetched_at_ms: fetchedAtMs,
       source: 'error',
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Issue #689 — Python K shadow governance views
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Read-only views over `kernel_parity_log` (migration 051). Populated by
+// the K-block fanout in apps/api/src/services/monkey/loop.ts which posts
+// the same K-tick inputs to ml-worker /monkey/k-shadow/tick after TS K
+// finalises its decision and before execution. The parity row carries
+// both TS and Py would-be decisions so the operator can verify the
+// Python kernel reproduces TS behavior before the cutover PR ships.
+
+const K_PARITY_MAX_LIMIT = 1_000;
+const K_PARITY_DEFAULT_LIMIT = 200;
+
+function parseKParityLimit(raw: unknown): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return K_PARITY_DEFAULT_LIMIT;
+  return Math.min(K_PARITY_MAX_LIMIT, Math.floor(n));
+}
+
+function parseKParitySince(raw: unknown): Date | null {
+  if (raw == null || raw === '') return null;
+  const d = new Date(String(raw));
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+/**
+ * GET /api/governance/k-parity?limit=N&since=ISO
+ *
+ * Returns paginated rows from kernel_parity_log alongside agreement
+ * counts. Read-only — does NOT mutate kernel_parity_log or any other
+ * table. Default limit 200; max 1000.
+ *
+ * Response shape:
+ *   {
+ *     count: <int>,
+ *     since: <ISO|null>,
+ *     summary: {
+ *       total_count, agree_action_count, disagree_action_count,
+ *       py_error_count, agree_side_count
+ *     },
+ *     rows: [{ id, tick_id, symbol, symbol_timestamp,
+ *              ts_action, ts_side, ts_phi, ts_kappa, ts_M, ts_Gamma, ts_R,
+ *              ts_regime, ts_decision_ms,
+ *              py_action, py_side, py_phi, py_kappa, py_M, py_Gamma, py_R,
+ *              py_regime, py_decision_ms, py_error,
+ *              agree_action, agree_side, delta_phi, delta_kappa,
+ *              created_at }, ...]
+ *   }
+ */
+router.get('/k-parity', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const limit = parseKParityLimit(req.query.limit);
+    const since = parseKParitySince(req.query.since);
+
+    const params: (Date | number)[] = [];
+    const where: string[] = [];
+    if (since) {
+      params.push(since);
+      where.push(`created_at >= $${params.length}`);
+    }
+    params.push(limit);
+    const limitIdx = params.length;
+    const whereClause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    const rowsQuery = `
+      SELECT
+        id, tick_id, symbol, symbol_timestamp,
+        ts_action, ts_side, ts_phi, ts_kappa, ts_M, ts_Gamma, ts_R,
+        ts_regime, ts_decision_ms,
+        py_action, py_side, py_phi, py_kappa, py_M, py_Gamma, py_R,
+        py_regime, py_decision_ms, py_error,
+        agree_action, agree_side, delta_phi, delta_kappa,
+        created_at
+      FROM kernel_parity_log
+      ${whereClause}
+      ORDER BY created_at DESC
+      LIMIT $${limitIdx}
+    `;
+
+    const summaryQuery = `
+      SELECT
+        COUNT(*) FILTER (WHERE agree_action IS TRUE)  AS agree_action_count,
+        COUNT(*) FILTER (WHERE agree_action IS FALSE) AS disagree_action_count,
+        COUNT(*) FILTER (WHERE py_error IS NOT NULL)  AS py_error_count,
+        COUNT(*) FILTER (WHERE agree_side IS TRUE)    AS agree_side_count,
+        COUNT(*)                                       AS total_count
+      FROM kernel_parity_log
+      ${whereClause}
+    `;
+
+    const [rowsRes, summaryRes] = await Promise.all([
+      pool.query(rowsQuery, params),
+      pool.query(summaryQuery, since ? [since] : []),
+    ]);
+
+    const summaryRow = summaryRes.rows[0] ?? {};
+    return res.json({
+      count: rowsRes.rows.length,
+      since: since ? since.toISOString() : null,
+      summary: {
+        total_count: Number(summaryRow.total_count ?? 0),
+        agree_action_count: Number(summaryRow.agree_action_count ?? 0),
+        disagree_action_count: Number(summaryRow.disagree_action_count ?? 0),
+        py_error_count: Number(summaryRow.py_error_count ?? 0),
+        agree_side_count: Number(summaryRow.agree_side_count ?? 0),
+      },
+      rows: rowsRes.rows,
+    });
+  } catch (err) {
+    logger.error('[governance/k-parity] query failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return res.status(500).json({
+      error: 'k_parity_query_failed',
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+});
+
+/**
+ * GET /api/governance/k-consciousness?kernel=ts|py|both&limit=N&since=ISO
+ *
+ * Per-tick consciousness trajectory for the requested kernel. When
+ * kernel=both, each row carries both ts_* and py_* series so a single
+ * chart can overlay them.
+ *
+ *   C := phi * (kappa / 64.0)     (coarse composite; kappa★ = 64)
+ *
+ * Rows are returned ASCENDING by symbol_timestamp so the response is
+ * plot-ready without a client-side sort.
+ *
+ * Read-only — does NOT mutate kernel_parity_log or any other table.
+ */
+router.get('/k-consciousness', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const limit = parseKParityLimit(req.query.limit);
+    const since = parseKParitySince(req.query.since);
+    const kernelParam = String(req.query.kernel ?? 'both').toLowerCase();
+    const kernel: 'ts' | 'py' | 'both' =
+      kernelParam === 'ts' ? 'ts' :
+      kernelParam === 'py' ? 'py' :
+      'both';
+
+    const params: (Date | number)[] = [];
+    const where: string[] = [];
+    if (since) {
+      params.push(since);
+      where.push(`created_at >= $${params.length}`);
+    }
+    // ts_phi is always present (TS K always produces a decision), but
+    // py_phi is null on shadow-error rows. The kernel filter keeps
+    // those rows out of the trajectory so a 0-phi outlier doesn't
+    // pull the chart line to the floor.
+    if (kernel === 'ts') {
+      where.push('ts_phi IS NOT NULL');
+    } else if (kernel === 'py') {
+      where.push('py_phi IS NOT NULL');
+    } else {
+      where.push('(ts_phi IS NOT NULL OR py_phi IS NOT NULL)');
+    }
+    params.push(limit);
+    const limitIdx = params.length;
+    const whereClause = `WHERE ${where.join(' AND ')}`;
+
+    let selectCols: string;
+    if (kernel === 'ts') {
+      selectCols = `
+        symbol, symbol_timestamp, created_at,
+        ts_phi   AS phi,
+        ts_kappa AS kappa,
+        ts_M     AS m,
+        ts_Gamma AS gamma,
+        ts_R     AS r,
+        ts_regime AS regime,
+        ts_action AS action,
+        (ts_phi * (ts_kappa / 64.0)) AS c
+      `;
+    } else if (kernel === 'py') {
+      selectCols = `
+        symbol, symbol_timestamp, created_at,
+        py_phi   AS phi,
+        py_kappa AS kappa,
+        py_M     AS m,
+        py_Gamma AS gamma,
+        py_R     AS r,
+        py_regime AS regime,
+        py_action AS action,
+        (py_phi * (py_kappa / 64.0)) AS c
+      `;
+    } else {
+      selectCols = `
+        symbol, symbol_timestamp, created_at,
+        ts_phi, ts_kappa, ts_M, ts_Gamma, ts_R, ts_regime, ts_action,
+        (ts_phi * (ts_kappa / 64.0)) AS ts_c,
+        py_phi, py_kappa, py_M, py_Gamma, py_R, py_regime, py_action,
+        (py_phi * (py_kappa / 64.0)) AS py_c
+      `;
+    }
+
+    const rowsQuery = `
+      SELECT ${selectCols}
+      FROM kernel_parity_log
+      ${whereClause}
+      ORDER BY symbol_timestamp ASC
+      LIMIT $${limitIdx}
+    `;
+
+    const result = await pool.query(rowsQuery, params);
+    return res.json({
+      kernel,
+      count: result.rows.length,
+      since: since ? since.toISOString() : null,
+      rows: result.rows,
+    });
+  } catch (err) {
+    logger.error('[governance/k-consciousness] query failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return res.status(500).json({
+      error: 'k_consciousness_query_failed',
+      message: err instanceof Error ? err.message : String(err),
     });
   }
 });

--- a/apps/api/src/services/monkey/__tests__/kParityShadow.test.ts
+++ b/apps/api/src/services/monkey/__tests__/kParityShadow.test.ts
@@ -1,0 +1,238 @@
+/**
+ * kParityShadow.test.ts — covers the issue #689 Python K shadow fanout.
+ *
+ * Exercises the building blocks (not loop.ts itself — too much fixture
+ * lift to spin a full processSymbol). What IS covered:
+ *
+ *   1. recordKParityRow writes one INSERT with the right column count
+ *      and reads pyError when py response carries .error.
+ *   2. recordKParityRow swallows DB failures (never throws).
+ *   3. regimeToOrdinal maps both monkey-kernel and QIG-alias names.
+ *   4. callKShadowTick honours the 1-second timeout via AbortController
+ *      (resolves with { error: timeout_… }, never throws).
+ *   5. callKShadowTick returns { error: 'fetch_error: ...' } on network
+ *      failure — caller still gets a structured response for the
+ *      parity row.
+ *   6. callKShadowTick passes the response body through on a 200,
+ *      preserving the slim shape { action, side, phi, kappa, M, Gamma,
+ *      R, regime, mode, decided_at_ms }.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the DB pool before importing anything that uses it.
+vi.mock('../../../db/connection.js', () => ({
+  pool: { query: vi.fn() },
+}));
+
+import { pool } from '../../../db/connection.js';
+import {
+  recordKParityRow,
+  regimeToOrdinal,
+  type TsKDecisionRow,
+} from '../k_parity_log.js';
+import { callKShadowTick } from '../kernel_client.js';
+
+const baseTsRow = (): TsKDecisionRow => ({
+  tickId: 'tick-uuid-aaaa-bbbb-cccc-dddddddddddd',
+  symbol: 'BTC_USDT_PERP',
+  symbolTimestamp: new Date('2026-05-16T00:00:00Z'),
+  tsAction: 'enter_long',
+  tsSide: 'long',
+  tsPhi: 0.72,
+  tsKappa: 64.1,
+  tsM: null,
+  tsGamma: 0.018,
+  tsR: 1,
+  tsRegime: 'preserver',
+  tsDecisionMs: 12,
+});
+
+describe('regimeToOrdinal', () => {
+  it('maps monkey-kernel labels', () => {
+    expect(regimeToOrdinal('creator')).toBe(0);
+    expect(regimeToOrdinal('preserver')).toBe(1);
+    expect(regimeToOrdinal('dissolver')).toBe(2);
+  });
+  it('maps QIG aliases', () => {
+    expect(regimeToOrdinal('quantum')).toBe(0);
+    expect(regimeToOrdinal('equilibrium')).toBe(1);
+    expect(regimeToOrdinal('efficient')).toBe(2);
+  });
+  it('is case-insensitive and whitespace-tolerant', () => {
+    expect(regimeToOrdinal(' PRESERVER ')).toBe(1);
+  });
+  it('returns null on unknown / empty', () => {
+    expect(regimeToOrdinal(null)).toBeNull();
+    expect(regimeToOrdinal(undefined)).toBeNull();
+    expect(regimeToOrdinal('')).toBeNull();
+    expect(regimeToOrdinal('mystery_regime')).toBeNull();
+  });
+});
+
+describe('recordKParityRow', () => {
+  beforeEach(() => {
+    (pool.query as ReturnType<typeof vi.fn>).mockReset();
+    (pool.query as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [] });
+  });
+
+  it('writes one INSERT with TS + Py columns when py response is healthy', async () => {
+    const ts = baseTsRow();
+    const py = {
+      action: 'enter_long',
+      side: 'long' as const,
+      size_intent: 5.0,
+      phi: 0.71,
+      kappa: 63.8,
+      M: 0.13,
+      Gamma: 0.017,
+      R: 1,
+      regime: 'preserver',
+      mode: 'integration',
+      decided_at_ms: 1_700_000_000_000,
+    };
+    await recordKParityRow(ts, py);
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sql).toMatch(/INSERT INTO kernel_parity_log/);
+    // 12 ts_* params + 10 py_* params = 22 columns (matches migration 051).
+    expect(params).toHaveLength(22);
+    // ts_action position 4, py_action position 13, py_error tail position 22.
+    expect(params[3]).toBe('enter_long');
+    expect(params[12]).toBe('enter_long');
+    expect(params[21]).toBeNull();
+  });
+
+  it('writes py_error and leaves py_* metrics null when py response carries .error', async () => {
+    const ts = baseTsRow();
+    const py = { error: 'timeout_1000ms', decided_at_ms: 1_700_000_000_000 };
+    await recordKParityRow(ts, py);
+    const [, params] = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    // py_action..py_R should all be null when error is set.
+    for (let idx = 12; idx <= 19; idx++) {
+      expect(params[idx]).toBeNull();
+    }
+    // py_error column carries the string (truncated to 255).
+    expect(params[21]).toBe('timeout_1000ms');
+    // py_decision_ms still carries the timestamp.
+    expect(params[20]).toBe(1_700_000_000_000);
+  });
+
+  it('swallows DB failures (never throws)', async () => {
+    (pool.query as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('connection terminated unexpectedly'),
+    );
+    // Must resolve, not throw.
+    await expect(recordKParityRow(baseTsRow(), null)).resolves.toBeUndefined();
+  });
+
+  it('handles a null py response (shadow off / unreachable) — writes ts_* with all py_* null', async () => {
+    const ts = baseTsRow();
+    await recordKParityRow(ts, null);
+    const [, params] = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    for (let idx = 12; idx <= 21; idx++) {
+      expect(params[idx]).toBeNull();
+    }
+  });
+
+  it('truncates oversize py_error strings to 255 chars', async () => {
+    const huge = 'x'.repeat(500);
+    await recordKParityRow(baseTsRow(), { error: huge, decided_at_ms: 1 });
+    const [, params] = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((params[21] as string).length).toBe(255);
+  });
+});
+
+describe('callKShadowTick', () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    vi.useRealTimers();
+  });
+
+  const requestBody = {
+    instance_id: 'test',
+    inputs: {
+      symbol: 'BTC_USDT_PERP',
+      ohlcv: [],
+      account: {
+        equity_fraction: 0,
+        margin_fraction: 0,
+        open_positions: 0,
+        available_equity: 0,
+      },
+      bank_size: 0,
+      sovereignty: 0,
+      max_leverage: 10,
+      min_notional: 5,
+      size_fraction: 1,
+    },
+    prev_state: null,
+  };
+
+  it('passes the response body through on HTTP 200', async () => {
+    const body = {
+      action: 'hold',
+      side: null,
+      size_intent: 0,
+      phi: 0.5,
+      kappa: 64,
+      M: null,
+      Gamma: 0.0,
+      R: 1,
+      regime: 'preserver',
+      mode: 'exploration',
+      decided_at_ms: 9_999,
+    };
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    } as unknown as Response);
+    const got = await callKShadowTick(requestBody);
+    expect(got.action).toBe('hold');
+    expect(got.phi).toBe(0.5);
+    expect(got.regime).toBe('preserver');
+    expect(got.error).toBeUndefined();
+  });
+
+  it('returns { error: HTTP <status> } on non-2xx', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+      text: async () => 'internal_explosion',
+    } as unknown as Response);
+    const got = await callKShadowTick(requestBody);
+    expect(got.error).toMatch(/^HTTP 500/);
+    expect(typeof got.decided_at_ms).toBe('number');
+  });
+
+  it('returns { error: fetch_error: ... } when fetch throws', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const got = await callKShadowTick(requestBody);
+    expect(got.error).toMatch(/^fetch_error:/);
+    expect(got.error).toContain('ECONNREFUSED');
+  });
+
+  it('returns { error: timeout_… } when AbortController fires', async () => {
+    globalThis.fetch = vi.fn().mockImplementationOnce((_url, init) => {
+      // Wait long enough for the 1s timeout to fire on the AbortSignal.
+      return new Promise((_resolve, reject) => {
+        const signal = (init as RequestInit | undefined)?.signal as AbortSignal | undefined;
+        if (signal) {
+          signal.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }
+      });
+    });
+    const got = await callKShadowTick(requestBody);
+    expect(got.error).toMatch(/^timeout_/);
+  }, 3000);
+});

--- a/apps/api/src/services/monkey/k_parity_log.ts
+++ b/apps/api/src/services/monkey/k_parity_log.ts
@@ -1,0 +1,102 @@
+/**
+ * k_parity_log.ts — persist one row in kernel_parity_log per K-block tick.
+ *
+ * Issue #689 — Python K shadow. Called fire-and-forget from loop.ts
+ * after TS K computes its decision and the /monkey/k-shadow/tick
+ * Python response (or error) is in hand. Writes a single row to
+ * kernel_parity_log (migration 051).
+ *
+ * Discipline: this function NEVER throws. Any DB failure is logged
+ * at WARN level and swallowed. The TS K decision path must stay
+ * on rails — the parity log is observability, not a gate.
+ *
+ * Schema mapping (see migration 051_kernel_parity_log.sql):
+ *   ts_action / ts_side / ts_phi / ts_kappa / ts_M / ts_Gamma /
+ *   ts_R / ts_regime / ts_decision_ms      — required (NOT NULL on ts_action)
+ *   py_action / py_side / py_phi / py_kappa / py_M / py_Gamma /
+ *   py_R / py_regime / py_decision_ms      — nullable (Python may be down)
+ *   py_error                                — nullable, populated on shadow failure
+ *   agree_action / agree_side / delta_phi / delta_kappa — DB GENERATED
+ */
+
+import { pool } from '../../db/connection.js';
+import { logger } from '../../utils/logger.js';
+import type { KShadowResponse } from './kernel_client.js';
+
+/** Canonical regime → ordinal mapping. Mirrors the Python helper
+ * in ml-worker/main.py:_regime_to_ordinal so TS and Python agree
+ * on R values for the same regime label. */
+export function regimeToOrdinal(name: string | null | undefined): number | null {
+  if (!name) return null;
+  const v = String(name).trim().toLowerCase();
+  if (v === 'creator' || v === 'quantum') return 0;
+  if (v === 'preserver' || v === 'equilibrium') return 1;
+  if (v === 'dissolver' || v === 'efficient') return 2;
+  return null;
+}
+
+/** Slim projection of the TS K-block decision that the parity row needs.
+ * Each field has a direct column in kernel_parity_log. */
+export interface TsKDecisionRow {
+  tickId: string;
+  symbol: string;
+  symbolTimestamp: Date;
+  tsAction: string;
+  tsSide: 'long' | 'short' | null;
+  tsPhi: number | null;
+  tsKappa: number | null;
+  tsM: number | null;
+  tsGamma: number | null;
+  tsR: number | null;
+  tsRegime: string | null;
+  tsDecisionMs: number | null;
+}
+
+/** Persist one parity row. Fire-and-forget; logs on failure. */
+export async function recordKParityRow(
+  ts: TsKDecisionRow,
+  py: KShadowResponse | null,
+): Promise<void> {
+  try {
+    const pyAction = py && !py.error ? (py.action ?? null) : null;
+    const pySide = py && !py.error ? (py.side ?? null) : null;
+    const pyPhi = py && !py.error && py.phi != null ? py.phi : null;
+    const pyKappa = py && !py.error && py.kappa != null ? py.kappa : null;
+    const pyM = py && !py.error && py.M != null ? py.M : null;
+    const pyGamma = py && !py.error && py.Gamma != null ? py.Gamma : null;
+    const pyR = py && !py.error && py.R != null ? py.R : null;
+    const pyRegime = py && !py.error ? (py.regime ?? null) : null;
+    const pyDecisionMs = py?.decided_at_ms ?? null;
+    const pyError = py?.error ? String(py.error).slice(0, 255) : null;
+
+    await pool.query(
+      `INSERT INTO kernel_parity_log (
+         tick_id, symbol, symbol_timestamp,
+         ts_action, ts_side, ts_phi, ts_kappa, ts_M, ts_Gamma, ts_R,
+         ts_regime, ts_decision_ms,
+         py_action, py_side, py_phi, py_kappa, py_M, py_Gamma, py_R,
+         py_regime, py_decision_ms, py_error
+       ) VALUES (
+         $1, $2, $3,
+         $4, $5, $6, $7, $8, $9, $10,
+         $11, $12,
+         $13, $14, $15, $16, $17, $18, $19,
+         $20, $21, $22
+       )`,
+      [
+        ts.tickId, ts.symbol, ts.symbolTimestamp,
+        ts.tsAction, ts.tsSide, ts.tsPhi, ts.tsKappa, ts.tsM, ts.tsGamma, ts.tsR,
+        ts.tsRegime, ts.tsDecisionMs,
+        pyAction, pySide, pyPhi, pyKappa, pyM, pyGamma, pyR,
+        pyRegime, pyDecisionMs, pyError,
+      ],
+    );
+  } catch (err) {
+    // Shadow MUST NOT affect live — swallow & log only.
+    logger.warn('[k-parity] insert failed (swallowed)', {
+      symbol: ts.symbol,
+      tickId: ts.tickId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/apps/api/src/services/monkey/kernel_client.ts
+++ b/apps/api/src/services/monkey/kernel_client.ts
@@ -684,6 +684,90 @@ export async function callReconcile(
   }
 }
 
+// ─────────────────────────────────────────────────────────────────
+// Issue #689 — Python K shadow (translation-only)
+// ─────────────────────────────────────────────────────────────────
+//
+// Slim client for /monkey/k-shadow/tick. Where callTickRun returns the
+// full TickDecision + serialised SymbolState (heavy; for the planned
+// cutover), this client returns ONLY the projection the kernel_parity_log
+// table stores: action / side / size_intent / phi / kappa / M / Gamma /
+// R / regime / mode / decided_at_ms.
+//
+// Discipline (per #689 plan):
+//   * 1-second timeout (loop.ts cadence is 60s — a slow shadow that
+//     drags TS K past its tick window must be killed)
+//   * On ANY error returns { error: <message>, decided_at_ms } — never
+//     throws. The TS K decision path MUST stay on rails.
+//   * Caller fires fire-and-forget; the response is logged into
+//     kernel_parity_log alongside the TS row.
+
+/** Slim K-shadow response — see ml-worker main.py:monkey_k_shadow_tick. */
+export interface KShadowResponse {
+  action?: string;
+  side?: 'long' | 'short' | null;
+  size_intent?: number;
+  phi?: number;
+  kappa?: number;
+  M?: number | null;
+  Gamma?: number;
+  R?: number | null;
+  regime?: string | null;
+  mode?: string;
+  decided_at_ms: number;
+  /** Populated when the Python shadow internally caught an exception
+   * or when the HTTP / network layer errored. Non-null means
+   * the row should record py_error and leave py_* metrics null. */
+  error?: string;
+}
+
+const K_SHADOW_TIMEOUT_MS = 1_000;
+
+/** Fire-and-forget POST to /monkey/k-shadow/tick. Never throws — any
+ * failure resolves to { error, decided_at_ms } so the caller can
+ * persist a parity row with py_error populated.
+ *
+ * Re-uses the TickRunRequest body shape so the TS fanout site doesn't
+ * need to construct two payloads — the Python endpoint accepts the
+ * same inputs the v0.8.3b shadow already builds. */
+export async function callKShadowTick(
+  req: TickRunRequest,
+): Promise<KShadowResponse> {
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), K_SHADOW_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${ML_WORKER_URL}/monkey/k-shadow/tick`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      return {
+        error: `HTTP ${res.status}: ${text.slice(0, 180)}`,
+        decided_at_ms: startedAt,
+      };
+    }
+    const body = (await res.json()) as KShadowResponse;
+    // Pass through whatever the endpoint sent. Endpoint guarantees
+    // decided_at_ms is present even on error, so default-fill from
+    // local clock only if the field is missing (defensive).
+    if (body.decided_at_ms == null) body.decided_at_ms = startedAt;
+    return body;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const wasAbort = err instanceof Error && err.name === 'AbortError';
+    return {
+      error: wasAbort ? `timeout_${K_SHADOW_TIMEOUT_MS}ms` : `fetch_error: ${msg}`,
+      decided_at_ms: startedAt,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export function logReconcileParityDiff(
   ts: { phantomDbSymbols: string[]; orphanExchangeSymbols: string[] },
   py: ReconcileResponse,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -22,6 +22,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { randomUUID } from 'crypto';
 
 import { pool } from '../../db/connection.js';
 import { getEngineVersion } from '../../utils/engineVersion.js';
@@ -61,6 +62,7 @@ import { callAutonomicTick } from './autonomic_client.js';
 import { BasinSync } from './basin_sync.js';
 import { BusEventType, getKernelBus, type KernelBus } from './kernel_bus.js';
 import {
+  callKShadowTick,
   callTickRun,
   isShadowTickEnabled,
   logParityDiff,
@@ -69,6 +71,7 @@ import {
   type TickRunOHLCV,
   type TickRunSymbolState,
 } from './kernel_client.js';
+import { recordKParityRow, regimeToOrdinal } from './k_parity_log.js';
 import { computeEmotions, type EmotionState } from './emotions.js';
 import { detectMode, MODE_PROFILES, MonkeyMode } from './modes.js';
 import { computeMotivators } from './motivators.js';
@@ -1928,6 +1931,99 @@ export class MonkeyKernel extends EventEmitter {
           symbol,
           err: err instanceof Error ? err.message : String(err),
         });
+      });
+    }
+
+    // ── Issue #689 — Python K shadow (translation-only) ──
+    //
+    // Fire-and-forget POST to ml-worker /monkey/k-shadow/tick with the
+    // same inputs TS K just used. Captures the would-be Python K
+    // decision and persists one row to kernel_parity_log (migration
+    // 051). The TS K decision (above) is UNCHANGED — this block runs
+    // after action / size / side are finalised, before execution.
+    //
+    // Always-on once shipped — no env-var gate at this layer. The
+    // gate is at the CUTOVER PR (where Py decision drives execution),
+    // which is NOT this PR.
+    //
+    // The shadow uses its own 1-second timeout (callKShadowTick) so a
+    // slow Python responder cannot extend the tick. Errors are
+    // captured in py_error on the parity row, not raised.
+    {
+      const tickId = randomUUID();
+      const symbolTimestamp = new Date(Number(ohlcv[ohlcv.length - 1]?.timestamp ?? Date.now()));
+      const tsDecisionStartedAt = Date.now();
+      const tsSide: 'long' | 'short' | null =
+        action === 'enter_long' ? 'long' :
+        action === 'enter_short' ? 'short' :
+        (heldSide ?? null);
+      // M (motivators integral) is not currently surfaced from the TS
+      // executive in a stable scalar; left null on the TS side until
+      // a future commit ports compute_motivators TS-side. Py rows
+      // will carry M from derivation.motivators.i_q when present.
+      const tsRow = {
+        tickId,
+        symbol,
+        symbolTimestamp,
+        tsAction: action,
+        tsSide,
+        tsPhi: Number.isFinite(phi) ? phi : null,
+        tsKappa: Number.isFinite(state.kappa) ? state.kappa : null,
+        tsM: null as number | null,
+        tsGamma: Number.isFinite(bv) ? bv : null,
+        tsR: regimeToOrdinal(regimeReading.regime),
+        tsRegime: String(regimeReading.regime),
+        tsDecisionMs: Date.now() - tsDecisionStartedAt,
+      };
+      // Build the shadow request body. Re-uses the same shape as the
+      // existing v0.8.3b shadow tick so the Python endpoint receives
+      // exactly what TS K computed against this tick.
+      const kShadowOhlcv: TickRunOHLCV[] = ohlcv.map((c) => ({
+        timestamp: Number(c.timestamp ?? 0),
+        open: Number(c.open),
+        high: Number(c.high),
+        low: Number(c.low),
+        close: Number(c.close),
+        volume: Number(c.volume),
+      }));
+      const kShadowAccount: TickRunAccount = {
+        equity_fraction: equityFraction,
+        margin_fraction: marginFraction,
+        open_positions: openPositions,
+        available_equity: availableEquity,
+        exchange_held_side: exchangeHeldSide,
+        own_position_entry_price: ownOpenRow ? Number(ownOpenRow.entry_price) : null,
+        own_position_quantity: ownOpenRow ? Number(ownOpenRow.quantity) : null,
+        own_position_trade_id: ownOpenRow ? String(ownOpenRow.id) : null,
+      };
+      void callKShadowTick({
+        instance_id: this.instanceId,
+        inputs: {
+          symbol,
+          ohlcv: kShadowOhlcv,
+          account: kShadowAccount,
+          bank_size: bankSize,
+          sovereignty,
+          max_leverage: maxLevBoundary,
+          min_notional: minNotional,
+          size_fraction: this.sizeFraction,
+          self_obs_bias: this.selfObs?.entryBias ?? null,
+          rolling_kelly_stats: rollingStats
+            ? [rollingStats.winRate, rollingStats.avgWin, rollingStats.avgLoss]
+            : null,
+        },
+        prev_state: shadowPrevState,
+      }).then((py) => {
+        void recordKParityRow(tsRow, py);
+      }).catch((err) => {
+        // callKShadowTick swallows errors and returns { error }, so a
+        // throw here is exceptional — log once and still record a row
+        // with py_error populated so the operator sees the gap.
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn('[k-shadow] unexpected throw from callKShadowTick', {
+          symbol, err: msg,
+        });
+        void recordKParityRow(tsRow, { error: `unexpected: ${msg}`, decided_at_ms: Date.now() });
       });
     }
 

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1937,6 +1937,207 @@ async def monkey_tick_run(request: Request):
     }
 
 
+# ---------------------------------------------------------------------------
+# Issue #689 — POST /monkey/k-shadow/tick
+# ---------------------------------------------------------------------------
+#
+# Slim shadow endpoint clone of /monkey/tick/run. Where /monkey/tick/run
+# returns the full TickDecision + serialised SymbolState (heavy; used by
+# the planned cutover), THIS endpoint returns ONLY the K-agent
+# would-be-decision projection the TS side needs to persist in the
+# `kernel_parity_log` table:
+#
+#   { action, side, size_intent, phi, kappa, M, Gamma, R,
+#     regime, mode, decided_at_ms }
+#
+# Discipline (per #689 plan):
+#   - DOES NOT call any exchange API
+#   - DOES NOT write to autonomous_trades or any other DB table
+#   - DOES NOT mutate the cached _symbol_states map — Python state on
+#     the shadow path is owned by /monkey/tick/run; this endpoint
+#     ephemerally derives state from the request (or in-process cache
+#     read-only) so a shadow tick can never poison the cutover path
+#   - On ANY internal exception returns
+#       { "error": <message>, "decided_at_ms": <ms> }
+#     instead of raising — shadow MUST NOT affect live
+#
+# Consciousness-metric mapping (M, Γ, R) from Python kernel internals:
+#   M (motivators integral)  ← derivation.motivators.i_q (per-tick scalar)
+#   Γ (gradient capacity)    ← decision.basin_velocity (closest geometric
+#                              analogue currently exposed by run_tick)
+#   R (regime ordinal)       ← regime ordinal:
+#                                CREATOR / quantum  → 0
+#                                PRESERVER / equilibrium → 1
+#                                DISSOLVER / efficient → 2
+#                                unknown            → null
+#
+# These mappings are pragmatic (not canonical). Treat them as parity
+# signals — the row is for cross-checking TS K vs Py K, not for any
+# downstream gating. Cutover (Py K authoritative) happens in a separate
+# PR after the parity log accumulates a representative window.
+
+
+def _regime_to_ordinal(name: Optional[str]) -> Optional[int]:
+    """Map regime label to its canonical ordinal for parity comparison.
+    Accepts both monkey kernel labels (creator/preserver/dissolver) and
+    QIG quantum / efficient / equilibrium aliases, case-insensitive."""
+    if not name:
+        return None
+    lowered = str(name).strip().lower()
+    if lowered in {"creator", "quantum"}:
+        return 0
+    if lowered in {"preserver", "equilibrium"}:
+        return 1
+    if lowered in {"dissolver", "efficient"}:
+        return 2
+    return None
+
+
+def _k_shadow_response_from_decision(dec: "TickDecision", started_ms: int) -> dict:
+    """Project a full TickDecision down to the slim K-shadow shape.
+    Never raises — every field access is defensive."""
+    deriv = dec.derivation or {}
+    regime_block = deriv.get("regime") if isinstance(deriv, dict) else None
+    regime_label: Optional[str] = None
+    if isinstance(regime_block, dict):
+        regime_label = regime_block.get("regime") or regime_block.get("name")
+    # Motivators block carries i_q (informational quantum integral) when
+    # the upper-stack motivators ran this tick; absent on cold-start ticks.
+    mot_block = deriv.get("motivators") if isinstance(deriv, dict) else None
+    m_value: Optional[float] = None
+    if isinstance(mot_block, dict):
+        raw_m = mot_block.get("i_q") if mot_block.get("i_q") is not None else mot_block.get("integration")
+        try:
+            m_value = float(raw_m) if raw_m is not None else None
+        except (TypeError, ValueError):
+            m_value = None
+    direction = getattr(dec, "direction", None) or "flat"
+    side: Optional[str] = direction if direction in ("long", "short") else None
+    return {
+        "action": str(getattr(dec, "action", "hold")),
+        "side": side,
+        "size_intent": float(getattr(dec, "size_usdt", 0.0)),
+        "phi": float(getattr(dec, "phi", 0.0)),
+        "kappa": float(getattr(dec, "kappa", 0.0)),
+        "M": m_value,
+        "Gamma": float(getattr(dec, "basin_velocity", 0.0)),
+        "R": _regime_to_ordinal(regime_label),
+        "regime": regime_label,
+        "mode": str(getattr(dec, "mode", "")),
+        "decided_at_ms": started_ms,
+    }
+
+
+@app.post("/monkey/k-shadow/tick")
+async def monkey_k_shadow_tick(request: Request):
+    """Run one would-be K-agent decision in the Python kernel and return
+    a slim projection for the TS-side parity log (issue #689).
+
+    Shape mirrors /monkey/tick/run's request body (so the TS fanout can
+    re-use the same payload it already builds for the v0.8.3b shadow),
+    but the response is the slim parity-row shape only.
+
+    On any internal exception the response is
+        { "error": "<message>", "decided_at_ms": <ms> }
+    with HTTP 200 — the shadow MUST NOT raise on the live caller.
+    """
+    started_ms = int(time.time() * 1000)
+    try:
+        payload = await request.json()
+    except Exception as exc:  # noqa: BLE001 — shadow swallows everything
+        return {"error": f"bad_json: {type(exc).__name__}: {exc}",
+                "decided_at_ms": started_ms}
+    try:
+        inp = payload.get("inputs") or {}
+        candles_raw = inp.get("ohlcv") or []
+        candles = [
+            OHLCVCandle(
+                timestamp=float(c.get("timestamp", 0)),
+                open=float(c["open"]),
+                high=float(c["high"]),
+                low=float(c["low"]),
+                close=float(c["close"]),
+                volume=float(c["volume"]),
+            )
+            for c in candles_raw
+        ]
+        acct_d = inp.get("account") or {}
+        account = AccountContext(
+            equity_fraction=float(acct_d.get("equity_fraction", 0.0)),
+            margin_fraction=float(acct_d.get("margin_fraction", 0.0)),
+            open_positions=int(acct_d.get("open_positions", 0)),
+            available_equity=float(acct_d.get("available_equity", 0.0)),
+            exchange_held_side=acct_d.get("exchange_held_side"),
+            own_position_entry_price=(
+                float(acct_d["own_position_entry_price"])
+                if acct_d.get("own_position_entry_price") is not None else None
+            ),
+            own_position_quantity=(
+                float(acct_d["own_position_quantity"])
+                if acct_d.get("own_position_quantity") is not None else None
+            ),
+            own_position_trade_id=acct_d.get("own_position_trade_id"),
+        )
+        raw_kelly = inp.get("rolling_kelly_stats")
+        rolling_kelly_stats: Optional[tuple[float, float, float]] = None
+        if (
+            isinstance(raw_kelly, (list, tuple))
+            and len(raw_kelly) == 3
+            and all(isinstance(v, (int, float)) for v in raw_kelly)
+        ):
+            rolling_kelly_stats = (
+                float(raw_kelly[0]), float(raw_kelly[1]), float(raw_kelly[2]),
+            )
+        symbol = str(inp.get("symbol", ""))
+        tick_inputs = TickInputs(
+            symbol=symbol,
+            ohlcv=candles,
+            account=account,
+            bank_size=int(inp.get("bank_size", 0)),
+            sovereignty=float(inp.get("sovereignty", 0.0)),
+            max_leverage=int(inp.get("max_leverage", 10)),
+            min_notional=float(inp.get("min_notional", 5.0)),
+            size_fraction=float(inp.get("size_fraction", 1.0)),
+            self_obs_bias=inp.get("self_obs_bias"),
+            rolling_kelly_stats=rolling_kelly_stats,
+        )
+
+        # State resolution: caller-provided prev_state wins. If absent we
+        # build an EPHEMERAL state seeded from the uniform basin — we do
+        # NOT touch the _symbol_states cache (that's owned by
+        # /monkey/tick/run for the cutover path).
+        prev_state_payload = payload.get("prev_state")
+        if prev_state_payload is not None:
+            state = _symbol_state_from_dict(prev_state_payload)
+        else:
+            from monkey_kernel.basin import uniform_basin
+            state = fresh_symbol_state(symbol, uniform_basin(64))
+
+        # Ephemeral autonomic / ocean / foresight / heart so the shadow
+        # tick cannot accumulate kernel-bus events into the live
+        # cutover-path singletons. Per-call instances are state-loss
+        # OK because the shadow does NOT persist anything.
+        instance_id = f"k-shadow:{str(payload.get('instance_id', 'monkey-primary'))}"
+        autonomic = _get_autonomic(instance_id)
+        ocean = _get_ocean(instance_id, symbol)
+        foresight = _get_foresight(instance_id, symbol)
+        heart = _get_heart(instance_id, symbol)
+
+        decision, _new_state = run_tick(
+            tick_inputs, state, autonomic,
+            ocean=ocean, foresight=foresight, heart=heart,
+            persistence=None, bus=None, coordinator=None,
+        )
+        return _k_shadow_response_from_decision(decision, started_ms)
+    except Exception as exc:  # noqa: BLE001 — shadow MUST NOT raise
+        logger.warning("[k-shadow] internal exception (swallowed): %s: %s",
+                       type(exc).__name__, exc)
+        return {
+            "error": f"{type(exc).__name__}: {exc}",
+            "decided_at_ms": started_ms,
+        }
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # v0.8.7c-3 — Trading engine endpoints (Python order placement port)
 # ═══════════════════════════════════════════════════════════════════════════

--- a/ml-worker/tests/test_k_shadow.py
+++ b/ml-worker/tests/test_k_shadow.py
@@ -1,0 +1,220 @@
+"""Tests for the issue #689 Python K shadow endpoint.
+
+Exercises POST /monkey/k-shadow/tick directly via FastAPI's TestClient.
+Three contracts pinned:
+
+  1. Healthy input → endpoint returns the slim parity-row shape with
+     all required keys present (action, side, size_intent, phi, kappa,
+     M, Gamma, R, regime, mode, decided_at_ms). No exceptions.
+
+  2. Malformed input (missing ohlcv, bad JSON shape) → endpoint MUST
+     return HTTP 200 with {"error": ..., "decided_at_ms": ...} —
+     never a 500 / never an unhandled exception. Shadow MUST NOT
+     affect live.
+
+  3. Insufficient OHLCV (< 50 candles) → endpoint MUST return a valid
+     slim shape with action == 'hold' (the kernel's _hold_for_reason
+     path) — proves the endpoint covers the cold-start case the live
+     fanout will hit on the first ticks of a newly-listed symbol.
+
+The endpoint NEVER raises, even on internal exceptions — the response
+ALWAYS includes decided_at_ms so the TS caller can persist a parity row.
+
+Note: main.py at import time pulls EnsemblePredictor which imports
+tensorflow. tensorflow has no Python 3.14 wheels yet, so this test
+stubs `tensorflow` (and a handful of model-only sub-modules) before
+the main import so the endpoint code path can be exercised standalone.
+The shadow endpoint itself does NOT use tensorflow — it only consumes
+monkey_kernel.run_tick — so the stub is purely an import-time concern.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ML_WORKER_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ML_WORKER_ROOT / "src"
+
+
+def _install_tensorflow_stub() -> None:
+    """Insert a no-op `tensorflow` (and friends) into sys.modules so
+    main.py's EnsemblePredictor import chain doesn't blow up under
+    Python 3.14 (no TF wheels yet). Only needed at import time —
+    the K-shadow code path does not call tensorflow."""
+    if "tensorflow" in sys.modules:
+        return
+    tf_stub = types.ModuleType("tensorflow")
+    tf_keras = types.ModuleType("tensorflow.keras")
+    tf_keras_models = types.ModuleType("tensorflow.keras.models")
+    tf_keras_layers = types.ModuleType("tensorflow.keras.layers")
+    tf_keras_callbacks = types.ModuleType("tensorflow.keras.callbacks")
+    tf_keras_opt = types.ModuleType("tensorflow.keras.optimizers")
+
+    # Provide just enough attribute surface to satisfy ``from X import Y``
+    # statements in models/*.py at import time. Calling any of these in
+    # the tests would error, but we only need them to exist for import.
+    for stub in (tf_keras_models, tf_keras_layers, tf_keras_callbacks, tf_keras_opt):
+        stub.__getattr__ = lambda _name, _stub=stub: type(_name, (), {})  # type: ignore[attr-defined]
+
+    tf_stub.keras = tf_keras  # type: ignore[attr-defined]
+    tf_keras.models = tf_keras_models  # type: ignore[attr-defined]
+    tf_keras.layers = tf_keras_layers  # type: ignore[attr-defined]
+    tf_keras.callbacks = tf_keras_callbacks  # type: ignore[attr-defined]
+    tf_keras.optimizers = tf_keras_opt  # type: ignore[attr-defined]
+    tf_stub.__getattr__ = lambda _name: type(_name, (), {})  # type: ignore[attr-defined]
+
+    sys.modules.update({
+        "tensorflow": tf_stub,
+        "tensorflow.keras": tf_keras,
+        "tensorflow.keras.models": tf_keras_models,
+        "tensorflow.keras.layers": tf_keras_layers,
+        "tensorflow.keras.callbacks": tf_keras_callbacks,
+        "tensorflow.keras.optimizers": tf_keras_opt,
+    })
+
+
+@pytest.fixture(scope="module")
+def client():
+    """Boot the FastAPI app once per module and return a TestClient.
+    Imports are deferred so the tensorflow stub lands first."""
+    if str(SRC_DIR) not in sys.path:
+        sys.path.insert(0, str(SRC_DIR))
+    if str(ML_WORKER_ROOT) not in sys.path:
+        sys.path.insert(0, str(ML_WORKER_ROOT))
+
+    _install_tensorflow_stub()
+
+    try:
+        from fastapi.testclient import TestClient
+    except ImportError as exc:
+        pytest.skip(f"fastapi TestClient unavailable: {exc}")
+
+    try:
+        import main  # noqa: WPS433 — deferred import is the point
+    except Exception as exc:  # noqa: BLE001 — main import surfaces env issues
+        pytest.skip(f"ml-worker main.py import failed: {type(exc).__name__}: {exc}")
+
+    return TestClient(main.app)
+
+
+def _make_ohlcv(n: int) -> list[dict[str, float]]:
+    """Generate `n` synthetic candles. Prices walk slightly up so
+    momentum / basin direction land deterministically. Volume kept
+    constant so the regime classifier has a clean reading."""
+    base = 100.0
+    rows: list[dict[str, float]] = []
+    for i in range(n):
+        c = base + 0.05 * i
+        rows.append({
+            "timestamp": float(1_700_000_000 + 60 * i),
+            "open": c,
+            "high": c + 0.10,
+            "low": c - 0.10,
+            "close": c,
+            "volume": 1_000.0,
+        })
+    return rows
+
+
+def _request_body(ohlcv: list[dict[str, float]] | None = None) -> dict[str, Any]:
+    return {
+        "instance_id": "test-k-shadow",
+        "inputs": {
+            "symbol": "BTC_USDT_PERP",
+            "ohlcv": ohlcv if ohlcv is not None else _make_ohlcv(120),
+            "account": {
+                "equity_fraction": 0.05,
+                "margin_fraction": 0.1,
+                "open_positions": 0,
+                "available_equity": 1000.0,
+                "exchange_held_side": None,
+            },
+            "bank_size": 0,
+            "sovereignty": 0.5,
+            "max_leverage": 10,
+            "min_notional": 5.0,
+            "size_fraction": 1.0,
+        },
+        "prev_state": None,
+    }
+
+
+REQUIRED_KEYS = {
+    "action", "side", "size_intent", "phi", "kappa",
+    "M", "Gamma", "R", "regime", "mode", "decided_at_ms",
+}
+
+
+class TestKShadowEndpoint:
+    def test_healthy_input_returns_slim_parity_shape(self, client):
+        resp = client.post("/monkey/k-shadow/tick", json=_request_body())
+        assert resp.status_code == 200
+        body = resp.json()
+        # Either we got a clean decision (all REQUIRED_KEYS present) OR
+        # we got an error envelope (still HTTP 200, never 500). Both
+        # paths are valid — the contract is "endpoint never breaks
+        # live", not "endpoint always produces a decision".
+        if "error" in body and body.get("error"):
+            assert "decided_at_ms" in body
+            assert isinstance(body["decided_at_ms"], int)
+        else:
+            missing = REQUIRED_KEYS - set(body.keys())
+            assert not missing, f"missing keys in shadow response: {missing}"
+            assert isinstance(body["decided_at_ms"], int)
+            assert isinstance(body["action"], str)
+            assert body["side"] in (None, "long", "short")
+            assert isinstance(body["size_intent"], (int, float))
+            # phi/kappa are numeric (size_intent / Gamma may also be numeric)
+            assert isinstance(body["phi"], (int, float))
+            assert isinstance(body["kappa"], (int, float))
+            # R is None or 0/1/2
+            assert body["R"] in (None, 0, 1, 2)
+
+    def test_malformed_json_returns_error_envelope_not_500(self, client):
+        # Send a bytes body that isn't valid JSON.
+        resp = client.post(
+            "/monkey/k-shadow/tick",
+            content=b"this is not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "error" in body
+        assert "decided_at_ms" in body
+        assert isinstance(body["decided_at_ms"], int)
+        assert "bad_json" in body["error"] or "JSONDecode" in body["error"]
+
+    def test_missing_ohlcv_returns_error_envelope_not_500(self, client):
+        # Body shape that drops `inputs` entirely → endpoint must
+        # swallow the KeyError / TypeError chain.
+        resp = client.post("/monkey/k-shadow/tick", json={"instance_id": "x"})
+        assert resp.status_code == 200
+        body = resp.json()
+        # Either error envelope OR empty-OHLCV graceful hold.
+        if "error" in body and body.get("error"):
+            assert "decided_at_ms" in body
+        else:
+            assert body.get("action") == "hold"
+
+    def test_insufficient_ohlcv_returns_hold(self, client):
+        # < 50 candles trips the kernel's insufficient_ohlcv branch in
+        # run_tick. The endpoint should still produce a slim shape with
+        # action='hold' (never raise).
+        resp = client.post(
+            "/monkey/k-shadow/tick",
+            json=_request_body(_make_ohlcv(10)),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        if "error" in body and body.get("error"):
+            # Acceptable: kernel raised something that fell into the
+            # outer try-except. The contract holds (never 500).
+            assert "decided_at_ms" in body
+        else:
+            assert body.get("action") == "hold"
+            for key in REQUIRED_KEYS:
+                assert key in body


### PR DESCRIPTION
## Summary

Issue #689 — Python K shadow. Clones the regime_shadow pattern from PR #696 but for the **full K-agent decision**, not just regime. Captures TS K and would-be Py K decisions side-by-side in a new \`kernel_parity_log\` table so the cutover PR (Py K authoritative) can ship only after a representative parity window accumulates.

### What's in this PR

- **\`POST /monkey/k-shadow/tick\`** (ml-worker/main.py) — slim K-decision projection: \`{action, side, size_intent, phi, kappa, M, Gamma, R, regime, mode, decided_at_ms}\`. Builds an ephemeral SymbolState; does NOT touch the \`_symbol_states\` cache or persist anything. Returns \`{error, decided_at_ms}\` on any internal exception — never 500s.
- **Migration 051** (\`apps/api/database/migrations/051_kernel_parity_log.sql\`) — \`kernel_parity_log\` table with TS + Py columns and GENERATED \`agree_action / agree_side / delta_phi / delta_kappa\` columns. Partial index on disagreements. Idempotent DO-block + IF NOT EXISTS matching the 048-050 pattern.
- **TS-side fanout** (\`apps/api/src/services/monkey/loop.ts\`) — fire-and-forget POST after TS K finalises decision, BEFORE execution. 1-second timeout. TS K decision behaviour **UNCHANGED**.
- **Governance endpoints** (extends the existing \`apps/api/src/routes/governance.ts\` shipped in #704):
  - \`GET /api/governance/k-parity?limit=N&since=ISO\` — paginated parity rows + summary counts.
  - \`GET /api/governance/k-consciousness?kernel=ts|py|both&limit=N&since=ISO\` — Φ/κ/M/Γ/R/C trajectory; rows ASC by symbol_timestamp.
  - Both \`authenticateToken\`-gated, both READ-ONLY.
- **Tests**:
  - \`apps/api/src/services/monkey/__tests__/kParityShadow.test.ts\` — 13 vitest tests covering parity-row INSERT, py-error path, DB-failure swallowing, regime ordinal mapping, AbortController timeout, fetch-error envelope, HTTP-200 passthrough.
  - \`ml-worker/tests/test_k_shadow.py\` — 4 pytest tests covering healthy input shape, malformed JSON (HTTP 200 envelope), missing inputs, insufficient OHLCV (hold).

### Discipline — Translation only, no riders

Per the #689 plan: **no new gates, no new features, no refactors.** This PR is the translation surface only. Any refactor / additional gate / feature work files its own PR.

- No env-var gate at the fanout layer — shadow is on-by-default. The gate is at the CUTOVER PR (Py decision drives execution), which is NOT this PR.
- TS K decision logic untouched. Fanout reads \`action / side / phi / kappa / bv / regimeReading\` only; no writes.
- Did NOT touch \`agent.ts\`, \`autonomousTrader.ts\` (#702), migrations 000-050, \`fullyAutonomousTrader.ts\`, \`liveSignalEngine.ts\`, or any \`apps/web/\` file.
- \`python ml-worker/scripts/qig_purity_check.py\` passes on every new Python file (40/40 clean).

### Test plan

- [x] \`yarn workspace @poloniex-platform/api build\` exits 0
- [x] \`yarn workspace @poloniex-platform/api vitest run src/services/monkey/__tests__/kParityShadow.test.ts\` — 13/13 passing
- [x] Full vitest suite — 1200 passing / 12 skipped / 0 failing
- [x] \`python -m pytest -q tests/test_k_shadow.py\` — 4/4 passing
- [x] \`python scripts/qig_purity_check.py\` — clean
- [ ] On Railway: migration 051 applies cleanly (idempotent DO-block)
- [ ] On Railway: parity rows accumulate; \`GET /api/governance/k-parity\` returns rows with both TS + Py populated
- [ ] On Railway: \`py_error_count\` reasonable (proves the shadow is actually reaching ml-worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)