### PR TITLE
chore(monkey): PARAM-1 cleanup — remove env-var gate + sslmode workaround + seed 3 missing params

### DIFF
--- a/apps/api/database/migrations/054_seed_missing_monkey_parameters.sql
+++ b/apps/api/database/migrations/054_seed_missing_monkey_parameters.sql
@@ -1,0 +1,62 @@
+-- Migration 054: PARAM-1 follow-up — seed 3 monkey_parameters rows added
+-- to code after migration 047 shipped.
+--
+-- Discovered when MONKEY_PARAM_REGISTRY_DB=true was flipped on ml-worker
+-- (2026-05-17): the registry loaded successfully but warned about three
+-- parameter names that the Python code references with hardcoded defaults
+-- but that 047 didn't seed:
+--
+--   ocean.phi_damping_lower         default 0.85
+--   ocean.phi_mushroom_floor        default 0.70
+--   executive.lane.swing.budget_frac default 0.50
+--
+-- The warnings emit once per name, so they're not noise — but they signal
+-- that operator tuning via propose_change() for these names is a no-op
+-- (the row doesn't exist; the missing-row warning fires; the default is
+-- used; nothing in the DB ever changes the effective value).
+--
+-- Per the registry contract in parameters.py: when a parameter exists in
+-- the DB, propose_change() round-trips through monkey_parameter_changes
+-- with full audit. When it doesn't, the default is used silently. This
+-- migration brings these three names into the registry surface area.
+
+INSERT INTO monkey_parameters
+    (name, category, value, bounds_low, bounds_high, justification, version)
+VALUES
+    (
+        'ocean.phi_damping_lower',
+        'SAFETY_BOUND',
+        0.85,
+        0.5,
+        0.95,
+        'DAMPING intervention floor — when Φ falls below this and isn''t '
+        'in ESCAPE/MUSHROOM territory, Ocean applies damping to the '
+        'executive output. Tighter than phi_dream_bound (0.5) since '
+        'damping is the lightest intervention. Bounded conservatively.',
+        1
+    ),
+    (
+        'ocean.phi_mushroom_floor',
+        'SAFETY_BOUND',
+        0.70,
+        0.4,
+        0.85,
+        'MUSHROOM intervention trigger — when Φ falls below phi_damping_lower '
+        'but stays above this floor, the system enters MUSHROOM (gentle '
+        'collapse to subset of agents). Above this = damping is enough. '
+        'Below this = ESCAPE or SLEEP needed.',
+        1
+    ),
+    (
+        'executive.lane.swing.budget_frac',
+        'OPERATIONAL',
+        0.50,
+        0.10,
+        0.80,
+        'Fraction of total per-symbol margin budget allocated to the swing '
+        'lane (5m timeframe). Remainder split across other lanes (scalp + '
+        'trend). 0.50 = swing gets half. Bounded so swing can''t starve or '
+        'dominate the other lanes.',
+        1
+    )
+ON CONFLICT (name) DO NOTHING;

--- a/ml-worker/src/monkey_kernel/parameters.py
+++ b/ml-worker/src/monkey_kernel/parameters.py
@@ -285,23 +285,19 @@ class ParameterRegistry:
         synchronous psycopg; raises on any DB/parse failure for _load to
         catch.
 
