### PR TITLE
feat(autonomous): PATCH /api/autonomous/config + UI reset button — fix stale baseline

### DIFF
--- a/apps/api/src/routes/autonomousTrader.ts
+++ b/apps/api/src/routes/autonomousTrader.ts
@@ -223,6 +223,128 @@ router.get('/performance', authenticateToken, async (req: Request, res: Response
 });
 
 /**
+ * PATCH /api/autonomous/config
+ *
+ * Reset the user's autonomous-trading baseline (initial_capital) to a
+ * new value. Use case: user deposits or withdraws capital from the
+ * exchange and the dashboard's Total P&L % goes nonsensical because
+ * it's still measured against the old stored baseline. This endpoint
+ * lets the user (or a deposit/withdrawal auto-detector) update the
+ * baseline so the % display reflects the actual current capital.
+ *
+ * Request body (any combination of these fields is allowed; all
+ * optional; at least one must be present):
+ *   {
+ *     initialCapital?: number,      // dollars, > 0
+ *     maxRiskPerTrade?: number,     // [0, 1]
+ *     maxDrawdown?: number,         // [0, 1]
+ *     targetDailyReturn?: number,   // [0, 1]
+ *     paperTrading?: boolean
+ *   }
+ *
+ * Response: 200 + updated config (same shape as GET /status.config).
+ * 400 on validation failure; 404 if the user has no config row; 500
+ * on DB failure.
+ *
+ * Auth required (same as the rest of /api/autonomous/*).
+ */
+router.patch('/config', authenticateToken, async (req: Request, res: Response) => {
+  try {
+    const userId = String(req.user.id);
+    const {
+      initialCapital,
+      maxRiskPerTrade,
+      maxDrawdown,
+      targetDailyReturn,
+      paperTrading,
+    } = req.body ?? {};
+
+    // Validate: at least one field, each within its valid range.
+    const updates: { col: string; val: number | boolean }[] = [];
+    if (initialCapital !== undefined) {
+      if (typeof initialCapital !== 'number' || !Number.isFinite(initialCapital) || initialCapital <= 0) {
+        return res.status(400).json({
+          success: false,
+          error: 'initialCapital must be a positive number (dollars)',
+        });
+      }
+      updates.push({ col: 'initial_capital', val: initialCapital });
+    }
+    if (maxRiskPerTrade !== undefined) {
+      if (typeof maxRiskPerTrade !== 'number' || maxRiskPerTrade < 0 || maxRiskPerTrade > 1) {
+        return res.status(400).json({ success: false, error: 'maxRiskPerTrade must be in [0, 1]' });
+      }
+      updates.push({ col: 'max_risk_per_trade', val: maxRiskPerTrade });
+    }
+    if (maxDrawdown !== undefined) {
+      if (typeof maxDrawdown !== 'number' || maxDrawdown < 0 || maxDrawdown > 1) {
+        return res.status(400).json({ success: false, error: 'maxDrawdown must be in [0, 1]' });
+      }
+      updates.push({ col: 'max_drawdown', val: maxDrawdown });
+    }
+    if (targetDailyReturn !== undefined) {
+      if (typeof targetDailyReturn !== 'number' || targetDailyReturn < 0 || targetDailyReturn > 1) {
+        return res.status(400).json({ success: false, error: 'targetDailyReturn must be in [0, 1]' });
+      }
+      updates.push({ col: 'target_daily_return', val: targetDailyReturn });
+    }
+    if (paperTrading !== undefined) {
+      if (typeof paperTrading !== 'boolean') {
+        return res.status(400).json({ success: false, error: 'paperTrading must be boolean' });
+      }
+      updates.push({ col: 'paper_trading', val: paperTrading });
+    }
+
+    if (updates.length === 0) {
+      return res.status(400).json({
+        success: false,
+        error: 'At least one field must be provided (initialCapital | maxRiskPerTrade | maxDrawdown | targetDailyReturn | paperTrading)',
+      });
+    }
+
+    // Build parameterised UPDATE statement.
+    const setClauses = updates.map((u, i) => `${u.col} = $${i + 2}`).join(', ');
+    const values: (string | number | boolean)[] = [userId, ...updates.map((u) => u.val)];
+    const result = await pool.query(
+      `UPDATE autonomous_trading_configs
+         SET ${setClauses}, updated_at = NOW()
+       WHERE user_id = $1
+       RETURNING *`,
+      values,
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({
+        success: false,
+        error: 'No autonomous_trading_configs row found for this user. Use POST /api/autonomous/enable to create one first.',
+      });
+    }
+
+    const row = result.rows[0];
+    logger.info('[autonomousTrader] config patched', {
+      userId, updatedFields: updates.map((u) => u.col),
+    });
+    return res.json({
+      success: true,
+      config: {
+        initialCapital: parseFloat(row.initial_capital),
+        maxRiskPerTrade: parseFloat(row.max_risk_per_trade),
+        maxDrawdown: parseFloat(row.max_drawdown),
+        targetDailyReturn: parseFloat(row.target_daily_return),
+        symbols: row.symbols,
+        paperTrading: row.paper_trading,
+      },
+    });
+  } catch (error: unknown) {
+    logger.error('Error patching autonomous trading config:', error);
+    return res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to patch config',
+    });
+  }
+});
+
+/**
  * GET /api/autonomous/trades
  * Get trade history
  */

