### PR TITLE
fix(monkey): close coordinator — eliminate multi-kernel close race

### DIFF
--- a/apps/api/src/services/monkey/__tests__/closeCoordinator.test.ts
+++ b/apps/api/src/services/monkey/__tests__/closeCoordinator.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  tryAcquireClose, releaseClose, isLikelyRaceLoss, _resetCloseCoordinator, _peekCloseCoordinator,
+} from '../close_coordinator.js';
+
+describe('close_coordinator', () => {
+  beforeEach(() => {
+    _resetCloseCoordinator();
+  });
+
+  it('grants the lock to the first caller and blocks a sibling kernel', () => {
+    const t0 = 1_700_000_000_000;
+    const first = tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    expect(first).toEqual({ ok: true });
+
+    const sibling = tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 50);
+    expect(sibling).toEqual({
+      ok: false,
+      reason: 'in_flight',
+      heldBy: 'monkey-position',
+      ageMs: 50,
+    });
+  });
+
+  it('lets the same instance re-acquire (defensive against self-collision)', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    const reentry = tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0 + 100);
+    expect(reentry).toEqual({ ok: true });
+  });
+
+  it('arms the cooldown after a successful close and blocks siblings', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    releaseClose('ETH_USDT_PERP', 'long', 'monkey-position', /*success*/ true, t0 + 200);
+
+    // 500ms later — sibling tries: should be blocked by recently-closed cooldown
+    const sibling = tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 700);
+    expect(sibling).toEqual({
+      ok: false,
+      reason: 'recently_closed',
+      heldBy: 'monkey-position',
+      ageMs: 500,
+    });
+  });
+
+  it('does not arm the cooldown when the close failed', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    releaseClose('ETH_USDT_PERP', 'long', 'monkey-position', /*success*/ false, t0 + 200);
+
+    const sibling = tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 300);
+    expect(sibling).toEqual({ ok: true });
+  });
+
+  it('lifts the cooldown once it expires (2s window)', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    releaseClose('ETH_USDT_PERP', 'long', 'monkey-position', true, t0 + 100);
+
+    // Just after the 2000ms cooldown
+    const sibling = tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 2200);
+    expect(sibling).toEqual({ ok: true });
+  });
+
+  it('serializes per (symbol, side) — different sides are independent', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    const otherSide = tryAcquireClose('ETH_USDT_PERP', 'short', 'monkey-position', t0);
+    expect(otherSide).toEqual({ ok: true });
+  });
+
+  it('serializes per (symbol, side) — different symbols are independent', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    const otherSymbol = tryAcquireClose('BTC_USDT_PERP', 'long', 'monkey-position', t0);
+    expect(otherSymbol).toEqual({ ok: true });
+  });
+
+  it('steals a stale in-flight lock after 30s', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+
+    // Position kernel crashed mid-close; 31s later swing tries.
+    const sibling = tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 31_000);
+    expect(sibling).toEqual({ ok: true });
+
+    // And the lock is now held by swing.
+    const peek = _peekCloseCoordinator();
+    expect(peek.inFlight).toHaveLength(1);
+    expect(peek.inFlight[0]!.holder).toBe('monkey-swing');
+  });
+
+  it('isLikelyRaceLoss flags closes within cooldown by another instance', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    releaseClose('ETH_USDT_PERP', 'long', 'monkey-position', true, t0 + 200);
+
+    const race = isLikelyRaceLoss('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 500);
+    expect(race).toEqual({ raced: true, siblingId: 'monkey-position', ageMs: 300 });
+  });
+
+  it('isLikelyRaceLoss does NOT flag self', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    releaseClose('ETH_USDT_PERP', 'long', 'monkey-position', true, t0 + 200);
+
+    const race = isLikelyRaceLoss('ETH_USDT_PERP', 'long', 'monkey-position', t0 + 500);
+    expect(race).toEqual({ raced: false });
+  });
+
+  it('isLikelyRaceLoss does NOT flag once cooldown expires', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    releaseClose('ETH_USDT_PERP', 'long', 'monkey-position', true, t0 + 100);
+
+    const race = isLikelyRaceLoss('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 2_500);
+    expect(race).toEqual({ raced: false });
+  });
+
+  it('release without holding the lock is a no-op (does not crash)', () => {
+    const t0 = 1_700_000_000_000;
+    // monkey-swing never held the lock; release should silently no-op.
+    expect(() => releaseClose('ETH_USDT_PERP', 'long', 'monkey-swing', true, t0)).not.toThrow();
+    const peek = _peekCloseCoordinator();
+    // The success-flagged release still arms the cooldown — that's documented
+    // behavior: the caller asserts the close happened.
+    expect(peek.recentlyClosed).toHaveLength(1);
+  });
+
+  it('reproduces the observed prod race window (280ms swing-vs-position)', () => {
+    // Live observation at 2026-05-17T00:59:40Z:
+    //   00:59:40.658  Swing close SUCCESS
+    //   00:59:40.937  Position close → code=21002 "Position not enough"
+    // The coordinator should treat the second as race_lost not error.
+    const swingClose = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'short', 'monkey-swing', swingClose - 100);
+    releaseClose('ETH_USDT_PERP', 'short', 'monkey-swing', true, swingClose);
+
+    const positionAttempt = tryAcquireClose(
+      'ETH_USDT_PERP', 'short', 'monkey-position',
+      swingClose + 279,
+    );
+    expect(positionAttempt.ok).toBe(false);
+    expect((positionAttempt as { reason: string }).reason).toBe('recently_closed');
+  });
+});

