### PR TITLE
fix(observable_governance): add tick_count_total — unbounded freshness counter

### DIFF
--- a/ml-worker/src/observable_governance.py
+++ b/ml-worker/src/observable_governance.py
@@ -74,6 +74,12 @@ class GovernanceBuffer:
     warp_regime: deque[str] = field(default_factory=lambda: deque(maxlen=200))
     gr_direction: deque[str] = field(default_factory=lambda: deque(maxlen=200))
     regime_confidence: deque[str] = field(default_factory=lambda: deque(maxlen=200))
+    # Unbounded monotonic tick counter (2026-05-17). The rolling buffers
+    # above cap at ``capacity`` so ``len(deque)`` plateaus at 200 once
+    # full and can no longer signal freshness — external freshness
+    # checks must use this counter instead. Incremented once per
+    # successful ``record()`` call.
+    tick_count_total: int = 0
 
     def record(
         self,
@@ -87,6 +93,7 @@ class GovernanceBuffer:
         gr_direction: Optional[str] = None,
         regime_confidence: Optional[str] = None,
     ) -> None:
+        self.tick_count_total += 1
         self.raw_drift_pct.append(float(raw_drift_pct))
         self.signal_str.append(str(signal))
         if regime is not None:
@@ -106,7 +113,8 @@ class GovernanceBuffer:
 @dataclass
 class GovernanceReport:
     available: bool
-    sample_count: int
+    sample_count: int             # current rolling-buffer length (caps at capacity)
+    tick_count_total: int         # unbounded monotonic — use this for freshness
     amplitude_violations: list[dict[str, Any]]
     regime_violations: list[dict[str, Any]]
     # Local heuristic checks (always run, even without qig-compute)
@@ -242,6 +250,7 @@ def run_governance_check(buf: GovernanceBuffer) -> GovernanceReport:
     return GovernanceReport(
         available=_GOVERNANCE_AVAILABLE,
         sample_count=n,
+        tick_count_total=buf.tick_count_total,
         amplitude_violations=amplitude_violations,
         regime_violations=regime_violations,
         signal_distribution=dist,
@@ -298,6 +307,7 @@ def report_as_dict() -> dict[str, Any]:
     return {
         "available": r.available,
         "sample_count": r.sample_count,
+        "tick_count_total": r.tick_count_total,
         "amplitude_violations": r.amplitude_violations,
         "regime_violations": r.regime_violations,
         "signal_distribution": r.signal_distribution,

--- a/ml-worker/tests/test_observable_governance_warp.py
+++ b/ml-worker/tests/test_observable_governance_warp.py
@@ -106,3 +106,59 @@ class TestReportSurfacesWarpTelemetry:
         report = og.report_as_dict()
         assert "warp_telemetry" in report
         assert report["warp_telemetry"] == {}
+
+
+class TestTickCountTotalFreshness:
+    """Regression: ``sample_count`` plateaus at the deque ``maxlen``
+    (200) once the rolling buffer fills, so external freshness checks
+    cannot use it. ``tick_count_total`` is the unbounded monotonic
+    counter that DOES advance on every record — overnight monitor
+    2026-05-17T18:13Z surfaced this false-positive freshness alert
+    when the buffer hit capacity. This test proves the counter
+    advances past the buffer cap."""
+
+    def test_tick_count_total_advances_past_buffer_cap(self) -> None:
+        """Push more ticks than the buffer capacity. ``sample_count``
+        caps at 200; ``tick_count_total`` keeps climbing."""
+        # Small buffer for the test — same shape as production.
+        og._buffer = og.GovernanceBuffer(capacity=200)
+        # Override the deque maxlens to match the capacity parameter
+        # so we don't have to push thousands of ticks.
+        from collections import deque
+        og._buffer.raw_drift_pct = deque(maxlen=10)
+        og._buffer.signal_str = deque(maxlen=10)
+        og._buffer.regime = deque(maxlen=10)
+        og._buffer.bridge_exponent = deque(maxlen=10)
+        og._buffer.screening_length = deque(maxlen=10)
+        og._buffer.warp_regime = deque(maxlen=10)
+        og._buffer.gr_direction = deque(maxlen=10)
+        og._buffer.regime_confidence = deque(maxlen=10)
+
+        for i in range(25):
+            og.record_tick(
+                raw_drift_pct=0.001,
+                signal="HOLD",
+                regime="dissolver",
+                bridge_exponent=0.38,
+                screening_length=0.784,
+                warp_regime="disordered",
+            )
+
+        report = og.report_as_dict()
+        # sample_count is the len() of the bounded deque — capped at 10.
+        assert report["sample_count"] == 10
+        # tick_count_total is the monotonic ground-truth — 25 because
+        # 25 ticks were pushed.
+        assert report["tick_count_total"] == 25
+        # Continued ticks → counter keeps climbing past buffer cap.
+        for _ in range(15):
+            og.record_tick(raw_drift_pct=0.001, signal="HOLD", regime="dissolver")
+        report = og.report_as_dict()
+        assert report["sample_count"] == 10  # still capped
+        assert report["tick_count_total"] == 40
+
+    def test_tick_count_total_starts_at_zero(self) -> None:
+        og._buffer = og.GovernanceBuffer(capacity=200)
+        report = og.report_as_dict()
+        assert report["tick_count_total"] == 0
+        assert report["sample_count"] == 0


### PR DESCRIPTION
## Symptom (caught overnight)

Overnight monitor at 17:22Z UTC fired a false-positive frozen-telemetry alert: `sample_count` was stuck at 200 for 30 minutes despite `/ml/predict` actively recording.

## Root cause

`GovernanceBuffer`'s rolling deques cap at `maxlen=200`. Once the buffer fills, `len(deque)` plateaus at the cap forever — `sample_count` becomes a constant, not a freshness signal. The overnight monitor was using `sample_count` as the freshness probe; the moment production caught up to the cap (~80 min post-MIG-5-hotfix deploy), the freshness check broke.

## Fix

Add an unbounded monotonic `tick_count_total` counter, incremented once per `record()` call. Ground-truth signal for "is `/ml/predict` still being called" — survives buffer cap, monotonic for the process lifetime.

| Surface | Behaviour |
|---|---|
| `GovernanceBuffer.tick_count_total: int` | Default 0, +1 per `record()` |
| `GovernanceReport.tick_count_total` | New field on report |
| `report_as_dict()` | Exposes `tick_count_total` at `/governance/status` |
| `sample_count` | Retained for buffer-fill diagnostics (different signal) |

Overnight monitor will be restarted post-merge to use `tick_count_total` for freshness; `sample_count` becomes a "is buffer full?" diagnostic.

## Test (`tests/test_observable_governance_warp.py`)

- `test_tick_count_total_advances_past_buffer_cap`: push 25 ticks into a 10-cap buffer → `sample_count=10`, `tick_count_total=25`. Push 15 more → `tick_count_total=40` while `sample_count` stays capped.
- `test_tick_count_total_starts_at_zero`: fresh buffer has counter=0.

## Pre-merge gates

| Gate | Result |
|---|---|
| AST parse on both touched files | ✅ |
| qig-purity scan on full ml-worker tree | ✅ zero violations |
| apps/api `tsc --noEmit` | ✅ 0 errors |
| apps/api `vitest run` | ✅ 1336 passed, 1 skipped |

## Origin story

Filed under "edge case the user told me to investigate while monitoring overnight" — a monitor blind-spot surfaced by a false-positive alert at 18:13Z UTC. Per the "highest quality long-term solution always" principle, the fix is a proper code change to give the system a real freshness signal, not a monitor workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)