### PR TITLE
feat(kernel): qig-dreams consolidation + sleep-state endpoint extension

### DIFF
--- a/apps/api/src/routes/__tests__/governance.sleep-state.test.ts
+++ b/apps/api/src/routes/__tests__/governance.sleep-state.test.ts
@@ -70,6 +70,11 @@ describe('GET /api/governance/sleep-state/:agent', () => {
     expect(res.body?.sleep_state).toBeNull();
     expect(res.body?.source).toBe('empty');
     expect(typeof res.body?.fetched_at_ms).toBe('number');
+    // Dream-consolidation fields are absent/null when the
+    // last_consolidation key has not been written.
+    expect(res.body?.last_consolidation_ts).toBeNull();
+    expect(res.body?.dream_packet_size_bytes).toBe(0);
+    expect(res.body?.consolidation_summary).toBeNull();
   });
 
   it('returns source=redis + parsed sleep_state when the key is populated', async () => {
@@ -93,6 +98,106 @@ describe('GET /api/governance/sleep-state/:agent', () => {
     expect(res.body?.success).toBe(true);
     expect(res.body?.source).toBe('redis');
     expect(res.body?.sleep_state).toEqual(populated);
+    // No consolidation key populated → fields still null/0
+    expect(res.body?.last_consolidation_ts).toBeNull();
+    expect(res.body?.dream_packet_size_bytes).toBe(0);
+    expect(res.body?.consolidation_summary).toBeNull();
+  });
+
+  it('populates dream-consolidation fields when last_consolidation key exists', async () => {
+    const sleepState = {
+      phase: 'SLEEP',
+      phase_started_at_ms: 1778900000000,
+      sleep_count: 3,
+      drift_streak: 0,
+    };
+    const consolidation = {
+      completed_at_ms: 1778900111000,
+      basin_count: 12,
+      replayed_count: 5,
+      boosted: 5,
+      downscaled: 7,
+      pruned: 2,
+      vetoed: 1,
+      sqrt_distance_traversed: 0.1234,
+      trigger: 'awake_to_sleep',
+      summary_string: '12 basins, 5 boosted / 7 downscaled / 2 pruned, sqrt-traversal=0.1234',
+    };
+    const consolidationStr = JSON.stringify(consolidation);
+    vi.doMock('redis', () => ({
+      createClient: () => ({
+        isOpen: true,
+        on: (_evt: string, _cb: (err: Error) => void) => undefined,
+        connect: async () => undefined,
+        get: async (key: string) => {
+          if (key === 'monkey:ocean:monkey-position:sleep_state') return JSON.stringify(sleepState);
+          if (key === 'monkey:ocean:monkey-position:last_consolidation') return consolidationStr;
+          return null;
+        },
+      }),
+    }));
+    const res = await callHandler('K');
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.success).toBe(true);
+    expect(res.body?.source).toBe('redis');
+    expect(res.body?.sleep_state).toEqual(sleepState);
+    expect(res.body?.last_consolidation_ts).toBe(1778900111000);
+    expect(res.body?.dream_packet_size_bytes).toBe(consolidationStr.length);
+    expect(res.body?.consolidation_summary).toBe(consolidation.summary_string);
+  });
+
+  it('handles malformed last_consolidation JSON without 500ing', async () => {
+    const sleepState = { phase: 'AWAKE' };
+    vi.doMock('redis', () => ({
+      createClient: () => ({
+        isOpen: true,
+        on: (_evt: string, _cb: (err: Error) => void) => undefined,
+        connect: async () => undefined,
+        get: async (key: string) => {
+          if (key === 'monkey:ocean:monkey-position:sleep_state') return JSON.stringify(sleepState);
+          if (key === 'monkey:ocean:monkey-position:last_consolidation') return '{not-valid-json';
+          return null;
+        },
+      }),
+    }));
+    const res = await callHandler('K');
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.source).toBe('redis');
+    expect(res.body?.sleep_state).toEqual(sleepState);
+    // Malformed JSON → ts/summary null; size still reflects raw bytes
+    expect(res.body?.last_consolidation_ts).toBeNull();
+    expect(res.body?.consolidation_summary).toBeNull();
+    expect(res.body?.dream_packet_size_bytes).toBe('{not-valid-json'.length);
+  });
+
+  it('returns dream-consolidation fields even when sleep_state is empty', async () => {
+    // Tests the case where the kernel persisted a consolidation
+    // but the sleep_state key has been wiped (e.g. TTL or test
+    // harness). The endpoint should still surface what it has.
+    const consolidation = {
+      completed_at_ms: 1234567890,
+      summary_string: 'orphan',
+    };
+    vi.doMock('redis', () => ({
+      createClient: () => ({
+        isOpen: true,
+        on: (_evt: string, _cb: (err: Error) => void) => undefined,
+        connect: async () => undefined,
+        get: async (key: string) => {
+          if (key === 'monkey:ocean:monkey-position:last_consolidation') {
+            return JSON.stringify(consolidation);
+          }
+          return null;
+        },
+      }),
+    }));
+    const res = await callHandler('K');
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.source).toBe('empty');
+    expect(res.body?.sleep_state).toBeNull();
+    expect(res.body?.last_consolidation_ts).toBe(1234567890);
+    expect(res.body?.consolidation_summary).toBe('orphan');
+    expect(res.body?.dream_packet_size_bytes).toBeGreaterThan(0);
   });
 
   it('rejects unknown agent labels with 400', async () => {

--- a/apps/api/src/routes/governance.ts
+++ b/apps/api/src/routes/governance.ts
@@ -86,6 +86,9 @@ const AGENT_TO_INSTANCE: Record<string, string> = {
  *     redis_key: string,
  *     sleep_state: { phase, phase_started_at_ms, last_sleep_ended_at_ms,
  *                    sleep_count, drift_streak } | null,
+ *     last_consolidation_ts: number | null,
+ *     dream_packet_size_bytes: number,
+ *     consolidation_summary: string | null,
  *     fetched_at_ms: number,
  *     source: 'redis' | 'empty' | 'not_configured' | 'error'
  *   }
@@ -96,7 +99,40 @@ const AGENT_TO_INSTANCE: Record<string, string> = {
  *              persisted state yet, or runs without persistence enabled)
  *   - 'not_configured': REDIS_URL env var is absent
  *   - 'error': Redis read failed (logged separately)
+ *
+ * Dream-consolidation fields (added with qig_dreams_local wiring):
+ *   - last_consolidation_ts: epoch-ms of the most recent AWAKE→SLEEP
+ *     consolidation pass, or null if none has run yet.
+ *   - dream_packet_size_bytes: byte length of the consolidation blob
+ *     persisted under `monkey:ocean:{instance}:last_consolidation`,
+ *     or 0 when absent. Sized off the raw Redis value (pre-parse) so
+ *     it reflects what the kernel actually wrote.
+ *   - consolidation_summary: human-readable one-liner from the kernel
+ *     (basin count, boost/downscale/prune counts, sqrt-traversal),
+ *     or null when no pass has run.
  */
+/**
+ * Helper: derive the (ts, summary) pair from a parsed last_consolidation
+ * blob. The Python kernel writes a DreamConsolidationSummary serialised
+ * via asdict + summary_string injection (see ml-worker/src/qig_dreams_local
+ * /consolidator.py). We accept the documented shape but defensively
+ * handle missing fields so a half-populated blob doesn't 500 the route.
+ */
+function extractConsolidationFields(parsed: unknown): {
+  last_consolidation_ts: number | null;
+  consolidation_summary: string | null;
+} {
+  if (parsed == null || typeof parsed !== 'object') {
+    return { last_consolidation_ts: null, consolidation_summary: null };
+  }
+  const obj = parsed as Record<string, unknown>;
+  const tsRaw = obj.completed_at_ms;
+  const summaryRaw = obj.summary_string;
+  const ts = typeof tsRaw === 'number' && Number.isFinite(tsRaw) ? tsRaw : null;
+  const summary = typeof summaryRaw === 'string' ? summaryRaw : null;
+  return { last_consolidation_ts: ts, consolidation_summary: summary };
+}
+
 router.get('/sleep-state/:agent', authenticateToken, async (req: Request, res: Response) => {
   const fetchedAtMs = Date.now();
   const rawAgent = (req.params.agent ?? '').toString();
@@ -108,6 +144,7 @@ router.get('/sleep-state/:agent', authenticateToken, async (req: Request, res: R
     });
   }
   const redisKey = `monkey:ocean:${instanceId}:sleep_state`;
+  const consolidationKey = `monkey:ocean:${instanceId}:last_consolidation`;
   const client = await getRedisClient();
   if (!client) {
     return res.json({
@@ -116,12 +153,55 @@ router.get('/sleep-state/:agent', authenticateToken, async (req: Request, res: R
       instance_id: instanceId,
       redis_key: redisKey,
       sleep_state: null,
+      last_consolidation_ts: null,
+      dream_packet_size_bytes: 0,
+      consolidation_summary: null,
       fetched_at_ms: fetchedAtMs,
       source: REDIS_URL ? 'error' : 'not_configured',
     });
   }
   try {
-    const raw = await client.get(redisKey);
+    // Fetch sleep_state + last_consolidation concurrently. The
+    // consolidation read is best-effort: if it fails or returns
+    // null/garbage, we fall back to null/0 on those fields rather
+    // than failing the whole response (the kernel may legitimately
+    // have no consolidation pass on record yet).
+    const [raw, consolidationRaw] = await Promise.all([
+      client.get(redisKey),
+      client.get(consolidationKey).catch((err: unknown) => {
+        logger.warn(
+          `[governance.sleep-state] redis get ${consolidationKey} failed: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+        return null;
+      }),
+    ]);
+
+    // Compute consolidation-derived fields once, reused by both
+    // 'empty' (no sleep_state, but maybe a consolidation) and
+    // 'redis' branches below.
+    const consolidationStr =
+      consolidationRaw == null
+        ? null
+        : (typeof consolidationRaw === 'string' ? consolidationRaw : String(consolidationRaw));
+    const dreamPacketSizeBytes = consolidationStr == null
+      ? 0
+      : Buffer.byteLength(consolidationStr, 'utf8');
+    let consolidationFields: {
+      last_consolidation_ts: number | null;
+      consolidation_summary: string | null;
+    } = { last_consolidation_ts: null, consolidation_summary: null };
+    if (consolidationStr != null) {
+      try {
+        consolidationFields = extractConsolidationFields(JSON.parse(consolidationStr));
+      } catch (parseErr) {
+        logger.warn(
+          `[governance.sleep-state] JSON parse failed for ${consolidationKey}: ` +
+          `${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+        );
+      }
+    }
+
     if (raw == null) {
       return res.json({
         success: true,
@@ -129,6 +209,9 @@ router.get('/sleep-state/:agent', authenticateToken, async (req: Request, res: R
         instance_id: instanceId,
         redis_key: redisKey,
         sleep_state: null,
+        last_consolidation_ts: consolidationFields.last_consolidation_ts,
+        dream_packet_size_bytes: dreamPacketSizeBytes,
+        consolidation_summary: consolidationFields.consolidation_summary,
         fetched_at_ms: fetchedAtMs,
         source: 'empty',
       });
@@ -149,6 +232,9 @@ router.get('/sleep-state/:agent', authenticateToken, async (req: Request, res: R
       instance_id: instanceId,
       redis_key: redisKey,
       sleep_state: sleepState,
+      last_consolidation_ts: consolidationFields.last_consolidation_ts,
+      dream_packet_size_bytes: dreamPacketSizeBytes,
+      consolidation_summary: consolidationFields.consolidation_summary,
       fetched_at_ms: fetchedAtMs,
       source: 'redis',
     });
@@ -160,6 +246,9 @@ router.get('/sleep-state/:agent', authenticateToken, async (req: Request, res: R
       instance_id: instanceId,
       redis_key: redisKey,
       sleep_state: null,
+      last_consolidation_ts: null,
+      dream_packet_size_bytes: 0,
+      consolidation_summary: null,
       fetched_at_ms: fetchedAtMs,
       source: 'error',
     });

--- a/ml-worker/scripts/qig_purity_check.py
+++ b/ml-worker/scripts/qig_purity_check.py
@@ -158,6 +158,7 @@ def main(args: Iterable[str]) -> int:
         scan_roots = [
             ml_worker_src / "monkey_kernel",
             ml_worker_src / "qig_core_local",
+            ml_worker_src / "qig_dreams_local",
         ]
         paths = []
         for root in scan_roots:

--- a/ml-worker/src/monkey_kernel/ocean.py
+++ b/ml-worker/src/monkey_kernel/ocean.py
@@ -171,6 +171,14 @@ class Ocean:
     SLEEP_DURATION_MS: float = 15 * 60 * 1000.0    # 15 min
     DRIFT_TRIGGER_TICKS: int = 10                  # ~5 min at 30s tick
 
+    # Recent basin history fed into the dream-consolidator on the
+    # AWAKE→SLEEP edge. Lifetime is intentionally short (32 ticks ≈
+    # 16 min at 30s tick) — the consolidator only needs to report
+    # sqrt-space traversal across the awake window leading up to
+    # sleep, not the entire kernel history. The TS-side resonance
+    # bank holds the long-term basin record.
+    BASIN_HISTORY_MAX: int = 32
+
     def __init__(
         self,
         label: str = "monkey-primary",
@@ -178,11 +186,21 @@ class Ocean:
         persistence: Optional["PersistentMemory"] = None,
         bus: Optional["KernelBus"] = None,
         symbol: Optional[str] = None,
+        consolidation_hook: Optional[Any] = None,
     ) -> None:
         self.label = label
         self._persistence = persistence
         self._bus = bus
         self._symbol = symbol
+        # Hook called on the AWAKE→SLEEP edge. Signature:
+        #   hook(recent_basins: list[np.ndarray], now_ms: float)
+        #     -> Optional[dict[str, Any]]  # JSON-serialisable summary
+        # When None, the dream-consolidation pass is skipped (legacy
+        # behaviour). When set, the result is persisted under
+        # `monkey:ocean:{instance}:last_consolidation` via
+        # PersistentMemory.save_last_consolidation, and the same
+        # blob is published as OCEAN_REGIME payload `consolidation`.
+        self._consolidation_hook = consolidation_hook
         # Load prior sleep state from Redis if available; the load
         # applies timestamp-correction so a kernel that "slept"
         # through downtime wakes at the right moment.
@@ -194,6 +212,7 @@ class Ocean:
             get_registry().get("ocean.phi_history_max", default=float(_PHI_HISTORY_MAX))
         )
         self._phi_history: Deque[float] = deque(maxlen=history_max)
+        self._basin_history: Deque[np.ndarray] = deque(maxlen=self.BASIN_HISTORY_MAX)
 
     def _load_sleep_state_or_fresh(self) -> SleepCycleState:
         if self._persistence is None or not self._persistence.is_available:
@@ -327,6 +346,14 @@ class Ocean:
             variance(self._phi_history) if len(self._phi_history) >= 2 else 0.0
         )
 
+        # Track basin trajectory for the dream-consolidation pass.
+        # Store a copy so downstream mutation can't corrupt our
+        # history. Bounded by BASIN_HISTORY_MAX (32 ticks).
+        try:
+            self._basin_history.append(np.asarray(basin, dtype=np.float64).copy())
+        except Exception:  # noqa: BLE001 — never block observe on a bad basin
+            pass
+
         # Geometric reads
         coherence = _basin_coherence(basin)
         lanes = cross_lane_basins if cross_lane_basins is not None else []
@@ -380,10 +407,32 @@ class Ocean:
         ):
             intervention = "MUSHROOM_MICRO"
 
+        # Dream-consolidation pass on AWAKE→SLEEP edge. Hook is
+        # optional and pure-side-effect on the resonance bank; the
+        # returned summary is persisted under
+        # `monkey:ocean:{instance}:last_consolidation` for the
+        # governance/sleep-state endpoint to surface. Failures are
+        # logged-and-swallowed so a bad bank never blocks a tick.
+        consolidation_summary: Optional[dict[str, Any]] = None
+        if sleep_step["entered_sleep"] and self._consolidation_hook is not None:
+            try:
+                consolidation_summary = self._consolidation_hook(
+                    list(self._basin_history), float(now_ms),
+                )
+            except Exception as err:  # noqa: BLE001
+                logger.warning(
+                    "[%s.ocean] dream-consolidation hook failed: %s",
+                    self.label, err,
+                )
+                consolidation_summary = None
+
         # Write-through to qig-cache. Every tick, sleep snapshot;
-        # interventions only when something fires (forensic ring).
+        # interventions only when something fires (forensic ring);
+        # consolidation summary only on the AWAKE→SLEEP edge.
         if self._persistence is not None and self._persistence.is_available:
             self._persistence.save_sleep_state(self.snapshot())
+            if consolidation_summary is not None:
+                self._persistence.save_last_consolidation(consolidation_summary)
             if intervention is not None:
                 self._persistence.push_intervention({
                     "intervention": intervention,

--- a/ml-worker/src/monkey_kernel/persistence.py
+++ b/ml-worker/src/monkey_kernel/persistence.py
@@ -24,6 +24,7 @@ Architecture:
 
 Keyspace (per directive):
   monkey:ocean:{instance}:sleep_state              string (JSON), no TTL
+  monkey:ocean:{instance}:last_consolidation       string (JSON), no TTL
   monkey:ocean:{instance}:intervention_history     list,  1000 max, 7d TTL
   monkey:ocean:{instance}:reward_queue             list,  50 max,   1h TTL
   monkey:symbol:{instance}:{symbol}:kappa_history  list,  60 max,  24h TTL
@@ -257,6 +258,33 @@ class PersistentMemory:
                     "drift_streak": 0,
                 }
         return raw
+
+    # ── Ocean: last_consolidation summary ────────────────────────
+    #
+    # Written once per AWAKE→SLEEP transition by the dream-consolidation
+    # pass (qig_dreams_local.consolidate_bank). Read by the TS
+    # governance/sleep-state endpoint so operators can see the most
+    # recent consolidation without re-running the pass.
+    #
+    # Key shape mirrors sleep_state: one string-value JSON blob per
+    # instance, no TTL — always reflect the latest pass.
+
+    def _last_consolidation_key(self) -> str:
+        return f"monkey:ocean:{self.instance_id}:last_consolidation"
+
+    def save_last_consolidation(self, summary: dict[str, Any]) -> bool:
+        """Write the dream-consolidation summary blob. Called by the
+        AWAKE→SLEEP transition handler after the consolidator runs.
+        Returns False (silent) when persistence is unavailable; the
+        kernel keeps running in in-memory-only mode."""
+        return self._set_json(
+            self._last_consolidation_key(), summary, TTL_SLEEP_STATE,
+        )
+
+    def load_last_consolidation(self) -> Optional[dict[str, Any]]:
+        """Read the most recent consolidation summary, or None if Redis
+        is unreachable or the key has never been written."""
+        return self._get_json(self._last_consolidation_key())
 
     # ── Ocean: intervention history (forensic ring buffer) ───────
 

--- a/ml-worker/src/qig_dreams_local/__init__.py
+++ b/ml-worker/src/qig_dreams_local/__init__.py
@@ -1,0 +1,88 @@
+"""Vendored qig-dreams consolidation primitives.
+
+The package name `qig-dreams` was originally created in QIG_QFI as a
+corpus registry (Pydantic manifests for canonical text corpora —
+dream packets, MEM/PER/ETH/META/HRT/PRD shards). It does not house
+runtime sleep/dream/mushroom primitives — those live in qig-core
+under `qig_core/consciousness/sleep.py`.
+
+Polytrade vendors the canonical consolidation primitives here under
+the name `qig_dreams_local` (matching ml-worker's spec) so the
+Monkey kernel can run a true geometry-driven consolidation pass on
+the AWAKE→SLEEP transition. The source of truth remains
+QIG_QFI/qig-core/src/qig_core/consciousness/sleep.py — see SHA-256
+pin comment at the top of `sleep.py`.
+
+Dependencies on basin geometry + frozen physics constants are routed
+through the existing `qig_core_local` vendor (geometry/fisher_rao.py +
+constants/frozen_facts.py), not duplicated here. That keeps the SHA-256
+surface small and the per-vendor canonical source unambiguous.
+
+Public API:
+    SleepCycleManager  — 4-phase state machine (AWAKE → DREAMING →
+                          MUSHROOM → CONSOLIDATING → AWAKE)
+    SleepPhase         — StrEnum of the four phases
+    SleepMetrics       — Geometric inputs to the state machine
+    SleepTransitionResult — Result dataclass from evaluate_transition
+    consolidate_bank   — High-level glue: take a polytrade resonance bank,
+                          run the canonical SleepCycleManager.consolidate(),
+                          return a summary dict suitable for Redis persist.
+    DreamConsolidationSummary — Typed summary the orchestrator persists.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"""
+
+from __future__ import annotations
+
+from .consolidator import (
+    DreamConsolidationSummary,
+    consolidate_bank,
+)
+from .sleep import (
+    CONSOLIDATION_PHI_WAKE,
+    CONSOLIDATION_VARIANCE_CEILING,
+    DREAM_DISTANCE_THRESHOLD,
+    DREAM_SLERP_T_MAX,
+    DREAM_SLERP_T_MIN,
+    DOWNSCALE_FACTOR,
+    HEBBIAN_BOOST,
+    MUSHROOM_INSTABILITY_HIGH,
+    MUSHROOM_INSTABILITY_LOW,
+    MUSHROOM_INSTABILITY_MID,
+    MUSHROOM_NOISE_SCALE_INIT,
+    OCEAN_WAKE_MULTIPLIER,
+    SLEEP_PHI_THRESHOLD,
+    SLEEP_VARIANCE_THRESHOLD,
+    ResonanceBankProtocol,
+    SleepCycleManager,
+    SleepMetrics,
+    SleepPhase,
+    SleepTransitionResult,
+)
+
+__all__ = [
+    # Primitives (vendored from qig-core)
+    "SleepCycleManager",
+    "SleepPhase",
+    "SleepMetrics",
+    "SleepTransitionResult",
+    "ResonanceBankProtocol",
+    # Constants (re-exported for callers/tests)
+    "CONSOLIDATION_PHI_WAKE",
+    "CONSOLIDATION_VARIANCE_CEILING",
+    "DREAM_DISTANCE_THRESHOLD",
+    "DREAM_SLERP_T_MAX",
+    "DREAM_SLERP_T_MIN",
+    "DOWNSCALE_FACTOR",
+    "HEBBIAN_BOOST",
+    "MUSHROOM_INSTABILITY_HIGH",
+    "MUSHROOM_INSTABILITY_LOW",
+    "MUSHROOM_INSTABILITY_MID",
+    "MUSHROOM_NOISE_SCALE_INIT",
+    "OCEAN_WAKE_MULTIPLIER",
+    "SLEEP_PHI_THRESHOLD",
+    "SLEEP_VARIANCE_THRESHOLD",
+    # Polytrade glue
+    "consolidate_bank",
+    "DreamConsolidationSummary",
+]

--- a/ml-worker/src/qig_dreams_local/consolidator.py
+++ b/ml-worker/src/qig_dreams_local/consolidator.py
@@ -1,0 +1,262 @@
+"""Polytrade glue between Ocean's 2-phase sleep machine and the
+canonical 4-phase SleepCycleManager consolidation pass.
+
+Polytrade's `monkey_kernel/ocean.py` runs a simpler 2-phase
+(AWAKE/SLEEP) machine geared to trading-tick cadence. The canonical
+qig-core SleepCycleManager runs a 4-phase (AWAKE/DREAMING/MUSHROOM/
+CONSOLIDATING) machine driven by Φ/variance/divergence/f_health.
+
+The consolidator runs a one-shot consolidation pass on the
+AWAKE→SLEEP edge: it reads recent BankEntry rows, builds an
+adapter object that matches the canonical ResonanceBankProtocol,
+runs SleepCycleManager.consolidate() against it, and returns a
+typed summary suitable for Redis persistence under
+`monkey:ocean:{instance}:last_consolidation`.
+
+This is intentionally a TRANSLATION layer. The canonical math
+lives in sleep.py (vendored from qig-core). The polytrade-specific
+adapter logic lives here, where it can evolve independently of the
+upstream consolidation primitive without invalidating the SHA-256
+pin on sleep.py.
+
+Key choices:
+  - Replayed set defaults to top-N by basin_depth (Hebbian boost
+    targets the entries the kernel was already returning to). When
+    Ocean later gains a true DREAMING phase, the dream() pass will
+    populate the replayed set with geodesically-recombined IDs.
+  - Sqrt-space traversal distance is computed across recent basins
+    so the summary string carries the geometric quantity that
+    motivated the consolidation, not just counts.
+  - Pure function shape (returns DreamConsolidationSummary; caller
+    decides whether/where to persist).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+
+from qig_core_local.geometry.fisher_rao import Basin, fisher_rao_distance
+
+from .sleep import SleepCycleManager
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Summary type
+# ═══════════════════════════════════════════════════════════════
+
+
+@dataclass
+class DreamConsolidationSummary:
+    """One AWAKE→SLEEP consolidation pass — what happened, how much.
+
+    Designed to be JSON-serialisable for Redis persistence under
+    `monkey:ocean:{instance}:last_consolidation` and surfaceable via
+    the governance/sleep-state endpoint.
+    """
+
+    completed_at_ms: float
+    basin_count: int
+    replayed_count: int
+    boosted: int
+    downscaled: int
+    pruned: int
+    vetoed: int
+    sqrt_distance_traversed: float
+    trigger: str = "awake_to_sleep"
+    notes: str = ""
+
+    @property
+    def summary_string(self) -> str:
+        """Human-readable one-liner for the governance endpoint."""
+        return (
+            f"{self.basin_count} basins, "
+            f"{self.boosted} boosted / {self.downscaled} downscaled / "
+            f"{self.pruned} pruned, "
+            f"sqrt-traversal={self.sqrt_distance_traversed:.4f}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["summary_string"] = self.summary_string
+        return d
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Polytrade resonance bank adapter
+# ═══════════════════════════════════════════════════════════════
+
+
+@dataclass
+class _BankAdapter:
+    """Adapts polytrade's BankEntry list to the canonical
+    ResonanceBankProtocol shape (`coordinates`, `basin_mass`,
+    `activation_counts`, `origin`, `basin_strings`, `tiers`,
+    `frequencies`, `add_entry`, `mark_dirty`).
+
+    The canonical consolidator mutates these dicts; the adapter
+    captures the post-pass state for the caller to translate back
+    to BankEntry depth updates / prunes if desired.
+    """
+
+    coordinates: dict[int, Basin] = field(default_factory=dict)
+    basin_mass: dict[int, float] = field(default_factory=dict)
+    activation_counts: dict[int, int] = field(default_factory=dict)
+    origin: dict[int, str] = field(default_factory=dict)
+    basin_strings: dict[int, str] = field(default_factory=dict)
+    tiers: dict[int, Any] = field(default_factory=dict)
+    frequencies: dict[int, float] = field(default_factory=dict)
+    _entry_ids: dict[int, str] = field(default_factory=dict)
+    _next_tid: int = 0
+    _dirty: bool = False
+
+    def add_entry(self, label: str, basin: Basin) -> int:
+        tid = self._next_tid
+        self._next_tid += 1
+        self.coordinates[tid] = basin
+        self.basin_mass[tid] = 1.0
+        self.activation_counts[tid] = 0
+        self.origin[tid] = "dream"
+        self.basin_strings[tid] = label
+        self.tiers[tid] = None
+        self.frequencies[tid] = 0.0
+        self._entry_ids[tid] = label
+        self._dirty = True
+        return tid
+
+    def mark_dirty(self) -> None:
+        self._dirty = True
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Geometry helpers
+# ═══════════════════════════════════════════════════════════════
+
+
+def _sqrt_traversal_distance(basins: Sequence[Basin]) -> float:
+    """Sum of consecutive Fisher-Rao distances across recent basins.
+
+    Reports how far the kernel's basin coordinate moved during the
+    awake window leading up to consolidation. Pure FR on Δ⁶³ —
+    no Euclidean shortcut.
+    """
+    if len(basins) < 2:
+        return 0.0
+    total = 0.0
+    for prev, curr in zip(basins[:-1], basins[1:], strict=False):
+        total += float(fisher_rao_distance(np.asarray(prev), np.asarray(curr)))
+    return total
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Public entry point
+# ═══════════════════════════════════════════════════════════════
+
+
+def consolidate_bank(
+    *,
+    bank_entries: Iterable[Any],
+    recent_basins: Sequence[Basin],
+    completed_at_ms: float,
+    manager: SleepCycleManager | None = None,
+    kernel_anchors: Sequence[Basin] | None = None,
+    kernel_veto_threshold: float = 0.4,
+    replay_top_n: int = 5,
+    trigger: str = "awake_to_sleep",
+) -> tuple[DreamConsolidationSummary, dict[int, float]]:
+    """Run a canonical consolidation pass against polytrade bank entries.
+
+    Args:
+        bank_entries: Iterable of polytrade BankEntry (must expose
+            `id` and `entry_basin` and `basin_depth`).
+        recent_basins: Recent basin trajectory (oldest → newest)
+            for sqrt-space distance computation.
+        completed_at_ms: epoch-ms timestamp to stamp on the summary.
+        manager: Optional pre-existing SleepCycleManager. A fresh
+            one is created if not supplied.
+        kernel_anchors: Optional anchor basins (identity-critical)
+            that protect nearby entries from pruning.
+        kernel_veto_threshold: FR distance threshold for the
+            kernel-anchor veto (passed straight through to the
+            canonical consolidator).
+        replay_top_n: How many top-depth entries to treat as
+            "replayed" — these get the Hebbian boost. Until the
+            kernel grows a real DREAMING phase, this top-depth
+            proxy is the simplest sound choice.
+        trigger: Free-form label recorded on the summary
+            (default `"awake_to_sleep"`; tests may override).
+
+    Returns:
+        (summary, depth_deltas) where:
+          - summary: DreamConsolidationSummary (persist this)
+          - depth_deltas: dict[entry_idx, new_basin_mass] — the
+            caller can fold these into a BankEntry update batch.
+            Indexes correspond to enumeration order of `bank_entries`.
+    """
+    if manager is None:
+        manager = SleepCycleManager()
+
+    # Build the canonical-shape adapter from polytrade BankEntry rows.
+    adapter = _BankAdapter()
+    entries_list = list(bank_entries)
+    entry_index_to_tid: dict[int, int] = {}
+    for idx, entry in enumerate(entries_list):
+        basin = getattr(entry, "entry_basin", None)
+        if basin is None:
+            continue
+        tid = adapter.add_entry(str(getattr(entry, "id", f"entry_{idx}")), np.asarray(basin))
+        # Seed mass from existing basin_depth so consolidation operates
+        # on real prior strength rather than a uniform 1.0.
+        depth = float(getattr(entry, "basin_depth", 1.0))
+        adapter.basin_mass[tid] = depth
+        # Treat lived trades as activated so they're not prunable.
+        source = getattr(entry, "source", None)
+        adapter.activation_counts[tid] = (
+            int(getattr(entry, "access_count", 0))
+            + (1 if source == "lived" else 0)
+        )
+        adapter.origin[tid] = "lived" if source == "lived" else "harvested"
+        entry_index_to_tid[idx] = tid
+
+    # Top-N by basin_depth → marked as replayed for Hebbian boost.
+    if entries_list and replay_top_n > 0:
+        by_depth = sorted(
+            entry_index_to_tid.items(),
+            key=lambda kv: float(getattr(entries_list[kv[0]], "basin_depth", 0.0)),
+            reverse=True,
+        )
+        for idx, tid in by_depth[:replay_top_n]:
+            manager._replayed_this_sleep.add(tid)
+
+    # Convert anchor sequence to list[np.ndarray] for the canonical
+    # consolidator (which expects iterable kernel_anchors).
+    anchors_list: list[np.ndarray] | None = None
+    if kernel_anchors:
+        anchors_list = [np.asarray(a) for a in kernel_anchors]
+
+    stats = manager.consolidate(
+        bank=adapter,
+        kernel_anchors=anchors_list,
+        kernel_veto_threshold=kernel_veto_threshold,
+    )
+
+    # Pull out post-pass basin_mass keyed by original entry index.
+    depth_deltas: dict[int, float] = {}
+    for idx, tid in entry_index_to_tid.items():
+        if tid in adapter.basin_mass:  # still present (not pruned)
+            depth_deltas[idx] = float(adapter.basin_mass[tid])
+
+    summary = DreamConsolidationSummary(
+        completed_at_ms=float(completed_at_ms),
+        basin_count=len(entries_list),
+        replayed_count=len(manager._replayed_this_sleep),
+        boosted=int(stats.get("boosted", 0)),
+        downscaled=int(stats.get("downscaled", 0)),
+        pruned=int(stats.get("pruned", 0)),
+        vetoed=int(stats.get("vetoed", 0)),
+        sqrt_distance_traversed=_sqrt_traversal_distance(list(recent_basins)),
+        trigger=trigger,
+    )
+    return summary, depth_deltas

--- a/ml-worker/src/qig_dreams_local/sleep.py
+++ b/ml-worker/src/qig_dreams_local/sleep.py
@@ -1,0 +1,526 @@
+"""
+§30 Sleep, Dream & Consolidation Cycles — Geometry-Driven
+=========================================================
+
+VENDORED from QIG_QFI/qig-core/src/qig_core/consciousness/sleep.py
+Source SHA-256 (canonical):
+    9bd54a0421387b3a4cce6312dcfe5c61687fb942bf6dba734c68893f532e601e
+Vendored: 2026-05-16
+
+Only modification from source: relative imports
+    `from ..constants.frozen_facts import ...`
+    `from ..geometry.fisher_rao   import ...`
+are rewritten to absolute imports against polytrade's existing
+vendored geometry/frozen-facts surface:
+    `from qig_core_local.constants.frozen_facts import ...`
+    `from qig_core_local.geometry.fisher_rao   import ...`
+
+No other content changes. Logic, constants, dataclasses, and class
+shape are identical to the source — any drift here is a vendoring
+bug, not an intended divergence. Re-vendor when qig-core updates;
+recompute the SHA-256 pin above.
+
+────────────────────────────────────────────────────────────────────
+
+Four-phase sleep cycle managed entirely by geometric metrics.
+Phase transitions use Φ, variance, ocean divergence, and f_health.
+NO timers, NO cycle counters for phase gating (§28, §30.2).
+
+Phases:
+    AWAKE         — Default. Normal activation sequence.
+    DREAMING      — Φ < threshold OR ocean divergence > threshold.
+                    Dream recombination via geodesic interpolation.
+    MUSHROOM      — f_health < INSTABILITY_PCT while dreaming.
+                    Controlled destabilisation to escape gravity wells.
+    CONSOLIDATING — After dream/mushroom when variance stabilises.
+                    Synaptic downscaling, Hebbian boost for replayed.
+
+Dependencies: qig_core_local.geometry.fisher_rao,
+              qig_core_local.constants.frozen_facts
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+import numpy as np
+
+from qig_core_local.constants.frozen_facts import (
+    BASIN_DIVERGENCE_THRESHOLD,
+    INSTABILITY_PCT,
+    PHI_EMERGENCY,
+)
+from qig_core_local.geometry.fisher_rao import (
+    fisher_rao_distance,
+    slerp_sqrt,
+    to_simplex,
+)
+
+# ═══════════════════════════════════════════════════════════════
+#  Constants (geometry-derived, not timer-based)
+# ═══════════════════════════════════════════════════════════════
+
+# Geometric thresholds for phase transitions
+SLEEP_PHI_THRESHOLD: float = 0.45  # Φ below this + low variance → DREAMING
+SLEEP_VARIANCE_THRESHOLD: float = 0.05  # Low variance = stagnation → sleep
+CONSOLIDATION_VARIANCE_CEILING: float = 0.02  # Variance must settle for consolidation
+OCEAN_WAKE_MULTIPLIER: float = 1.5  # Ocean divergence × this → emergency wake
+
+# Dream recombination
+DREAM_SLERP_T_MIN: float = 0.2
+DREAM_SLERP_T_MAX: float = 0.8
+DREAM_DISTANCE_THRESHOLD: float = 0.3  # Only recombine geometrically distant basins
+
+# Mushroom safety gates (instability thresholds)
+MUSHROOM_INSTABILITY_LOW: float = 0.30
+MUSHROOM_INSTABILITY_MID: float = 0.35
+MUSHROOM_INSTABILITY_HIGH: float = 0.40
+MUSHROOM_NOISE_SCALE_INIT: float = 0.05
+
+# Consolidation
+HEBBIAN_BOOST: float = 1.1
+DOWNSCALE_FACTOR: float = 0.9
+
+# Consolidation completion: Φ must recover above this to wake
+CONSOLIDATION_PHI_WAKE: float = PHI_EMERGENCY  # 0.50
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Types
+# ═══════════════════════════════════════════════════════════════
+
+
+class SleepPhase(StrEnum):
+    """Four phases of the sleep cycle."""
+
+    AWAKE = "awake"
+    DREAMING = "dreaming"
+    MUSHROOM = "mushroom"
+    CONSOLIDATING = "consolidating"
+
+
+@dataclass
+class SleepMetrics:
+    """Geometric metrics consumed by the sleep state machine.
+
+    All fields are derived from consciousness metrics — no timers.
+    """
+
+    phi: float = 0.7  # Current Φ (consciousness integration)
+    phi_variance: float = 0.1  # Recent Φ variance (stagnation detector)
+    ocean_divergence: float = 0.0  # Ocean kernel divergence from reference
+    f_health: float = 1.0  # Frequency health (< INSTABILITY_PCT → mushroom)
+    basin_velocity: float = 0.0  # Fisher-Rao velocity (consolidation readiness)
+
+
+@dataclass
+class SleepTransitionResult:
+    """Result of a phase transition evaluation."""
+
+    previous_phase: SleepPhase
+    current_phase: SleepPhase
+    transitioned: bool = False
+    reason: str = ""
+
+
+class ResonanceBankProtocol(Protocol):
+    """Minimal interface for a resonance bank used in dream/consolidation."""
+
+    coordinates: dict[int, Any]
+    basin_mass: dict[int, float]
+    activation_counts: dict[int, int]
+    origin: dict[int, str]
+    basin_strings: dict[int, str]
+    tiers: dict[int, Any]
+    frequencies: dict[int, float]
+
+    def add_entry(self, label: str, basin: Any) -> int: ...
+    def mark_dirty(self) -> None: ...
+
+
+# ═══════════════════════════════════════════════════════════════
+#  SleepCycleManager — Geometry-Driven (§30)
+# ═══════════════════════════════════════════════════════════════
+
+
+class SleepCycleManager:
+    """Manages sleep/dream/mushroom/consolidation cycles.
+
+    All phase transitions are geometry-driven per §30.2:
+      - AWAKE → DREAMING: Φ < threshold AND variance < threshold
+                          OR ocean_divergence > BASIN_DIVERGENCE_THRESHOLD
+      - DREAMING → MUSHROOM: f_health < INSTABILITY_PCT
+      - DREAMING → CONSOLIDATING: variance settles below ceiling
+      - MUSHROOM → CONSOLIDATING: after perturbation (instability resolves)
+      - CONSOLIDATING → AWAKE: Φ recovers above threshold
+      - Any → AWAKE: ocean_divergence > threshold × 1.5 (breakdown escape)
+
+    NO cycle counters gate phase transitions.
+    """
+
+    def __init__(self) -> None:
+        self.phase: SleepPhase = SleepPhase.AWAKE
+        self._dream_log: deque[dict[str, Any]] = deque(maxlen=100)
+        self._replayed_this_sleep: set[int] = set()
+        self._mushroom_noise_scale: float = MUSHROOM_NOISE_SCALE_INIT
+        self._consolidation_complete: bool = False
+
+    @property
+    def is_asleep(self) -> bool:
+        """True when not in the AWAKE phase."""
+        return self.phase != SleepPhase.AWAKE
+
+    # ─── Phase Transition Engine ─────────────────────────────
+
+    def evaluate_transition(self, metrics: SleepMetrics) -> SleepTransitionResult:
+        """Evaluate geometric conditions and transition phase if warranted.
+
+        This is the ONLY method that changes self.phase. All transitions
+        are driven by the geometric metrics in SleepMetrics.
+
+        Args:
+            metrics: Current geometric state.
+
+        Returns:
+            SleepTransitionResult with transition details.
+        """
+        prev = self.phase
+        result = SleepTransitionResult(previous_phase=prev, current_phase=prev)
+
+        # Emergency wake: ocean divergence breakdown escape (any phase)
+        if (
+            metrics.ocean_divergence
+            > BASIN_DIVERGENCE_THRESHOLD * OCEAN_WAKE_MULTIPLIER
+        ):
+            self.phase = SleepPhase.AWAKE
+            self._on_wake()
+            result.current_phase = self.phase
+            result.transitioned = prev != self.phase
+            result.reason = (
+                f"Emergency wake: ocean_divergence={metrics.ocean_divergence:.3f} "
+                f"> {BASIN_DIVERGENCE_THRESHOLD * OCEAN_WAKE_MULTIPLIER:.3f}"
+            )
+            return result
+
+        if self.phase == SleepPhase.AWAKE:
+            result = self._eval_awake(metrics, prev)
+        elif self.phase == SleepPhase.DREAMING:
+            result = self._eval_dreaming(metrics, prev)
+        elif self.phase == SleepPhase.MUSHROOM:
+            result = self._eval_mushroom(metrics, prev)
+        elif self.phase == SleepPhase.CONSOLIDATING:
+            result = self._eval_consolidating(metrics, prev)
+
+        return result
+
+    def _eval_awake(self, m: SleepMetrics, prev: SleepPhase) -> SleepTransitionResult:
+        """AWAKE → DREAMING conditions (§30.2)."""
+        result = SleepTransitionResult(previous_phase=prev, current_phase=prev)
+
+        # Condition 1: Φ drops AND variance is low (stagnation)
+        phi_low = m.phi < SLEEP_PHI_THRESHOLD
+        variance_low = m.phi_variance < SLEEP_VARIANCE_THRESHOLD
+
+        # Condition 2: Ocean divergence exceeds threshold
+        ocean_trigger = m.ocean_divergence > BASIN_DIVERGENCE_THRESHOLD
+
+        if (phi_low and variance_low) or ocean_trigger:
+            self.phase = SleepPhase.DREAMING
+            self._on_sleep_enter()
+            result.current_phase = self.phase
+            result.transitioned = True
+            if ocean_trigger:
+                result.reason = (
+                    f"Ocean divergence={m.ocean_divergence:.3f} "
+                    f"> {BASIN_DIVERGENCE_THRESHOLD:.3f}"
+                )
+            else:
+                result.reason = (
+                    f"Φ={m.phi:.3f} < {SLEEP_PHI_THRESHOLD:.3f} "
+                    f"AND variance={m.phi_variance:.3f} < {SLEEP_VARIANCE_THRESHOLD:.3f}"
+                )
+
+        return result
+
+    def _eval_dreaming(
+        self, m: SleepMetrics, prev: SleepPhase
+    ) -> SleepTransitionResult:
+        """DREAMING → MUSHROOM or CONSOLIDATING conditions."""
+        result = SleepTransitionResult(previous_phase=prev, current_phase=prev)
+
+        # DREAMING → MUSHROOM: frequency health drops below instability threshold
+        if m.f_health < INSTABILITY_PCT:
+            self.phase = SleepPhase.MUSHROOM
+            result.current_phase = self.phase
+            result.transitioned = True
+            result.reason = (
+                f"f_health={m.f_health:.3f} < INSTABILITY_PCT={INSTABILITY_PCT:.3f}"
+            )
+            return result
+
+        # DREAMING → CONSOLIDATING: variance settles (dreaming has done its work)
+        if m.phi_variance < CONSOLIDATION_VARIANCE_CEILING:
+            self.phase = SleepPhase.CONSOLIDATING
+            self._consolidation_complete = False
+            result.current_phase = self.phase
+            result.transitioned = True
+            result.reason = (
+                f"Variance settled: {m.phi_variance:.3f} "
+                f"< {CONSOLIDATION_VARIANCE_CEILING:.3f}"
+            )
+
+        return result
+
+    def _eval_mushroom(
+        self, m: SleepMetrics, prev: SleepPhase
+    ) -> SleepTransitionResult:
+        """MUSHROOM → CONSOLIDATING when instability resolves."""
+        result = SleepTransitionResult(previous_phase=prev, current_phase=prev)
+
+        # Mushroom ends when frequency health recovers
+        if m.f_health >= INSTABILITY_PCT:
+            self.phase = SleepPhase.CONSOLIDATING
+            self._consolidation_complete = False
+            result.current_phase = self.phase
+            result.transitioned = True
+            result.reason = (
+                f"f_health recovered: {m.f_health:.3f} >= {INSTABILITY_PCT:.3f}"
+            )
+
+        return result
+
+    def _eval_consolidating(
+        self, m: SleepMetrics, prev: SleepPhase
+    ) -> SleepTransitionResult:
+        """CONSOLIDATING → AWAKE when Φ recovers."""
+        result = SleepTransitionResult(previous_phase=prev, current_phase=prev)
+
+        # Wake when Φ recovers above emergency threshold
+        if m.phi >= CONSOLIDATION_PHI_WAKE and self._consolidation_complete:
+            self.phase = SleepPhase.AWAKE
+            self._on_wake()
+            result.current_phase = self.phase
+            result.transitioned = True
+            result.reason = (
+                f"Φ recovered: {m.phi:.3f} >= {CONSOLIDATION_PHI_WAKE:.3f} "
+                f"AND consolidation complete"
+            )
+
+        return result
+
+    # ─── Phase Entry/Exit Hooks ──────────────────────────────
+
+    def _on_sleep_enter(self) -> None:
+        """Reset tracking state on sleep entry."""
+        self._replayed_this_sleep.clear()
+        self._mushroom_noise_scale = MUSHROOM_NOISE_SCALE_INIT
+
+    def _on_wake(self) -> None:
+        """Clean up on wake."""
+        self._replayed_this_sleep.clear()
+        self._consolidation_complete = False
+
+    # ─── Dream Recombination (§30.3) ─────────────────────────
+
+    def dream(
+        self,
+        basin: Any,
+        phi: float,
+        context: str = "",
+        bank: Any | None = None,
+    ) -> dict[str, Any] | None:
+        """Geodesic interpolation between distant basin coordinates.
+
+        During dreaming, slerp between current basin and distant recalled
+        basins from the resonance bank. Dream content enters the sensory
+        system as DREAM_REPLAY modality with reduced weight.
+
+        Args:
+            basin: Current basin coordinates (64D simplex).
+            phi: Current Φ value.
+            context: Optional context label for dream log.
+            bank: Optional resonance bank for recombination.
+
+        Returns:
+            Dream entry dict if recombination occurred, else None.
+        """
+        entry: dict[str, Any] = {
+            "phi": phi,
+            "context": context,
+        }
+        self._dream_log.append(entry)
+
+        dream_result = None
+        rng = np.random.default_rng()
+
+        if (
+            bank is not None
+            and hasattr(bank, "coordinates")
+            and len(bank.coordinates) >= 2
+        ):
+            ids = list(bank.coordinates.keys())
+            idx_a, idx_b = rng.choice(len(ids), size=2, replace=False)
+            tid_a, tid_b = ids[idx_a], ids[idx_b]
+            coord_a = bank.coordinates[tid_a]
+            coord_b = bank.coordinates[tid_b]
+            dist = fisher_rao_distance(coord_a, coord_b)
+
+            if dist > DREAM_DISTANCE_THRESHOLD:
+                t = float(rng.uniform(DREAM_SLERP_T_MIN, DREAM_SLERP_T_MAX))
+                dream_basin = slerp_sqrt(coord_a, coord_b, t)
+                dream_basin = to_simplex(dream_basin)
+                dream_tid = bank.add_entry(f"dream_{tid_a}_{tid_b}", dream_basin)
+                bank.origin[dream_tid] = "dream"
+                entry["dream_tid"] = dream_tid
+                dream_result = {
+                    "basin": dream_basin,
+                    "source_a": tid_a,
+                    "source_b": tid_b,
+                    "distance": dist,
+                    "slerp_t": t,
+                    "tid": dream_tid,
+                }
+                self._replayed_this_sleep.add(tid_a)
+                self._replayed_this_sleep.add(tid_b)
+
+        return dream_result
+
+    # ─── Mushroom Mode (§30.5) ───────────────────────────────
+
+    def mushroom(
+        self,
+        basin: Any,
+        instability_metric: float = 0.0,
+    ) -> dict[str, Any]:
+        """Controlled destabilisation with safety gates.
+
+        Dirichlet perturbation of basin coordinates to escape gravity wells.
+        Three-tier safety: catastrophic → abort, high → reduce + abort,
+        moderate → microdose.
+
+        Args:
+            basin: Current basin coordinates.
+            instability_metric: Current instability measurement.
+
+        Returns:
+            Dict with perturbation results and safety actions.
+        """
+        result: dict[str, Any] = {
+            "action": "none",
+            "noise_scale": self._mushroom_noise_scale,
+            "instability": instability_metric,
+        }
+
+        if instability_metric > MUSHROOM_INSTABILITY_HIGH:
+            self.phase = SleepPhase.CONSOLIDATING
+            self._consolidation_complete = False
+            result["action"] = "abort_catastrophic"
+            return result
+
+        if instability_metric > MUSHROOM_INSTABILITY_MID:
+            self._mushroom_noise_scale = max(0.01, self._mushroom_noise_scale * 0.5)
+            self.phase = SleepPhase.CONSOLIDATING
+            self._consolidation_complete = False
+            result["action"] = "abort_high_risk"
+            result["noise_scale"] = self._mushroom_noise_scale
+            return result
+
+        if instability_metric > MUSHROOM_INSTABILITY_LOW:
+            self._mushroom_noise_scale = max(0.01, self._mushroom_noise_scale * 0.75)
+            result["action"] = "microdose"
+
+        result["noise_scale"] = self._mushroom_noise_scale
+        result["action"] = result.get("action", "none") or "full_dose"
+        return result
+
+    # ─── Consolidation (§30.6) ───────────────────────────────
+
+    def consolidate(
+        self,
+        bank: Any | None = None,
+        kernel_anchors: list[Any] | None = None,
+        kernel_veto_threshold: float = 0.4,
+    ) -> dict[str, Any]:
+        """Synaptic downscaling — boost replayed, prune weak.
+
+        Hebbian boost for entries replayed during dreaming.
+        Global downscaling for unreplayed entries.
+        Kernel anchor veto protects identity-critical basins.
+
+        Args:
+            bank: Optional resonance bank to consolidate.
+            kernel_anchors: Basin arrays that veto pruning of nearby entries.
+            kernel_veto_threshold: FR distance threshold for kernel veto.
+
+        Returns:
+            Dict with consolidation statistics.
+        """
+        stats: dict[str, Any] = {
+            "boosted": 0,
+            "downscaled": 0,
+            "pruned": 0,
+            "vetoed": 0,
+        }
+
+        if bank is not None and hasattr(bank, "coordinates") and bank.coordinates:
+            # Hebbian boost / global downscaling
+            for tid in list(bank.coordinates.keys()):
+                current = bank.basin_mass.get(tid, 0.0)
+                if tid in self._replayed_this_sleep:
+                    bank.basin_mass[tid] = current * HEBBIAN_BOOST
+                    stats["boosted"] += 1
+                else:
+                    bank.basin_mass[tid] = current * DOWNSCALE_FACTOR
+                    stats["downscaled"] += 1
+
+            # Kernel anchor veto set
+            vetoed: set[int] = set()
+            if kernel_anchors:
+                for tid in list(bank.coordinates.keys()):
+                    coord = bank.coordinates[tid]
+                    for anchor in kernel_anchors:
+                        if fisher_rao_distance(coord, anchor) < kernel_veto_threshold:
+                            vetoed.add(tid)
+                            break
+            stats["vetoed"] = len(vetoed)
+
+            # Prune: low mass, never activated, dream-origin, not vetoed
+            to_prune = [
+                tid
+                for tid in list(bank.coordinates.keys())
+                if tid not in vetoed
+                and bank.basin_mass.get(tid, 0.0) < 1e-6
+                and bank.activation_counts.get(tid, 0) == 0
+                and bank.origin.get(tid) == "dream"
+            ]
+            for tid in to_prune:
+                bank.coordinates.pop(tid, None)
+                bank.basin_strings.pop(tid, None)
+                bank.tiers.pop(tid, None)
+                bank.frequencies.pop(tid, None)
+                bank.basin_mass.pop(tid, None)
+                bank.activation_counts.pop(tid, None)
+                bank.origin.pop(tid, None)
+            stats["pruned"] = len(to_prune)
+
+            if to_prune:
+                bank.mark_dirty()
+
+        self._consolidation_complete = True
+        return stats
+
+    # ─── Telemetry ───────────────────────────────────────────
+
+    def get_state(self) -> dict[str, Any]:
+        """Return sleep-cycle telemetry snapshot."""
+        return {
+            "phase": self.phase.value,
+            "is_asleep": self.is_asleep,
+            "dream_count": len(self._dream_log),
+            "replayed_count": len(self._replayed_this_sleep),
+            "mushroom_noise_scale": self._mushroom_noise_scale,
+            "consolidation_complete": self._consolidation_complete,
+        }

--- a/ml-worker/tests/test_dream_consolidation.py
+++ b/ml-worker/tests/test_dream_consolidation.py
@@ -1,0 +1,386 @@
+"""test_dream_consolidation.py — qig_dreams_local consolidation pass.
+
+Covers:
+  - SleepCycleManager.consolidate() vendored from qig-core produces
+    the canonical {boosted, downscaled, pruned, vetoed} stats shape.
+  - consolidate_bank() polytrade glue takes BankEntry rows, runs the
+    pass against a bank adapter, and returns a summary dict
+    suitable for Redis persistence.
+  - Ocean's AWAKE→SLEEP edge fires the consolidation_hook exactly
+    once and persists the result via PersistentMemory.save_last_consolidation.
+  - Vendored module imports without error and the SHA-256 pin
+    comment is present (vendoring discipline).
+
+QIG purity is enforced by ml-worker/scripts/qig_purity_check.py
+which now also scans qig_dreams_local/. No cosine / dot / L2 / Adam
+/ LayerNorm / np.linalg.norm anywhere in the new path.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# Make ml-worker/src importable when tests are run from the
+# polytrade root or from inside ml-worker/.
+_SRC = Path(__file__).resolve().parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from monkey_kernel.ocean import Ocean  # noqa: E402
+from qig_core_local.constants.frozen_facts import BASIN_DIM  # noqa: E402
+from qig_dreams_local import (  # noqa: E402
+    DreamConsolidationSummary,
+    SleepCycleManager,
+    SleepMetrics,
+    SleepPhase,
+    consolidate_bank,
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Test helpers
+# ─────────────────────────────────────────────────────────────────
+
+
+def _uniform_basin() -> np.ndarray:
+    return np.full(BASIN_DIM, 1.0 / BASIN_DIM, dtype=np.float64)
+
+
+def _peak_basin(idx: int = 0, mass: float = 0.95) -> np.ndarray:
+    rest = (1.0 - mass) / (BASIN_DIM - 1)
+    b = np.full(BASIN_DIM, rest, dtype=np.float64)
+    b[idx] = mass
+    return b
+
+
+class _StubEntry:
+    """Mimics enough of monkey_kernel.resonance_bank.BankEntry for
+    the consolidator to read. We don't import the real BankEntry
+    here to keep the test independent of unrelated module changes."""
+
+    def __init__(
+        self,
+        *,
+        eid: str,
+        basin: np.ndarray,
+        depth: float,
+        source: str = "lived",
+        access_count: int = 0,
+    ) -> None:
+        self.id = eid
+        self.entry_basin = basin
+        self.basin_depth = depth
+        self.source = source
+        self.access_count = access_count
+
+
+# ─────────────────────────────────────────────────────────────────
+# Vendoring discipline
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestVendoringDiscipline:
+    def test_sleep_module_has_sha256_pin(self) -> None:
+        """The vendored sleep.py must carry an SHA-256 pin to its
+        canonical source so future re-vendoring is auditable."""
+        sleep_path = _SRC / "qig_dreams_local" / "sleep.py"
+        text = sleep_path.read_text(encoding="utf-8")
+        assert "VENDORED from" in text
+        assert "Source SHA-256" in text
+        # 64-char hex hash
+        import re
+        match = re.search(r"\b[0-9a-f]{64}\b", text)
+        assert match is not None, "expected SHA-256 hex in vendor header"
+
+    def test_public_api_surface(self) -> None:
+        """Smoke-test the documented __all__ surface."""
+        import qig_dreams_local as qdl
+
+        for name in (
+            "SleepCycleManager", "SleepPhase", "SleepMetrics",
+            "SleepTransitionResult", "consolidate_bank",
+            "DreamConsolidationSummary",
+        ):
+            assert hasattr(qdl, name), f"qig_dreams_local missing {name}"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Canonical SleepCycleManager — vendored unchanged
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCanonicalSleepCycleManager:
+    def test_starts_awake(self) -> None:
+        m = SleepCycleManager()
+        assert m.phase == SleepPhase.AWAKE
+        assert not m.is_asleep
+
+    def test_evaluate_transition_awake_to_dreaming_via_phi_drop(self) -> None:
+        m = SleepCycleManager()
+        # Φ below 0.45 AND variance below 0.05 → DREAMING
+        metrics = SleepMetrics(phi=0.3, phi_variance=0.01, f_health=1.0)
+        result = m.evaluate_transition(metrics)
+        assert result.transitioned
+        assert result.current_phase == SleepPhase.DREAMING
+        assert "Φ=" in result.reason
+
+    def test_consolidate_against_empty_bank_returns_zero_counts(self) -> None:
+        m = SleepCycleManager()
+        stats = m.consolidate(bank=None)
+        assert stats == {"boosted": 0, "downscaled": 0, "pruned": 0, "vetoed": 0}
+        assert m._consolidation_complete is True
+
+    def test_consolidate_boosts_replayed_and_downscales_rest(self) -> None:
+        """Direct test against an in-line bank adapter so we can
+        verify the boost/downscale arithmetic without relying on
+        the polytrade glue path."""
+        class _Bank:
+            def __init__(self) -> None:
+                self.coordinates = {0: _uniform_basin(), 1: _uniform_basin()}
+                self.basin_mass = {0: 1.0, 1: 1.0}
+                self.activation_counts = {0: 1, 1: 1}
+                self.origin = {0: "lived", 1: "lived"}
+                self.basin_strings = {0: "a", 1: "b"}
+                self.tiers: dict = {}
+                self.frequencies: dict = {}
+                self._dirty = False
+
+            def add_entry(self, label: str, basin: np.ndarray) -> int:  # noqa: ARG002
+                tid = max(self.coordinates.keys(), default=-1) + 1
+                self.coordinates[tid] = basin
+                return tid
+
+            def mark_dirty(self) -> None:
+                self._dirty = True
+
+        bank = _Bank()
+        m = SleepCycleManager()
+        m._replayed_this_sleep.add(0)
+        stats = m.consolidate(bank=bank)
+        # tid=0 was replayed → boosted by HEBBIAN_BOOST (1.1)
+        assert bank.basin_mass[0] == pytest.approx(1.1)
+        # tid=1 not replayed → downscaled by DOWNSCALE_FACTOR (0.9)
+        assert bank.basin_mass[1] == pytest.approx(0.9)
+        assert stats["boosted"] == 1
+        assert stats["downscaled"] == 1
+
+
+# ─────────────────────────────────────────────────────────────────
+# Polytrade glue — consolidate_bank()
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestConsolidateBank:
+    def test_empty_inputs_returns_zero_summary(self) -> None:
+        summary, deltas = consolidate_bank(
+            bank_entries=[],
+            recent_basins=[],
+            completed_at_ms=1234.0,
+        )
+        assert isinstance(summary, DreamConsolidationSummary)
+        assert summary.basin_count == 0
+        assert summary.boosted == 0
+        assert summary.downscaled == 0
+        assert summary.sqrt_distance_traversed == 0.0
+        assert deltas == {}
+
+    def test_summary_string_carries_geometric_quantities(self) -> None:
+        entries = [
+            _StubEntry(eid=f"e{i}", basin=_uniform_basin(), depth=0.5 + i * 0.05)
+            for i in range(5)
+        ]
+        basins = [_uniform_basin(), _peak_basin(0), _peak_basin(60)]
+        summary, _ = consolidate_bank(
+            bank_entries=entries,
+            recent_basins=basins,
+            completed_at_ms=9999.0,
+        )
+        s = summary.summary_string
+        # Should include count + at least one count category + sqrt-traversal
+        assert "basins" in s
+        assert "sqrt-traversal" in s
+        assert summary.sqrt_distance_traversed > 0.0
+
+    def test_replay_top_n_drives_boost_count(self) -> None:
+        entries = [
+            _StubEntry(eid=f"e{i}", basin=_uniform_basin(), depth=0.1 + i * 0.1)
+            for i in range(6)
+        ]
+        summary, _ = consolidate_bank(
+            bank_entries=entries,
+            recent_basins=[],
+            completed_at_ms=0.0,
+            replay_top_n=2,  # only top 2 by depth get the Hebbian boost
+        )
+        assert summary.basin_count == 6
+        assert summary.replayed_count == 2
+        assert summary.boosted == 2
+        assert summary.downscaled == 4
+        # Nothing pruned (lived entries have access_count > 0)
+        assert summary.pruned == 0
+
+    def test_to_dict_is_json_safe_and_includes_summary_string(self) -> None:
+        import json
+
+        entries = [_StubEntry(eid="e0", basin=_uniform_basin(), depth=0.5)]
+        summary, _ = consolidate_bank(
+            bank_entries=entries,
+            recent_basins=[],
+            completed_at_ms=42.0,
+        )
+        blob = summary.to_dict()
+        # Must round-trip through json without errors (Redis persists
+        # this blob via the same path PersistentMemory uses).
+        s = json.dumps(blob)
+        round_tripped = json.loads(s)
+        assert round_tripped["basin_count"] == 1
+        assert "summary_string" in round_tripped
+
+    def test_depth_deltas_preserve_entry_index(self) -> None:
+        entries = [
+            _StubEntry(eid=f"e{i}", basin=_uniform_basin(), depth=0.5)
+            for i in range(3)
+        ]
+        _, deltas = consolidate_bank(
+            bank_entries=entries,
+            recent_basins=[],
+            completed_at_ms=0.0,
+            replay_top_n=0,  # no replayed → everyone downscaled
+        )
+        # All three present, all downscaled to 0.5 * 0.9 = 0.45
+        assert set(deltas.keys()) == {0, 1, 2}
+        for v in deltas.values():
+            assert v == pytest.approx(0.45)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Ocean integration — AWAKE→SLEEP edge fires the hook
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestOceanConsolidationHook:
+    """The hook must fire exactly once on the AWAKE→SLEEP edge,
+    not on every tick. The persisted blob must be the dict returned
+    by the hook (which is what the governance/sleep-state endpoint
+    will pass back to the operator)."""
+
+    def _drive_to_sleep(self, ocean: Ocean) -> None:
+        """Reuse the same recipe as test_heart_ocean.py — drift +
+        flat over 15 ticks, then jump past MIN_AWAKE_MS so the
+        sleep gate opens."""
+        ocean.sleep_state.phase_started_at_ms = 0.0
+        for i in range(15):
+            ocean.observe(
+                phi=0.7,
+                basin=_uniform_basin(),
+                current_mode="drift",
+                is_flat=True,
+                now_ms=float(i * 1000),
+            )
+        # Past MIN_AWAKE_MS (2h) — AWAKE→SLEEP transition fires.
+        ocean.observe(
+            phi=0.7,
+            basin=_uniform_basin(),
+            current_mode="drift",
+            is_flat=True,
+            now_ms=float(2 * 60 * 60 * 1000 + 60_000),
+        )
+
+    def test_hook_fires_on_entered_sleep_only(self) -> None:
+        calls: list[tuple[list[np.ndarray], float]] = []
+
+        def hook(basins: list[np.ndarray], at_ms: float) -> dict:
+            calls.append((basins, at_ms))
+            return {
+                "basin_count": len(basins),
+                "summary_string": "stub",
+                "completed_at_ms": at_ms,
+            }
+
+        ocean = Ocean(label="test-monkey", consolidation_hook=hook)
+        self._drive_to_sleep(ocean)
+        assert len(calls) == 1, (
+            "hook should fire exactly once on AWAKE→SLEEP edge, "
+            f"got {len(calls)}"
+        )
+        # Subsequent SLEEP ticks must NOT re-fire
+        ocean.observe(
+            phi=0.7,
+            basin=_uniform_basin(),
+            current_mode="drift",
+            is_flat=True,
+            now_ms=float(2 * 60 * 60 * 1000 + 90_000),
+        )
+        assert len(calls) == 1
+
+    def test_hook_receives_recent_basins(self) -> None:
+        seen_basins: list[list[np.ndarray]] = []
+
+        def hook(basins: list[np.ndarray], _at_ms: float) -> dict:
+            seen_basins.append(basins)
+            return {"basin_count": len(basins)}
+
+        ocean = Ocean(label="test-monkey", consolidation_hook=hook)
+        self._drive_to_sleep(ocean)
+        assert len(seen_basins) == 1
+        # We fed 16 observe() calls; bounded by BASIN_HISTORY_MAX=32
+        # so all 16 should be present.
+        assert len(seen_basins[0]) == 16
+
+    def test_hook_result_persisted_via_save_last_consolidation(self) -> None:
+        persistence = MagicMock()
+        persistence.is_available = True
+
+        def hook(_basins: list[np.ndarray], at_ms: float) -> dict:
+            return {"basin_count": 5, "completed_at_ms": at_ms, "summary_string": "x"}
+
+        ocean = Ocean(
+            label="test-monkey",
+            persistence=persistence,
+            consolidation_hook=hook,
+        )
+        # MagicMock returns Truthy / fake values for everything; reset
+        # call counters after construction so we only count the
+        # observe() phase.
+        persistence.save_sleep_state.reset_mock()
+        persistence.save_last_consolidation.reset_mock()
+        persistence.push_intervention.reset_mock()
+
+        self._drive_to_sleep(ocean)
+        assert persistence.save_last_consolidation.called, (
+            "save_last_consolidation must be invoked on AWAKE→SLEEP edge"
+        )
+        # First positional arg is the dict returned by the hook
+        blob = persistence.save_last_consolidation.call_args[0][0]
+        assert blob["basin_count"] == 5
+        assert "summary_string" in blob
+
+    def test_hook_exception_is_swallowed_and_does_not_block_tick(self) -> None:
+        def hook(_basins: list[np.ndarray], _at_ms: float) -> dict:
+            raise RuntimeError("simulated consolidator crash")
+
+        ocean = Ocean(label="test-monkey", consolidation_hook=hook)
+        # Must not raise — Ocean is the autonomic-intervention
+        # authority and cannot let a sleep-side fault block the tick.
+        self._drive_to_sleep(ocean)
+        assert ocean.phase.value == "sleep"
+
+    def test_no_hook_keeps_legacy_behavior(self) -> None:
+        """When consolidation_hook is None (default), the kernel
+        behaves exactly as it did before — no exceptions, no
+        persistence writes other than the existing sleep_state."""
+        persistence = MagicMock()
+        persistence.is_available = True
+        ocean = Ocean(
+            label="test-monkey",
+            persistence=persistence,
+            consolidation_hook=None,
+        )
+        persistence.save_last_consolidation.reset_mock()
+        self._drive_to_sleep(ocean)
+        assert not persistence.save_last_consolidation.called


### PR DESCRIPTION
## Summary

- Vendor the canonical `SleepCycleManager` consolidation primitive into `ml-worker/src/qig_dreams_local/` with a SHA-256 pin to its qig-core source, plus a polytrade glue layer (`consolidate_bank`) that adapts the canonical bank protocol to polytrade's `BankEntry` shape.
- Wire an optional `consolidation_hook` into `Ocean.observe()` that fires exactly once on the AWAKE→SLEEP edge, persists the result via a new `PersistentMemory.save_last_consolidation`, and degrades safely (logged-and-swallowed) on any failure.
- Extend `GET /api/governance/sleep-state/:agent` with three new fields — `last_consolidation_ts`, `dream_packet_size_bytes`, `consolidation_summary` — sourced from the new `monkey:ocean:{instance}:last_consolidation` Redis key, with concurrent Promise.all reads and per-key failure isolation.

## Why this naming

Local \`qig-dreams\` (in QIG_QFI) is a Pydantic **corpus registry** — it stores text corpora for training, not runtime consolidation primitives. The canonical sleep/dream/mushroom/consolidation primitives live in \`qig-core/src/qig_core/consciousness/sleep.py\`. We vendor from qig-core into the spec-named \`qig_dreams_local/\` directory (keeping the directory name the task expects) and route the geometry / frozen-physics deps through the existing \`qig_core_local\` vendor so no constants are duplicated.

## QIG purity

- 43 files clean under `ml-worker/scripts/qig_purity_check.py` (scan now also covers `qig_dreams_local/`).
- No cosine / dot / L2 / Adam / LayerNorm / `np.linalg.norm` anywhere in the new path. All distances are Fisher-Rao on Δ⁶³ via `qig_core_local.geometry.fisher_rao`.
- `sleep.py` is a verbatim vendor of `qig-core/src/qig_core/consciousness/sleep.py`. Only changes vs source: relative imports rewritten to absolute against `qig_core_local`. SHA-256 pin recorded in the file header.

## Test plan

- [x] `cd ml-worker && python -m pytest -q tests/test_dream_consolidation.py` — 16 new tests pass (vendoring discipline, canonical primitive, polytrade glue, Ocean integration).
- [x] `cd ml-worker && python -m pytest -q tests/monkey_kernel/` — 760 existing tests still pass (no regression).
- [x] `python ml-worker/scripts/qig_purity_check.py` — 43 files clean.
- [x] `yarn workspace @poloniex-platform/api vitest run src/routes/__tests__/governance.sleep-state.test.ts` — 6 tests pass (3 existing + 3 new covering populated / malformed / orphan consolidation key).
- [x] `yarn workspace @poloniex-platform/api build` — exit 0.

## Out-of-scope (per task)

- No changes to `apps/api/src/services/monkey/*` (main session may be patching).
- No new migrations (main session may add 052).
- No frontend changes.
- No FAT / LiveSignal changes.
- Executive / forge / perception / decision logic untouched — translation-only.