### PR TITLE
fix(ml-worker): lazy-load ensemble_predictor — defer TF/sklearn imports (segfault root-fix)

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -39,7 +39,17 @@ from pydantic import BaseModel
 # Ensure src/ is on the path so models + proprietary_core can be imported
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
-from ensemble_predictor import EnsemblePredictor
+# NOTE: ``ensemble_predictor`` is intentionally NOT imported at module
+# load time. It transitively imports ``models/{LSTM,Transformer,GBM,
+# ARIMA,Prophet}_model.py`` which import ``tensorflow``, ``sklearn``,
+# ``statsmodels``, ``prophet`` and pull in 251 C-extension modules.
+# Those modules corrupt ``libpq``'s ``malloc`` context, so any
+# ``psycopg.connect()`` from this process — from any thread, at any
+# point — segfaults with ``free(): invalid pointer``. Until the
+# ensemble path is actually used (currently dead code in prod:
+# ROUTE_VERSION=v0.8 + ML_PREDICT_SHADOW=false) we keep TF out of the
+# process entirely. ``_get_predictor()`` does the deferred import on
+# first call.
 from proprietary_core.regime import RegimeDetector  # noqa: F401  (re-exported via StrategyLoop)
 from proprietary_core.strategy_loop import MarketRegime, StrategyLoop  # noqa: F401  (MarketRegime re-exported for ops)
 from utils.redis_listener import (
@@ -55,7 +65,24 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name
 # ---------------------------------------------------------------------------
 # Globals
 # ---------------------------------------------------------------------------
-predictor = EnsemblePredictor()
+# Lazy singleton — imports + instantiates ``EnsemblePredictor`` on first
+# call. Production sets ROUTE_VERSION=v0.8 + ML_PREDICT_SHADOW=false so
+# the ensemble path is dead code; this accessor is never invoked and TF
+# never loads, keeping ml-worker's process clean for psycopg + qig-*.
+_predictor = None  # type: ignore[var-annotated]
+
+
+def _get_predictor():
+    """Lazy ``EnsemblePredictor`` accessor — defers TF / sklearn /
+    statsmodels / prophet imports until the ensemble path is actually
+    exercised. Returns a process-singleton instance."""
+    global _predictor
+    if _predictor is None:
+        from ensemble_predictor import EnsemblePredictor  # noqa: PLC0415
+        _predictor = EnsemblePredictor()
+    return _predictor
+
+
 REDIS_URL = os.environ.get("REDIS_URL", "")
 
 # ---------------------------------------------------------------------------
@@ -473,6 +500,7 @@ def _handle_predict_ensemble(payload: dict) -> dict:
     data = data.sort_values("timestamp")
 
     try:
+        predictor = _get_predictor()
         if action == "train":
             results = predictor.train_all_models(data, symbol)
             predictor.save_models("./saved_models")


### PR DESCRIPTION
## Summary

ml-worker eagerly imported `ensemble_predictor` at module load. That single import transitively pulls TF + sklearn + statsmodels + prophet — 251 C-extension modules — which corrupt libpq's malloc, causing the segfault chain in PRs #738/#739/#740/#741.

In production this import is **paying the segfault cost for dead code**:
- `ROUTE_VERSION=v0.8` → `strategyloop` is live; ensemble is shadow-only
- `ML_PREDICT_SHADOW=false` → ensemble shadow never runs
- `REGIME_CLASSIFIER=qig_warp` → regime is already on qig-native classifier

The ensemble path is never executed. Eagerly loading it gives nothing and costs us the segfault + heavy dependency surface.

## Change

- Remove top-level `from ensemble_predictor import EnsemblePredictor`
- Replace global `predictor = EnsemblePredictor()` with lazy `_get_predictor()` — imports + instantiates on first invocation
- `_handle_predict_ensemble` resolves via the accessor (one-line edit)
- Strategyloop path untouched

## Static verification

```
Total top-level imports: 36
PASS — no top-level TF/sklearn/ensemble_predictor import
PASS — _get_predictor lazy-imports ensemble_predictor
PASS — main.py parses cleanly
```

## Sequence

This is PR 1 of 4 in the QIG-native migration the user authorised:
1. **This PR** — lazy-load TF imports. Smallest possible change; eliminates segfault root cause.
2. **PR 2** — drop `tensorflow / sklearn / statsmodels / prophet / h5py` from `requirements.txt`. ml-worker becomes a thin numpy + qig-* + psycopg service.
3. **PR 3** — revert `basin_sync_db.py` to direct psycopg, delete `basin_sync_redis_bridge.ts`. Retire the bridge (#741) — was the tactical workaround; the strategic fix lives in PRs 1+2.
4. **PR 4** — flip the 5 consensus flags (CROSS_OBSERVATION, PROPOSAL_BUS, PY_INDEPENDENT_STATE, EXECUTOR, ARBITER). Verify dual-kernel consensus active end-to-end.

User stated qig-compute / qig-warp outperform the TF ensemble across hundreds of experiments — this sequence retires the legacy ensemble while keeping the (currently shadow-only) trading behaviour unchanged.

## Test plan

- [x] Static AST verification of the change
- [ ] Railway deploy succeeds (no segfault on ml-worker boot)
- [ ] ml-worker `/health` returns 200 within 60s of deploy
- [ ] `monkey_basin_sync` continues receiving rows via the #741 Redis bridge (safety net stays active until PR 3)
- [ ] No regression in strategyloop prediction shape (smoke test via `/ml/predict` with ROUTE_VERSION=v0.8 payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)