-        sslmode=disable: the Railway internal network
-        (postgres.railway.internal) is already private — SSL adds
-        nothing — and psycopg[binary]'s bundled libpq+openssl can
-        SEGFAULT during the TLS handshake when its openssl symbols
-        collide with the other native extensions loaded in the
-        ml-worker process (TensorFlow, scipy, sklearn, h5py). Skipping
-        the handshake avoids that crash path. Only appended when the
-        DSN doesn't already pin sslmode.
+        Prior to MIG-1 (2026-05-16) this path appended sslmode=disable
+        because psycopg[binary]'s bundled libpq+openssl could SEGFAULT
+        during the TLS handshake when its openssl symbols collided with
+        TensorFlow / scipy / sklearn / h5py loaded in the same process.
+        MIG-1 stripped TF and the other native libs out of ml-worker, so
+        the segfault path no longer exists. The DSN now passes through
+        unchanged — psycopg defaults to sslmode=prefer, which TLS-handshakes
+        opportunistically and falls back to plaintext on the private
+        Railway internal network if SSL isn't offered.
         """
         import psycopg
 
-        dsn = self._dsn
-        if dsn and "sslmode=" not in dsn:
-            sep = "&" if "?" in dsn else "?"
-            dsn = f"{dsn}{sep}sslmode=disable"
-
-        with psycopg.connect(dsn) as conn:
+        with psycopg.connect(self._dsn) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
@@ -356,26 +352,14 @@ class ParameterRegistry:
                 self._loaded = True
             return
 
-        # 2026-05-14: the live DB load is GATED OFF by default. psycopg's
-        # binary wheel bundles libpq+openssl; in the ml-worker process
-        # (TensorFlow / scipy / sklearn / h5py also loaded) the connect()
-        # path SEGFAULTS the whole process — an uncatchable native crash
-        # that restart-loops the service. Until the connect path is
-        # proven safe in that environment (sslmode=disable + a clean
-        # endpoint smoke-test), the registry runs on its hardcoded
-        # defaults — its documented fail-soft mode, and per migration
-        # 047 equal to the current DB values anyway. Flip
-        # MONKEY_PARAM_REGISTRY_DB=true to re-enable once verified.
-        if os.environ.get("MONKEY_PARAM_REGISTRY_DB", "").lower() != "true":
-            if not self._loaded:
-                logger.info(
-                    "parameter registry DB load disabled "
-                    "(MONKEY_PARAM_REGISTRY_DB != 'true') — using hardcoded "
-                    "defaults; this is the documented fail-soft mode",
-                )
-                self._defaults_only = True
-                self._loaded = True
-            return
+        # PARAM-1 (2026-05-17): the MONKEY_PARAM_REGISTRY_DB gate that
+        # used to live here was added 2026-05-14 to guard against a
+        # psycopg/libpq/openssl SEGFAULT that only manifested when the
+        # ml-worker process had TensorFlow + scipy + sklearn loaded
+        # alongside. MIG-1 (PR #743) stripped those out, eliminating the
+        # crash path. The gate flipped to true on Railway 2026-05-17T01:51Z
+        # and the live DB load has been clean since. The gate is removed
+        # so the registry always loads when DATABASE_URL is present.
 
         try:
             future = _DB_EXECUTOR.submit(self._query_parameters_table)
@@ -386,10 +370,14 @@ class ParameterRegistry:
         except Exception as exc:
             # Fail-soft: keep serving from existing cache / defaults.
             # Covers DB-unreachable, query errors, AND the executor
-            # timeout — the process stays up either way.
+            # timeout — the process stays up either way. Setting
+            # _defaults_only suppresses the per-parameter "missing from
+            # registry" warning in get() so a failed load doesn't flood
+            # the log with one WARN per get() call per tick.
             logger.warning("parameter registry load failed: %s", exc)
             if not self._loaded:
                 self._loaded = True  # don't retry every .get() call
+                self._defaults_only = True
 
 
 # ── Process-global singleton ─────────────────────────────────────

--- a/ml-worker/tests/monkey_kernel/test_parameters_psycopg_isolation.py
+++ b/ml-worker/tests/monkey_kernel/test_parameters_psycopg_isolation.py
@@ -45,44 +45,40 @@ from monkey_kernel.parameters import (  # noqa: E402
 
 
 @pytest.fixture
-def db_gate_on(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Enable the live DB-load path. _load() is GATED OFF by default
-    (MONKEY_PARAM_REGISTRY_DB != 'true' → defaults-only) because
-    psycopg's binary wheel segfaults the ml-worker process during
-    connect. The DB-path tests below opt in via this fixture so they
-    actually reach _query_parameters_table / the executor."""
-    monkeypatch.setenv("MONKEY_PARAM_REGISTRY_DB", "true")
+def db_gate_on() -> None:
+    """PARAM-1 (2026-05-17) removed the env-var gate. The fixture is now
+    a no-op; left in place so the rest of the test surface continues to
+    document where the live-DB path is exercised."""
+    return None
 
 
-def test_db_load_gated_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The load-bearing safety property: with MONKEY_PARAM_REGISTRY_DB
-    unset, _load() must NOT touch psycopg at all — it short-circuits to
-    defaults-only. This is what keeps ml-worker from segfaulting: no
-    psycopg.connect() call = no native crash."""
+def test_db_load_runs_when_dsn_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PARAM-1 contract: when a DSN is configured, _load() always reaches
+    _query_parameters_table — the old MONKEY_PARAM_REGISTRY_DB gate is
+    gone. The segfault path it guarded against was eliminated by MIG-1
+    (TensorFlow + scipy + sklearn + h5py removed from ml-worker)."""
     monkeypatch.delenv("MONKEY_PARAM_REGISTRY_DB", raising=False)
     reg = ParameterRegistry(dsn="postgresql://stub/notused")
     called = {"n": 0}
 
-    def must_not_run() -> dict:
+    def fake_query() -> dict:
         called["n"] += 1
         return {}
 
-    reg._query_parameters_table = must_not_run  # type: ignore[method-assign]
+    reg._query_parameters_table = fake_query  # type: ignore[method-assign]
     reg._load()
 
-    assert called["n"] == 0, (
-        "_query_parameters_table ran despite the DB gate being OFF — "
-        "this re-opens the segfault path"
-    )
+    assert called["n"] == 1, "_query_parameters_table should run regardless of env var"
     assert reg._loaded is True