--- a/apps/api/src/services/monkey/close_coordinator.ts
+++ b/apps/api/src/services/monkey/close_coordinator.ts
@@ -1,0 +1,175 @@
+/**
+ * close_coordinator.ts — per-symbol+side serialization for Monkey closes.
+ *
+ * Two Monkey kernels (`monkey-position` 15m + `monkey-swing` 5m) and the
+ * agent-K/M/T/L decision arms inside each share the same Node.js process.
+ * Each can independently decide to close ETH long (or BTC short, etc.)
+ * within the same ~second when market conditions trigger conviction-failed
+ * across the board.
+ *
+ * Poloniex futures HEDGE mode keeps ONE position per (symbol, side). Two
+ * close orders submitted in parallel produce one of two pathological
+ * outcomes:
+ *
+ *   1. Loser's `getPositions()` reads qty=0 after winner's close settles →
+ *      logs `exchange_position_vanished` and bails (alarming but harmless).
+ *   2. Loser's `getPositions()` reads pre-close qty before winner's order
+ *      settles → loser submits a close → Poloniex returns
+ *      `code=21002 Position not enough` (red ERROR in the prod log).
+ *
+ * This module coordinates closes across all in-process callers so:
+ *   - Only one close per (symbol, side) is in flight at any time
+ *   - After a successful close, a short cooldown blocks sibling attempts
+ *     so the exchange-side reduction has time to settle in subsequent
+ *     `getPositions()` reads
+ *   - When a sibling kernel races us, we recognize the loss and emit a
+ *     `race_lost_to_sibling` reason instead of attempting a close
+ *
+ * The cooldown is empirically sized: observed prod race window is
+ * ~280ms (Swing close at 00:59:40.658 → Position attempt at 00:59:40.937
+ * → 21002). 2000ms gives ~7× headroom while staying short enough that a
+ * legitimate re-entry isn't blocked for a noticeable period.
+ */
+
+export type Side = 'long' | 'short';
+
+interface InFlight {
+  /** Kernel instanceId that holds the lock. */
+  holder: string;
+  /** Wall-clock ms when acquired. */
+  at: number;
+}
+
+interface RecentClose {
+  /** Kernel instanceId that performed the successful close. */
+  holder: string;
+  /** Wall-clock ms of release (close success). */
+  at: number;
+}
+
+const inFlight = new Map<string, InFlight>();
+const recentlyClosed = new Map<string, RecentClose>();
+
+/** Cooldown window after a successful close. Sized to comfortably exceed
+ *  the observed prod race window (~280ms) while staying short enough that
+ *  a legitimate re-entry isn't blocked perceptibly. */
+const RECENT_CLOSE_COOLDOWN_MS = 2000;
+
+/** Defensive max — an in-flight close should never take longer than this.
+ *  If the lock holder crashes mid-close, the next caller after this window
+ *  will steal the lock rather than blocking forever. */
+const IN_FLIGHT_STALE_MS = 30_000;
+
+function key(symbol: string, side: Side): string {
+  return `${symbol}:${side}`;
+}
+
+/**
+ * Try to acquire the close lock for (symbol, side).
+ *
+ * Returns:
+ *   - `{ ok: true }` — lock acquired; caller must call `release` when done.
+ *   - `{ ok: false, reason: 'in_flight', heldBy, ageMs }` — another caller is
+ *     mid-close. Caller should treat as a race loss.
+ *   - `{ ok: false, reason: 'recently_closed', heldBy, ageMs }` — another
+ *     caller just closed this side within the cooldown window. Caller
+ *     should treat as a race loss; the exchange position is already gone.
+ *
+ * Self-collision (same instanceId already holds the lock) returns `ok: true`
+ * — the caller is re-entering (defensive; the regular call path should not
+ * do this).
+ */
+export function tryAcquireClose(
+  symbol: string,
+  side: Side,
+  instanceId: string,
+  nowMs: number = Date.now(),
+):
+  | { ok: true }
+  | { ok: false; reason: 'in_flight'; heldBy: string; ageMs: number }
+  | { ok: false; reason: 'recently_closed'; heldBy: string; ageMs: number } {
+  const k = key(symbol, side);
+
+  const recent = recentlyClosed.get(k);
+  if (recent) {
+    const ageMs = nowMs - recent.at;
+    if (ageMs >= 0 && ageMs < RECENT_CLOSE_COOLDOWN_MS && recent.holder !== instanceId) {
+      return { ok: false, reason: 'recently_closed', heldBy: recent.holder, ageMs };
+    }
+    if (ageMs >= RECENT_CLOSE_COOLDOWN_MS) {
+      recentlyClosed.delete(k);
+    }
+  }
+
+  const cur = inFlight.get(k);
+  if (cur) {
+    const ageMs = nowMs - cur.at;
+    if (cur.holder === instanceId) {
+      return { ok: true };
+    }
+    if (ageMs < IN_FLIGHT_STALE_MS) {
+      return { ok: false, reason: 'in_flight', heldBy: cur.holder, ageMs };
+    }
+    // Stale — previous holder crashed mid-close. Steal.
+    inFlight.delete(k);
+  }
+
+  inFlight.set(k, { holder: instanceId, at: nowMs });
+  return { ok: true };
+}
+
+/** Release the close lock and (optionally) record a recent successful close.
+ *  Always call from a `finally`. The `success` flag controls whether the
+ *  cooldown timer arms — failed closes leave no cooldown so the next caller
+ *  can retry immediately. */
+export function releaseClose(
+  symbol: string,
+  side: Side,
+  instanceId: string,
+  success: boolean,
+  nowMs: number = Date.now(),
+): void {
+  const k = key(symbol, side);
+  const cur = inFlight.get(k);
+  if (cur && cur.holder === instanceId) {
+    inFlight.delete(k);
+  }
+  if (success) {
+    recentlyClosed.set(k, { holder: instanceId, at: nowMs });
+  }
+}
+
+/** Check whether an exchange error (typically 21002 "Position not enough")
+ *  is most likely a race-loss against a recent sibling close rather than a
+ *  real failure. Used to demote the log level + clarify the message. */
+export function isLikelyRaceLoss(
+  symbol: string,
+  side: Side,
+  instanceId: string,
+  nowMs: number = Date.now(),
+): { raced: boolean; siblingId?: string; ageMs?: number } {
+  const k = key(symbol, side);
+  const recent = recentlyClosed.get(k);
+  if (!recent) return { raced: false };
+  const ageMs = nowMs - recent.at;
+  if (ageMs < 0 || ageMs >= RECENT_CLOSE_COOLDOWN_MS) return { raced: false };
+  if (recent.holder === instanceId) return { raced: false };
+  return { raced: true, siblingId: recent.holder, ageMs };
+}
+
+/** Test-only — reset all coordinator state between tests. */
+export function _resetCloseCoordinator(): void {
+  inFlight.clear();
+  recentlyClosed.clear();
+}
+
+/** Test-only — peek at current state. */
+export function _peekCloseCoordinator(): {
+  inFlight: Array<{ key: string; holder: string; at: number }>;
+  recentlyClosed: Array<{ key: string; holder: string; at: number }>;
+} {
+  return {
+    inFlight: Array.from(inFlight.entries()).map(([key, v]) => ({ key, ...v })),
+    recentlyClosed: Array.from(recentlyClosed.entries()).map(([key, v]) => ({ key, ...v })),
+  };
+}

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -135,6 +135,7 @@ import {
   clampMarginToNotionalHeadroom,
 } from './agentEquityBound.js';
 import { planCloseChunks } from './closeChunker.js';
