### PR TITLE
fix(monkey): bound selfObsPressure via z-score sigmoid — [0.5, 1.5]

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1663,28 +1663,50 @@ export class MonkeyKernel extends EventEmitter {
         symbol, basinDir, tapeTrend, direction, wantedShort: true,
       });
     }
-    // 2026-05-16 (#717 derivation refactor): selfObsBias =
+    // 2026-05-16 (#717 derivation refactor + clamp hotfix): selfObsBias =
     //   winRate(mode, side) × selfObsPressure
-    // where selfObsPressure is derived purely from the basin's own
-    // observable state:
-    //   pressure = (current_surprise / mean(surpriseHistory))
-    // A pure ratio — dimensionless, no externally chosen gain. When
-    // current surprise exceeds the basin's typical surprise → pressure
-    // > 1 → executive enters more cautiously (Protocol v6.6 §43 Loop 1
-    // "turn inward on mispredict"). When current surprise is below
-    // typical → pressure < 1 → trust the direct signal.
+    // where selfObsPressure is derived from the basin's own observable
+    // state via z-score-of-current-surprise, mapped through sigmoid to
+    // a naturally bounded range:
+    //   z = (surpriseNow - mean) / stddev   (basin's own stddev IS the gain)
+    //   pressure = 0.5 + sigmoid(z)         → [0.5, 1.5], neutral at z=0
     //
-    // No constant clamps. The ratio naturally bounds itself: with
-    // hundreds of samples in the history, the mean is stable; the
-    // ratio rarely strays far from 1 unless current surprise is a
-    // genuine outlier. Cold start (empty history) → identity 1.
+    // Same Protocol v6.6 §43 Loop 1 semantics ("turn inward on mispredict"):
+    // current surprise above typical → pressure > 1; below typical → pressure
+    // < 1. But the output is bounded so a cold-start surprise spike (small
+    // history → small mean → huge ratio in the prior formula) cannot push
+    // the downstream entry-threshold multiplier into paralysis territory.
+    //
+    // Original ratio `surpriseNow / mean` was unbounded — observed live at
+    // selfObsBias=9.05 with only 5-10 surprise samples in history (cold
+    // start post-restart). All downstream gates (currentEntryThreshold T,
+    // shouldExit threshold) already clamp their final outputs, so the
+    // unbounded ratio was absorbed in practice — but it was misleading in
+    // telemetry and a latent footgun if any future caller used selfObsBias
+    // un-clamped. Stddev gain preserves derivation-only purity per the
+    // operator directive.
+    //
+    // Cold start (history length < 2 → stddev undefined → identity 1).
     const selfObsWinRateBias = this.selfObs?.entryBias[mode]?.[sideCandidate] ?? 1.0;
     let selfObsPressure: number;
-    if (state.surpriseHistory.length > 0) {
+    if (state.surpriseHistory.length >= 2) {
+      const n = state.surpriseHistory.length;
       let sum = 0;
       for (const s of state.surpriseHistory) sum += s;
-      const meanSurprise = sum / state.surpriseHistory.length;
-      selfObsPressure = meanSurprise > 0 ? surpriseNow / meanSurprise : 1;
+      const mean = sum / n;
+      let sqSum = 0;
+      for (const s of state.surpriseHistory) {
+        const d = s - mean;
+        sqSum += d * d;
+      }
+      const stddev = Math.sqrt(sqSum / (n - 1));  // Bessel-corrected
+      if (stddev > 0) {
+        const z = (surpriseNow - mean) / stddev;
+        const sig = 1 / (1 + Math.exp(-z));
+        selfObsPressure = 0.5 + sig;  // ∈ [0.5, 1.5]
+      } else {
+        selfObsPressure = 1;  // degenerate history (all identical samples)
+      }
     } else {
       selfObsPressure = 1;
     }


### PR DESCRIPTION
## Summary

PR #722's `selfObsPressure = surpriseNow / mean(surpriseHistory)` is unbounded. With cold-start history (~5-10 samples), a basin-velocity spike pushes the ratio to 5-9x. Observed live at **selfObsBias=9.05** (12:30Z BTC) and 3.67-5.65 on adjacent ticks.

Downstream gates absorbed the misleading values (entry T clamps to [0.1, 0.9]; exit threshold caps at 0.825 via the `0.55 * (1 + 0.5 * ne)` formula). But:
- Telemetry is misleading — operator reading "selfObsBias 9.05" reasonably concluded gates were paralyzed; in fact ML conviction weakness is the actual entry blocker.
- Latent footgun if any future caller multiplies by selfObsBias without clamping.

## Fix

Replace ratio with z-score-of-surprise mapped through sigmoid:
```ts
z = (surpriseNow - mean) / stddev         // basin's own stddev IS the gain
pressure = 0.5 + sigmoid(z)               // ∈ [0.5, 1.5], neutral = 1
```

Same architectural pattern as `nc.dop` / `nc.ne` in PR #722. Same Bessel-corrected stddev. Same derivation-only purity (no external constants — basin's own stddev is the gain).

## Properties preserved
- Derivation-only — basin's own stddev as gain, no constants
- Directional — high surprise → pressure > 1 (turn inward); low surprise → pressure < 1 (trust direct signal)
- Cold-start safe — `history.length < 2` → identity 1
- Degenerate-history safe — stddev=0 → identity 1

## Properties added
- Bounded output — pressure ∈ [0.5, 1.5] regardless of input distribution
- Telemetry truth — logged selfObsBias matches what downstream gates can actually consume

## Verification
- 18/18 autonomic feedback tests pass
- API build green

## What this does NOT fix
- The kernel's reluctance to enter at low ML conviction (HOLD @ 0.04-0.26) — that's the entry-T clamp at min 0.1 vs typical conviction ≤ 0.35. Separate analysis.
- DCA gate requiring ±1% from entry — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bound the monkey kernel self-observation pressure bias using a z-score-based sigmoid to keep it within a safe range while preserving existing behavioral semantics.

Bug Fixes:
- Prevent self-observation pressure from producing unbounded values that can mislead telemetry and pose a latent risk to downstream consumers.

Enhancements:
- Derive self-observation pressure from a z-score of surprise mapped through a sigmoid, ensuring a stable bounded range with cold-start and degenerate-history safeguards.