-    # get() still works — defaults-only fail-soft mode.
+    # Empty cache + default still works via get().
     assert reg.get("physics.kappa_star", default=64.0) == 64.0
 
 
-def test_query_appends_sslmode_disable() -> None:
-    """_query_parameters_table appends sslmode=disable when the DSN
-    doesn't pin it — the Railway internal network is private (SSL adds
-    nothing) and psycopg[binary]'s bundled openssl is the crash path."""
+def test_query_passes_dsn_through_unchanged() -> None:
+    """PARAM-1 contract: the sslmode=disable workaround is removed. The
+    DSN passes to psycopg.connect unchanged — psycopg defaults to
+    sslmode=prefer, which TLS-handshakes opportunistically and falls
+    back to plaintext on the private Railway internal network."""
     seen: dict[str, str] = {}
     reg = ParameterRegistry(dsn="postgresql://u:p@postgres.railway.internal:5432/railway")
 
@@ -97,30 +93,20 @@ def test_query_appends_sslmode_disable() -> None:
                 def fetchall(self_): return []
             return _Cur()
 
-    import monkey_kernel.parameters as pm
-
     class _FakePsycopg:
         @staticmethod
         def connect(dsn: str):
             seen["dsn"] = dsn
             return _FakeConn()
 
-    # _query_parameters_table does `import psycopg` locally; patch sys.modules.
     sys.modules["psycopg"] = _FakePsycopg  # type: ignore[assignment]
     try:
         reg._query_parameters_table()
     finally:
         del sys.modules["psycopg"]
 
-    assert "sslmode=disable" in seen["dsn"], seen["dsn"]
-    # already had a query-string, so the separator must be '&'
-    reg2 = ParameterRegistry(dsn="postgresql://h/db?connect_timeout=5")
-    sys.modules["psycopg"] = _FakePsycopg  # type: ignore[assignment]
-    try:
-        reg2._query_parameters_table()
-    finally:
-        del sys.modules["psycopg"]
-    assert "?connect_timeout=5&sslmode=disable" in seen["dsn"], seen["dsn"]
+    assert seen["dsn"] == "postgresql://u:p@postgres.railway.internal:5432/railway"
+    assert "sslmode" not in seen["dsn"], "DSN must not be mutated post-PARAM-1"
 
 
 def test_query_runs_on_db_executor_thread_not_caller(db_gate_on: None) -> None:


### PR DESCRIPTION
## Summary

Follow-up to the Railway env flip at 2026-05-17T01:51Z (`MONKEY_PARAM_REGISTRY_DB=true` on ml-worker). The flip succeeded — registry loaded from DB cleanly, no segfault, only 3 once-per-name "missing from registry" warnings (parameters added to code after migration 047).

Per the comprehensive audit, the env-var gate AND the `sslmode=disable` DSN workaround were both put in place 2026-05-14 to guard against a psycopg/libpq/openssl segfault that only fired when TensorFlow + scipy + sklearn + h5py were loaded in the same process. MIG-1 (PR #743) stripped those native libs out of ml-worker, eliminating the crash path. Both workarounds can come off.

## Changes

**ml-worker/src/monkey_kernel/parameters.py**:
- Removed the `MONKEY_PARAM_REGISTRY_DB` env-var gate — when a DSN is configured, `_load()` always runs.
- Removed the `sslmode=disable` DSN-mutation workaround — DSN passes through unchanged; psycopg defaults to `sslmode=prefer` (opportunistic TLS, plaintext fallback on the private Railway internal network).
- Hardened fail-soft on load failure: sets `_defaults_only=True` so a failed load doesn't flood the log with a per-`get()` "missing from registry" warning.

**ml-worker/tests/monkey_kernel/test_parameters_psycopg_isolation.py**:
- Rewrote two tests that pinned the OLD safety properties:
  - `test_db_load_gated_off_by_default` → `test_db_load_runs_when_dsn_present`
  - `test_query_appends_sslmode_disable` → `test_query_passes_dsn_through_unchanged`

**apps/api/database/migrations/054_seed_missing_monkey_parameters.sql** (new):
- Seeds `ocean.phi_damping_lower` (0.85, SAFETY_BOUND), `ocean.phi_mushroom_floor` (0.70, SAFETY_BOUND), `executive.lane.swing.budget_frac` (0.50, OPERATIONAL).
- These names were added to Python code after migration 047 shipped. Without these rows `propose_change()` for these params is a silent no-op; with these rows it round-trips through the `monkey_parameter_changes` audit trail.
- `ON CONFLICT (name) DO NOTHING` — idempotent.

## Test plan

- [x] ml-worker pytest: 865 passed, 7 skipped (the two tests pinned to old behavior rewritten to pin new contract)
- [x] qig_purity_check: 45 files clean
- [ ] Post-deploy: migration 054 runs (Railway auto-runs migrations on api boot); ml-worker still healthy; "missing from registry" warnings for the 3 params disappear after next ml-worker restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)