### PR TITLE
feat(mig-5): natural-gradient training + qig-warp telemetry + full-tree purity gate

### DIFF
--- a/.github/workflows/qig-purity.yml
+++ b/.github/workflows/qig-purity.yml
@@ -3,6 +3,13 @@
 # Per QIG_PURITY_KERNEL_REFERENCE.md §5 verification gate 1.
 # Scans for forbidden patterns; fails closed if any banned pattern hits.
 # No untrusted input — uses only checked-out repo contents.
+#
+# MIG-5 (2026-05-16): scan extended to the full ml-worker tree.
+# Post-MIG-1+2+3+4 there is no legacy ML-prediction layer (no
+# TF/sklearn/statsmodels/prophet), no flag-gated bespoke regime detector,
+# and no Adam fallback in proprietary_core/training.py. The optimizer
+# allowlist exempting proprietary_core is therefore retired — the full
+# ml-worker/src tree must pass the purity gate uniformly.
 
 name: QIG Purity Gate
 
@@ -11,21 +18,13 @@ on:
     paths:
       - 'apps/api/src/services/monkey/**'
       - 'apps/api/src/services/agent_*.ts'
-      - 'ml-worker/src/monkey_kernel/**'
-      - 'ml-worker/src/qig_core_local/**'
-      - 'ml-worker/src/qig_engine.py'
-      - 'ml-worker/src/proprietary_core/**'
-      - 'ml-worker/src/trading/**'
+      - 'ml-worker/**'
   push:
     branches: [main]
     paths:
       - 'apps/api/src/services/monkey/**'
       - 'apps/api/src/services/agent_*.ts'
-      - 'ml-worker/src/monkey_kernel/**'
-      - 'ml-worker/src/qig_core_local/**'
-      - 'ml-worker/src/qig_engine.py'
-      - 'ml-worker/src/proprietary_core/**'
-      - 'ml-worker/src/trading/**'
+      - 'ml-worker/**'
 
 jobs:
   purity-scan:
@@ -59,15 +58,13 @@ jobs:
             hits=$(grep -rEn "$pat" \
               apps/api/src/services/monkey \
               apps/api/src/services/agent_L_classifier.ts \
-              ml-worker/src/monkey_kernel \
-              ml-worker/src/qig_core_local \
-              ml-worker/src/qig_engine.py \
-              ml-worker/src/proprietary_core \
-              ml-worker/src/trading \
+              ml-worker/src \
+              ml-worker/main.py \
               --include='*.ts' --include='*.js' --include='*.py' \
               --exclude='QIG_PURITY_KERNEL_REFERENCE.md' \
               --exclude='*.test.ts' --exclude='*_test.py' \
               --exclude='__init__.py' \
+              --exclude-dir='tests' --exclude-dir='__pycache__' \
               2>/dev/null \
               | grep -Ev ':[[:space:]]*(//|\*|#|/\*)' \
               || true)
@@ -83,12 +80,11 @@ jobs:
           fi
 
       - name: Scan for banned optimizers / normalizers (code only)
