### PR TITLE
diag(observable_governance): expose raw (h, J) lattice inputs + h/J ratio

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -322,6 +322,8 @@ def _record_warp_telemetry_for_tick(
             warp_regime=warp_reg,
             gr_direction=gr_dir,
             regime_confidence=rc_conf,
+            h_input=h_value,
+            j_input=j_value,
         )
     except Exception as exc:  # noqa: BLE001 — telemetry must not break /ml/predict
         logger.debug("[mig-5] observable_governance.record_tick failed: %s", exc)

--- a/ml-worker/src/observable_governance.py
+++ b/ml-worker/src/observable_governance.py
@@ -74,6 +74,16 @@ class GovernanceBuffer:
     warp_regime: deque[str] = field(default_factory=lambda: deque(maxlen=200))
     gr_direction: deque[str] = field(default_factory=lambda: deque(maxlen=200))
     regime_confidence: deque[str] = field(default_factory=lambda: deque(maxlen=200))
+    # Diagnostic (2026-05-17): the raw (h, J) lattice inputs that
+    # qig_warp.regime_constants was called with. Critical for
+    # diagnosing scale mismatches between market data and qig_warp's
+    # physics-calibrated h_c=3.044J threshold. If h/J consistently
+    # exceeds 3.65 the system pins to DISORDERED regardless of market
+    # activity — operator watches the rolling h, J stats in
+    # warp_telemetry to confirm whether the inputs themselves vary or
+    # whether the qig_warp output is being quantized away.
+    h_input: deque[float] = field(default_factory=lambda: deque(maxlen=200))
+    j_input: deque[float] = field(default_factory=lambda: deque(maxlen=200))
     # Unbounded monotonic tick counter (2026-05-17). The rolling buffers
     # above cap at ``capacity`` so ``len(deque)`` plateaus at 200 once
     # full and can no longer signal freshness — external freshness
@@ -92,6 +102,8 @@ class GovernanceBuffer:
         warp_regime: Optional[str] = None,
         gr_direction: Optional[str] = None,
         regime_confidence: Optional[str] = None,
+        h_input: Optional[float] = None,
+        j_input: Optional[float] = None,
     ) -> None:
         self.tick_count_total += 1
         self.raw_drift_pct.append(float(raw_drift_pct))
@@ -108,6 +120,10 @@ class GovernanceBuffer:
             self.gr_direction.append(str(gr_direction))
         if regime_confidence is not None:
             self.regime_confidence.append(str(regime_confidence))
+        if h_input is not None:
+            self.h_input.append(float(h_input))
+        if j_input is not None:
+            self.j_input.append(float(j_input))
 
 
 @dataclass
@@ -247,6 +263,51 @@ def run_governance_check(buf: GovernanceBuffer) -> GovernanceReport:
             conf_dist[label] = conf_dist.get(label, 0) + 1
         warp_telemetry["regime_confidence_distribution"] = conf_dist
 
