### PR TITLE
feat(arbiter): ARBITER_MIN_SHARE_FACTOR env override — operator tuning for laggard floor

### DIFF
--- a/apps/api/src/services/arbiter/__tests__/arbiter.test.ts
+++ b/apps/api/src/services/arbiter/__tests__/arbiter.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { Arbiter } from '../arbiter.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Arbiter, readMinShareFactor } from '../arbiter.js';
 
 describe('Arbiter', () => {
   it('splits 50/50 with insufficient data', () => {
@@ -249,6 +249,207 @@ describe('Arbiter N-agent (proposal #6)', () => {
     // Each laggard at least 0.05 * 100 = 5 USDT.
     for (const lab of labels.slice(1)) {
       expect(m[lab]).toBeGreaterThanOrEqual(5 - 1e-6);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// ARBITER_MIN_SHARE_FACTOR env override (2026-05-16, see PR notes).
+// Lets the operator tighten the laggard floor without code change so
+// high-WR agents (L, T) can claim the capital they've earned. opts.minShare
+// STILL wins over env (env is operational tuning, opts is for tests).
+// ────────────────────────────────────────────────────────────────────────
+describe('Arbiter ARBITER_MIN_SHARE_FACTOR env override', () => {
+  // Saturated 4-agent scenario: K wins big, everyone else loses big. With
+  // adaptiveFloor = min(0.10, 0.5/4) = 0.10, factor=1.0 floors laggards
+  // at exactly 10% (10 USDT on 100). Factor scales that linearly.
+  const LABELS = ['K', 'M', 'T', 'L'];
+
+  function seedSaturated(a: Arbiter): void {
+    for (let i = 0; i < 50; i++) {
+      a.recordSettled('K', 100);
+      a.recordSettled('M', -100);
+      a.recordSettled('T', -100);
+      a.recordSettled('L', -100);
+    }
+  }
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('factor unset → treated as 1.0 (behavior identical to today)', () => {
+    // No env stub — readMinShareFactor sees undefined.
+    expect(readMinShareFactor()).toBe(1.0);
+
+    const a = new Arbiter();
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    // Laggards floored at exactly 10% (the existing adaptive floor).
+    for (const lab of ['M', 'T', 'L']) {
+      expect(m[lab]).toBeCloseTo(10, 5);
+    }
+    const total = LABELS.reduce((s, l) => s + (m[l] ?? 0), 0);
+    expect(total).toBeCloseTo(100, 4);
+  });
+
+  it('factor=1.0 explicit → effective floor = adaptive (10% at N=4)', () => {
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '1.0');
+    expect(readMinShareFactor()).toBe(1.0);
+
+    const a = new Arbiter();
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    for (const lab of ['M', 'T', 'L']) {
+      expect(m[lab]).toBeCloseTo(10, 5);
+    }
+  });
+
+  it('factor=0.5 → floor halved (5% at N=4 instead of 10%)', () => {
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '0.5');
+    expect(readMinShareFactor()).toBe(0.5);
+
+    const a = new Arbiter();
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    // Each laggard floored at 5 USDT (5%), letting K claim more.
+    for (const lab of ['M', 'T', 'L']) {
+      expect(m[lab]).toBeCloseTo(5, 5);
+    }
+    // K gains the freed mass: 100 - 3*5 = 85.
+    expect(m.K).toBeCloseTo(85, 5);
+  });
+
+  it('factor=0.25 → floor quartered (2.5% at N=4); laggards >= floor', () => {
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '0.25');
+    expect(readMinShareFactor()).toBe(0.25);
+
+    // factor=0.5 baseline (laggard saturates the floor at 5%).
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '0.5');
+    const half = new Arbiter();
+    seedSaturated(half);
+    const mHalf = half.allocateMany(100, LABELS);
+
+    // factor=0.25 — the floor is lower but the SLERP-toward-performance
+    // shares may already exceed 2.5% (the floor is a clamp, not an exact
+    // value). Assert: (a) each laggard is at least the floor, (b) K
+    // claims strictly MORE than at factor=0.5 (or at worst equal — the
+    // floor relaxed so K's share can only go up or stay flat), and
+    // (c) shares sum to 100.
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '0.25');
+    const a = new Arbiter();
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    for (const lab of ['M', 'T', 'L']) {
+      expect(m[lab]).toBeGreaterThanOrEqual(2.5 - 1e-6);
+    }
+    expect(m.K).toBeGreaterThanOrEqual(mHalf.K! - 1e-6);
+    const total = LABELS.reduce((s, l) => s + (m[l] ?? 0), 0);
+    expect(total).toBeCloseTo(100, 4);
+  });
+
+  it('factor=2.0 → floor doubled (20% at N=4); allowed even if over-floor', () => {
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '2.0');
+    expect(readMinShareFactor()).toBe(2.0);
+
+    const a = new Arbiter();
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    // 4 * 20% = 80% < 100% so no pathological-fallback; floor honored.
+    for (const lab of ['M', 'T', 'L']) {
+      expect(m[lab]).toBeCloseTo(20, 5);
+    }
+    expect(m.K).toBeCloseTo(40, 5);
+  });
+
+  it('factor=0 → treated as 1.0 (refuses to disable floor entirely)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '0');
+    expect(readMinShareFactor()).toBe(1.0);
+
+    const a = new Arbiter();
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    // Floor stays at default 10%, NOT removed.
+    for (const lab of ['M', 'T', 'L']) {
+      expect(m[lab]).toBeCloseTo(10, 5);
+    }
+    warnSpy.mockRestore();
+  });
+
+  it('factor negative → treated as 1.0', () => {
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '-0.5');
+    expect(readMinShareFactor()).toBe(1.0);
+
+    const a = new Arbiter();
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    for (const lab of ['M', 'T', 'L']) {
+      expect(m[lab]).toBeCloseTo(10, 5);
+    }
+  });
+
+  it('factor non-numeric → treated as 1.0', () => {
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', 'not-a-number');
+    expect(readMinShareFactor()).toBe(1.0);
+
+    const a = new Arbiter();
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    for (const lab of ['M', 'T', 'L']) {
+      expect(m[lab]).toBeCloseTo(10, 5);
+    }
+  });
+
+  it('factor empty string → treated as 1.0', () => {
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '');
+    expect(readMinShareFactor()).toBe(1.0);
+  });
+
+  it('opts.minShare wins over env factor', () => {
+    // Env says half-the-floor; opts says floor at 20%. Opts wins.
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '0.5');
+
+    const a = new Arbiter({ minShare: 0.20 });
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    // Laggards floored at 20 USDT each (opts), not 5 USDT (env factor).
+    for (const lab of ['M', 'T', 'L']) {
+      expect(m[lab]).toBeCloseTo(20, 5);
+    }
+    expect(m.K).toBeCloseTo(40, 5);
+  });
+
+  it('factor preserves existing N=5 behavior (adaptive floor=0.10 * 1.0)', () => {
+    // Existing 'respects min-share floor with N=5' test asserts >=0.10.
+    // Confirm that factor=1.0 (default) keeps that contract.
+    const a = new Arbiter();
+    const labels = ['K', 'M', 'K2', 'K3', 'K4'];
+    for (let i = 0; i < 50; i++) {
+      a.recordSettled('K', 100);
+      for (const lab of labels.slice(1)) a.recordSettled(lab, -100);
+    }
+    const m = a.allocateMany(100, labels);
+    for (const lab of labels.slice(1)) {
+      expect(m[lab]).toBeGreaterThanOrEqual(0.10 * 100 - 1e-6);
+    }
+  });
+
+  it('factor large enough to over-floor falls back to uniform', () => {
+    // factor=3.0 at N=4 → floor = 0.10 * 3 = 0.30, n*floor = 1.20 > 1.
+    // Arbiter's existing pathological-config guard kicks in → uniform.
+    vi.stubEnv('ARBITER_MIN_SHARE_FACTOR', '3.0');
+
+    const a = new Arbiter();
+    seedSaturated(a);
+    const m = a.allocateMany(100, LABELS);
+    // Uniform 1/N = 25 USDT each.
+    for (const lab of LABELS) {
+      expect(m[lab]).toBeCloseTo(25, 5);
     }
   });
 });

