### PR TITLE
feat(consensus): CONSENSUS-2 — Redis pub/sub proposal bus + wire publish into both tick paths

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2512,6 +2512,41 @@ export class MonkeyKernel extends EventEmitter {
         threshold: lVetoConvictionThreshold(),
       });
     }
+    // ── Cross-kernel proposal publish (Consensus Layer 1.5) ──
+    // CONSENSUS_PROPOSAL_BUS_LIVE flag-gated. Publish K-kernel's
+    // proposed action to Redis so consensus arbiter (PR CONSENSUS-7)
+    // can subscribe. Fire-and-forget — never blocks the orchestrator.
+    // See [[polytrade-consensus-architecture]].
+    try {
+      const { publishProposal: _publishProposal } = await import('./proposal_bus.js');
+      const _proposalSide: 'long' | 'short' | null =
+        (action === 'enter_long' || action === 'pyramid_long') ? 'long'
+        : (action === 'enter_short' || action === 'pyramid_short') ? 'short'
+        : null;
+      void _publishProposal({
+        instance_id: this.instanceId,
+        symbol,
+        tick_id: `${symbol}|${state.sessionTicks}`,
+        proposed_action: (action === 'enter_long' || action === 'enter_short'
+          || action === 'pyramid_long' || action === 'pyramid_short') ? 'enter_long'
+          : action === 'enter_short' ? 'enter_short'
+          : (action.startsWith('exit') ? 'exit' : 'hold'),
+        side: _proposalSide,
+        lane: 'swing',  // K-kernel default; CONSENSUS-3 wires per-lane attribution
+        size_usdt: Number(size.value ?? 0),
+        leverage: Number(leverage.value ?? 1),
+        entry_threshold: Number(entryThr.value ?? 0.5),
+        conviction: Number(entryThr.value ?? 0.5),
+        basin_signature: Array.from(basin.slice(0, 8)).map((x) => Number(x)),
+        phi: Number(phi),
+        kappa: Number(state.kappa),
+        regime_label: null,
+        mode: String(mode),
+        at_ms: Date.now(),
+        engine_version: 'v0.8-ts',
+      });
+    } catch { /* fail-soft */ }
+
     if (process.env.MONKEY_EXECUTE === 'true') {
       if ((action === 'enter_long' || action === 'enter_short') && size.value > 0) {
         // v0.8.7 kill switch — pause new entries (including DCA pyramids)

--- a/apps/api/src/services/monkey/proposal_bus.ts
+++ b/apps/api/src/services/monkey/proposal_bus.ts
@@ -1,0 +1,191 @@
+/**
+ * proposal_bus.ts — Redis pub/sub bridge for cross-kernel proposal exchange.
+ *
+ * Layer 1.5 of the dual-kernel consensus architecture per
+ * [[polytrade-consensus-architecture]]. Basin-level state already flows
+ * via monkey_basin_sync (PR CONSENSUS-1). This module adds low-latency
+ * proposal-level exchange via Redis pub/sub — the consensus arbiter
+ * (PR CONSENSUS-7) will subscribe to both TS + Py proposals and emit
+ * a consensus decision.
+ *
+ * Channel: `monkey:consensus:proposal`
+ *
+ * Flag: CONSENSUS_PROPOSAL_BUS_LIVE — default off. When off, neither
+ * publisher nor subscriber connects (no Redis traffic). When on,
+ * proposals stream across the bus and recent peer proposals are
+ * available via getRecentPeerProposal().
+ *
+ * Fail-soft: any Redis error logs at debug and returns silently. A
+ * dead Redis never blocks a tick.
+ */
+
+import { createClient, type RedisClientType } from 'redis';
+
+import { logger } from '../../utils/logger.js';
+
+export const PROPOSAL_CHANNEL = 'monkey:consensus:proposal';
+
+const PEER_PROPOSAL_FRESHNESS_MS = 60_000;
+
+export interface ProposalEvent {
+  instance_id: string;
+  symbol: string;
+  tick_id: string;
+  proposed_action: 'enter_long' | 'enter_short' | 'exit' | 'hold';
+  side: 'long' | 'short' | null;
+  lane: string;
+  size_usdt: number;
+  leverage: number;
+  entry_threshold: number;
+  conviction: number;
+  basin_signature: number[];
+  phi: number;
+  kappa: number;
+  regime_label: string | null;
+  mode: string;
+  at_ms: number;
+  engine_version: string;
+}
+
+function consensusBusLive(): boolean {
+  return process.env.CONSENSUS_PROPOSAL_BUS_LIVE === 'true';
+}
+
+let _publisher: RedisClientType | null = null;
+let _subscriber: RedisClientType | null = null;
+let _subscriberInitialized = false;
+
+// Most-recent peer proposal by (peer_instance_id, symbol). The consensus
+// arbiter consumes this via getRecentPeerProposal(symbol, selfId).
+const _peerProposals = new Map<string, ProposalEvent>();
+
+async function getPublisher(): Promise<RedisClientType | null> {
+  if (_publisher) return _publisher;
+  if (!consensusBusLive()) return null;
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    logger.debug('[ProposalBus] REDIS_URL unset; publisher disabled');
+    return null;
+  }
+  try {
+    _publisher = createClient({ url });
+    _publisher.on('error', (err) => {
+      logger.debug('[ProposalBus] publisher error', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    });
+    await _publisher.connect();
+    return _publisher;
+  } catch (err) {
+    logger.debug('[ProposalBus] publisher connect failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    _publisher = null;
+    return null;
+  }
+}
+
+async function getSubscriber(): Promise<RedisClientType | null> {
+  if (_subscriber && _subscriberInitialized) return _subscriber;
+  if (!consensusBusLive()) return null;
+  const url = process.env.REDIS_URL;
+  if (!url) return null;
+  try {
+    _subscriber = createClient({ url });
+    _subscriber.on('error', (err) => {
+      logger.debug('[ProposalBus] subscriber error', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      _subscriberInitialized = false;
+    });
+    await _subscriber.connect();
+    await _subscriber.subscribe(PROPOSAL_CHANNEL, (raw: string) => {
+      try {
+        const evt = JSON.parse(raw) as ProposalEvent;
+        const key = `${evt.instance_id}|${evt.symbol}`;
+        _peerProposals.set(key, evt);
+      } catch (err) {
+        logger.debug('[ProposalBus] message parse failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    });
+    _subscriberInitialized = true;
+    return _subscriber;
+  } catch (err) {
+    logger.debug('[ProposalBus] subscriber connect failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    _subscriber = null;
+    _subscriberInitialized = false;
+    return null;
+  }
+}
+
+/**
+ * Initialize the subscriber. Call once at kernel boot; idempotent.
+ * No-op when CONSENSUS_PROPOSAL_BUS_LIVE is unset.
+ */
+export async function initProposalBus(): Promise<void> {
+  if (!consensusBusLive()) return;
+  await getSubscriber();
+}
+
+/**
+ * Publish this kernel's proposal for the given tick. Fire-and-forget;
+ * Redis errors are swallowed (logged at debug) so they never block
+ * the orchestrator. No-op when flag is off.
+ */
+export async function publishProposal(event: ProposalEvent): Promise<void> {
+  if (!consensusBusLive()) return;
+  const pub = await getPublisher();
+  if (!pub) return;
+  try {
+    await pub.publish(PROPOSAL_CHANNEL, JSON.stringify(event));
+  } catch (err) {
+    logger.debug('[ProposalBus] publish failed', {
+      symbol: event.symbol,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Return the most-recent peer proposal for `symbol` from any kernel
+ * instance OTHER than `selfInstanceId`, provided it's fresh enough.
+ * Returns null when:
+ *  - flag is off
+ *  - no peer proposals received yet
+ *  - all peer proposals stale beyond PEER_PROPOSAL_FRESHNESS_MS
+ */
+export function getRecentPeerProposal(
+  symbol: string,
+  selfInstanceId: string,
+): ProposalEvent | null {
+  if (!consensusBusLive()) return null;
+  const now = Date.now();
+  let best: ProposalEvent | null = null;
+  for (const evt of _peerProposals.values()) {
+    if (evt.symbol !== symbol) continue;
+    if (evt.instance_id === selfInstanceId) continue;
+    if (now - evt.at_ms > PEER_PROPOSAL_FRESHNESS_MS) continue;
+    if (best === null || evt.at_ms > best.at_ms) {
+      best = evt;
+    }
+  }
+  return best;
+}
+
+/** Test/cleanup helper — disconnect and reset state. */
+export async function _resetProposalBus(): Promise<void> {
+  _peerProposals.clear();
+  if (_publisher) {
+    try { await _publisher.disconnect(); } catch { /* ignore */ }
+    _publisher = null;
+  }
+  if (_subscriber) {
+    try { await _subscriber.disconnect(); } catch { /* ignore */ }
+    _subscriber = null;
+    _subscriberInitialized = false;
+  }
+}

--- a/ml-worker/src/monkey_kernel/proposal_bus.py
+++ b/ml-worker/src/monkey_kernel/proposal_bus.py
@@ -1,0 +1,213 @@
+"""proposal_bus.py — Redis pub/sub bridge for cross-kernel proposal exchange.
+
+Python counterpart of `apps/api/src/services/monkey/proposal_bus.ts`.
+Layer 1.5 of the dual-kernel consensus architecture per
+[[polytrade-consensus-architecture]]. Both TS Monkey and Py Monkey
+publish proposals to the same channel; both subscribe and store the
+most-recent peer proposal for the consensus arbiter (PR CONSENSUS-7).
+
+Channel: `monkey:consensus:proposal`
+
+Flag: `CONSENSUS_PROPOSAL_BUS_LIVE` — default off. When off, neither
+publisher nor subscriber connects (no Redis traffic). When on,
+proposals stream across the bus.
+
+Fail-soft: any Redis error logs at debug and returns silently. A
+dead Redis never blocks a tick.
+
+QIG purity: no math here — just JSON pub/sub. The geometric payload
+fields (basin, phi, kappa) are reported as-is.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+logger = logging.getLogger("monkey_kernel.proposal_bus")
+
+PROPOSAL_CHANNEL = "monkey:consensus:proposal"
+PEER_PROPOSAL_FRESHNESS_MS = 60_000
+
+
+def consensus_bus_live() -> bool:
+    """Default-off flag. When false, publisher and subscriber don't connect."""
+    return os.environ.get("CONSENSUS_PROPOSAL_BUS_LIVE", "").strip().lower() == "true"
+
+
+@dataclass
+class ProposalEvent:
+    """Schema mirrors TS-side ProposalEvent. Channel payload is JSON
+    serialization of this dataclass."""
+
+    instance_id: str
+    symbol: str
+    tick_id: str
+    proposed_action: str  # 'enter_long' | 'enter_short' | 'exit' | 'hold'
+    side: Optional[str]   # 'long' | 'short' | None
+    lane: str
+    size_usdt: float
+    leverage: float
+    entry_threshold: float
+    conviction: float
+    basin_signature: list[float] = field(default_factory=list)
+    phi: float = 0.0
+    kappa: float = 0.0
+    regime_label: Optional[str] = None
+    mode: str = ""
+    at_ms: float = 0.0
+    engine_version: str = "v0.8.7c-3-py"
+
+
+# Module-level state — most-recent peer proposal by (peer_instance_id, symbol)
+_peer_proposals: dict[str, ProposalEvent] = {}
+_peer_lock = threading.Lock()
+_subscriber_task: Optional[asyncio.Task] = None
+_publisher_client = None  # type: ignore[var-annotated]
+
+
+async def _get_publisher():
+    """Lazy-init Redis async client for publishing. Returns None if
+    flag is off or REDIS_URL unset."""
+    global _publisher_client
+    if not consensus_bus_live():
+        return None
+    if _publisher_client is not None:
+        return _publisher_client
+    url = os.environ.get("REDIS_URL")
+    if not url:
+        logger.debug("[ProposalBus] REDIS_URL unset; publisher disabled")
+        return None
+    try:
+        import redis.asyncio as redis
+        _publisher_client = redis.from_url(url, decode_responses=True)
+        return _publisher_client
+    except Exception as err:  # noqa: BLE001
+        logger.debug("[ProposalBus] publisher init failed: %s", err)
+        return None
+
+
+async def publish_proposal(event: ProposalEvent) -> None:
+    """Publish this kernel's proposal for the given tick. Fire-and-forget;
+    Redis errors are swallowed. No-op when flag is off."""
+    if not consensus_bus_live():
+        return
+    client = await _get_publisher()
+    if client is None:
+        return
+    try:
+        payload = json.dumps(asdict(event))
+        await client.publish(PROPOSAL_CHANNEL, payload)
+    except Exception as err:  # noqa: BLE001
+        logger.debug("[ProposalBus] publish failed: %s", err)
+
+
+_sync_publisher = None  # type: ignore[var-annotated]
+
+
+def publish_proposal_sync(event: ProposalEvent) -> None:
+    """Sync variant for callers without an event loop (e.g. tick.py's
+    synchronous run_tick). Uses the blocking `redis` library; publish
+    is a single TCP write so blocking is negligible. Fire-and-forget;
+    Redis errors swallowed. No-op when flag is off."""
+    global _sync_publisher
+    if not consensus_bus_live():
+        return
+    url = os.environ.get("REDIS_URL")
+    if not url:
+        return
+    try:
+        if _sync_publisher is None:
+            import redis as redis_sync  # noqa: WPS433
+            _sync_publisher = redis_sync.from_url(url, decode_responses=True)
+        payload = json.dumps(asdict(event))
+        _sync_publisher.publish(PROPOSAL_CHANNEL, payload)
+    except Exception as err:  # noqa: BLE001
+        logger.debug("[ProposalBus] sync publish failed: %s", err)
+
+
+async def _subscriber_loop() -> None:
+    """Background coroutine — subscribes to the proposal channel and
+    stores the most-recent peer proposal per (instance_id, symbol)."""
+    url = os.environ.get("REDIS_URL")
+    if not url:
+        return
+    try:
+        import redis.asyncio as redis
+        client = redis.from_url(url, decode_responses=True)
+        pubsub = client.pubsub()
+        await pubsub.subscribe(PROPOSAL_CHANNEL)
+        async for message in pubsub.listen():
+            if message is None or message.get("type") != "message":
+                continue
+            try:
+                raw = message.get("data", "")
+                evt_dict = json.loads(raw)
+                evt = ProposalEvent(**evt_dict)
+                key = f"{evt.instance_id}|{evt.symbol}"
+                with _peer_lock:
+                    _peer_proposals[key] = evt
+            except Exception as err:  # noqa: BLE001
+                logger.debug("[ProposalBus] message parse failed: %s", err)
+    except Exception as err:  # noqa: BLE001
+        logger.debug("[ProposalBus] subscriber loop crashed: %s", err)
+
+
+def init_proposal_bus() -> None:
+    """Idempotently start the subscriber background task. Call once at
+    kernel boot. No-op when flag is off."""
+    global _subscriber_task
+    if not consensus_bus_live():
+        return
+    if _subscriber_task is not None and not _subscriber_task.done():
+        return
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            _subscriber_task = loop.create_task(_subscriber_loop())
+        else:
+            # Defer subscriber creation until event loop is available.
+            # Caller likely runs us during sync init; the FastAPI startup
+            # hook will pick this up on first request via get_event_loop.
+            logger.debug("[ProposalBus] init deferred — event loop not running")
+    except Exception as err:  # noqa: BLE001
+        logger.debug("[ProposalBus] init failed: %s", err)
+
+
+def get_recent_peer_proposal(symbol: str, self_instance_id: str) -> Optional[ProposalEvent]:
+    """Return the most-recent peer proposal for `symbol` from any kernel
+    instance OTHER than `self_instance_id`, provided it's fresh enough.
+    Returns None when flag is off, no peer proposals received, or all
+    stale beyond PEER_PROPOSAL_FRESHNESS_MS."""
+    if not consensus_bus_live():
+        return None
+    now_ms = time.time() * 1000.0
+    best: Optional[ProposalEvent] = None
+    with _peer_lock:
+        for evt in _peer_proposals.values():
+            if evt.symbol != symbol:
+                continue
+            if evt.instance_id == self_instance_id:
+                continue
+            if now_ms - evt.at_ms > PEER_PROPOSAL_FRESHNESS_MS:
+                continue
+            if best is None or evt.at_ms > best.at_ms:
+                best = evt
+    return best
+
+
+def _reset_for_tests() -> None:
+    """Test cleanup — clear peer proposals + publisher client."""
+    global _publisher_client, _subscriber_task
+    with _peer_lock:
+        _peer_proposals.clear()
+    _publisher_client = None
+    if _subscriber_task is not None and not _subscriber_task.done():
+        _subscriber_task.cancel()
+    _subscriber_task = None

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -1350,6 +1350,41 @@ def run_tick(
     effective_size_frac = inputs.size_fraction
     dca_intent = is_dca
 
+    # ── Cross-kernel proposal publish (Consensus Layer 1.5) ────
+    # CONSENSUS_PROPOSAL_BUS_LIVE flag-gated. Publish this kernel's
+    # proposed action to the shared Redis channel so the consensus
+    # arbiter (PR CONSENSUS-7) can subscribe. Fire-and-forget — never
+    # blocks the tick. See [[polytrade-consensus-architecture]].
+    try:
+        from .proposal_bus import ProposalEvent as _ProposalEvent
+        from .proposal_bus import publish_proposal_sync as _publish_proposal
+        _side: Optional[str] = (
+            "long" if direction == "long"
+            else "short" if direction == "short"
+            else None
+        )
+        _publish_proposal(_ProposalEvent(
+            instance_id=os.environ.get("MONKEY_PY_INSTANCE_ID", "monkey-py-shadow"),
+            symbol=inputs.symbol,
+            tick_id=f"{inputs.symbol}|{state.session_ticks}",
+            proposed_action=str(action),
+            side=_side,
+            lane=str(lane),
+            size_usdt=float(size_d["value"]),
+            leverage=float(leverage_d["value"]),
+            entry_threshold=float(entry_thr_d["value"]),
+            conviction=float(entry_thr_d["value"]),  # placeholder until ML conviction wired
+            basin_signature=[float(x) for x in np.asarray(basin).ravel()[:8]],
+            phi=float(phi),
+            kappa=float(state.kappa),
+            regime_label=None,  # populated in CONSENSUS-3 (regime_label tracking)
+            mode=str(mode),
+            at_ms=float(now_ms),
+            engine_version="v0.8.7c-3-py",
+        ))
+    except Exception:  # noqa: BLE001
+        pass
+
     return TickDecision(
         action=action,
         reason=reason,


### PR DESCRIPTION
Layer 1.5 of the dual-kernel consensus architecture. Adds low-latency proposal-level exchange via Redis pub/sub on channel `monkey:consensus:proposal`. Both TS Monkey and Py Monkey publish proposals each tick when CONSENSUS_PROPOSAL_BUS_LIVE=true. Consensus arbiter (PR CONSENSUS-7) will consume via getRecentPeerProposal(). Flag-gated default-off; behavior change when off = NONE. Build clean; 843 Python tests pass.