### PR TITLE
fix(api): MTF-bootstrap 429 storm — cap candle bucket initial burst + add 429 retry

### DIFF
--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -848,59 +848,79 @@ class PoloniexFuturesService {
 
     // Apply rate limiting
     return rateLimiter.execute(endpoint, async () => {
-      try {
-        const requestPath = `/v3${endpoint}`;
-        const url = `${this.baseURL}${requestPath}`;
-        
-        const queryString = Object.keys(params).length > 0
-          ? '?' + new globalThis.URLSearchParams(params).toString()
-          : '';
-        
-        const fullUrl = url + queryString;
-        
-        const config = {
-          method: method.toLowerCase(),
-          url: fullUrl,
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          timeout: this.timeout
-        };
-        
-        if (Object.keys(params).length > 0 && method === 'GET') {
-          config.params = params;
-        }
-        
-        logger.info(`Making Poloniex v3 public ${method} request to ${requestPath}`);
-        const response = await axios(config);
-        
-        // Poloniex V3 API returns: { code: 200, data: [...], msg: "Success" }
-        // Extract the data field if present, otherwise return the full response
-        let result;
-        if (response.data && typeof response.data === 'object' && 'data' in response.data) {
-          result = response.data.data;
-        } else {
-          result = response.data;
-        }
+      const requestPath = `/v3${endpoint}`;
+      const url = `${this.baseURL}${requestPath}`;
+      const queryString = Object.keys(params).length > 0
+        ? '?' + new globalThis.URLSearchParams(params).toString()
+        : '';
+      const fullUrl = url + queryString;
+      const config = {
+        method: method.toLowerCase(),
+        url: fullUrl,
+        headers: { 'Content-Type': 'application/json' },
+        timeout: this.timeout,
+      };
+      if (Object.keys(params).length > 0 && method === 'GET') {
+        config.params = params;
+      }
 
-        // Cache successful GET responses
-        if (method === 'GET') {
-          const ttl = getTtlForEndpoint(endpoint);
-          if (ttl > 0) {
-            const cacheKey = `GET:${endpoint}:${serializeParams(params)}`;
-            apiCache.set(cacheKey, result, ttl);
+      // 429 retry-with-backoff. Live evidence 2026-05-17: the MTF bootstrap
+      // burst + LiveSignal startup occasionally trips Poloniex's instant
+      // burst guard for /market/candles even when within the 20/s window
+      // cap. Treat 429 as transient — honour Retry-After when present,
+      // exponential backoff otherwise. Bubble up the underlying error
+      // after MAX_429_RETRIES so genuine sustained throttling still
+      // surfaces.
+      const MAX_429_RETRIES = 3;
+      let attempt = 0;
+      // Read-only loop: only the 429 branch retries; every other path
+      // returns or throws.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        try {
+          logger.info(`Making Poloniex v3 public ${method} request to ${requestPath}`);
+          const response = await axios(config);
+
+          // Poloniex V3 API returns: { code: 200, data: [...], msg: "Success" }
+          let result;
+          if (response.data && typeof response.data === 'object' && 'data' in response.data) {
+            result = response.data.data;
+          } else {
+            result = response.data;
           }
+          if (method === 'GET') {
+            const ttl = getTtlForEndpoint(endpoint);
+            if (ttl > 0) {
+              const cacheKey = `GET:${endpoint}:${serializeParams(params)}`;
+              apiCache.set(cacheKey, result, ttl);
+            }
+          }
+          return result;
+        } catch (error) {
+          const status = error.response?.status;
+          const retriable = status === 429 || status === 503;
+          if (retriable && attempt < MAX_429_RETRIES) {
+            const retryAfterHeader = error.response?.headers?.['retry-after'];
+            const headerSeconds = retryAfterHeader != null ? Number(retryAfterHeader) : NaN;
+            const waitMs = Number.isFinite(headerSeconds) && headerSeconds > 0
+              ? Math.min(headerSeconds * 1000, 10_000)
+              : Math.min(250 * Math.pow(2, attempt), 4_000);
+            logger.warn(`Poloniex v3 public request ${status} (transient); backing off`, {
+              endpoint, status, attempt: attempt + 1, waitMs,
+            });
+            await new Promise((r) => setTimeout(r, waitMs));
+            attempt += 1;
+            continue;
+          }
+          logger.error('Poloniex v3 public API request error:', {
+            endpoint: endpoint,
+            status,
+            data: error.response?.data,
+            message: error.message,
+            attempts: attempt + 1,
+          });
+          throw error;
         }
-
-        return result;
-      } catch (error) {
-        logger.error('Poloniex v3 public API request error:', {
-          endpoint: endpoint,
-          status: error.response?.status,
-          data: error.response?.data,
-          message: error.message
-        });
-        throw error;
       }
     });
   }

--- a/apps/api/src/tests/rateLimiter.test.js
+++ b/apps/api/src/tests/rateLimiter.test.js
@@ -175,6 +175,23 @@ describe('RateLimiter', () => {
       expect(elapsed).toBeGreaterThan(0);
     });
 
+    it('caps the candle bucket initial burst at 5 (steady-state refill stays 15/s)', () => {
+      // Production 429 storm 2026-05-17: starting candles at the full 15-token
+      // burst let 15 calls fire instantly at deploy boot, landing at Poloniex
+      // within ~50ms and tripping their instant burst guard. Capping the
+      // *initial* burst at 5 forces the post-burst calls through the 15/s
+      // refill pace.
+      const fresh = new RateLimiter();
+      const candles = fresh.getBucket('candles');
+      expect(candles.tokens).toBe(5);
+      expect(candles.maxTokens).toBe(15);
+      expect(candles.refillRate).toBe(15);
+
+      // Other buckets remain at full burst capacity.
+      const orders = fresh.getBucket('orders');
+      expect(orders.tokens).toBe(orders.maxTokens);
+    });
+
     it('throttles a concurrent burst instead of letting waiters over-consume', async () => {
       // The MTF-bootstrap pattern: many candle calls fired at once. The
       // old single-wait waitForToken let all concurrent waiters wake and

--- a/apps/api/src/utils/rateLimiter.js
+++ b/apps/api/src/utils/rateLimiter.js
@@ -125,15 +125,23 @@ class RateLimiter {
   getBucket(endpointType) {
     if (!this.buckets.has(endpointType)) {
       const limit = this.getRateLimit(endpointType);
-      
+      // Candle bucket: cap the *initial* burst capacity below the steady-state
+      // refill rate so a process-startup burst (both Monkey kernels + LiveSignal
+      // all warming OHLCV at once) can't fire 15 instantaneous calls. Refill
+      // rate stays 15/s, so steady-state throughput is unchanged. Production
+      // 429 storm 2026-05-17 was the trigger: 6 instant calls cleared the
+      // limiter at deploy boot but landed at Poloniex within ~50ms, exceeding
+      // their instantaneous-burst guard despite being under the 20/s window cap.
+      const initialBurst = endpointType === 'candles' ? Math.min(limit, 5) : limit;
+
       this.buckets.set(endpointType, {
-        tokens: limit,
+        tokens: initialBurst,
         maxTokens: limit,
         lastRefill: Date.now(),
         refillRate: limit // tokens per second
       });
     }
-    
+
     return this.buckets.get(endpointType);
   }
 


### PR DESCRIPTION
## Summary

Production log monitoring caught a repeating storm of `code=429 Position not enough` from `/v3/market/candles` every time a new deploy boots — up to 6 red ERROR lines within a 100ms window during MTFBootstrap.

Root cause: the rate limiter's candle bucket is correctly sized at 15 req/s (under Poloniex's 20/s per-IP cap) but starts FULL. At process boot, two Monkey kernels + LiveSignal can fire 15 simultaneous candle calls in < 50ms — under the 1s window quota but tripping Poloniex's instantaneous-burst guard.

## Changes

**apps/api/src/utils/rateLimiter.js** — Candle bucket initial token count: 15 → 5. Refill rate stays 15/s, so steady-state throughput is unchanged. Only the first-call burst is constrained. Other buckets unchanged.

**apps/api/src/services/poloniexFuturesService.js** — Added 429/503 retry-with-backoff to `makePublicRequest`. Honours `Retry-After` when present, otherwise exponential 250 → 500 → 1000 → 2000ms. Max 3 retries. Catches the residual cases where another IP consumer races our request through Poloniex's quota.

**apps/api/src/tests/rateLimiter.test.js** (+1 test) — Verifies candle bucket initial tokens = 5, maxTokens = 15, and that other buckets retain full burst capacity.

## Test plan

- [x] tsc --noEmit (after prebuild): 0 errors
- [x] vitest: 1355 passed
- [ ] Post-deploy: monitor for 10 min — expect zero MTFBootstrap 429 ERROR lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)