--- a/apps/api/src/services/arbiter/arbiter.ts
+++ b/apps/api/src/services/arbiter/arbiter.ts
@@ -30,7 +30,19 @@
  *     callers that have not migrated yet.
  *   * Min-share floor scales as ``1/(2N)`` by default so the laggard
  *     in an N-agent race still gets exploration capital.
+ *
+ * Operator tuning (2026-05-16):
+ *   * ``ARBITER_MIN_SHARE_FACTOR`` env var (parseFloat) multiplies the
+ *     adaptive floor at runtime. Default 1.0 (unchanged behavior). Set
+ *     0.5 to halve the floor (e.g. 5% per agent at N=4 instead of 10%)
+ *     when high-WR agents (L, T) have earned more capital and a thick
+ *     laggard floor is over-protecting K. Set > 1.0 to be more cautious.
+ *     Invalid/zero/negative values fall back to 1.0 with a warn log.
+ *     Constructor-supplied ``opts.minShare`` STILL wins over env (env
+ *     is operational tuning; opts is for tests).
  */
+
+import { logger } from '../../utils/logger.js';
 
 /** Back-compat 2-agent allocation shape — preserved so existing
  *  callers (loop.ts, telemetry, snapshots) keep compiling. New
@@ -72,6 +84,43 @@ export interface ArbiterOptions {
   warmupTrades?: number;
 }
 
+/** Read ``ARBITER_MIN_SHARE_FACTOR`` from the environment with a
+ *  defensive parse. The factor multiplies the adaptive min-share floor
+ *  computed inside ``allocateMany``:
+ *
+ *    effectiveFloor = adaptiveFloor * factor
+ *
+ *  Defaults to 1.0 (no change from today) when:
+ *   * the var is unset
+ *   * the var is empty / non-numeric (warn-logged so the operator can
+ *     see their typo and fix it)
+ *   * the parsed value is <= 0 or non-finite (we don't allow disabling
+ *     the floor entirely via this knob — tests can still pass
+ *     ``opts.minShare: 0`` if they need that)
+ *
+ *  Exported for tests and so loop.ts can log the effective config on
+ *  startup. */
+export function readMinShareFactor(): number {
+  const raw = process.env.ARBITER_MIN_SHARE_FACTOR;
+  if (raw === undefined || raw === null || raw === '') return 1.0;
+  const parsed = parseFloat(raw);
+  if (!Number.isFinite(parsed)) {
+    logger.warn(
+      `arbiter: ARBITER_MIN_SHARE_FACTOR=${JSON.stringify(raw)} is not a ` +
+      'finite number; using factor=1.0 (no change to floor).',
+    );
+    return 1.0;
+  }
+  if (parsed <= 0) {
+    logger.warn(
+      `arbiter: ARBITER_MIN_SHARE_FACTOR=${parsed} is <= 0; using ` +
+      'factor=1.0 (refusing to disable the laggard floor entirely).',
+    );
+    return 1.0;
+  }
+  return parsed;
+}
+
 export class Arbiter {
   /** Per-agent rolling PnL window. ``Map<label, number[]>`` so
    *  arbitrary labels are first-class. */
@@ -79,15 +128,40 @@ export class Arbiter {
   private readonly window: number;
   private readonly minShareOverride: number | undefined;
   private readonly warmupTrades: number;
+  /** Multiplier applied to the adaptive floor inside ``allocateMany``.
+   *  Sourced from ``ARBITER_MIN_SHARE_FACTOR`` at construction time so
+   *  one Arbiter instance has stable floor behavior across ticks. */
+  private readonly minShareFactor: number;
 
   constructor(opts: ArbiterOptions = {}) {
     this.window = opts.window ?? 50;
     this.minShareOverride = opts.minShare;
     this.warmupTrades = opts.warmupTrades ?? 5;
+    this.minShareFactor = readMinShareFactor();
     // Pre-create K and M buffers so legacy snapshots still report
     // 0 trades / 0 PnL for them even when no events have arrived.
     this.pnls.set('K', []);
     this.pnls.set('M', []);
+    // One-shot operator visibility: log effective floor config so the
+    // operator can confirm ARBITER_MIN_SHARE_FACTOR took effect. We
+    // illustrate against N=4 (the default K|M|T|L lineup) so the
+    // number is concrete; the actual N is per allocate-call.
+    if (this.minShareOverride !== undefined) {
+      logger.info(
+        `arbiter: min-share floor = ${this.minShareOverride} (explicit ` +
+        'opts.minShare; env factor ignored)',
+      );
+    } else {
+      const sampleN = 4;
+      const sampleAdaptive = Math.min(0.10, 0.5 / sampleN);
+      const sampleEffective = sampleAdaptive * this.minShareFactor;
+      logger.info(
+        `arbiter: min-share factor = ${this.minShareFactor} ` +
+        `(ARBITER_MIN_SHARE_FACTOR; effective floor at N=${sampleN}: ` +
+        `${sampleEffective.toFixed(4)} = ${sampleAdaptive} * ` +
+        `${this.minShareFactor})`,
+      );
+    }
   }
 
   /** Record a settled trade outcome for ``agent`` (string label). */
@@ -142,7 +216,14 @@ export class Arbiter {
     // gets exploration capital but the floor doesn't dominate the
     // mass distribution among 6+ agents. Caller can override via
     // ``ArbiterOptions.minShare``.
-    const adaptiveFloor = Math.min(0.10, 0.5 / n);
+    //
+    // Operator knob: ARBITER_MIN_SHARE_FACTOR (default 1.0) multiplies
+    // the adaptive floor so the operator can tighten the floor
+    // (factor=0.5 → halved, factor=0.25 → quartered) when high-WR
+    // agents have earned more capital than the floor would let them
+    // claim. opts.minShare STILL wins — env is operational tuning, opts
+    // is for tests / per-instance overrides.
+    const adaptiveFloor = Math.min(0.10, 0.5 / n) * this.minShareFactor;
     const minShare = this.minShareOverride ?? adaptiveFloor;
     // Bootstrap path — uniform split until every agent has data.
     const allWarm = agents.every((a) => (this.pnls.get(a)?.length ?? 0) >= this.warmupTrades);


### PR DESCRIPTION
## Summary

Operator-tunable knob for the Arbiter's laggard min-share floor — no code change required to react to evolving WR signal.

Today's adaptive floor `min(0.10, 0.5/n)` guarantees the laggard keeps producing data (a good thing in cold-start). But once high-WR agents have earned more capital than the floor allows, the floor becomes **capital protection for a losing agent**:

| Agent | WR | Trades |
|---|---|---|
| K | 17% | 265 |
| T | 44% | 27 |
| L | 76% | historical |

At N=4, the floor reserves 10% for each laggard → K is guaranteed ≥10% even when L should be claiming more.

## What changes

- New env var `ARBITER_MIN_SHARE_FACTOR` (parseFloat). Default `1.0` → behavior identical to today.
- Multiplies the adaptive floor at allocation time:
  - `effective = min(0.10, 0.5/n) * factor`
  - factor=`0.5` → halved (5% at N=4 → K can claim up to 85%)
  - factor=`0.25` → quartered (2.5% at N=4)
  - factor=`2.0` → doubled (20% at N=4, more cautious)
- Defensive parse: unset / empty / non-numeric / zero / negative all fall back to `1.0` with a warn log.
- `opts.minShare` STILL wins over env — env is operational tuning, opts is for tests / per-instance overrides.
- Pathological `n*floor > 1` still falls back to uniform (existing guard, untouched).
- Constructor logs the effective floor once for operator visibility.

## Discipline

- SLERP-toward-performance math is unchanged
- QIG purity preserved (no cosine / Adam / LayerNorm / `np.linalg.norm`)
- Only file in `apps/api/src/services/arbiter/` touched
- All existing tests still pass (default factor=1.0 preserves today's behavior exactly)

## Test plan

- [x] `yarn workspace @poloniex-platform/api build` exits 0
- [x] `vitest run src/services/arbiter/__tests__/arbiter.test.ts` — **34/34 pass**
- [x] Existing tests (factor unset → 1.0 → exact today's behavior) — 22/22 pass unchanged
- [x] New test cases (12 added) cover:
  - factor unset → `1.0`
  - factor `1.0` / `0.5` / `0.25` / `2.0` → multiplied correctly
  - factor `0` / negative / non-numeric / empty string → `1.0` (warn-logged)
  - `opts.minShare` wins over env
  - N=5 back-compat at default factor
  - Over-floor (n*floor > 1) → uniform fallback
- [ ] Operator post-deploy: set `ARBITER_MIN_SHARE_FACTOR=0.5` on Railway api service; confirm log line `arbiter: min-share factor = 0.5 ... effective floor at N=4: 0.0500 = 0.1 * 0.5` and watch K share decay below 10% as L's PnL diverges further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)