### PR TITLE
feat(web): surface ml-worker /governance/status in the agent dashboard

### DIFF
--- a/apps/api/src/routes/governance.ts
+++ b/apps/api/src/routes/governance.ts
@@ -481,4 +481,49 @@ router.get('/k-consciousness', authenticateToken, async (req: Request, res: Resp
   }
 });
 
+/**
+ * GET /api/governance/status
+ * Thin proxy to ml-worker's GET /governance/status — surfaces the two
+ * governance layers (observable-governance distributional drift +
+ * forecast-horizon observer state) that previously required curl to
+ * inspect. The UI calls this directly so operators don't have to
+ * remember the ml-worker URL or use the CLI.
+ */
+router.get('/status', authenticateToken, async (_req: Request, res: Response) => {
+  const base = (process.env.ML_WORKER_URL ?? '').replace(/\/$/, '');
+  if (!base) {
+    return res.status(503).json({
+      error: 'ml_worker_unconfigured',
+      message: 'ML_WORKER_URL env var is not set',
+      ml_worker_url_configured: false,
+    });
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const r = await fetch(`${base}/governance/status`, { signal: controller.signal });
+    if (!r.ok) {
+      return res.status(502).json({
+        error: 'ml_worker_governance_status_non_2xx',
+        status: r.status,
+        ml_worker_url_configured: true,
+      });
+    }
+    const body = await r.json();
+    return res.json({
+      ...body,
+      ml_worker_url_configured: true,
+      fetched_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    return res.status(502).json({
+      error: 'ml_worker_unreachable',
+      message: err instanceof Error ? err.message : String(err),
+      ml_worker_url_configured: true,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+});
+
 export default router;

--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -6,6 +6,7 @@ import { getAccessToken } from '@/utils/auth';
 import { usePersistedState } from '@/hooks/usePersistedState';
 import { getBackendUrl } from '@/utils/environment';
 import ActiveStrategiesPanel from './ActiveStrategiesPanel';
+import GovernanceStatusPanel from './GovernanceStatusPanel';
 import LiveTradingActivityFeed from './LiveTradingActivityFeed';
 import MLLiveRecommendations from './MLLiveRecommendations';
 import PerformanceAnalytics from './PerformanceAnalytics';
@@ -1393,6 +1394,9 @@ const AutonomousAgentDashboard: React.FC = () => {
       {/* Capability Tiers card retired — data source returned hardcoded zeros.
           Block fully removed in favour of a comment so eslint's
           no-constant-binary-expression rule isn't tripped by `{false && (...)}`. */}
+
+      {/* Governance Status — observable drift + forecast observer state */}
+      <GovernanceStatusPanel />
 
       {/* Live Trading Activity Feed */}
       <LiveTradingActivityFeed agentStatus={agentStatus?.status} />

--- a/apps/web/src/components/agent/GovernanceStatusPanel.tsx
+++ b/apps/web/src/components/agent/GovernanceStatusPanel.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Activity, AlertTriangle, CheckCircle2, RefreshCw } from 'lucide-react';
+import { getBackendUrl } from '@/utils/environment';
+
+const API_BASE_URL = getBackendUrl();
+const POLL_INTERVAL_MS = 30_000;
+
+interface ObservableGovernanceReport {
+  available?: boolean;
+  error?: string;
+  amplitude_violations?: Array<{ type?: string; [k: string]: unknown }>;
+  regime_violations?: Array<{ type?: string; regime?: string; [k: string]: unknown }>;
+  signal_distribution?: { buy?: number; sell?: number; hold?: number; bias?: number };
+  drift?: { mean?: number; std?: number };
+  n?: number;
+  tick_count_total?: number;
+  recent_h_j?: { h?: number | null; J?: number | null; h_over_J?: number | null };
+}
+
+interface ForecastObserverReport {
+  available?: boolean;
+  error?: string;
+  observer?: {
+    n_per_regime?: Record<string, number>;
+    amplitude_per_regime?: Record<string, number>;
+    temporal_scale_per_regime_lags?: Record<string, number>;
+    warmup_regimes?: string[];
+  };
+  regime_history_per_symbol?: Record<string, { len: number; recent: string[] }>;
+}
+
+interface GovernanceStatusResponse {
+  observable_governance?: ObservableGovernanceReport;
+  forecast_governance?: ForecastObserverReport;
+  ml_worker_url_configured?: boolean;
+  fetched_at?: string;
+  error?: string;
+  message?: string;
+}
+
+function pct(n: number | undefined | null, digits = 1): string {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return '—';
+  return `${(n * 100).toFixed(digits)}%`;
+}
+
+function fmt(n: number | undefined | null, digits = 4): string {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return '—';
+  return n.toFixed(digits);
+}
+
+export default function GovernanceStatusPanel() {
+  const [data, setData] = useState<GovernanceStatusResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastFetched, setLastFetched] = useState<Date | null>(null);
+
+  const fetchStatus = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const token = localStorage.getItem('auth_token') ?? localStorage.getItem('access_token');
+      const res = await axios.get<GovernanceStatusResponse>(`${API_BASE_URL}/api/governance/status`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        timeout: 8000,
+      });
+      setData(res.data);
+      setLastFetched(new Date());
+    } catch (err) {
+      const message = axios.isAxiosError(err)
+        ? err.response?.data?.message || err.response?.data?.error || err.message
+        : err instanceof Error ? err.message : String(err);
+      setError(String(message));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStatus();
+    const id = setInterval(fetchStatus, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const og = data?.observable_governance;
+  const fg = data?.forecast_governance;
+  const ogAvailable = og?.available !== false && !og?.error;
+  const fgAvailable = fg?.available !== false && !fg?.error;
+  const amplViolations = og?.amplitude_violations ?? [];
+  const regimeViolations = og?.regime_violations ?? [];
+  const totalViolations = amplViolations.length + regimeViolations.length;
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Activity className="w-5 h-5 text-cyan-600" />
+          <h2 className="text-lg font-semibold text-gray-900">Governance Status</h2>
+          {totalViolations > 0 ? (
+            <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-amber-100 text-amber-800 inline-flex items-center gap-1">
+              <AlertTriangle className="w-3 h-3" />
+              {totalViolations} {totalViolations === 1 ? 'violation' : 'violations'}
+            </span>
+          ) : ogAvailable && fgAvailable ? (
+            <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-green-100 text-green-800 inline-flex items-center gap-1">
+              <CheckCircle2 className="w-3 h-3" />
+              clean
+            </span>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-3 text-xs text-gray-500">
+          {lastFetched && <span>Updated {lastFetched.toLocaleTimeString()}</span>}
+          <button
+            onClick={fetchStatus}
+            disabled={loading}
+            className="p-1.5 rounded hover:bg-gray-100 disabled:opacity-50"
+            aria-label="Refresh governance status"
+            title="Refresh now"
+          >
+            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-800">
+          Failed to fetch: {error}
+        </div>
+      )}
+
+      {!data && !error && !loading && (
+        <p className="text-sm text-gray-500">No data yet.</p>
+      )}
+
+      {data && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <section>
+            <h3 className="text-sm font-semibold text-gray-700 mb-2">Observable Governance</h3>
+            {ogAvailable ? (
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Ticks observed</span>
+                  <span className="font-mono text-gray-900">{og?.tick_count_total ?? og?.n ?? '—'}</span>
+                </div>
+                {og?.signal_distribution && (
+                  <div className="flex justify-between">
+                    <span className="text-gray-600">Signal mix (buy / sell / hold)</span>
+                    <span className="font-mono text-gray-900">
+                      {og.signal_distribution.buy ?? 0} / {og.signal_distribution.sell ?? 0} / {og.signal_distribution.hold ?? 0}
+                      {typeof og.signal_distribution.bias === 'number' && (
+                        <span className="ml-2 text-xs text-gray-500">bias {pct(og.signal_distribution.bias)}</span>
+                      )}
+                    </span>
+                  </div>
+                )}
+                {og?.drift && (
+                  <div className="flex justify-between">
+                    <span className="text-gray-600">Drift μ ± σ</span>
+                    <span className="font-mono text-gray-900">
+                      {fmt(og.drift.mean)} ± {fmt(og.drift.std)}
+                    </span>
+                  </div>
+                )}
+                {og?.recent_h_j && (
+                  <div className="flex justify-between">
+                    <span className="text-gray-600">Recent h / J / h-over-J</span>
+                    <span className="font-mono text-gray-900">
+                      {fmt(og.recent_h_j.h, 3)} / {fmt(og.recent_h_j.J, 3)} / {fmt(og.recent_h_j.h_over_J, 2)}
+                    </span>
+                  </div>
+                )}
+                {amplViolations.length > 0 && (
+                  <div className="mt-2 p-2 bg-amber-50 border border-amber-200 rounded">
+                    <div className="text-xs font-medium text-amber-800 mb-1">
+                      {amplViolations.length} amplitude violation{amplViolations.length === 1 ? '' : 's'}
+                    </div>
+                    <ul className="text-xs text-amber-900 space-y-0.5">
+                      {amplViolations.slice(0, 3).map((v, i) => (
+                        <li key={i} className="font-mono">{String(v.type ?? 'unknown')}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {regimeViolations.length > 0 && (
+                  <div className="mt-2 p-2 bg-amber-50 border border-amber-200 rounded">
+                    <div className="text-xs font-medium text-amber-800 mb-1">
+                      {regimeViolations.length} regime violation{regimeViolations.length === 1 ? '' : 's'}
+                    </div>
+                    <ul className="text-xs text-amber-900 space-y-0.5">
+                      {regimeViolations.slice(0, 3).map((v, i) => (
+                        <li key={i} className="font-mono">
+                          {String(v.type ?? 'unknown')}{v.regime ? ` (${v.regime})` : ''}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500">
+                {og?.error ? `Unavailable: ${og.error}` : 'Detector pool not initialised yet.'}
+              </p>
+            )}
+          </section>
+
+          <section>
+            <h3 className="text-sm font-semibold text-gray-700 mb-2">Forecast Observer (CAL-4)</h3>
+            {fgAvailable && fg?.observer ? (
+              <div className="space-y-2 text-sm">
+                {fg.observer.warmup_regimes && fg.observer.warmup_regimes.length > 0 && (
+                  <div className="p-2 bg-blue-50 border border-blue-200 rounded text-xs text-blue-900">
+                    <span className="font-medium">Warming up:</span>{' '}
+                    {fg.observer.warmup_regimes.join(', ')}
+                  </div>
+                )}
+                {fg.observer.n_per_regime && (
+                  <div>
+                    <div className="text-gray-600 mb-1">Observations per regime</div>
+                    <div className="grid grid-cols-3 gap-2 text-xs font-mono">
+                      {Object.entries(fg.observer.n_per_regime).map(([regime, n]) => (
+                        <div key={regime} className="text-center">
+                          <div className="text-gray-500">{regime}</div>
+                          <div className="text-gray-900 font-semibold">{n}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {fg.observer.amplitude_per_regime && (
+                  <div>
+                    <div className="text-gray-600 mb-1">Amplitude (observer-derived)</div>
+                    <div className="grid grid-cols-3 gap-2 text-xs font-mono">
+                      {Object.entries(fg.observer.amplitude_per_regime).map(([regime, amp]) => (
+                        <div key={regime} className="text-center">
+                          <div className="text-gray-500">{regime}</div>
+                          <div className="text-gray-900 font-semibold">{fmt(amp, 3)}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {fg.observer.temporal_scale_per_regime_lags && (
+                  <div>
+                    <div className="text-gray-600 mb-1">Temporal scale (1/e lags)</div>
+                    <div className="grid grid-cols-3 gap-2 text-xs font-mono">
+                      {Object.entries(fg.observer.temporal_scale_per_regime_lags).map(([regime, lags]) => (
+                        <div key={regime} className="text-center">
+                          <div className="text-gray-500">{regime}</div>
+                          <div className="text-gray-900 font-semibold">{fmt(lags, 1)}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {fg.regime_history_per_symbol && Object.keys(fg.regime_history_per_symbol).length > 0 && (
+                  <div className="mt-3 pt-3 border-t border-gray-100">
+                    <div className="text-gray-600 mb-1 text-xs">Recent regime per symbol</div>
+                    <ul className="text-xs space-y-1">
+                      {Object.entries(fg.regime_history_per_symbol).map(([sym, h]) => (
+                        <li key={sym} className="flex justify-between">
+                          <span className="font-mono text-gray-700">{sym}</span>
+                          <span className="font-mono text-gray-900">{h.recent.slice(-3).join(' → ')}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500">
+                {fg?.error ? `Unavailable: ${fg.error}` : 'Observer not initialised yet.'}
+              </p>
+            )}
+          </section>
+        </div>
+      )}
+
+      {data?.ml_worker_url_configured === false && (
+        <div className="mt-4 p-2 bg-gray-50 border border-gray-200 rounded text-xs text-gray-700">
+          ML worker URL not configured (<code className="font-mono">ML_WORKER_URL</code> env var unset).
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

User directive: "/governance/status and /api/governance/perception-parity and anything else that is endpoint only available must be available in the UI. thats why i have a ui. i dont want to have to remember countless endpoints."

Adds a Governance Status panel to the autonomous-agent dashboard so the two layers of ml-worker governance (observable distributional drift + forecast-horizon observer state) are visible without curling the worker.

## Changes

**apps/api/src/routes/governance.ts** — `GET /api/governance/status`: 5s-timeout authenticated proxy to ml-worker's `/governance/status`. Returns the worker body plus `fetched_at` + `ml_worker_url_configured`. Surfaces clear 503/502 on missing config / unreachable worker.

**apps/web/src/components/agent/GovernanceStatusPanel.tsx** (new): Two-column panel rendering:
- Left — Observable Governance: tick count, signal mix (buy/sell/hold + bias), drift μ±σ, recent h/J/h-over-J, amplitude + regime violations (up to 3 each)
- Right — Forecast Observer (CAL-4): per-regime n, observer-derived amplitude, temporal-scale lags, warmup-regime list, recent regime per symbol

Polls every 30s, manual refresh button, header pill (green clean / amber violation count).

**apps/web/src/components/agent/AutonomousAgentDashboard.tsx**: mounts the panel just above LiveTradingActivityFeed. Kept as a child component (rather than inline state) because the dashboard is already 1400+ lines with 20+ state hooks; governance is independent.

## Test plan

- [x] apps/api tsc --noEmit (after prebuild): 0 errors
- [x] apps/web tsc --noEmit: 0 errors (2 pre-existing ApiKeyManagement.tsx errors unchanged)
- [x] apps/api vitest: 1354 passed
- [ ] Deployed UX: visit /autonomous-agent, confirm panel renders; with valid ML_WORKER_URL it shows observer state; without it shows the configuration banner

## Follow-up (not in this PR)

The MTFBootstrap 429 storm seen in prod logs is unrelated — multiple kernels fire concurrent /market/candles at startup. Will diagnose separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)