### PR TITLE
fix(monkey): SELFOBS-1 — Wilson 95% CI gate replaces MIN_SAMPLE_FOR_BIAS=3

### DIFF
--- a/apps/api/src/services/monkey/__tests__/selfObservationWilson.test.ts
+++ b/apps/api/src/services/monkey/__tests__/selfObservationWilson.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { wilsonCI } from '../self_observation.js';
+
+describe('wilsonCI', () => {
+  it('returns full [0,1] when trades=0 (no information sentinel)', () => {
+    expect(wilsonCI(0, 0)).toEqual({ lower: 0, upper: 1 });
+  });
+
+  it('produces a wide CI that includes 0.5 with small samples', () => {
+    // 3 trades, 2 wins (winRate=0.67) — classic small-sample case where the
+    // old MIN_SAMPLE_FOR_BIAS=3 gate would have fired but the CI is so wide
+    // there is no real evidence of asymmetry.
+    const ci = wilsonCI(2, 3);
+    expect(ci.lower).toBeLessThan(0.5);
+    expect(ci.upper).toBeGreaterThan(0.5);
+    // Wilson 95% for 2/3: roughly [0.21, 0.94]
+    expect(ci.lower).toBeGreaterThan(0.15);
+    expect(ci.lower).toBeLessThan(0.30);
+    expect(ci.upper).toBeGreaterThan(0.85);
+    expect(ci.upper).toBeLessThan(0.98);
+  });
+
+  it('CI tightens as sample size grows', () => {
+    const small = wilsonCI(20, 30);  // 0.67 with n=30
+    const large = wilsonCI(200, 300); // 0.67 with n=300
+    const veryLarge = wilsonCI(2000, 3000);
+    const smallWidth = small.upper - small.lower;
+    const largeWidth = large.upper - large.lower;
+    const veryLargeWidth = veryLarge.upper - veryLarge.lower;
+    expect(largeWidth).toBeLessThan(smallWidth);
+    expect(veryLargeWidth).toBeLessThan(largeWidth);
+    // Very-large sample CI should be narrow enough to clearly exclude 0.5
+    expect(veryLarge.lower).toBeGreaterThan(0.5);
+  });
+
+  it('CI is bounded to [0, 1]', () => {
+    const allWins = wilsonCI(50, 50);
+    expect(allWins.lower).toBeGreaterThanOrEqual(0);
+    expect(allWins.upper).toBeLessThanOrEqual(1);
+    expect(allWins.lower).toBeLessThan(1);  // even all-wins doesn't give point estimate
+
+    const allLosses = wilsonCI(0, 50);
+    expect(allLosses.lower).toBeGreaterThanOrEqual(0);
+    expect(allLosses.upper).toBeLessThanOrEqual(1);
+    expect(allLosses.upper).toBeGreaterThan(0);  // even all-losses doesn't give point estimate
+  });
+
+  it('is symmetric around 0.5 for symmetric inputs', () => {
+    const wins70 = wilsonCI(7, 10);   // 70 % win
+    const wins30 = wilsonCI(3, 10);   // 30 % win
+    // The widths should match; the centers should be equidistant from 0.5.
+    const w70Width = wins70.upper - wins70.lower;
+    const w30Width = wins30.upper - wins30.lower;
+    expect(Math.abs(w70Width - w30Width)).toBeLessThan(1e-9);
+    const center70 = (wins70.lower + wins70.upper) / 2;
+    const center30 = (wins30.lower + wins30.upper) / 2;
+    expect(Math.abs((center70 - 0.5) + (center30 - 0.5))).toBeLessThan(1e-9);
+  });
+
+  it('matches a known reference point: 100/200 = 0.5 ± ~0.07', () => {
+    // 100 wins out of 200 — Wilson 95% CI is approximately [0.430, 0.570]
+    const ci = wilsonCI(100, 200);
+    expect(ci.lower).toBeGreaterThan(0.42);
+    expect(ci.lower).toBeLessThan(0.44);
+    expect(ci.upper).toBeGreaterThan(0.56);
+    expect(ci.upper).toBeLessThan(0.58);
+  });
+
+  it('reproduces the SELFOBS-1 audit motivating example', () => {
+    // The audit's complaint about MAX_BIAS_SWING=0.30 + MIN_SAMPLE_FOR_BIAS=3:
+    // with 3 trades and 1 win, the old code would have emitted a bias of
+    // 1 + 2*0.30*(0.5-0.33) = 1.10 (10% harder entry) even though the
+    // Wilson CI is wildly uncertain.
+    const ci = wilsonCI(1, 3);
+    // CI should clearly cover 0.5 → no evidence → bias should stay neutral
+    expect(ci.lower).toBeLessThan(0.5);
+    expect(ci.upper).toBeGreaterThan(0.5);
+  });
+});