--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -85,6 +85,11 @@ const AutonomousAgentDashboard: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [lastPolled, setLastPolled] = useState<Date | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<'connected' | 'disconnected' | 'polling'>('polling');
+  // Baseline-rebase action state — drives the "Reset baseline" CTA in the
+  // stale-baseline banner. Tracks the in-flight POST so we can disable the
+  // button + show feedback on success/failure.
+  const [rebasing, setRebasing] = useState<boolean>(false);
+  const [rebaseMsg, setRebaseMsg] = useState<string | null>(null);
   const [circuitBreaker, setCircuitBreaker] = useState<{
     isTripped: boolean;
     reason?: string;
@@ -336,6 +341,37 @@ const AutonomousAgentDashboard: React.FC = () => {
       }
     } catch {
       // Non-critical — badge/banner just won't render.
+    }
+  };
+
+  // Reset the stored autonomous_trading_configs.initial_capital to the
+  // current futures equity. Invoked from the stale-baseline banner CTA
+  // when the user has added/removed capital from the exchange and the
+  // % P&L display is measuring against a now-meaningless baseline.
+  const rebaseBaselineToCurrent = async (newBaseline: number) => {
+    if (!Number.isFinite(newBaseline) || newBaseline <= 0) return;
+    setRebasing(true);
+    setRebaseMsg(null);
+    try {
+      const response = await axios.patch(
+        `${API_BASE_URL}/api/autonomous/config`,
+        { initialCapital: newBaseline },
+        { headers: getAuthHeaders() },
+      );
+      if (response.data.success) {
+        setRebaseMsg(`Baseline reset to $${newBaseline.toFixed(2)}.`);
+        // Pull fresh status so the banner re-evaluates and disappears.
+        await fetchAutonomousStatus();
+      } else {
+        setRebaseMsg(
+          response.data.error || 'Reset failed for an unknown reason.',
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setRebaseMsg(`Reset failed: ${msg}`);
+    } finally {
+      setRebasing(false);
     }
   };
 
@@ -663,17 +699,12 @@ const AutonomousAgentDashboard: React.FC = () => {
         </div>
       </div>
 
-      {/* C7 — Baseline-divergence banner.
+      {/* Baseline-divergence banner.
           totalPnlPercent on this dashboard is computed against the
           stored autonomous_trading_configs.initial_capital. If that
           baseline is more than 20% off the current futures equity,
-          the % display goes nonsensical (e.g. 777% when $440 baseline
-          vs $91 actual). Surface a warning + the suggested reset
-          value so the user can fix it via the config endpoint.
-
-          NOTE: there is no BE reset endpoint today — this banner is
-          informational only. Once /api/autonomous/config (or similar)
-          accepts a PATCH for initial_capital, wire the CTA to it. */}
+          the % display goes nonsensical. Surface the diff + a one-
+          click reset CTA wired to PATCH /api/autonomous/config. */}
       {autonomousStatus?.initialCapital !== undefined
         && autonomousStatus?.initialCapital !== null
         && autonomousStatus.initialCapital > 0
@@ -699,16 +730,28 @@ const AutonomousAgentDashboard: React.FC = () => {
                   {' '}but current equity is{' '}
                   <strong>${safeNum(currentBalance).toFixed(2)}</strong>
                   {' '}— a {safeNum(drift * 100).toFixed(0)}% drift {direction} the baseline.
-                  The Total P&amp;L % shown on this dashboard is computed against
-                  the stored baseline and will read as nonsense until the baseline
-                  is reset to the current equity.
+                  Reset to make the Total P&amp;L % accurate.
                 </p>
-                <p className="text-amber-700 text-xs mt-2">
-                  TODO: wire a backend PATCH endpoint (e.g.
-                  <code className="px-1 mx-1 bg-amber-100 rounded">PATCH /api/autonomous/config</code>
-                  with <code className="px-1 bg-amber-100 rounded">{`{ initialCapital: ${safeNum(currentBalance).toFixed(2)} }`}</code>)
-                  to reset baseline from the UI.
-                </p>
+                <div className="flex items-center gap-3 mt-3">
+                  <button
+                    type="button"
+                    onClick={() => rebaseBaselineToCurrent(safeNum(currentBalance))}
+                    disabled={rebasing}
+                    className="px-4 py-2 bg-amber-600 text-white rounded-md text-sm font-medium hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
+                  >
+                    {rebasing
+                      ? 'Resetting…'
+                      : `Reset baseline to $${safeNum(currentBalance).toFixed(2)}`}
+                  </button>
+                  {rebaseMsg && (
+                    <span
+                      className={`text-xs ${rebaseMsg.startsWith('Reset failed') ? 'text-red-700' : 'text-amber-800'}`}
+                      role="status"
+                    >
+                      {rebaseMsg}
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
           );


### PR DESCRIPTION
## User report

> "this is a shit setup. i should be able to add and remove capital and have the system re-calculate automatically"

Dashboard was showing $440.97 stored baseline vs $189.81 current equity → 57% drift → Total P&L % rendering as nonsense.

The FE already had the warning UI and TODO'd the endpoint shape. This PR builds it.

## Backend (`apps/api/src/routes/autonomousTrader.ts`)

New endpoint:
```
PATCH /api/autonomous/config
body: {
  initialCapital?: number,      // > 0
  maxRiskPerTrade?: number,     // [0, 1]
  maxDrawdown?: number,         // [0, 1]
  targetDailyReturn?: number,   // [0, 1]
  paperTrading?: boolean
}
auth: same as the rest of /api/autonomous/*
```

Validates each provided field, builds a parameterised UPDATE on `autonomous_trading_configs`, sets `updated_at = NOW()`. 400 on validation failure; 404 if no config row exists; 500 on DB. Returns the updated config in the same shape as `GET /api/autonomous/status`.

## Frontend (`AutonomousAgentDashboard.tsx`)

- New state: `rebasing` + `rebaseMsg` for in-flight tracking + result feedback
- New action: `rebaseBaselineToCurrent(newBaseline)` → PATCH `/api/autonomous/config` with `{ initialCapital: newBaseline }`, re-fetches status on success so the banner disappears when drift drops below 20%
- Stale-baseline banner: replaced the TODO text with an actual button labeled `Reset baseline to $X` (where X = current equity). Disabled while in-flight; success/error message shown inline.

## Not in this PR (filed as follow-ups)

- **Auto-detect deposit/withdrawal events** — equity changed > threshold AND no trade explains it → auto-rebase. Needs careful heuristic design so a legitimate large P&L swing doesn't trigger a false rebase. The PATCH endpoint shipped here is what auto-detection would call.

## Pre-merge gates (all green)

| Gate | Result |
|---|---|
| apps/api `tsc --noEmit` | ✅ 0 errors |
| apps/api `vitest run` | ✅ 1346 passed, 1 skipped |
| apps/web `tsc` on touched file | ✅ clean (pre-existing errors in Account.tsx + Backtesting.tsx unaffected) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)