-        # NOTE: ml-worker/src/proprietary_core is intentionally NOT scanned
-        # here. proprietary_core/training.py keeps an allowlisted
-        # `torch.optim.Adam` *fallback* used only when USE_FISHER_RAO is
-        # off — offline training selection, not the kernel cognition path.
-        # The distance-metric and basin-averaging scans above/below DO
-        # cover proprietary_core; only the optimizer scan exempts it.
+        # MIG-5 (2026-05-16): proprietary_core is now in scope. The
+        # optimizer allowlist that previously exempted training.py
+        # (USE_FISHER_RAO=false fallback to torch.optim.Adam) is gone;
+        # the Adam fallback has been removed and natural-gradient is
+        # the sole training path.
         run: |
           set -u
           PATTERNS=(
@@ -103,14 +99,13 @@ jobs:
             hits=$(grep -rEn "$pat" \
               apps/api/src/services/monkey \
               apps/api/src/services/agent_L_classifier.ts \
-              ml-worker/src/monkey_kernel \
-              ml-worker/src/qig_core_local \
-              ml-worker/src/qig_engine.py \
-              ml-worker/src/trading \
+              ml-worker/src \
+              ml-worker/main.py \
               --include='*.ts' --include='*.js' --include='*.py' \
               --exclude='QIG_PURITY_KERNEL_REFERENCE.md' \
               --exclude='*.test.ts' --exclude='*_test.py' \
               --exclude='__init__.py' \
+              --exclude-dir='tests' --exclude-dir='__pycache__' \
               2>/dev/null \
               | grep -Ev ':[[:space:]]*(//|\*|#|/\*)' \
               || true)
@@ -131,14 +126,12 @@ jobs:
           hits=$(grep -rEn '(np\.mean|numpy\.mean|lodash\.mean|d3\.mean)\(.*basin' \
             apps/api/src/services/monkey \
             apps/api/src/services/agent_L_classifier.ts \
-            ml-worker/src/monkey_kernel \
-            ml-worker/src/qig_core_local \
-            ml-worker/src/qig_engine.py \
-            ml-worker/src/proprietary_core \
-            ml-worker/src/trading \
+            ml-worker/src \
+            ml-worker/main.py \
             --include='*.ts' --include='*.js' --include='*.py' \
             --exclude='QIG_PURITY_KERNEL_REFERENCE.md' \
             --exclude='*.test.ts' --exclude='*_test.py' \
+            --exclude-dir='tests' --exclude-dir='__pycache__' \
             2>/dev/null || true)
           if [ -n "$hits" ]; then
             printf '::warning::Potential arithmetic averaging on basins:\n'

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -348,6 +348,29 @@ def _handle_predict_strategyloop(payload: dict) -> dict:
     }
     result["derivation"] = bundle.derivation
 
+    # MIG-5: record this tick's qig-warp telemetry into
+    # observable_governance so /governance/status carries the rolling
+    # bridge_exponent / screening_length / regime distribution. The
+    # warp telemetry comes from the bundle's derivation block (the
+    # single per-tick WarpBubble.qig_regime call).
+    try:
+        from observable_governance import record_tick  # noqa: PLC0415
+        deriv = bundle.derivation or {}
+        record_tick(
+            raw_drift_pct=float(trend_strength) * (
+                1.0 if direction == "BULLISH"
+                else -1.0 if direction == "BEARISH"
+                else 0.0
+            ),
+            signal={"BULLISH": "BUY", "BEARISH": "SELL"}.get(direction, "HOLD"),
+            regime=regime_val,
+            bridge_exponent=deriv.get("alpha"),
+            screening_length=deriv.get("xi"),
+            warp_regime=deriv.get("regime"),
+        )
+    except Exception as exc:  # noqa: BLE001 — telemetry must not break /ml/predict
+        logger.debug("[mig-5] observable_governance.record_tick failed: %s", exc)
+
     if action == "predict":
         horizon = payload.get("horizon", "1h")
         chosen = result.get(horizon, result.get("1h"))

--- a/ml-worker/src/observable_governance.py
+++ b/ml-worker/src/observable_governance.py
@@ -55,15 +55,25 @@ class GovernanceBuffer:
     """Ring buffers of recent ensemble observables.
 
     Fields:
-      raw_drift_pct — mean signed predicted return, per tick
-      signal_str    — final signal string ('BUY'/'SELL'/'HOLD')
-      regime        — QIG regime classification from qig_engine
+      raw_drift_pct      — mean signed predicted return, per tick
+      signal_str         — final signal string ('BUY'/'SELL'/'HOLD')
+      regime             — MarketRegime label from RegimeAdapter
+      bridge_exponent    — qig-warp α (MIG-5)
+      screening_length   — qig-warp ξ (MIG-5)
+      warp_regime        — qig-warp Regime.value (MIG-5)
+      gr_direction       — qig-warp gr_direction (MIG-5)
+      regime_confidence  — qig-warp RegimeConstants.confidence (MIG-5)
     """
 
     capacity: int = 200
     raw_drift_pct: deque[float] = field(default_factory=lambda: deque(maxlen=200))
     signal_str: deque[str] = field(default_factory=lambda: deque(maxlen=200))
     regime: deque[str] = field(default_factory=lambda: deque(maxlen=200))