--- a/apps/api/src/services/monkey/self_observation.ts
+++ b/apps/api/src/services/monkey/self_observation.ts
@@ -46,17 +46,62 @@ export interface SelfObservation {
   entryBias: Record<MonkeyMode, Record<Side, number>>;
 }
 
-const MAX_BIAS_SWING = 0.30;  // ±30 % from neutral 1.0
+/**
+ * Soft cap on bias deflection magnitude — the "even with strong evidence,
+ * don't lean harder than this". Replaces the previous unconditional
+ * MAX_BIAS_SWING constant with a documented bound. SELFOBS-1 v2 will
+ * derive this from the empirical spread of |winRate-0.5| observed across
+ * all populated buckets, once a basin-wide running-stats accumulator is
+ * available. Until then, 0.30 carries forward the previously-shipped
+ * cap value so behaviour is bit-for-bit identical when sample evidence
+ * is strong (Wilson CI tight + winRate extreme).
+ */
+const MAX_BIAS_SWING = 0.30;
 
 /**
- * Minimum closed trades PER (mode, side) bucket before the bucket's
- * win-rate influences the bias. The right value is a speed-vs-noise
- * tradeoff — see README below for the decision.
- *
- * TODO (user): pick the bucket-min-sample strategy. See computeEntryBias()
- * below for where this gets used.
+ * Wilson 95% CI z-score. Two-sided confidence for binomial proportions —
+ * standard reference: https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval
  */
