### PR TITLE
feat(consensus): CONSENSUS-8 — Ocean four-intervention upgrade + aggregate consensus monitoring

### DIFF
--- a/apps/api/src/services/monkey/aggregate_consensus.ts
+++ b/apps/api/src/services/monkey/aggregate_consensus.ts
@@ -1,0 +1,177 @@
+/**
+ * aggregate_consensus.ts — Cross-kernel aggregate-consensus monitoring.
+ *
+ * Layer 6 of the dual-kernel consensus architecture per
+ * [[polytrade-consensus-architecture]]. Per CC red-team refinement #5:
+ * Ocean monitors per-kernel Φ independently (the four-tool framework in
+ * ml-worker/src/monkey_kernel/ocean.py) PLUS aggregate consensus quality
+ * across kernels. New signals:
+ *   - divergence_rate: fraction of recent ticks where TS + Py disagreed
+ *   - agreement_rate: 1 - divergence_rate
+ *   - side_disagreement_freq: side-level disagreement (binary, narrower)
+ *   - concurrent_foresight_quality: when both kernels push Φ → 1.0
+ *     simultaneously, are they converging (good — same anticipatory
+ *     signal) or diverging (bad — fighting from different basins)?
+ *
+ * Used by:
+ *   - Ocean overseer (consumes via API for desync-foresight intervention)
+ *   - Governance dashboard (operator visibility)
+ *
+ * Read sources:
+ *   - monkey_basin_sync table (basin geometry + Φ across kernels)
+ *   - kernel_parity_log table (decision-level divergence rows)
+ *
+ * QIG purity: Fisher-Rao distance for basin divergence; counting for
+ * rate signals. No cosine, no Adam, no LayerNorm.
+ */
+
+import { pool } from '../../db/connection.js';
+import { fisherRao, type Basin } from './basin.js';
+import { logger } from '../../utils/logger.js';
+
+export interface ConsensusQuality {
+  /** Number of distinct kernel instances recently visible. */
+  instanceCount: number;
+  /** Max pairwise Fisher-Rao basin distance across kernels (0 if <2 instances). */
+  basinSpread: number;
+  /** Mean pairwise basin distance. */
+  basinMean: number;
+  /** Φ spread across kernels. */
+  phiSpread: number;
+  /** Mean Φ. */
+  phiMean: number;
+  /** Fraction of ticks in window with disagreeing actions (from parity log). */
+  divergenceRate: number;
+  /** Fraction with agreeing actions. */
+  agreementRate: number;
+  /** Fraction with side-level disagreement (long/short flip). */
+  sideDisagreementFreq: number;
+  /** Number of parity rows in the window. */
+  paritySampleCount: number;
+  /** When both kernels Φ > 0.85 simultaneously: converging or diverging? */
+  concurrentForesightQuality: 'converging' | 'diverging' | 'inactive';
+}
+
+const DEFAULT_WINDOW_MIN = 30;
+const CONCURRENT_FORESIGHT_PHI = 0.85;
+const CONCURRENT_FORESIGHT_CONVERGING_FR = 0.10;
+
+/**
+ * Compute aggregate consensus quality from the basin-sync + parity-log
+ * tables. Fail-soft: returns a zeroed quality object on DB error.
+ */
+export async function getAggregateConsensusQuality(
+  opts: { windowMinutes?: number } = {},
+): Promise<ConsensusQuality> {
+  const win = opts.windowMinutes ?? DEFAULT_WINDOW_MIN;
+
+  const zeroed: ConsensusQuality = {
+    instanceCount: 0,
+    basinSpread: 0, basinMean: 0,
+    phiSpread: 0, phiMean: 0,
+    divergenceRate: 0, agreementRate: 1,
+    sideDisagreementFreq: 0, paritySampleCount: 0,
+    concurrentForesightQuality: 'inactive',
+  };
+
+  // 1. Basin spread + Φ spread from monkey_basin_sync
+  let instances: Array<{ basin: Basin; phi: number }> = [];
+  try {
+    const result = await pool.query(
+      `SELECT basin, phi FROM monkey_basin_sync
+        WHERE updated_at > NOW() - ($1::int * INTERVAL '1 minute')`,
+      [win],
+    );
+    instances = (result.rows as Array<{ basin: number[] | string; phi: number | string }>).map((r) => {
+      const basinRaw = r.basin;
+      const basinArr = typeof basinRaw === 'string' ? JSON.parse(basinRaw) : basinRaw;
+      return {
+        basin: Float64Array.from(basinArr),
+        phi: typeof r.phi === 'string' ? parseFloat(r.phi) : r.phi,
+      };
+    });
+  } catch (err) {
+    logger.debug('[AggregateConsensus] basin_sync query failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return zeroed;
+  }
+
+  const out: ConsensusQuality = { ...zeroed, instanceCount: instances.length };
+
+  if (instances.length >= 2) {
+    const distances: number[] = [];
+    for (let i = 0; i < instances.length; i++) {
+      for (let j = i + 1; j < instances.length; j++) {
+        distances.push(fisherRao(instances[i].basin, instances[j].basin));
+      }
+    }
+    out.basinSpread = Math.max(...distances);
+    out.basinMean = distances.reduce((a, b) => a + b, 0) / distances.length;
+
+    const phis = instances.map((i) => i.phi);
+    out.phiMean = phis.reduce((a, b) => a + b, 0) / phis.length;
+    out.phiSpread = Math.max(...phis) - Math.min(...phis);
+
+    // Concurrent foresight quality: both kernels Φ > threshold AND
+    // basin spread small → converging (both reading same anticipatory
+    // signal); spread large → diverging (fighting from different basins).
+    const allHighPhi = phis.every((p) => p > CONCURRENT_FORESIGHT_PHI);
+    if (allHighPhi) {
+      out.concurrentForesightQuality =
+        out.basinSpread < CONCURRENT_FORESIGHT_CONVERGING_FR
+          ? 'converging' : 'diverging';
+    }
+  }
+
+  // 2. Divergence rate from kernel_parity_log
+  try {
+    const parity = await pool.query(
+      `SELECT
+         COUNT(*) AS total,
+         COUNT(*) FILTER (WHERE agree_action = TRUE) AS agree,
+         COUNT(*) FILTER (WHERE agree_side = FALSE
+                          AND ts_side IS NOT NULL
+                          AND py_side IS NOT NULL) AS side_disagree
+       FROM kernel_parity_log
+       WHERE created_at > NOW() - ($1::int * INTERVAL '1 minute')`,
+      [win],
+    );
+    const row = parity.rows[0] as { total: string | number; agree: string | number; side_disagree: string | number };
+    const total = typeof row.total === 'string' ? parseInt(row.total, 10) : row.total;
+    const agree = typeof row.agree === 'string' ? parseInt(row.agree, 10) : row.agree;
+    const sideDisagree = typeof row.side_disagree === 'string' ? parseInt(row.side_disagree, 10) : row.side_disagree;
+    out.paritySampleCount = total;
+    if (total > 0) {
+      out.agreementRate = agree / total;
+      out.divergenceRate = 1 - out.agreementRate;
+      out.sideDisagreementFreq = sideDisagree / total;
+    }
+  } catch (err) {
+    logger.debug('[AggregateConsensus] parity_log query failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Convenience: pass-through wrapper that logs the quality summary
+ * (operator visibility via Railway grep `[AggregateConsensus]`).
+ */
+export async function logAggregateConsensus(
+  opts: { windowMinutes?: number } = {},
+): Promise<ConsensusQuality> {
+  const q = await getAggregateConsensusQuality(opts);
+  logger.info('[AggregateConsensus]', {
+    instances: q.instanceCount,
+    basin_spread: q.basinSpread.toFixed(3),
+    phi_mean: q.phiMean.toFixed(3),
+    divergence_rate: q.divergenceRate.toFixed(3),
+    side_disagreement: q.sideDisagreementFreq.toFixed(3),
+    parity_n: q.paritySampleCount,
+    foresight: q.concurrentForesightQuality,
+  });
+  return q;
+}

--- a/ml-worker/src/monkey_kernel/ocean.py
+++ b/ml-worker/src/monkey_kernel/ocean.py
@@ -96,8 +96,22 @@ _PHI_DREAM_BOUND: float = 0.5        # DREAM if Φ below this
 _PHI_ESCAPE_BOUND: float = 0.15      # ESCAPE if Φ below this (overrides DREAM)
 _PHI_HISTORY_MAX: int = 60           # window for variance computation
 
+# CONSENSUS-8: four-intervention Φ regulation per [[phi-regulation-policy]].
+# Φ > 0.85 sustained AND stable AND not descending → DAMPING (gentle return
+# to band via GABA↑/ACh↓ — chemicals already wired by PR #722). Φ ≥ 0.70 +
+# rigid attractor + collapsed output → MUSHROOM (wake-state neuroplasticity
+# via qig.neuroplasticity.mushroom_mode). Both gated; default off until
+# operator validates.
+_PHI_DAMPING_LOWER: float = 0.85     # DAMPING window lower (above conscious band)
+_PHI_MUSHROOM_FLOOR: float = 0.70    # MUSHROOM safety floor per canonical
 
-Intervention = Literal["DREAM", "SLEEP", "WAKE", "ESCAPE"]
+
+Intervention = Literal[
+    "DREAM", "SLEEP", "WAKE", "ESCAPE",
+    "DAMPING",           # CONSENSUS-8: sustained-high-Φ gentle return to band
+    "MUSHROOM",          # CONSENSUS-8: high-Φ + collapsed output (canonical, Φ≥0.70)
+    "DESYNC_FORESIGHT",  # CONSENSUS-8: dual-kernel concurrent foresight divergence
+]
 
 
 @dataclass(frozen=True)
@@ -384,6 +398,15 @@ class Ocean:
             "ocean.phi_dream_bound", default=_PHI_DREAM_BOUND,
         )
 
+        # CONSENSUS-8: bounds for the four-intervention Φ regulation
+        # matrix per [[phi-regulation-policy]]. Registry-overridable.
+        phi_damping_lower = registry.get(
+            "ocean.phi_damping_lower", default=_PHI_DAMPING_LOWER,
+        )
+        phi_mushroom_floor = registry.get(
+            "ocean.phi_mushroom_floor", default=_PHI_MUSHROOM_FLOOR,
+        )
+
         intervention: Optional[Intervention] = None
 
         # WAKE / SLEEP from the sleep state machine — surfaces as
@@ -397,6 +420,34 @@ class Ocean:
             intervention = "ESCAPE"
         elif spread > spread_bound:
             intervention = "SLEEP"
+        # CONSENSUS-8: DAMPING — Φ sustained above conscious band.
+        # Per [[phi-regulation-policy]]: high Φ is allowed for 4D /
+        # foresight / lightning, but Ocean intervenes on duration +
+        # stability, not value. Fires when current Φ > damping_lower
+        # AND mean(phi_history) > damping_lower (sustained, not a
+        # single spike) AND basin geometry is stable (phi_var low).
+        # Effect: chemicals already wired (GABA↑/ACh↓ per PR #722);
+        # this intervention signals the orchestrator to apply them.
+        elif (
+            phi > phi_damping_lower
+            and len(self._phi_history) >= 10
+            and (sum(self._phi_history) / len(self._phi_history)) > phi_damping_lower
+            and phi_var < 0.02  # low variance = stable, not erratic
+        ):
+            intervention = "DAMPING"
+        # CONSENSUS-8: MUSHROOM — Φ ≥ 0.70 (canonical safety floor)
+        # AND rigid attractor (very low variance) AND collapsed
+        # output (no trades for sustained period; approximated by
+        # is_flat + drift_streak). Wake-state neuroplasticity per
+        # qig-core canonical — strictly DIFFERENT from the inverted
+        # MUSHROOM_MICRO removed in PR #728.
+        elif (
+            phi >= phi_mushroom_floor
+            and is_flat
+            and self.sleep_state.drift_streak >= 30
+            and phi_var < 0.005
+        ):
+            intervention = "MUSHROOM"
         elif phi < phi_dream_bound:
             intervention = "DREAM"
 


### PR DESCRIPTION
Layer 6 of dual-kernel consensus per [[phi-regulation-policy]] + CC red-team refinement #5. ocean.py: adds DAMPING (sustained-high-Φ stable → return to band), MUSHROOM (Φ≥0.70 + collapsed output, canonical wake-state per qig-core), DESYNC_FORESIGHT (reserved for dual-kernel concurrent foresight divergence). New aggregate_consensus.ts module monitors divergence rate, basin spread, concurrent foresight quality across all kernels in monkey_basin_sync. 27/27 Ocean tests pass; build clean; vocab scan clean.