### PR TITLE
feat(monkey): per-agent neurochemistry for M/T/L — extend PR #700 K-isolation pattern

### DIFF
--- a/apps/api/src/services/monkey/__tests__/perAgentNC.test.ts
+++ b/apps/api/src/services/monkey/__tests__/perAgentNC.test.ts
@@ -1,0 +1,200 @@
+/**
+ * perAgentNC.test.ts — per-agent neurochemistry reward isolation.
+ *
+ * Extends PR #700 (commit b39be2e) K-only filter to M/T/L. The invariant
+ * under test:
+ *
+ *   decayedRewardSums(now, 'X') returns only the rewards tagged 'X'.
+ *   decayedRewardSums(now)      returns the legacy shared-pool sum.
+ *
+ * Before this change, every pushReward in the close path was tagged 'K',
+ * so M/T/L wins diluted K's dopamine even though K's executive was the
+ * only consumer. After this change, M/T/L close paths push with their
+ * own agent tag and the executive's K-only filter is honoured exactly.
+ *
+ * The test pushes one reward per agent (K, M, T, L), then asserts that
+ * each agent's filtered view sees only its own reward, and the unfiltered
+ * view pools all of them — matching the cross-agent telemetry surface
+ * already used by `derivation.ncByAgent`.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the env config so importing loop.ts (→ encryptionService → env)
+// doesn't blow up on missing DATABASE_URL / JWT_SECRET in the test
+// environment. Mirrors the pattern in kellyCapLane.test.ts.
+vi.mock('../../../config/env.js', () => ({
+  env: {
+    NODE_ENV: 'test',
+    PORT: 8765,
+    DATABASE_URL: 'postgresql://test:5432/test',
+    JWT_SECRET: 'test-jwt-secret-32-characters-xxxxxxxxxx',
+  },
+}));
+
+// Pool is touched by loop.ts at module load via import chains, but
+// pushReward + decayedRewardSums never call it — mock returns a stub
+// so accidental queries surface as test failures, not silent hangs.
+vi.mock('../../../db/connection.js', () => ({
+  pool: { query: vi.fn() },
+}));
+
+describe('per-agent neurochemistry reward isolation', () => {
+  it('isolates K rewards from M/T/L pool dilution (and vice versa)', async () => {
+    const { MonkeyKernel } = await import('../loop.js');
+    const kernel = new MonkeyKernel({
+      instanceId: 'test-kernel-nc-mtl',
+      symbols: ['BTC_USDT_PERP'],
+      label: 'TestNCMTL',
+    });
+
+    // Push one reward per agent. Use the SAME pnl + margin so each agent
+    // produces an identical dopamine delta — that way per-agent sums are
+    // easy to reason about (each = the single-event delta).
+    kernel.pushReward({
+      source: 'test_close',
+      symbol: 'BTC_USDT_PERP',
+      realizedPnlUsdt: 1.0,    // 10 % win on 10 USDT margin
+      marginUsdt: 10,
+      agent: 'K',
+    });
+    kernel.pushReward({
+      source: 'test_close',
+      symbol: 'BTC_USDT_PERP',
+      realizedPnlUsdt: 1.0,
+      marginUsdt: 10,
+      agent: 'M',
+    });
+    kernel.pushReward({
+      source: 'test_close',
+      symbol: 'BTC_USDT_PERP',
+      realizedPnlUsdt: 1.0,
+      marginUsdt: 10,
+      agent: 'T',
+    });
+    kernel.pushReward({
+      source: 'test_close',
+      symbol: 'BTC_USDT_PERP',
+      realizedPnlUsdt: 1.0,
+      marginUsdt: 10,
+      agent: 'L',
+    });
+
+    const now = Date.now();
+
+    // K-only filter — sees exactly K's contribution (the legacy K-only
+    // invariant from PR #700 must still hold). With all four events
+    // pushed at ~now (decay ≈ 1), K's window equals one single-event
+    // dop delta.
+    const kOnly = kernel.decayedRewardSums(now, 'K');
+    expect(kOnly.dopamine).toBeGreaterThan(0);
+
+    // M, T, L filters — each must see its own event AND match K's
+    // magnitude (same pnl + margin + age). This is the new property:
+    // M's window is no longer diluted with K's + T's + L's events, and
+    // K's window is no longer diluted with M's + T's + L's events.
+    const mOnly = kernel.decayedRewardSums(now, 'M');
+    const tOnly = kernel.decayedRewardSums(now, 'T');
+    const lOnly = kernel.decayedRewardSums(now, 'L');
+
+    expect(mOnly.dopamine).toBeCloseTo(kOnly.dopamine, 6);
+    expect(tOnly.dopamine).toBeCloseTo(kOnly.dopamine, 6);
+    expect(lOnly.dopamine).toBeCloseTo(kOnly.dopamine, 6);
+
+    // Unfiltered (legacy shared-pool behaviour) — sums all four. Must
+    // be ~4× any single agent's window. This is the telemetry path
+    // (`derivation.ncByAgent` iterates per-agent for the dashboard
+    // surface but kept unfiltered access for cross-agent diagnostics).
+    const pooled = kernel.decayedRewardSums(now);
+    expect(pooled.dopamine).toBeCloseTo(kOnly.dopamine * 4, 5);
+    expect(pooled.serotonin).toBeCloseTo(kOnly.serotonin * 4, 5);
+    expect(pooled.endorphin).toBeCloseTo(kOnly.endorphin * 4, 5);
+  });
+
+  it('cross-agent isolation: an M-only push does not leak into K/T/L windows', async () => {
+    const { MonkeyKernel } = await import('../loop.js');
+    const kernel = new MonkeyKernel({
+      instanceId: 'test-kernel-nc-mtl-2',
+      symbols: ['BTC_USDT_PERP'],
+      label: 'TestNCMTL2',
+    });
+
+    kernel.pushReward({
+      source: 'test_close',
+      symbol: 'BTC_USDT_PERP',
+      realizedPnlUsdt: 2.0,
+      marginUsdt: 10,
+      agent: 'M',
+    });
+
+    const now = Date.now();
+    const kView = kernel.decayedRewardSums(now, 'K');
+    const tView = kernel.decayedRewardSums(now, 'T');
+    const lView = kernel.decayedRewardSums(now, 'L');
+    const mView = kernel.decayedRewardSums(now, 'M');
+
+    expect(kView.dopamine).toBe(0);
+    expect(tView.dopamine).toBe(0);
+    expect(lView.dopamine).toBe(0);
+    expect(mView.dopamine).toBeGreaterThan(0);
+  });
+
+  it('back-compat: pushReward without an agent param defaults to K', async () => {
+    const { MonkeyKernel } = await import('../loop.js');
+    const kernel = new MonkeyKernel({
+      instanceId: 'test-kernel-nc-mtl-3',
+      symbols: ['BTC_USDT_PERP'],
+      label: 'TestNCMTL3',
+    });
+
+    // Legacy callsite shape — no `agent` field. Must land in K's
+    // window per the `agent ?? 'K'` default in pushReward, so any
+    // pre-2026-05-16 deploys that race a fresh build see no behaviour
+    // regression on K.
+    kernel.pushReward({
+      source: 'legacy_close',
+      symbol: 'BTC_USDT_PERP',
+      realizedPnlUsdt: 1.5,
+      marginUsdt: 10,
+    });
+
+    const now = Date.now();
+    expect(kernel.decayedRewardSums(now, 'K').dopamine).toBeGreaterThan(0);
+    expect(kernel.decayedRewardSums(now, 'M').dopamine).toBe(0);
+    expect(kernel.decayedRewardSums(now, 'T').dopamine).toBe(0);
+    expect(kernel.decayedRewardSums(now, 'L').dopamine).toBe(0);
+  });
+
+  it('losing trades produce negative dopamine but stay agent-isolated', async () => {
+    const { MonkeyKernel } = await import('../loop.js');
+    const kernel = new MonkeyKernel({
+      instanceId: 'test-kernel-nc-mtl-4',
+      symbols: ['BTC_USDT_PERP'],
+      label: 'TestNCMTL4',
+    });
+
+    // T loses, K wins — verify the T-only window shows the negative
+    // mood dip and K's window shows the positive lift, neither bleeds.
+    kernel.pushReward({
+      source: 'test_close',
+      symbol: 'BTC_USDT_PERP',
+      realizedPnlUsdt: -1.0,
+      marginUsdt: 10,
+      agent: 'T',
+    });
+    kernel.pushReward({
+      source: 'test_close',
+      symbol: 'BTC_USDT_PERP',
+      realizedPnlUsdt: 1.0,
+      marginUsdt: 10,
+      agent: 'K',
+    });
+
+    const now = Date.now();
+    const kView = kernel.decayedRewardSums(now, 'K');
+    const tView = kernel.decayedRewardSums(now, 'T');
+
+    expect(kView.dopamine).toBeGreaterThan(0);   // K's win lifted K's dop
+    expect(tView.dopamine).toBeLessThan(0);      // T's loss dipped T's dop
+    expect(kView.dopamine).not.toBeCloseTo(tView.dopamine, 6);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -667,6 +667,24 @@ export class MonkeyKernel extends EventEmitter {
           src.startsWith('reconciler_recovered');
         if (!isRecovered) return;
         this.applyOutcomeToAgent(event.symbol, agent, side as 'long' | 'short', pnl);
+        // 2026-05-16 per-agent NC: also feed reconciler-recovered
+        // ghost-closes into the agent's chemistry queue. Without this,
+        // M/T/L closes that the close-path missed (exchange-side
+        // liquidation, manual UI close, partial-fill cleanup) would
+        // update emotion state but NOT the agent's dopamine window.
+        // Margin estimation: ghost-recovered events lack qty + mark
+        // price; reuse the witnessExit pattern of a fixed nominal
+        // margin (5 USDT) so pnlFraction = pnl / 5 stays bounded and
+        // doesn't blow out the dop/ser/endo deltas on a one-off ghost.
+        try {
+          this.pushReward({
+            source: `reconciler_recovered:${String(payload.ghostReason ?? 'unknown')}`,
+            symbol: event.symbol,
+            realizedPnlUsdt: pnl,
+            marginUsdt: 5,
+            agent,
+          });
+        } catch { /* non-fatal */ }
         const ghostReason = String(payload.ghostReason ?? 'unknown');
         logger.info(
           `[Monkey] Agent ${agent} emotion stack updated from recovered ghost close: pnl=${pnl.toFixed(4)} side=${side} reason=${ghostReason}`,
@@ -3800,6 +3818,8 @@ export class MonkeyKernel extends EventEmitter {
       });
 
       if (isMonkeyPaperMode()) {
+        let lPaperRealizedPnl = 0;
+        let lPaperRealizedQty = 0;
         try {
           for (const row of rows) {
             const rowQty = Math.abs(Number(row.quantity) || 0);
@@ -3819,6 +3839,8 @@ export class MonkeyKernel extends EventEmitter {
             );
             this.arbiter.recordSettled('L', rowPnl);
             this.applyOutcomeToAgent(symbol, 'L', sideKey, rowPnl);
+            lPaperRealizedPnl += rowPnl;
+            lPaperRealizedQty += rowQty;
           }
         } catch (err) {
           logger.error('[AgentL] force-harvest paper close failed', {
@@ -3826,6 +3848,17 @@ export class MonkeyKernel extends EventEmitter {
             err: err instanceof Error ? err.message : String(err),
           });
           continue;
+        }
+        // 2026-05-16 per-agent NC — L paper-harvest pushes into L's
+        // own reward window (was a no-op before; L outcomes never
+        // reached the chemistry queue).
+        if (lPaperRealizedQty > 0) {
+          this.pushPerAgentCloseRewards(symbol, lastPrice, {
+            K: { pnl: 0, qty: 0 },
+            M: { pnl: 0, qty: 0 },
+            T: { pnl: 0, qty: 0 },
+            L: { pnl: lPaperRealizedPnl, qty: lPaperRealizedQty },
+          });
         }
         logger.info('[AgentL] force-harvest PAPER CLOSED', {
           symbol, side: sideKey, rowsClosed: rows.length, aggPnl: aggPnl.toFixed(4), regime: regimeLabel,
@@ -3965,6 +3998,8 @@ export class MonkeyKernel extends EventEmitter {
       }
 
       // Update only L's rows (close them with proportional PnL).
+      let lLiveRealizedPnl = 0;
+      let lLiveRealizedQty = 0;
       try {
         for (const row of rows) {
           const rowQty = Math.abs(Number(row.quantity) || 0);
@@ -3979,10 +4014,23 @@ export class MonkeyKernel extends EventEmitter {
           );
           this.arbiter.recordSettled('L', rowPnl);
           this.applyOutcomeToAgent(symbol, 'L', sideKey, rowPnl);
+          lLiveRealizedPnl += rowPnl;
+          lLiveRealizedQty += rowQty;
         }
       } catch (err) {
         logger.error('[AgentL] force-harvest DB update failed — ORPHAN RISK', {
           symbol, err: err instanceof Error ? err.message : String(err),
+        });
+      }
+      // 2026-05-16 per-agent NC — L live-harvest pushes into L's own
+      // reward window. Before this, L outcomes never reached the
+      // chemistry queue (force-harvest skipped closeHeldPosition).
+      if (lLiveRealizedQty > 0) {
+        this.pushPerAgentCloseRewards(symbol, lastPrice, {
+          K: { pnl: 0, qty: 0 },
+          M: { pnl: 0, qty: 0 },
+          T: { pnl: 0, qty: 0 },
+          L: { pnl: lLiveRealizedPnl, qty: lLiveRealizedQty },
         });
       }
 
@@ -4073,6 +4121,15 @@ export class MonkeyKernel extends EventEmitter {
               [`monkey|kernel=${this.instanceId}|%`, symbol],
             );
         const rows = openRows.rows as Array<{ id: string; quantity: string; agent: string | null; order_id: string | null }>;
+        // 2026-05-16 per-agent NC — same pattern as the live close
+        // branch below. Accumulate per-agent totals so M/T/L close
+        // outcomes feed their own NC windows (not K's pool).
+        const paperPerAgentTotals: Record<AgentLabel, { pnl: number; qty: number }> = {
+          K: { pnl: 0, qty: 0 },
+          M: { pnl: 0, qty: 0 },
+          T: { pnl: 0, qty: 0 },
+          L: { pnl: 0, qty: 0 },
+        };
         if (rows.length === 0) {
           await pool.query(
             `UPDATE autonomous_trades
@@ -4083,6 +4140,12 @@ export class MonkeyKernel extends EventEmitter {
           );
           this.arbiter.recordSettled('K', pnlAtDecision);
           this.applyOutcomeToAgent(symbol, 'K', heldSide, pnlAtDecision);
+          paperPerAgentTotals.K.pnl += pnlAtDecision;
+          // Paper-mode single-row fallback: estimate qty from
+          // pnl/markPrice — only used for margin denominator below;
+          // a tiny floor keeps margin non-zero on near-flat closes.
+          paperPerAgentTotals.K.qty += Math.max(Math.abs(pnlAtDecision) / Math.max(markPrice, 1), 0.01);
+          this.pushPerAgentCloseRewards(symbol, markPrice, paperPerAgentTotals);
           return { executed: true, orderId: null, reason: 'closed_paper' };
         }
         const pnlPerRow = pnlAtDecision / rows.length;
@@ -4109,7 +4172,10 @@ export class MonkeyKernel extends EventEmitter {
                   : 'K';
           this.arbiter.recordSettled(agentLabel, rowPnl);
           this.applyOutcomeToAgent(symbol, agentLabel, heldSide, rowPnl);
+          paperPerAgentTotals[agentLabel].pnl += rowPnl;
+          paperPerAgentTotals[agentLabel].qty += Math.abs(Number(row.quantity) || 0);
         }
+        this.pushPerAgentCloseRewards(symbol, markPrice, paperPerAgentTotals);
 
         logger.info('[Monkey] PAPER POSITION CLOSED', {
           symbol, heldSide, markPrice, orderId, tradeId,
@@ -4333,6 +4399,19 @@ export class MonkeyKernel extends EventEmitter {
           );
       const rows = openRows.rows as Array<{ id: string; quantity: string; agent: string | null }>;
       const totalQty = rows.reduce((s, r) => s + Math.abs(Number(r.quantity) || 0), 0);
+      // Accumulate per-agent (pnl, qty) inside the row loop so we can
+      // push ONE reward event per agent at the end. Per-row pushes would
+      // flood the bounded reward queue (REWARD_QUEUE_MAX=50) on DCA
+      // closes; per-agent aggregation keeps the queue stable while still
+      // attributing chemistry to the agent that actually generated each
+      // win. Each agent gets its own margin estimate from its own qty
+      // share so pnlFraction = pnl / margin is meaningful per agent.
+      const perAgentTotals: Record<AgentLabel, { pnl: number; qty: number }> = {
+        K: { pnl: 0, qty: 0 },
+        M: { pnl: 0, qty: 0 },
+        T: { pnl: 0, qty: 0 },
+        L: { pnl: 0, qty: 0 },
+      };
       if (rows.length === 0 || totalQty === 0) {
         // Fallback — single-row close (covers edge case of race)
         await pool.query(
@@ -4348,9 +4427,12 @@ export class MonkeyKernel extends EventEmitter {
         // emotion + neurochemistry stack (dopamine on win, frustration
         // on loss). See per_agent_state.ts.
         this.applyOutcomeToAgent(symbol, 'K', heldSide, pnlAtDecision);
+        perAgentTotals.K.pnl += pnlAtDecision;
+        perAgentTotals.K.qty += exchangeQty || 0.01;
       } else {
         for (const row of rows) {
-          const qtyShare = Math.abs(Number(row.quantity) || 0) / totalQty;
+          const rowQty = Math.abs(Number(row.quantity) || 0);
+          const qtyShare = rowQty / totalQty;
           const rowPnl = pnlAtDecision * qtyShare;
           await pool.query(
             `UPDATE autonomous_trades
@@ -4372,8 +4454,15 @@ export class MonkeyKernel extends EventEmitter {
                   : 'K';
           this.arbiter.recordSettled(agentLabel, rowPnl);
           this.applyOutcomeToAgent(symbol, agentLabel, heldSide, rowPnl);
+          perAgentTotals[agentLabel].pnl += rowPnl;
+          perAgentTotals[agentLabel].qty += rowQty;
         }
       }
+
+      // v0.6.7 + 2026-05-16 per-agent NC: push one reward event per
+      // agent that contributed to this close. See
+      // pushPerAgentCloseRewards for margin derivation + rationale.
+      this.pushPerAgentCloseRewards(symbol, markPrice, perAgentTotals);
     } catch (err) {
       logger.error('[Monkey] close DB update failed — ORPHAN RISK (reconciler will catch)', {
         tradeId, err: err instanceof Error ? err.message : String(err),
@@ -4390,29 +4479,6 @@ export class MonkeyKernel extends EventEmitter {
       symbol,
       payload: { heldSide, markPrice, orderId, tradeId, pnl: pnlAtDecision, exitReason },
     });
-    // v0.6.7 autonomic reward event. Margin ≈ markPrice × totalQty / lev
-    // (she has only one kernel state; we use one of her symbol states
-    // for κ). Pushed as an EVENT; computeNeurochemicals derives the
-    // actual dopamine lift next tick.
-    //
-    // K-tagged: closeHeldPosition is the K-kernel's own close path
-    // (M/T/L use their own execution paths that call recordSettled
-    // separately). Tagging the reward 'K' means K's brain gets the
-    // dopamine on K's wins.
-    const symState = this.symbolStates.get(symbol);
-    try {
-      const totalQtyForMargin = exchangeQty || 0.01;
-      const notional = markPrice * totalQtyForMargin;
-      const margin = notional / Math.max(1, 16);  // typical lev on close; kappa boost uses exit κ
-      this.pushReward({
-        source: 'own_close',
-        symbol,
-        realizedPnlUsdt: pnlAtDecision,
-        marginUsdt: margin,
-        kappaAtExit: symState?.kappa,
-        agent: 'K',
-      });
-    } catch { /* non-fatal */ }
     return { executed: true, orderId, reason: 'closed' };
   }
 
@@ -4882,6 +4948,43 @@ export class MonkeyKernel extends EventEmitter {
    */
 
   /**
+   * Per-agent reward push helper (2026-05-16). Closes that touch
+   * multiple agent rows (M+T shared lane, K + L co-occupying trend,
+   * etc.) accumulate per-agent (pnl, qty) totals during the row loop
+   * and then call this once. Each agent with non-zero qty gets ONE
+   * reward event tagged with its own agent label, so
+   * `decayedRewardSums(now, 'M')` only sees M's outcomes.
+   *
+   * Margin = (markPrice × agentQty) / 16 — same formula
+   * closeHeldPosition has always used for the K-only aggregate, just
+   * stratified by agent now. Skipping zero-qty agents avoids a flood
+   * of zero-pnl reward events in the bounded queue.
+   */
+  private pushPerAgentCloseRewards(
+    symbol: string,
+    markPrice: number,
+    totals: Record<AgentLabel, { pnl: number; qty: number }>,
+  ): void {
+    const symState = this.symbolStates.get(symbol);
+    try {
+      for (const agentKey of ['K', 'M', 'T', 'L'] as const) {
+        const t = totals[agentKey];
+        if (t.qty <= 0) continue;
+        const notional = markPrice * t.qty;
+        const margin = notional / Math.max(1, 16);
+        this.pushReward({
+          source: 'own_close',
+          symbol,
+          realizedPnlUsdt: t.pnl,
+          marginUsdt: margin,
+          kappaAtExit: symState?.kappa,
+          agent: agentKey,
+        });
+      }
+    } catch { /* non-fatal */ }
+  }
+
+  /**
    * Push an autonomic reward event (v0.6.7). Called whenever a trade
    * closes with realized P&L. The kernel's tick loop will consume these
    * via `decayedRewardSums()` and pass the summed deltas to
@@ -4959,8 +5062,12 @@ export class MonkeyKernel extends EventEmitter {
    * processSymbol passes 'K' — K's wins reinforce K's dopamine, M/T/L
    * outcomes no longer dilute it. Omit the filter to get the legacy
    * shared-pool behaviour (useful for cross-agent telemetry).
+   *
+   * Public (2026-05-16) so per-agent NC telemetry tests + the dashboard
+   * snapshot path can read decayed windows by agent. Still pure / no-op
+   * if the queue is empty.
    */
-  private decayedRewardSums(
+  decayedRewardSums(
     nowMs: number = Date.now(),
     agentFilter?: AgentLabel,
   ): {


### PR DESCRIPTION
## Summary

Finishes PR #700's per-agent neurochemistry pattern. PR #700 introduced `decayedRewardSums(now, agentFilter?)` and tagged the queue events with an `agent` field, but every `pushReward` callsite was still passing `agent: 'K'` — so M/T/L outcomes never reached the chemistry queue at all, and K's "K-only filter" was reading from an effectively K-only queue (the filter was a no-op).

This PR tags every close path with the row's actual agent.

## What was already correct (PR #700, kept unchanged)

- `pushReward` accepts `agent?` defaulting to 'K' for back-compat
- `decayedRewardSums(now, agentFilter?)` filters the bounded queue
- `processSymbol` reads K-only window for K's executive
- `derivation.ncByAgent` iterates all four agents for telemetry

## What was broken (fixed here)

- `closeHeldPosition` (live + paper) loops rows tagged K|M|T|L for `recordSettled` + `applyOutcomeToAgent` correctly, but pushed ONE K-tagged reward after the loop with the aggregate PnL — so M/T close PnL went into K's dopamine window
- Agent L's force-harvest (`runAgentLForceHarvest`) skipped `closeHeldPosition` entirely and never called `pushReward` at all
- Reconciler-recovered OUTCOME bus subscriber called `applyOutcomeToAgent(agent)` but never fed the chemistry queue for ghost-closed M/T/L rows

## Changes

1. **`closeHeldPosition` (live + paper)** — accumulate per-agent (pnl, qty) totals in the row loop, then push one reward per non-zero agent via new private helper `pushPerAgentCloseRewards`. Margin = `markPrice × agentQty / 16` (same formula, stratified by agent).
2. **Agent L force-harvest (live + paper)** — accumulate L's realized pnl + qty, push one L-tagged reward at the end via the same helper.
3. **Reconciler OUTCOME subscriber** — alongside `applyOutcomeToAgent`, push a reward with the recovered agent tag (nominal 5 USDT margin, matching the `witnessExit` pattern for events that lack qty + markPrice).
4. **`decayedRewardSums` visibility** — `private` → public so tests can read decayed windows by agent without reflection. `processSymbol`'s internal call is unaffected.

## Test plan

- [x] `apps/api/src/services/monkey/__tests__/perAgentNC.test.ts` — 4 new tests covering K/M/T/L isolation, cross-agent isolation, back-compat default, and negative-dopamine on losses
- [x] `yarn workspace @poloniex-platform/api build` exits 0
- [x] `yarn vitest run src/services/monkey/__tests__/` — 29 files / 508 tests pass (508 includes the 4 new + 504 preexisting)
- [x] QIG purity gate clean on `apps/api/src/services/monkey/loop.ts` + `apps/api/src/services/monkey/__tests__/perAgentNC.test.ts` (no cosine, no `np.dot`, no `np.linalg.norm`, no Adam, no LayerNorm)
- [ ] Post-deploy: `/monkey/snapshot` `derivation.ncByAgent` shows distinct dop/ser/endo windows per agent in the live tape (was K-uniform before)

## Discipline

- Translation-only: no new gates, no new params, no decision-logic changes. K-only filter at line 1147 unchanged; executive/forge/perception unchanged; FAT/LiveSignal/ml-worker untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure per-agent neurochemistry windows receive correctly attributed close outcomes for all agents (K/M/T/L), including reconciler ghost closes and Agent L force-harvest paths.

New Features:
- Add a per-agent close reward helper that emits one reward event per agent based on aggregated PnL and quantity from shared close paths.
- Expose decayed reward sums as a public API to support per-agent neurochemistry telemetry and dashboard access.

Bug Fixes:
- Route reconciler-recovered ghost close outcomes into the appropriate agent’s reward queue instead of only updating emotion state.
- Ensure Agent L’s live and paper force-harvest paths emit L-tagged reward events so its outcomes affect its own neurochemistry window.
- Correct close position logic to send K/M/T/L close PnL into each agent’s own reward window rather than aggregating into K’s dopamine queue.

Tests:
- Add per-agent neurochemistry tests validating K/M/T/L isolation, cross-agent isolation, default agent behavior, and loss handling.