-const MIN_SAMPLE_FOR_BIAS = 3;
+const WILSON_Z = 1.96;
+
+/**
+ * Wilson 95% CI for a binomial proportion (wins/trades). Used by
+ * computeEntryBias() to gate bias deflection on statistical evidence
+ * rather than a hardcoded sample-count threshold (was
+ * MIN_SAMPLE_FOR_BIAS=3). With small n the CI is wide → bias stays
+ * neutral; as n grows the CI tightens and bias deflects.
+ *
+ * Returns NaN/wide-CI sentinel for trades=0 (caller treats as "no info").
+ */
+export function wilsonCI(
+  wins: number,
+  trades: number,
+  z = WILSON_Z,
+): { lower: number; upper: number } {
+  if (trades <= 0) return { lower: 0, upper: 1 };
+  const phat = wins / trades;
+  const z2_n = (z * z) / trades;
+  const denom = 1 + z2_n;
+  const center = (phat + z2_n / 2) / denom;
+  const margin = (z / denom) * Math.sqrt(phat * (1 - phat) / trades + z2_n / (4 * trades));
+  return {
+    lower: Math.max(0, center - margin),
+    upper: Math.min(1, center + margin),
+  };
+}
+
+/**
+ * Decides whether the Wilson CI for (wins, trades) excludes 0.5 — i.e.
+ * whether we have statistical evidence that the bucket's win-rate is
+ * meaningfully different from chance. Replaces the previous trades>=3
+ * gate, which was sample-count-based instead of evidence-based.
+ */
+function hasBiasEvidence(wins: number, trades: number): boolean {
+  if (trades <= 0) return false;
+  const { lower, upper } = wilsonCI(wins, trades);
+  // Strictly: CI must be entirely above or entirely below 0.5
+  return lower > 0.5 || upper < 0.5;
+}
 
 function emptyStats(mode: MonkeyMode, side: Side): ModeStats {
   return { mode, side, trades: 0, wins: 0, losses: 0, winRate: 0, avgPnl: 0, totalPnl: 0 };
@@ -152,28 +197,31 @@ function computeEntryBias(
   globalAll: { trades: number; wins: number; winRate: number },
 ): Record<MonkeyMode, Record<Side, number>> {
   const bias = buildNeutralBias();
-  // ──────── USER-CONTRIBUTED STRATEGY GOES HERE ────────
-  // Placeholder that implements strategy B (hierarchical fallback) so
-  // typecheck passes. Replace with your chosen strategy.
+  // Strategy B (hierarchical fallback) with Wilson 95% CI gate replacing
+  // the prior MIN_SAMPLE_FOR_BIAS=3 threshold. The CI gate is strictly
+  // stronger: with n=3 the Wilson CI is wide enough to include 0.5 for
+  // all but the most extreme splits, so bias stays neutral until there
+  // is actual statistical evidence of asymmetry. The fallback order is
+  // preserved so a less-populated bucket still inherits from a parent
+  // pool once the parent's evidence is firm.
   for (const mode of ALL_MODES) {
     for (const side of SIDES) {
       const bucket = bucketStats[mode][side];
       const modeS = modePooled[mode];
       const globalS = globalPooled[side];
-      if (bucket.trades >= MIN_SAMPLE_FOR_BIAS) {
+      if (hasBiasEvidence(bucket.wins, bucket.trades)) {
         bias[mode][side] = winRateToBias(bucket.winRate);
-      } else if (modeS.trades >= MIN_SAMPLE_FOR_BIAS) {
+      } else if (hasBiasEvidence(modeS.wins, modeS.trades)) {
         bias[mode][side] = winRateToBias(modeS.winRate);
-      } else if (globalS.trades >= MIN_SAMPLE_FOR_BIAS) {
+      } else if (hasBiasEvidence(globalS.wins, globalS.trades)) {
         bias[mode][side] = winRateToBias(globalS.winRate);
-      } else if (globalAll.trades >= MIN_SAMPLE_FOR_BIAS) {
+      } else if (hasBiasEvidence(globalAll.wins, globalAll.trades)) {
         bias[mode][side] = winRateToBias(globalAll.winRate);
       }
-      // else: stays 1.0 (neutral) — she hasn't learned anything yet
+      // else: stays 1.0 (neutral) — no level has CI-firm evidence yet
     }
   }
   return bias;
-  // ─────────────────────────────────────────────────────
 }
 
 /**


### PR DESCRIPTION
## Summary

Audit finding **SELFOBS-1 #764**: self_observation.ts hardcoded `MIN_SAMPLE_FOR_BIAS=3` and `MAX_BIAS_SWING=0.30` are P1 violations — magic thresholds chosen by intuition rather than derived from observed data.

The sample-count gate's specific flaw: with 3 trades + 2 wins (winRate=0.67), bias emitted as 0.898 (10% easier entry) when the Wilson 95% CI is ~[0.21, 0.94] — wildly uncertain, indistinguishable from chance. **Bias was firing on noise.**

## Solution

Replace the sample-count gate with a Wilson 95% CI predicate: bias deflects only when the CI excludes 0.5 (statistical evidence of asymmetry). Naturally sample-size aware — wide CI at small n closes the gate, tight CI at large n opens it under firm evidence.

## Behaviour comparison

| Bucket evidence | Old bias | New bias | Reason |
|---|---|---|---|
| 3 trades, 1 win | 1.10 | 1.00 | CI ~[0.01, 0.91] covers 0.5 — no evidence |
| 3 trades, 2 wins | 0.898 | 1.00 | CI ~[0.21, 0.94] covers 0.5 — no evidence |
| 30 trades, 20 wins | 0.898 | 1.00 | CI ~[0.49, 0.81] still just covers 0.5 |
| 50 trades, 35 wins | 0.880 | 0.880 | CI ~[0.56, 0.81] excludes 0.5 — fires |
| 200 trades, 140 wins | 0.880 | 0.880 | CI ~[0.63, 0.76] cleanly excludes |

Hierarchical fallback (B) preserved: bucket → mode-pooled → side-global → all. Each level gates on CI evidence.

`MAX_BIAS_SWING=0.30` kept as soft cap with v2 follow-up note (will be derived from empirical spread once a basin-wide running-stats accumulator is available).

## Test plan

- [x] tsc --noEmit (after prebuild): 0 errors
- [x] vitest: 1362 passed (+7 from new Wilson CI tests including audit's motivating example)
- [ ] Post-deploy: monitor `selfObsBias` in Monkey log lines — values should hover at 1.00 longer in early-life buckets, then snap to non-neutral once the bucket accumulates ≥ ~40 trades with a real win-rate asymmetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)