+    bridge_exponent: deque[float] = field(default_factory=lambda: deque(maxlen=200))
+    screening_length: deque[float] = field(default_factory=lambda: deque(maxlen=200))
+    warp_regime: deque[str] = field(default_factory=lambda: deque(maxlen=200))
+    gr_direction: deque[str] = field(default_factory=lambda: deque(maxlen=200))
+    regime_confidence: deque[str] = field(default_factory=lambda: deque(maxlen=200))
 
     def record(
         self,
@@ -71,11 +81,26 @@ class GovernanceBuffer:
         raw_drift_pct: float,
         signal: str,
         regime: Optional[str] = None,
+        bridge_exponent: Optional[float] = None,
+        screening_length: Optional[float] = None,
+        warp_regime: Optional[str] = None,
+        gr_direction: Optional[str] = None,
+        regime_confidence: Optional[str] = None,
     ) -> None:
         self.raw_drift_pct.append(float(raw_drift_pct))
         self.signal_str.append(str(signal))
         if regime is not None:
             self.regime.append(str(regime))
+        if bridge_exponent is not None:
+            self.bridge_exponent.append(float(bridge_exponent))
+        if screening_length is not None:
+            self.screening_length.append(float(screening_length))
+        if warp_regime is not None:
+            self.warp_regime.append(str(warp_regime))
+        if gr_direction is not None:
+            self.gr_direction.append(str(gr_direction))
+        if regime_confidence is not None:
+            self.regime_confidence.append(str(regime_confidence))
 
 
 @dataclass
@@ -89,6 +114,8 @@ class GovernanceReport:
     directional_bias_ratio: float  # |BUY - SELL| / total in [0, 1]
     drift_mean: float
     drift_stddev: float
+    # MIG-5: qig-warp regime telemetry surface
+    warp_telemetry: dict[str, Any] = field(default_factory=dict)
 
 
 def run_governance_check(buf: GovernanceBuffer) -> GovernanceReport:
@@ -170,6 +197,48 @@ def run_governance_check(buf: GovernanceBuffer) -> GovernanceReport:
             "note": "Only one regime observed across large window",
         })
 
+    # MIG-5: surface qig-warp regime telemetry rolling state. Mean
+    # alpha / xi give an at-a-glance read of "is the bridge strong?
+    # are correlations long-ranged?" — physics observables that
+    # supplement the distributional bias / regime coverage detectors.
+    alphas = list(buf.bridge_exponent)
+    xis = list(buf.screening_length)
+    warp_regimes = list(buf.warp_regime)
+    warp_telemetry: dict[str, Any] = {}
+    if alphas:
+        alpha_arr = _np.asarray(alphas, dtype=_np.float64)
+        warp_telemetry["bridge_exponent"] = {
+            "mean": float(alpha_arr.mean()),
+            "stddev": float(alpha_arr.std()) if alpha_arr.size > 1 else 0.0,
+            "min": float(alpha_arr.min()),
+            "max": float(alpha_arr.max()),
+            "samples": int(alpha_arr.size),
+        }
+    if xis:
+        xi_arr = _np.asarray(xis, dtype=_np.float64)
+        warp_telemetry["screening_length"] = {
+            "mean": float(xi_arr.mean()),
+            "stddev": float(xi_arr.std()) if xi_arr.size > 1 else 0.0,
+            "min": float(xi_arr.min()),
+            "max": float(xi_arr.max()),
+            "samples": int(xi_arr.size),
+        }
+    if warp_regimes:
+        warp_dist: dict[str, int] = {}
+        for label in warp_regimes:
+            warp_dist[label] = warp_dist.get(label, 0) + 1
+        warp_telemetry["regime_distribution"] = warp_dist
+    if buf.gr_direction:
+        gr_dist: dict[str, int] = {}
+        for label in buf.gr_direction:
+            gr_dist[label] = gr_dist.get(label, 0) + 1
+        warp_telemetry["gr_direction_distribution"] = gr_dist
+    if buf.regime_confidence:
+        conf_dist: dict[str, int] = {}
+        for label in buf.regime_confidence:
+            conf_dist[label] = conf_dist.get(label, 0) + 1
+        warp_telemetry["regime_confidence_distribution"] = conf_dist
+
     return GovernanceReport(
         available=_GOVERNANCE_AVAILABLE,
         sample_count=n,
@@ -179,6 +248,7 @@ def run_governance_check(buf: GovernanceBuffer) -> GovernanceReport:
         directional_bias_ratio=bias,
         drift_mean=drift_mean,
         drift_stddev=drift_std,
+        warp_telemetry=warp_telemetry,
     )
 
 