+    # Diagnostic add (2026-05-17): raw (h, J) lattice inputs +
+    # their ratio h/J. If h/J consistently exceeds 3.65 the qig_warp
+    # classifier pins to DISORDERED; if h/J stddev is tiny the inputs
+    # themselves are stuck (not just the regime quantization). h_j_ratio
+    # makes the "do we sit above the h_c threshold" question one number
+    # the operator can read.
+    h_vals = list(buf.h_input)
+    j_vals = list(buf.j_input)
+    if h_vals:
+        h_arr = _np.asarray(h_vals, dtype=_np.float64)
+        warp_telemetry["h_input"] = {
+            "mean": float(h_arr.mean()),
+            "stddev": float(h_arr.std()) if h_arr.size > 1 else 0.0,
+            "min": float(h_arr.min()),
+            "max": float(h_arr.max()),
+            "samples": int(h_arr.size),
+        }
+    if j_vals:
+        j_arr = _np.asarray(j_vals, dtype=_np.float64)
+        warp_telemetry["j_input"] = {
+            "mean": float(j_arr.mean()),
+            "stddev": float(j_arr.std()) if j_arr.size > 1 else 0.0,
+            "min": float(j_arr.min()),
+            "max": float(j_arr.max()),
+            "samples": int(j_arr.size),
+        }
+    if h_vals and j_vals and len(h_vals) == len(j_vals):
+        ratios = []
+        for h_v, j_v in zip(h_vals, j_vals):
+            if j_v > 1e-12:
+                ratios.append(h_v / j_v)
+        if ratios:
+            r_arr = _np.asarray(ratios, dtype=_np.float64)
+            warp_telemetry["h_j_ratio"] = {
+                "mean": float(r_arr.mean()),
+                "stddev": float(r_arr.std()) if r_arr.size > 1 else 0.0,
+                "min": float(r_arr.min()),
+                "max": float(r_arr.max()),
+                "samples": int(r_arr.size),
+                # h_c=3.044 for 2D; DISORDERED above 1.2*h_c=3.65
+                "above_disordered_threshold_frac": float(
+                    sum(1 for r in ratios if r > 3.653) / len(ratios)
+                ),
+            }
+
     return GovernanceReport(
         available=_GOVERNANCE_AVAILABLE,
         sample_count=n,
@@ -276,6 +337,8 @@ def record_tick(
     warp_regime: Optional[str] = None,
     gr_direction: Optional[str] = None,
     regime_confidence: Optional[str] = None,
+    h_input: Optional[float] = None,
+    j_input: Optional[float] = None,
 ) -> None:
     """Record one tick into the rolling governance buffer.
 
@@ -285,6 +348,11 @@ def record_tick(
     forecast_horizons.compute_forecast) supply them per tick so the
     /governance/status report can display the rolling distribution
     alongside the existing distributional-bias detectors.
+
+    Diagnostic add (2026-05-17): h_input / j_input let the operator
+    see the raw lattice inputs qig_warp was called with — surfaces
+    scale-mismatch issues where h/J consistently exceeds 3.65 and
+    pins the regime to DISORDERED regardless of market activity.
     """
     _buffer.record(
         raw_drift_pct=raw_drift_pct,
@@ -295,6 +363,8 @@ def record_tick(
         warp_regime=warp_regime,
         gr_direction=gr_direction,
         regime_confidence=regime_confidence,
+        h_input=h_input,
+        j_input=j_input,
     )
 
 

--- a/ml-worker/tests/test_observable_governance_warp.py
+++ b/ml-worker/tests/test_observable_governance_warp.py
@@ -162,3 +162,85 @@ class TestTickCountTotalFreshness:
         report = og.report_as_dict()
         assert report["tick_count_total"] == 0
         assert report["sample_count"] == 0
+
+
+class TestHJDiagnosticSurface:
+    """Regression: 2026-05-17T20:24Z escalation surfaced mono-DISORDERED
+    pinned for 80 minutes. To diagnose whether the cause is (a) genuine
+    extended chop, (b) identical (h,J) inputs across ticks, or (c)
+    qig_warp output being quantized away despite varied inputs, the
+    operator needs the rolling (h, J) input stats. These tests verify
+    that surface."""
+
+    def test_h_j_inputs_recorded_and_surfaced(self) -> None:
+        og._buffer = og.GovernanceBuffer(capacity=200)
+        # 10 ticks with varying h, J landing above the DISORDERED threshold
+        # (h/J > 3.65 for all). All would classify as DISORDERED.
+        for i in range(10):
+            og.record_tick(
+                raw_drift_pct=0.001,
+                signal="HOLD",
+                regime="dissolver",
+                bridge_exponent=0.38,
+                screening_length=0.784,
+                warp_regime="disordered",
+                h_input=3.5 + 0.1 * i,
+                j_input=0.05 + 0.005 * i,
+            )
+        report = og.report_as_dict()
+        wt = report["warp_telemetry"]
+        assert "h_input" in wt
+        assert wt["h_input"]["samples"] == 10
+        assert wt["h_input"]["min"] == pytest.approx(3.5)
+        assert wt["h_input"]["max"] == pytest.approx(4.4)
+        assert wt["h_input"]["stddev"] > 0
+        assert "j_input" in wt
+        assert wt["j_input"]["samples"] == 10
+        # h/J ratio
+        assert "h_j_ratio" in wt
+        # All 10 ratios > 3.65 (above DISORDERED threshold)
+        assert wt["h_j_ratio"]["above_disordered_threshold_frac"] == pytest.approx(1.0)
+        assert wt["h_j_ratio"]["min"] > 3.653
+
+    def test_h_j_diagnostic_detects_identical_inputs(self) -> None:
+        """If the same (h, J) is recorded 20 times, stddev == 0 — that
+        proves the inputs are stuck, not just the regime quantization."""
+        og._buffer = og.GovernanceBuffer(capacity=200)
+        for _ in range(20):
+            og.record_tick(
+                raw_drift_pct=0.001,
+                signal="HOLD",
+                regime="dissolver",
+                warp_regime="disordered",
+                bridge_exponent=0.38,
+                screening_length=0.784,
+                h_input=3.5,
+                j_input=0.5,
+            )
+        report = og.report_as_dict()
+        wt = report["warp_telemetry"]
+        assert wt["h_input"]["stddev"] == 0.0
+        assert wt["j_input"]["stddev"] == 0.0
+        assert wt["h_j_ratio"]["stddev"] == 0.0
+        assert wt["h_j_ratio"]["mean"] == pytest.approx(7.0)
+
+    def test_h_j_diagnostic_below_threshold_frac(self) -> None:
+        """When h/J straddles the DISORDERED threshold, the fraction
+        above shows it. Validates the threshold computation."""
+        og._buffer = og.GovernanceBuffer(capacity=200)
+        # 4 ticks above 3.65 + 6 ticks below = 0.4
+        for h, j in [(4.0, 1.0), (5.0, 1.0), (10.0, 1.0), (4.0, 1.0)]:
+            og.record_tick(
+                raw_drift_pct=0.001, signal="HOLD", regime="dissolver",
+                bridge_exponent=0.38, screening_length=0.784, warp_regime="disordered",
+                h_input=h, j_input=j,
+            )
+        for h, j in [(1.0, 1.0), (2.0, 1.0), (2.5, 1.0), (0.5, 1.0), (1.5, 1.0), (3.0, 1.0)]:
+            og.record_tick(
+                raw_drift_pct=0.001, signal="HOLD", regime="creator",
+                bridge_exponent=0.86, screening_length=0.618, warp_regime="critical",
+                h_input=h, j_input=j,
+            )
+        report = og.report_as_dict()
+        wt = report["warp_telemetry"]
+        assert wt["h_j_ratio"]["above_disordered_threshold_frac"] == pytest.approx(0.4)


### PR DESCRIPTION
## Surfaced by

Overnight monitor v3 ESCALATE at 20:24Z UTC: mono-DISORDERED regime pinned for 80 minutes (8 hourly heartbeats). Production diagnostic showed:

```
bridge_exponent: mean=0.380000 stddev=0.000000  (always DISORDERED's frozen α)
screening_length: mean=0.784000 stddev=0.000000  (clamped to table edge at h>=3.0)
regime_distribution: {disordered: 200}
gr_direction: {heavy_slower: 200}
regime_confidence: {low: 200}
```

The quantized regime outputs can't distinguish three causes:

| Cause | h/J variance | What to fix |
|---|---|---|
| (a) Genuine extended chop with diverse inputs | high stddev, both above + below threshold | wait it out |
| (b) Identical (h, J) across all ticks — data-feed stuck | stddev = 0 | upstream pipeline bug |
| (c) Physics/finance scale mismatch (h/J naturally ≫ h_c) | high stddev, all above threshold | calibration knob |

## This PR: diagnostic exposure (NOT a behavior change)

Adds rolling (h, J) input telemetry so the operator can distinguish (a)/(b)/(c) from one `/governance/status` response.

### `observable_governance.py`
- `GovernanceBuffer.h_input`, `j_input`: `deque[float]` maxlen 200
- `record_tick()` accepts optional `h_input` + `j_input` kwargs (backward compat preserved)
- `warp_telemetry` block adds:
  - `h_input`: `{min, mean, max, stddev, samples}`
  - `j_input`: `{min, mean, max, stddev, samples}`
  - `h_j_ratio`: `{min, mean, max, stddev, samples, above_disordered_threshold_frac}`

`above_disordered_threshold_frac` is the fraction of samples with `h/J > 3.653` (1.2 × h_c for 2D TFIM). At 1.0 with high stddev → physics/finance scale mismatch (case c). At any value with stddev=0 → data-feed bug (case b). Diverse distribution → real market state (case a).

### `main.py`
- `_record_warp_telemetry_for_tick` passes `h_value` + `j_value` through to `record_tick`. Values come from `decision.regime.entropy` and `decision.regime.trend_strength` — same numbers the RegimeAdapter fed to `qig_warp.classify_regime` in MIG-2.

## Tests

- `test_h_j_inputs_recorded_and_surfaced`: 10 varying inputs all above 3.65 → `above_disordered_threshold_frac == 1.0`, `stddev > 0`
- `test_h_j_diagnostic_detects_identical_inputs`: 20 identical inputs → `stddev == 0` (data-feed-stuck pattern)
- `test_h_j_diagnostic_below_threshold_frac`: 4 above + 6 below threshold → fraction == 0.4

## Pre-merge gates (all green)

| Gate | Result |
|---|---|
| AST parse on 3 touched files | ✅ |
| qig-purity scan full ml-worker tree | ✅ zero violations |
| apps/api `tsc --noEmit` | ✅ 0 errors |
| apps/api `vitest run` | ✅ 1336 passed, 1 skipped |

## Why diagnostic first, calibration patch later

Per "highest quality long-term solution always" — operator decides the calibration fix shape AFTER seeing real data. Two possible follow-ons depending on what the data shows:

- If case (c) confirmed: add `QIG_LATTICE_J_SCALE` env-tunable rescale knob
- If case (b) confirmed: investigate polytrade-be OHLCV pipeline for stale data
- If case (a) confirmed: no action; system correctly identifies extended chop and refuses to trade

🤖 Generated with [Claude Code](https://claude.com/claude-code)