### PR TITLE
fix(db): migration 052 — widen kernel_parity_log timing cols to BIGINT (unblocks parity inserts)

### DIFF
--- a/apps/api/database/migrations/052_kernel_parity_log_bigint.sql
+++ b/apps/api/database/migrations/052_kernel_parity_log_bigint.sql
@@ -1,0 +1,39 @@
+-- 052_kernel_parity_log_bigint.sql
+--
+-- PR #705 shipped kernel_parity_log with ts_decision_ms / py_decision_ms
+-- typed INTEGER, but the Python /monkey/k-shadow/tick endpoint returns
+-- `decided_at_ms` as an absolute Unix-ms timestamp (~1.78e12), not a
+-- duration. INTEGER tops out at 2.147e9, so every insert is failing
+-- with "value out of range for type integer" and the parity log stays
+-- empty in production.
+--
+-- Fix: widen both columns to BIGINT. Captures either interpretation
+-- (duration or absolute timestamp). Idempotent — only alters when
+-- current type is integer.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'kernel_parity_log'
+      AND column_name = 'ts_decision_ms'
+      AND data_type = 'integer'
+  ) THEN
+    ALTER TABLE kernel_parity_log ALTER COLUMN ts_decision_ms TYPE BIGINT;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'kernel_parity_log'
+      AND column_name = 'py_decision_ms'
+      AND data_type = 'integer'
+  ) THEN
+    ALTER TABLE kernel_parity_log ALTER COLUMN py_decision_ms TYPE BIGINT;
+  END IF;
+
+  -- ts_R / py_R also store ordinals that may exceed INTEGER if someone
+  -- later extends the regime enum; leave as INTEGER (current cap fits
+  -- comfortably) but document the intent.
+END $$;


### PR DESCRIPTION
## Summary

PR #705's migration 051 typed `ts_decision_ms` / `py_decision_ms` as INTEGER, but the Python `/monkey/k-shadow/tick` endpoint returns `decided_at_ms` as an absolute Unix-ms timestamp (~1.78e12), not a duration. INTEGER tops out at 2.147e9 → every insert is currently failing:

```
[k-parity] insert failed (swallowed)
  value "1778907620136" is out of range for type integer
```

Result: `/api/governance/k-parity?limit=N` returns `count: 0` even though the Py shadow IS firing (`POST 200 OK` every tick visible in ml-worker logs at `100.64.*:* - "POST /monkey/k-shadow/tick HTTP/1.1" 200 OK`).

This PR widens both columns to BIGINT. Idempotent DO-block — only alters when current type is integer.

## Verification

- [x] `yarn workspace api build` exits 0
- [x] Idempotent against re-apply (only alters when type is integer)
- [ ] Post-deploy: curl `/api/governance/k-parity?limit=5` returns rows > 0 within ~30s of next kernel tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update kernel parity log schema to support larger decision timestamps by widening timing columns to BIGINT when needed.

Bug Fixes:
- Prevent kernel_parity_log inserts from failing due to INTEGER overflow on decision timestamp columns.

Enhancements:
- Make the kernel_parity_log timing column migration idempotent by conditionally altering column types only when currently INTEGER.