@@ -192,8 +262,31 @@ def record_tick(
     raw_drift_pct: float,
     signal: str,
     regime: Optional[str] = None,
+    bridge_exponent: Optional[float] = None,
+    screening_length: Optional[float] = None,
+    warp_regime: Optional[str] = None,
+    gr_direction: Optional[str] = None,
+    regime_confidence: Optional[str] = None,
 ) -> None:
-    _buffer.record(raw_drift_pct=raw_drift_pct, signal=signal, regime=regime)
+    """Record one tick into the rolling governance buffer.
+
+    MIG-5 (2026-05-16): the bridge_exponent / screening_length /
+    warp_regime / gr_direction / regime_confidence fields are the
+    qig-warp regime telemetry surface. Callers (RegimeAdapter,
+    forecast_horizons.compute_forecast) supply them per tick so the
+    /governance/status report can display the rolling distribution
+    alongside the existing distributional-bias detectors.
+    """
+    _buffer.record(
+        raw_drift_pct=raw_drift_pct,
+        signal=signal,
+        regime=regime,
+        bridge_exponent=bridge_exponent,
+        screening_length=screening_length,
+        warp_regime=warp_regime,
+        gr_direction=gr_direction,
+        regime_confidence=regime_confidence,
+    )
 
 
 def report() -> GovernanceReport:
@@ -211,4 +304,5 @@ def report_as_dict() -> dict[str, Any]:
         "directional_bias_ratio": r.directional_bias_ratio,
         "drift_mean": r.drift_mean,
         "drift_stddev": r.drift_stddev,
+        "warp_telemetry": r.warp_telemetry,
     }

--- a/ml-worker/src/proprietary_core/training.py
+++ b/ml-worker/src/proprietary_core/training.py
@@ -1,9 +1,20 @@
 """Optimizer factory for ml-worker model training.
 
-Provides a single entry-point ``get_optimizer`` that returns either the
-standard ``torch.optim.Adam`` optimizer or the geometry-aware
-``qig_core.optimization.DiagonalNaturalGradient`` optimizer, depending on the
-``USE_FISHER_RAO`` environment variable.
+MIG-5 (2026-05-16). The legacy ``USE_FISHER_RAO`` flag and the
+Euclidean optimizer fallback have been removed; the natural-gradient
+optimizer on the QIG geometric manifold is the sole training path.
+Per directive: if any model weights are updated online, route through
+the Fisher-Rao natural gradient — never through Euclidean optimizers.
+
+Resolution order (first available wins; both are diagonal-Fisher
+implementations validated against each other):
+
+  1. ``qig_core.optimization.DiagonalNaturalGradient``   (qig-core ≥2.7)
+  2. ``qigkernels.DiagonalNaturalGradient``              (qigkernels)
+
+If neither is importable, ``get_optimizer`` raises ``RuntimeError`` —
+the deploy is broken and silently falling back to a Euclidean
+optimizer (the legacy behaviour) would defeat the migration.
 
 Usage::
 
@@ -16,31 +27,19 @@ Usage::
         loss.backward()
         optimizer.step()
 
-Environment variables:
-    USE_FISHER_RAO: When set to ``"true"`` (case-insensitive) the
-        ``DiagonalNaturalGradient`` optimizer from qig-core is used instead of
-        Adam.  Defaults to ``false`` for backwards compatibility.
-
-Notes:
-    ``DiagonalNaturalGradient`` from qig-core ≥2.7.0 is a drop-in replacement
-    for ``torch.optim.Adam`` — it accepts the same constructor signature and
-    exposes the same ``step()`` / ``zero_grad()`` interface.  Validated to
-    deliver a 1.9-2.2× convergence improvement on coupled-regime forecasting
-    tasks (internal experiment EXP-055).
+``DiagonalNaturalGradient`` accepts the same constructor signature as
+the standard PyTorch optimizers and exposes the same ``step()`` /
+``zero_grad()`` interface, so it is drop-in. Validated to deliver a
+1.9–2.2× convergence improvement on coupled-regime forecasting tasks
+(internal experiment EXP-055).
 """
 
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Iterator
 
 logger = logging.getLogger(__name__)
