### PR TITLE
fix(mig-5): record warp telemetry on every /ml/predict path (signal + forecast)

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -268,6 +268,65 @@ def _regime_to_direction(regime: str, prices: list[float]) -> str:
     return regime_to_direction(regime, prices)
 
 
+def _record_warp_telemetry_for_tick(
+    *,
+    decision: Any,
+    regime_val: str,
+    direction: str,
+) -> None:
+    """Push this tick's qig-warp regime telemetry into observable_governance.
+
+    Fires on every /ml/predict path (signal + forecast) so the
+    /governance/status rolling buffer reflects the actual load — the
+    original MIG-5 wiring placed this call after the action == "signal"
+    early-return, which is the high-volume trading path, leaving the
+    buffer permanently empty.
+
+    Fail-soft on qig_warp or observable_governance import errors —
+    telemetry must never break /ml/predict.
+    """
+    if decision is None or decision.regime is None:
+        return
+    h_value = float(decision.regime.entropy)
+    j_value = float(decision.regime.trend_strength)
+    bridge_exp: float | None = None
+    screen_len: float | None = None
+    warp_reg: str | None = None
+    gr_dir: str | None = None
+    rc_conf: str | None = None
+    try:
+        from qig_warp import regime_constants  # type: ignore[import-not-found]
+        rc = regime_constants(h=h_value, J=j_value, dim=2)
+        bridge_exp = float(rc.bridge_exponent)
+        screen_len = float(rc.screening_length)
+        warp_reg = getattr(rc.regime, "value", str(rc.regime))
+        gr_dir = str(rc.gr_direction) if getattr(rc, "gr_direction", None) else None
+        rc_conf = str(rc.confidence) if getattr(rc, "confidence", None) else None
+    except Exception as exc:  # noqa: BLE001 — fail-soft per tick contract
+        logger.debug("[mig-5] regime_constants failed (h=%.3f J=%.3f): %s",
+                     h_value, j_value, exc)
+
+    try:
+        from observable_governance import record_tick  # noqa: PLC0415
+        drift_pct = j_value * (
+            1.0 if direction == "BULLISH"
+            else -1.0 if direction == "BEARISH"
+            else 0.0
+        )
+        record_tick(
+            raw_drift_pct=drift_pct,
+            signal={"BULLISH": "BUY", "BEARISH": "SELL"}.get(direction, "HOLD"),
+            regime=regime_val,
+            bridge_exponent=bridge_exp,
+            screening_length=screen_len,
+            warp_regime=warp_reg,
+            gr_direction=gr_dir,
+            regime_confidence=rc_conf,
+        )
+    except Exception as exc:  # noqa: BLE001 — telemetry must not break /ml/predict
+        logger.debug("[mig-5] observable_governance.record_tick failed: %s", exc)
+
+
 def _handle_predict_strategyloop(payload: dict) -> dict:
     """Deterministic regime-based predictor.
 
@@ -322,6 +381,17 @@ def _handle_predict_strategyloop(payload: dict) -> dict:
     direction = _regime_to_direction(regime_val, prices)
     confidence_pct = int(min(max(confidence_raw * 100, 10), 95))
 
+    # MIG-5 HOTFIX (2026-05-17): record warp telemetry BEFORE the
+    # action == "signal" early-return so the recording fires on every
+    # /ml/predict path. polytrade-be drives most ticks via the signal
+    # action; placing the call after the signal return left the
+    # observable_governance buffer permanently empty.
+    _record_warp_telemetry_for_tick(
+        decision=decision,
+        regime_val=regime_val,
+        direction=direction,
+    )
+
     if action == "signal":
         sig = _strategy_to_signal(decision.selected_strategy.value, regime_val, direction)
         sig["strength"] = round(confidence_raw, 4)
@@ -331,9 +401,9 @@ def _handle_predict_strategyloop(payload: dict) -> dict:
     # extrapolation replaced with qig-warp bridge/screening-derived
     # forecast horizons (Path 1) wrapped in qig-compute observable
     # governance (Path 2) — both layers in one PR. Exactly one
-    # WarpBubble.qig_regime call per tick; derivation block in
-    # response so an operator can reproduce the forecast by hand
-    # from a single /ml/predict response.
+    # WarpBubble.qig_regime call per tick on the forecast path;
+    # derivation block in response so an operator can reproduce the
+    # forecast by hand from a single /ml/predict response.
     from forecast_horizons import compute_forecast  # noqa: PLC0415
     bundle = compute_forecast(
         symbol=symbol,
@@ -347,29 +417,6 @@ def _handle_predict_strategyloop(payload: dict) -> dict:
         label: hf.to_dict() for label, hf in bundle.horizons.items()
     }
     result["derivation"] = bundle.derivation
-
-    # MIG-5: record this tick's qig-warp telemetry into
-    # observable_governance so /governance/status carries the rolling
-    # bridge_exponent / screening_length / regime distribution. The
-    # warp telemetry comes from the bundle's derivation block (the
-    # single per-tick WarpBubble.qig_regime call).
-    try:
-        from observable_governance import record_tick  # noqa: PLC0415
-        deriv = bundle.derivation or {}
-        record_tick(
-            raw_drift_pct=float(trend_strength) * (
-                1.0 if direction == "BULLISH"
-                else -1.0 if direction == "BEARISH"
-                else 0.0
-            ),
-            signal={"BULLISH": "BUY", "BEARISH": "SELL"}.get(direction, "HOLD"),
-            regime=regime_val,
-            bridge_exponent=deriv.get("alpha"),
-            screening_length=deriv.get("xi"),
-            warp_regime=deriv.get("regime"),
-        )
-    except Exception as exc:  # noqa: BLE001 — telemetry must not break /ml/predict
-        logger.debug("[mig-5] observable_governance.record_tick failed: %s", exc)
 
     if action == "predict":
         horizon = payload.get("horizon", "1h")

--- a/ml-worker/tests/test_record_warp_telemetry_for_tick.py
+++ b/ml-worker/tests/test_record_warp_telemetry_for_tick.py
@@ -1,0 +1,158 @@
+"""test_record_warp_telemetry_for_tick.py — regression for the MIG-5
+empty-buffer bug.
+
+Symptom (caught by overnight monitor 2026-05-17T17:01Z): the
+observable_governance ``sample_count`` stayed at 0 for an hour after
+the MIG-5 deploy despite /ml/predict being called ~200 times. Root
+cause: MIG-5 placed ``record_tick()`` AFTER the
+``if action == "signal": return ...`` early-return in
+``_handle_predict_strategyloop``. polytrade-be drives most ticks via
+the signal action, so the recording path never fired.
+
+Fix: extract ``_record_warp_telemetry_for_tick`` and call it BEFORE
+the early-return. This file is the regression — it would fail under
+the bug and pass under the fix.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+ML_WORKER_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ML_WORKER_ROOT / "src"
+
+
+@pytest.fixture(scope="module")
+def main_module():
+    """Boot the FastAPI main module without dragging full env."""
+    if str(SRC_DIR) not in sys.path:
+        sys.path.insert(0, str(SRC_DIR))
+    if str(ML_WORKER_ROOT) not in sys.path:
+        sys.path.insert(0, str(ML_WORKER_ROOT))
+
+    try:
+        import main as m
+        return m
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"ml-worker main.py import failed: {type(exc).__name__}: {exc}")
+
+
+def _make_decision(
+    *, regime_value: str = "creator", entropy: float = 2.5,
+    trend_strength: float = 0.4, confidence: float = 0.9,
+) -> SimpleNamespace:
+    """Build a stand-in for the StrategyLoop decision the helper reads."""
+    regime = SimpleNamespace(
+        regime=SimpleNamespace(value=regime_value),
+        entropy=entropy,
+        fisher_info=0.1,
+        trend_strength=trend_strength,
+        volatility=0.02,
+        confidence=confidence,
+        is_transition=False,
+        pillar1_gate=True,
+    )
+    return SimpleNamespace(regime=regime)
+
+
+def _fake_qig_warp() -> mock.MagicMock:
+    """qig_warp.regime_constants returns a stable RegimeConstants stub."""
+    rc = mock.MagicMock()
+    rc.regime = mock.MagicMock()
+    rc.regime.value = "critical"
+    rc.bridge_exponent = 0.86
+    rc.screening_length = 0.618
+    rc.gr_direction = "transitional"
+    rc.confidence = "high"
+    fake_module = mock.MagicMock()
+    fake_module.regime_constants.return_value = rc
+    return fake_module
+
+
+class TestRecordTelemetryFiresOnEveryPath:
+    """The MIG-5 hotfix moves the telemetry recording before the
+    action == "signal" early-return. These tests would fail under
+    the pre-hotfix code path."""
+
+    def test_helper_records_with_warp_fields_populated(
+        self, main_module, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When qig_warp is reachable, every recorded row carries the
+        bridge_exponent / screening_length / warp_regime / gr_direction
+        / regime_confidence fields. This is the path the production
+        bug was blocking."""
+        # Reset the rolling buffer to a known state.
+        import observable_governance as og
+        monkeypatch.setattr(og, "_buffer", og.GovernanceBuffer(capacity=200))
+
+        with mock.patch.dict(sys.modules, {"qig_warp": _fake_qig_warp()}):
+            main_module._record_warp_telemetry_for_tick(
+                decision=_make_decision(),
+                regime_val="creator",
+                direction="BULLISH",
+            )
+
+        buf = og._buffer
+        assert len(buf.raw_drift_pct) == 1
+        assert len(buf.bridge_exponent) == 1
+        assert buf.bridge_exponent[0] == pytest.approx(0.86)
+        assert buf.screening_length[0] == pytest.approx(0.618)
+        assert buf.warp_regime[0] == "critical"
+        assert buf.gr_direction[0] == "transitional"
+        assert buf.regime_confidence[0] == "high"
+        assert buf.signal_str[0] == "BUY"
+        assert buf.regime[0] == "creator"
+
+    def test_helper_is_noop_when_decision_missing(
+        self, main_module, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Insufficient-data path: decision or decision.regime is None
+        → no recording (matches the strategyloop early-return shape)."""
+        import observable_governance as og
+        monkeypatch.setattr(og, "_buffer", og.GovernanceBuffer(capacity=200))
+
+        main_module._record_warp_telemetry_for_tick(
+            decision=None, regime_val="dissolver", direction="NEUTRAL",
+        )
+        assert len(og._buffer.raw_drift_pct) == 0
+
+        no_regime = SimpleNamespace(regime=None)
+        main_module._record_warp_telemetry_for_tick(
+            decision=no_regime, regime_val="dissolver", direction="NEUTRAL",
+        )
+        assert len(og._buffer.raw_drift_pct) == 0
+
+    def test_helper_records_even_when_qig_warp_unavailable(
+        self, main_module, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """qig_warp import failure → record_tick still fires with
+        regime + raw_drift_pct + signal populated; warp fields are
+        None. The buffer still advances → /ml/predict-call count is
+        observable through sample_count."""
+        import observable_governance as og
+        monkeypatch.setattr(og, "_buffer", og.GovernanceBuffer(capacity=200))
+
+        original = sys.modules.pop("qig_warp", None)
+        try:
+            with mock.patch.dict(sys.modules, {"qig_warp": None}):
+                main_module._record_warp_telemetry_for_tick(
+                    decision=_make_decision(),
+                    regime_val="creator",
+                    direction="BEARISH",
+                )
+        finally:
+            if original is not None:
+                sys.modules["qig_warp"] = original
+
+        buf = og._buffer
+        assert len(buf.raw_drift_pct) == 1
+        assert buf.signal_str[0] == "SELL"
+        assert buf.regime[0] == "creator"
+        # warp fields not populated → length stays 0
+        assert len(buf.bridge_exponent) == 0
+        assert len(buf.screening_length) == 0


### PR DESCRIPTION
## Symptom

The overnight monitor (b5zyuo55s) heartbeat at 17:01Z showed `samples=0 warp_samples=0` an hour after MIG-5 deployed — the observable_governance buffer was permanently empty in production despite ~200+ `/ml/predict` calls visible in Railway logs.

## Root cause

MIG-5 placed `record_tick()` AFTER the `action == "signal"` early-return in `_handle_predict_strategyloop`. polytrade-be drives most ticks via `action="signal"` (the trading-signal path); the recording site was unreachable on the high-volume path.

## Fix

Extract `_record_warp_telemetry_for_tick(decision, regime_val, direction)` helper that:
- Computes warp constants via `qig_warp.regime_constants(h=entropy, J=trend_strength, dim=2)` — small TFIM table lookup
- Calls `observable_governance.record_tick` with the full warp surface

Call the helper **before** the `action == "signal"` early-return so it fires on every `/ml/predict` path with a valid `decision.regime`.

Fail-soft preserved:
- `decision`/`decision.regime` None → no-op (insufficient-data shape preserved)
- `qig_warp` import or `regime_constants` exception → warp fields are None but `raw_drift_pct`/`signal`/`regime` still record, so the buffer keeps advancing
- `observable_governance` import failure → silent debug log

## Cost

One extra `qig_warp.regime_constants` call per `/ml/predict` (microseconds, TFIM table lookup). A follow-on refactor can share the constants between this helper and `forecast_horizons.compute_forecast`.

## Test

`tests/test_record_warp_telemetry_for_tick.py` — 3 regression tests that would fail under the pre-hotfix code path:
- records with all warp fields populated when qig_warp reachable
- no-op when `decision`/`decision.regime` is None
- still records (without warp fields) when qig_warp unavailable

## Pre-merge gates (all green)

| Gate | Result |
|---|---|
| AST parse on touched Python files | ✅ |
| qig-purity scan on full ml-worker tree | ✅ no banned patterns |
| apps/api `tsc --noEmit` | ✅ 0 errors |
| apps/api `vitest run` | ✅ 1336 passed, 1 skipped |

## Acceptance after deploy

The overnight monitor will report increasing `sample_count` + populated `warp_telemetry` block within the next two heartbeats. If it stays at 0, the root cause is something else (e.g. telemetry buffer in a different process; recording silently failing) and I'll diagnose further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)