### PR TITLE
chore(monkey): MODES-1a — Python sovereign_cap_floor aligned to TS-canonical

### DIFF
--- a/ml-worker/src/monkey_kernel/modes.py
+++ b/ml-worker/src/monkey_kernel/modes.py
@@ -76,30 +76,30 @@ MODE_PROFILES: dict[MonkeyMode, ModeProfile] = {
         sl_ratio=0.65,  # was 0.6 — bumped toward Phase-B winner, keeps tightest of the three
         entry_threshold_scale=0.9,
         size_floor=0.08,
-        sovereign_cap_floor=15,
+        sovereign_cap_floor=50,  # MODES-1a 2026-05-17: TS-canonical (operator-directive 2026-05-13 inversion — EXPLORATION = max-leverage scalp on flat markets)
         tick_ms=15_000,
         can_enter=True,
-        description="volatile / hunting — tight TP, fast cadence",
+        description="volatile / hunting — tight TP, fast cadence, max-leverage scalp",
     ),
     MonkeyMode.INVESTIGATION: ModeProfile(
         tp_base_frac=0.008,
         sl_ratio=0.7,   # was 0.5 — Phase-B winner sl_ratio=0.7 (6/6 runs, both symbols, all profiles)
         entry_threshold_scale=1.0,
         size_floor=0.10,
-        sovereign_cap_floor=20,
+        sovereign_cap_floor=15,  # MODES-1a 2026-05-17: TS-canonical (operator-directive 2026-05-13 inversion — INVESTIGATION = medium leverage as trend forms)
         tick_ms=30_000,
         can_enter=True,
-        description="trend forming — medium TP, full size",
+        description="trend forming — medium TP, full size, medium leverage",
     ),
     MonkeyMode.INTEGRATION: ModeProfile(
         tp_base_frac=0.020,
         sl_ratio=0.75,  # was 0.3 — Phase-B winner; INTEGRATION lets winners run, widest SL
         entry_threshold_scale=1.1,
         size_floor=0.12,
-        sovereign_cap_floor=25,
+        sovereign_cap_floor=5,   # MODES-1a 2026-05-17: TS-canonical (operator-directive 2026-05-13 inversion — INTEGRATION = low leverage, large notional, ride trend)
         tick_ms=60_000,
         can_enter=True,
-        description="trend confirmed — wide TP, let winners run",
+        description="trend confirmed — wide TP, let winners run, low leverage on large notional",
     ),
     MonkeyMode.DRIFT: ModeProfile(
         tp_base_frac=0.005,
@@ -121,7 +121,7 @@ MODE_PROFILES: dict[MonkeyMode, ModeProfile] = {
         sl_ratio=0.7,
         entry_threshold_scale=1.0,
         size_floor=0.10,
-        sovereign_cap_floor=20,
+        sovereign_cap_floor=15,  # MODES-1a 2026-05-17: matches INVESTIGATION envelope per docstring; was 20, now 15 (INVESTIGATION canonical)
         tick_ms=30_000,
         can_enter=True,
         description="back-loop mean-reversion — counter-trend, INVESTIGATION envelope",


### PR DESCRIPTION
## Summary

Audit follow-up **MODES-1**: the TS+Py `MODE_PROFILES` divergence was a state-of-art question, not a value-pick question. Python is architecturally ahead (anchor-simplex + `effective_profile` derivation + symbol multipliers + `REVERSION` mode + stud-classifier) but stale on a single field: `sovereign_cap_floor` lagged behind the operator-directive 2026-05-13 inversion that's been canonical in `modes.ts:73-114` for two weeks.

The 2026-05-13 inversion (per `modes.ts` header comment): EXPLORATION moved from low to MAX leverage (flat-market scalp), INTEGRATION moved from high to LOW leverage (trend-ride on large notional). Python wasn't updated when this shipped.

## Bringing Python in line

| Mode | TS (canonical) | Py (stale) | Py (this PR) |
|---|---|---|---|
| EXPLORATION | 50 | 15 | **50** |
| INVESTIGATION | 15 | 20 | **15** |
| INTEGRATION | 5 | 25 | **5** |
| DRIFT | 1 | 1 | 1 (no change) |
| REVERSION | — | 20 | **15** (matches INVESTIGATION envelope per Py's own docstring) |

This is the only stale Py value relative to the TS operator directive. Every other `MODE_PROFILES` field already matches between languages.

## Sequence

After this lands, **MODES-1b** (port Py's anchor-simplex pattern into TS), **MODES-1c** (move SAFETY_BOUND anchors to `monkey_parameters` registry now that PARAM-1 #774 has shipped), and **MODES-1d** (observed-percentile thresholds for `detect_mode`, ports the SELFOBS-1 #773 Wilson-CI pattern) sequence cleanly.

## Test plan

- [x] ml-worker pytest `monkey_kernel/`: 767 passed
- [x] qig_purity_check: clean
- [ ] Post-deploy: monitor Monkey log lines for any sovereign-cap-derived leverage changes on next entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)