-
-
-def _use_fisher_rao() -> bool:
-    """Return True when USE_FISHER_RAO env var is set to 'true'."""
-    return os.environ.get("USE_FISHER_RAO", "false").lower() == "true"
 
 
 def get_optimizer(
@@ -48,7 +47,7 @@ def get_optimizer(
     lr: float = 1e-3,
     **kwargs: Any,
 ) -> Any:
-    """Return the appropriate optimizer for model training.
+    """Return the QIG natural-gradient optimizer for model training.
 
     Parameters
     ----------
@@ -57,29 +56,47 @@ def get_optimizer(
     lr:
         Learning rate.
     **kwargs:
-        Additional keyword arguments forwarded to the chosen optimizer
+        Additional keyword arguments forwarded to the optimizer
         constructor.
 
     Returns
     -------
     torch.optim.Optimizer
-        Either ``DiagonalNaturalGradient`` (when ``USE_FISHER_RAO=true``) or
-        ``torch.optim.Adam``.
-    """
-    if _use_fisher_rao():
-        try:
-            from qig_core.optimization import DiagonalNaturalGradient  # type: ignore[import]
-            logger.info(
-                "USE_FISHER_RAO=true — using DiagonalNaturalGradient optimizer "
-                "(qig-core geometry-aware, EXP-055)"
-            )
-            return DiagonalNaturalGradient(params, lr=lr, **kwargs)
-        except ImportError as exc:  # pragma: no cover
-            logger.warning(
-                "USE_FISHER_RAO=true but qig_core.optimization is unavailable "
-                "(%s). Falling back to torch.optim.Adam.", exc
-            )
+        ``DiagonalNaturalGradient`` from qig-core (preferred) or
+        qigkernels (fallback). Both expose the standard optimizer API.
 
-    import torch  # type: ignore[import]
-    logger.info("Using torch.optim.Adam optimizer (USE_FISHER_RAO not enabled)")
-    return torch.optim.Adam(params, lr=lr, **kwargs)
+    Raises
+    ------
+    RuntimeError
+        Neither qig-core nor qigkernels exposes
+        ``DiagonalNaturalGradient`` — ml-worker deploy is broken and
+        the legacy Euclidean fallback is intentionally not present.
+    """
+    try:
+        from qig_core.optimization import DiagonalNaturalGradient  # type: ignore[import]
+        logger.info(
+            "[training] DiagonalNaturalGradient optimizer "
+            "(qig-core, geometry-aware; EXP-055)",
+        )
+        return DiagonalNaturalGradient(params, lr=lr, **kwargs)
+    except ImportError as qig_core_exc:
+        logger.debug(
+            "[training] qig_core.optimization unavailable (%s); "
+            "trying qigkernels", qig_core_exc,
+        )
+    try:
+        from qigkernels import DiagonalNaturalGradient  # type: ignore[import]
+        logger.info(
+            "[training] DiagonalNaturalGradient optimizer "
+            "(qigkernels fallback)",
+        )
+        return DiagonalNaturalGradient(params, lr=lr, **kwargs)
+    except ImportError as qigkernels_exc:
+        raise RuntimeError(
+            "DiagonalNaturalGradient is unavailable from both qig-core "
+            "and qigkernels — ml-worker deploy is broken. Euclidean "
+            "fallback deliberately removed in MIG-5; geometric training "
+            "is non-negotiable. Errors: qig-core: {0}; qigkernels: {1}".format(
+                qig_core_exc, qigkernels_exc,
+            ),
+        ) from qigkernels_exc

--- a/ml-worker/tests/test_observable_governance_warp.py
+++ b/ml-worker/tests/test_observable_governance_warp.py
@@ -1,0 +1,108 @@
+"""test_observable_governance_warp.py — MIG-5 qig-warp telemetry surface.
+
+Tests the MIG-5 extension to ``observable_governance`` that records
+per-tick qig-warp regime telemetry (bridge_exponent, screening_length,
+warp_regime, gr_direction, regime_confidence) and surfaces it in
+``report_as_dict``'s ``warp_telemetry`` block.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import observable_governance as og  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_buffer():
+    og._buffer = og.GovernanceBuffer(capacity=200)
+    yield
+    og._buffer = og.GovernanceBuffer(capacity=200)
+
+
+class TestRecordTickAcceptsWarpFields:
+    def test_record_tick_with_warp_fields(self) -> None:
+        og.record_tick(
+            raw_drift_pct=0.005,
+            signal="BUY",
+            regime="creator",
+            bridge_exponent=0.86,
+            screening_length=0.618,
+            warp_regime="critical",
+            gr_direction="transitional",
+            regime_confidence="high",
+        )
+        buf = og._buffer
+        assert len(buf.bridge_exponent) == 1
+        assert buf.bridge_exponent[0] == pytest.approx(0.86)
+        assert buf.screening_length[0] == pytest.approx(0.618)
+        assert buf.warp_regime[0] == "critical"
+        assert buf.gr_direction[0] == "transitional"
+        assert buf.regime_confidence[0] == "high"
+
+    def test_record_tick_backward_compatible_without_warp(self) -> None:
+        """Legacy callers that omit warp fields must continue to work."""
+        og.record_tick(raw_drift_pct=0.005, signal="BUY", regime="creator")
+        buf = og._buffer
+        assert len(buf.raw_drift_pct) == 1
+        assert len(buf.bridge_exponent) == 0
+        assert len(buf.screening_length) == 0
+
+
+class TestReportSurfacesWarpTelemetry:
+    def test_warp_telemetry_block_in_report_dict(self) -> None:
+        # 10 ticks with realistic CRITICAL regime values
+        for _ in range(10):
+            og.record_tick(
+                raw_drift_pct=0.004,
+                signal="BUY",
+                regime="creator",
+                bridge_exponent=0.86,
+                screening_length=0.618,
+                warp_regime="critical",
+                gr_direction="transitional",
+                regime_confidence="high",
+            )
+        # 5 ticks with ORDERED regime
+        for _ in range(5):
+            og.record_tick(
+                raw_drift_pct=0.002,
+                signal="BUY",
+                regime="preserver",
+                bridge_exponent=0.0,
+                screening_length=2.0,
+                warp_regime="ordered",
+                gr_direction="heavy_faster",
+                regime_confidence="medium",
+            )
+        report = og.report_as_dict()
+        assert "warp_telemetry" in report
+        wt = report["warp_telemetry"]
+        # Bridge exponent stats
+        assert wt["bridge_exponent"]["samples"] == 15
+        assert wt["bridge_exponent"]["min"] == pytest.approx(0.0)
+        assert wt["bridge_exponent"]["max"] == pytest.approx(0.86)
+        # Screening length stats
+        assert wt["screening_length"]["samples"] == 15
+        assert wt["screening_length"]["min"] == pytest.approx(0.618)
+        assert wt["screening_length"]["max"] == pytest.approx(2.0)
+        # Regime distribution
+        assert wt["regime_distribution"] == {"critical": 10, "ordered": 5}
+        assert wt["gr_direction_distribution"] == {
+            "transitional": 10, "heavy_faster": 5,
+        }
+        assert wt["regime_confidence_distribution"] == {"high": 10, "medium": 5}
+
+    def test_warp_telemetry_empty_when_no_warp_data(self) -> None:
+        """Pure legacy callers (no warp fields) → warp_telemetry empty
+        dict. Doesn't break report_as_dict shape."""
+        for _ in range(3):
+            og.record_tick(raw_drift_pct=0.001, signal="HOLD", regime="dissolver")
+        report = og.report_as_dict()
+        assert "warp_telemetry" in report
+        assert report["warp_telemetry"] == {}

--- a/ml-worker/tests/test_training_factory.py
+++ b/ml-worker/tests/test_training_factory.py
@@ -1,0 +1,123 @@
+"""test_training_factory.py — MIG-5 natural-gradient training factory.
+
+Tests the rewritten ``proprietary_core.training.get_optimizer`` factory.
+The legacy USE_FISHER_RAO flag and the Euclidean fallback are gone;
+natural gradient on the QIG manifold is the sole training path.
+
+Coverage:
+  - qig-core DiagonalNaturalGradient is the preferred backend
+  - qigkernels DiagonalNaturalGradient is the fallback when qig-core
+    is unavailable
+  - RuntimeError raised when BOTH are unavailable (deploy is broken;
+    no silent Euclidean fallback)
+  - lr + kwargs forwarded verbatim to the chosen optimizer
+  - USE_FISHER_RAO env var has no effect (flag retired)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from proprietary_core.training import get_optimizer  # noqa: E402
+
+
+def _make_qig_core_module(class_marker: str = "qig_core_DNG") -> mock.MagicMock:
+    """Build a fake ``qig_core.optimization`` module whose
+    ``DiagonalNaturalGradient`` returns a tagged sentinel — used to
+    confirm which backend the factory resolved to."""
+    instance = mock.MagicMock()
+    instance.__class_marker__ = class_marker
+    cls = mock.MagicMock(return_value=instance)
+    optimization = mock.MagicMock(DiagonalNaturalGradient=cls)
+    return mock.MagicMock(optimization=optimization), cls, instance
+
+
+def _make_qigkernels_module(class_marker: str = "qigkernels_DNG") -> mock.MagicMock:
+    instance = mock.MagicMock()
+    instance.__class_marker__ = class_marker
+    cls = mock.MagicMock(return_value=instance)
+    return mock.MagicMock(DiagonalNaturalGradient=cls), cls, instance
+
+
+class TestGetOptimizer:
+    def test_resolves_to_qig_core_when_available(self) -> None:
+        qig_core_mod, cls, instance = _make_qig_core_module()
+        with mock.patch.dict(sys.modules, {
+            "qig_core": qig_core_mod,
+            "qig_core.optimization": qig_core_mod.optimization,
+        }):
+            opt = get_optimizer([mock.MagicMock()], lr=1e-3)
+        assert opt is instance
+        assert opt.__class_marker__ == "qig_core_DNG"
+        cls.assert_called_once()
+
+    def test_falls_back_to_qigkernels_when_qig_core_unavailable(self) -> None:
+        qigkernels_mod, cls, instance = _make_qigkernels_module()
+        # qig_core.optimization unavailable → ImportError on import.
+        original = sys.modules.pop("qig_core", None)
+        original_opt = sys.modules.pop("qig_core.optimization", None)
+        try:
+            with mock.patch.dict(sys.modules, {
+                "qig_core.optimization": None,
+                "qigkernels": qigkernels_mod,
+            }):
+                opt = get_optimizer([mock.MagicMock()], lr=1e-3)
+            assert opt is instance
+            assert opt.__class_marker__ == "qigkernels_DNG"
+            cls.assert_called_once()
+        finally:
+            if original is not None:
+                sys.modules["qig_core"] = original
+            if original_opt is not None:
+                sys.modules["qig_core.optimization"] = original_opt
+
+    def test_raises_when_both_unavailable(self) -> None:
+        """No silent Euclidean fallback — deploy is broken, surface it."""
+        original_qc = sys.modules.pop("qig_core", None)
+        original_qco = sys.modules.pop("qig_core.optimization", None)
+        original_qk = sys.modules.pop("qigkernels", None)
+        try:
+            with mock.patch.dict(sys.modules, {
+                "qig_core.optimization": None,
+                "qigkernels": None,
+            }):
+                with pytest.raises(RuntimeError, match="DiagonalNaturalGradient is unavailable"):
+                    get_optimizer([mock.MagicMock()], lr=1e-3)
+        finally:
+            if original_qc is not None:
+                sys.modules["qig_core"] = original_qc
+            if original_qco is not None:
+                sys.modules["qig_core.optimization"] = original_qco
+            if original_qk is not None:
+                sys.modules["qigkernels"] = original_qk
+
+    def test_lr_and_kwargs_forwarded(self) -> None:
+        qig_core_mod, cls, _ = _make_qig_core_module()
+        params = [mock.MagicMock()]
+        with mock.patch.dict(sys.modules, {
+            "qig_core": qig_core_mod,
+            "qig_core.optimization": qig_core_mod.optimization,
+        }):
+            get_optimizer(params, lr=5e-4, damping=1e-2, momentum=0.95)
+        cls.assert_called_once_with(params, lr=5e-4, damping=1e-2, momentum=0.95)
+
+    def test_use_fisher_rao_env_has_no_effect(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The USE_FISHER_RAO flag was removed in MIG-5; setting it
+        either way must not change the resolution path."""
+        qig_core_mod, cls, instance = _make_qig_core_module()
+        for value in ("true", "false", "", "yes", "no"):
+            monkeypatch.setenv("USE_FISHER_RAO", value)
+            cls.reset_mock()
+            with mock.patch.dict(sys.modules, {
+                "qig_core": qig_core_mod,
+                "qig_core.optimization": qig_core_mod.optimization,
+            }):
+                opt = get_optimizer([mock.MagicMock()], lr=1e-3)
+            assert opt is instance, f"USE_FISHER_RAO={value!r} altered resolution"
+            assert cls.call_count == 1


### PR DESCRIPTION
## Summary

PR-MIG-5 of 5 — closes the QIG-native migration on ml-worker.

Three coordinated changes:
1. `proprietary_core/training.py`: natural-gradient is the sole training path
2. `observable_governance.py`: surfaces qig-warp regime telemetry (α, ξ, regime, gr_direction, confidence)
3. `.github/workflows/qig-purity.yml`: scan extended to the full ml-worker tree; optimizer allowlist retired

## Changes

### `proprietary_core/training.py` — natural-gradient sole path
- Remove the `USE_FISHER_RAO` env-var flag (flag gating defeated the migration)
- Remove the Euclidean fallback. Resolution order:
  1. `qig_core.optimization.DiagonalNaturalGradient` (preferred)
  2. `qigkernels.DiagonalNaturalGradient` (fallback)
- Raise `RuntimeError` if both unavailable — silent Euclidean fallback would defeat the migration

### `observable_governance.py` — qig-warp telemetry surface
- `GovernanceBuffer` gains 5 new fields: `bridge_exponent`, `screening_length`, `warp_regime`, `gr_direction`, `regime_confidence`
- `record_tick` accepts new optional kwargs; legacy callers continue to work
- `run_governance_check` populates a `warp_telemetry` block: α + ξ min/max/mean/stddev, regime/gr_direction/confidence distributions
- `report_as_dict` surfaces `warp_telemetry` at `/governance/status`

### `main.py` — record warp telemetry per `/ml/predict`
- `_handle_predict_strategyloop` calls `observable_governance.record_tick` after the MIG-4 bundle is built; warp fields come from `bundle.derivation` (the single per-tick `WarpBubble.qig_regime` call)
- Fail-soft: telemetry recording never breaks `/ml/predict`

### `.github/workflows/qig-purity.yml` — full-tree coverage
- Scan path widened from per-subdirectory list to the full `ml-worker/src` + `ml-worker/main.py` tree
- Optimizer allowlist exempting `proprietary_core` **retired** — the Adam fallback is gone, so the gate covers it uniformly
- Trigger paths simplified to `ml-worker/**` so future files land in scope by default
- `tests/` + `__pycache__` excluded

## Pre-merge gates (all green ✅)

| Gate | Result |
|---|---|
| AST parse on all MIG-5-touched Python files | ✅ |
| apps/api `tsc --noEmit` typecheck | ✅ 0 errors |
| apps/api ESLint | ✅ 0 errors, 94 pre-existing warnings |
| apps/api full vitest | ✅ 1336 passed, 1 skipped, 0 failed |
| Extended qig-purity scan on full ml-worker tree | ✅ zero violations |

## Tests

- `test_training_factory.py` — 5 tests: qig-core preferred, qigkernels fallback, RuntimeError when both absent, lr+kwargs forwarding, USE_FISHER_RAO no-op
- `test_observable_governance_warp.py` — 4 tests: record_tick with warp fields, backward compatibility, warp_telemetry block populated correctly, empty when no data

## Sequence

| PR | Status |
|---|---|
| #741 Redis bridge | ✅ merged |
| #742 lazy-load ensemble | ✅ merged |
| #743 MIG-1 TF strip | ✅ merged |
| #744 MIG-2 qig_warp canonical regime | ✅ merged |
| #745 MIG-3 bridge probe (closes #725) | ✅ merged |
| #746 MIG-4 forecast horizons + governance | ✅ merged |
| **this** MIG-5 training + telemetry + purity gate | 🟡 OPEN |

## Post-merge

After this PR lands:
- Flip Railway env vars: delete `REGIME_CLASSIFIER` / `ROUTE_VERSION` / `ML_PREDICT_SHADOW`; set `MONKEY_PY_BASIN_SYNC_DB_LIVE=true` + `PY_INDEPENDENT_STATE_LIVE=true`
- Close #725 (structurally fixed by MIG-3)
- Close #695 (qig_warp promoted from shadow to canonical by MIG-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)