+import { tryAcquireClose, releaseClose, isLikelyRaceLoss } from './close_coordinator.js';
 import { agentLDecide, type AgentLDecision } from './agent_L_classifier.js';
 import { QIGRAMv2State, isQigramV2Enabled } from './agent_L_qigram_v2.js';
 import {
@@ -1542,6 +1543,7 @@ export class MonkeyKernel extends EventEmitter {
     const mode = modeDecision.value;
     if (state.lastMode !== null && state.lastMode !== mode) {
       logger.info('[Monkey] mode transition', {
+        instanceId: this.instanceId,
         symbol,
         from: state.lastMode,
         to: mode,
@@ -4813,6 +4815,34 @@ export class MonkeyKernel extends EventEmitter {
       }
     }
 
+    // Cross-kernel close coordinator: serialize close attempts per
+    // (symbol, side) across both monkey kernels (Position 15m + Swing 5m)
+    // and all agent arms inside each. Without this, both kernels can
+    // independently submit close orders ~280ms apart and the loser gets
+    // Poloniex code=21002 "Position not enough" or sees qty=0 on the
+    // re-read and logs the misleading "exchange_position_vanished".
+    const acquired = tryAcquireClose(symbol, heldSide, this.instanceId);
+    if (acquired.ok === false) {
+      // Sibling kernel/agent is mid-close or just finished — the exchange
+      // position is gone (or about to be). Mark our local row closed so
+      // bookkeeping stays consistent; no exchange call needed.
+      await pool.query(
+        `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
+                exit_reason='race_lost_to_sibling', pnl=$2 WHERE id=$3`,
+        [markPrice, pnlAtDecision, tradeId],
+      ).catch(() => { /* non-fatal */ });
+      const reason = acquired.reason === 'recently_closed'
+        ? `race_lost_to_sibling: closed by ${acquired.heldBy} ${acquired.ageMs}ms ago`
+        : `race_lost_to_sibling: ${acquired.heldBy} mid-close (${acquired.ageMs}ms)`;
+      return { executed: false, orderId: null, reason };
+    }
+
+    // From here on every exit MUST go through `releaseClose`. Use a flag
+    // so the finally-style release can record success-vs-failure for the
+    // cooldown timer.
+    let closeSucceeded = false;
+    try {
+
     // Load credentials + position to know size to close.
     let credentials: { apiKey: string; apiSecret: string; passphrase?: string };
     try {
@@ -4862,14 +4892,22 @@ export class MonkeyKernel extends EventEmitter {
       };
     }
     if (exchangeQty <= 0) {
-      // Position vanished between decide and close — reconciler will
-      // catch the DB row; nothing for us to close on-exchange.
+      // Most often: a sibling kernel/agent's close just settled and the
+      // exchange-side aggregate is already 0. The coordinator lock should
+      // catch most of these via `recently_closed` BEFORE we reach the
+      // getPositions call, but the call can still slip through when the
+      // sibling's close settled between our acquire and our position read.
+      const race = isLikelyRaceLoss(symbol, heldSide, this.instanceId);
+      const dbExitReason = race.raced ? 'race_lost_to_sibling' : 'vanished_before_close';
+      const reason = race.raced
+        ? `race_lost_to_sibling: exchange position already 0 (sibling=${race.siblingId} ${race.ageMs}ms ago)`
+        : 'exchange_position_vanished';
       await pool.query(
         `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
-                exit_reason='vanished_before_close', pnl=$2 WHERE id=$3`,
-        [markPrice, pnlAtDecision, tradeId],
+                exit_reason=$2, pnl=$3 WHERE id=$4`,
+        [markPrice, dbExitReason, pnlAtDecision, tradeId],
       ).catch(() => { /* non-fatal */ });
-      return { executed: false, orderId: null, reason: 'exchange_position_vanished' };
+      return { executed: false, orderId: null, reason };
     }
 
     // Lot-size round.
@@ -4980,9 +5018,28 @@ export class MonkeyKernel extends EventEmitter {
       // exit_order_id reflects every leg. Single-order legacy keeps a single id.
       orderId = orderIds.length === 1 ? orderIds[0]! : orderIds.join(',');
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // 21002 "Position not enough" with a sibling close in the cooldown
+      // window is a benign race-loss, not a real error. Mark the local
+      // row closed and surface a clear reason; don't spam ERROR.
+      const is21002 = message.includes('21002') || message.toLowerCase().includes('position not enough');
+      if (is21002) {
+        const race = isLikelyRaceLoss(symbol, heldSide, this.instanceId);
+        if (race.raced) {
+          await pool.query(
+            `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
+                    exit_reason=$2, pnl=$3 WHERE id=$4`,
+            [markPrice, 'race_lost_to_sibling', pnlAtDecision, tradeId],
+          ).catch(() => { /* non-fatal */ });
+          return {
+            executed: false, orderId: null,
+            reason: `race_lost_to_sibling: 21002 after sibling close (${race.siblingId} ${race.ageMs}ms ago)`,
+          };
+        }
+      }
       return {
         executed: false, orderId: null,
-        reason: `close_exchange_rejected: ${err instanceof Error ? err.message : String(err)}`,
+        reason: `close_exchange_rejected: ${message}`,
       };
     }
 
@@ -5085,6 +5142,7 @@ export class MonkeyKernel extends EventEmitter {
     }
 
     logger.info('[Monkey] POSITION CLOSED', {
+      instanceId: this.instanceId,
       symbol, heldSide, markPrice, orderId, tradeId,
       pnl: pnlAtDecision.toFixed(4), exitReason,
     });
@@ -5094,7 +5152,11 @@ export class MonkeyKernel extends EventEmitter {
       symbol,
       payload: { heldSide, markPrice, orderId, tradeId, pnl: pnlAtDecision, exitReason },
     });
+    closeSucceeded = true;
     return { executed: true, orderId, reason: 'closed' };
+    } finally {
+      releaseClose(symbol, heldSide, this.instanceId, closeSucceeded);
+    }
   }
 
   /**
@@ -5524,6 +5586,7 @@ export class MonkeyKernel extends EventEmitter {
     }
 
     logger.info(req.isDCAAdd ? '[Monkey] DCA_ADD PLACED' : '[Monkey] ORDER PLACED', {
+      instanceId: this.instanceId,
       symbol, side, orderId,
       margin: marginUsdt.toFixed(2),
       notional: notionalUsdt.toFixed(2),


### PR DESCRIPTION
## Summary

Eliminates two production log shapes traced to the same root cause this morning:

1. `[Monkey] ... scalp_exit ... reason: conviction_failed | close: exchange_position_vanished` — looks like a close failure; is actually a sibling-kernel race noop
2. Red `ERROR Poloniex /v3/trade/order returned code=21002: Position not enough` — kernel B raced kernel A and lost; nothing actually wrong

Both stem from the two-kernel (monkey-position + monkey-swing) architecture against Poloniex HEDGE-mode aggregate positions: parallel close attempts within ~280ms produce one of the two pathologies above.

## Solution

`apps/api/src/services/monkey/close_coordinator.ts` (new) — in-process per-(symbol, side) coordinator:
- In-flight lock blocks a sibling from submitting a close while one is in flight
- 2000ms recently-closed cooldown blocks a sibling close right after a successful one (lets the exchange-side reduction settle in subsequent `getPositions` reads)
- `isLikelyRaceLoss()` classifies a 21002 as a race-loss when a sibling close landed within the cooldown window
- 30s stale-lock theft prevents permanent deadlock if a holder crashes mid-close

`apps/api/src/services/monkey/loop.ts`:
- `closeHeldPosition` acquires the lock before reading exchange position; race-losers mark their local DB row `exit_reason='race_lost_to_sibling'` with sibling attribution in the reason
- Existing `exchange_position_vanished` path now distinguishes true vanish (liquidation / manual / API hiccup) from race noop
- 21002 catch demotes from `close_exchange_rejected` to `race_lost_to_sibling` when a sibling just closed
- Adds `instanceId` to POSITION CLOSED / ORDER PLACED / mode transition logs so it's visible which kernel emitted the line
- `try/finally` ensures the lock always releases; `success` flag controls cooldown arming

## Live evidence (the reason we shipped this)

Two events captured on this morning's deploy:

```
00:50:25Z  ETH long:  Position kernel finds qty=0 after Swing closed 1.5s earlier
           → exchange_position_vanished log (noisy but harmless)

00:59:40Z  ETH short: Swing closes pnl=+0.2184 at .658Z
           Position kernel submits close at .937Z (279ms later)
           → Poloniex 21002, red ERROR in prod log
```

The coordinator test directly reproduces the 280ms race window.

## Test plan

- [x] `tsc -p tsconfig.build.json --noEmit` (after `prebuild.mjs`) — 0 errors
- [x] `vitest run` — 1354 passed, 12 skipped (+13 new from coordinator test)
- [ ] Post-deploy: monitor Railway logs for the next 30 min; expect zero `code=21002` lines and zero `exchange_position_vanished` lines (those become `race_lost_to_sibling` with sibling attribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)