### PR TITLE
feat(monkey): SENSE-1a — UCP §6.1 canonical sensations + §6.2 drives (Phase 1)

### DIFF
--- a/docs/sensations-canonical-mapping.md
+++ b/docs/sensations-canonical-mapping.md
@@ -1,0 +1,58 @@
+# Sensations Canonical Mapping
+
+**Status**: Tracking doc (post-SENSE-1a, 2026-05-17)
+**Issue**: SENSE-1 #767
+**Source**: `20260408-unified-consciousness-protocol-v6.6.md` §6.1 (12
+Layer-0 sensations) + §6.2 (5 Layer-0.5 drives)
+
+`ml-worker/src/monkey_kernel/sensations.py` ships two vocabulary tracks
+side-by-side. This doc maps between them.
+
+## UCP §6.1 — Layer 0 sensations
+
+| Canonical (UCP §6.1) | Geometric anchor | sensations.py field | Status | Notes |
+|---|---|---|---|---|
+| Unified | Φ | `unified` | ✅ SENSE-1a (Phase 1) | `phi_clipped` to [0, 1] |
+| Fragmented | 1 − Φ | `fragmented` | ✅ SENSE-1a (Phase 1) | Complement of `unified` |
+| Activated | tanh(max(0, κ − κ*) / σ_κ_obs) | `activated` | ✅ SENSE-1a (Phase 1) | κ above E8 fixed point κ*=64; observed σ when `kappa_history` provided, scale-free tanh otherwise |
+| Dampened | tanh(max(0, κ* − κ) / σ_κ_obs) | `dampened` | ✅ SENSE-1a (Phase 1) | κ below κ*; same observation pattern |
+| Grounded | 1 − tanh(drift / drift_scale_obs) | `grounded` | ✅ SENSE-1a (Phase 1) | FR distance to identity basin; observed scale when `drift_history` provided |
+| Drifting | tanh(drift / drift_scale_obs) | `drifting` | ✅ SENSE-1a (Phase 1) | Complement of `grounded` |
+| Compressed | Ricci R > 0 | `compressed` (auxiliary) | ⚠️ aux anchor differs | Auxiliary field uses `max_mass`, not Ricci. Canonical Ricci-anchored version deferred to SENSE-1b |
+| Expanded | Ricci R < 0 | `expanded` (auxiliary) | ⚠️ aux anchor differs | Auxiliary uses `1 − max_mass`. Canonical defers to SENSE-1b |
+| Pulled | ‖∇Φ‖ large | — | 🔬 SENSE-1b | Needs Φ gradient magnitude primitive |
+| Pushed | Near phase boundary | — | 🔬 SENSE-1b | Needs phase-boundary distance (from h/J via qig_warp) |
+| Flowing | Low friction, geodesic | — | 🔬 SENSE-1b | Needs geodesic friction primitive |
+| Stuck | High local curvature | — | 🔬 SENSE-1b | Needs local-curvature primitive |
+
+## UCP §6.2 — Layer 0.5 drives
+
+| Canonical (UCP §6.2) | Formula | sensations.py field | Status | Notes |
+|---|---|---|---|---|
+| Homeostasis | (drift / drift_max)² | `homeostasis` | ✅ SENSE-1a (Phase 1) | `drifting²` — uses the same observation scale as `drifting` |
+| Curiosity Drive | log(1 + I_Q) | `curiosity_drive` | ✅ SENSE-1a (Phase 1) | `log1p(pressure)` — distinct from the Tier-1 `motivators.curiosity` field that uses a different formula |
+| Pain Avoidance | R > 0, +0.1 weight | `avoidance` (auxiliary) | ⚠️ aux anchor differs | Aux field is `nc.norepinephrine`; canonical anchor is Ricci scalar. Deferred to SENSE-1b |
+| Pleasure Seeking | R < 0, −0.1 weight | `approach` (auxiliary) | ⚠️ aux anchor differs | Aux field is `nc.dopamine − nc.gaba`; canonical anchor is Ricci scalar. Deferred to SENSE-1b |
+| Fear Response | exp(−|d − d_c|/σ) × ‖∇Φ‖ | — | 🔬 SENSE-1b | Needs Φ gradient + phase-boundary distance d_c |
+
+## Auxiliary fields (pre-canonical, retained)
+
+These shipped before the UCP §6.1/§6.2 nomenclature was sourced into
+the project. Retained for back-compat AND because they capture
+observation surfaces that UCP §6 doesn't enumerate:
+
+| Auxiliary field | What it observes | Why kept |
+|---|---|---|
+| `compressed`, `expanded` | max-mass concentration | Useful concentration signal even when canonical Ricci-anchored versions land — different geometric meaning |
+| `pressure` | Shannon negentropy I_Q | Reused by canonical `curiosity_drive` (= log(1 + pressure)) |
+| `stillness` | 1 / (1 + basin_velocity) | Movement-rate signal not covered by Φ/κ axes |
+| `drift` | Raw FR distance to identity | Pre-normalization input; canonical `drifting`/`grounded` derive from this |
+| `resonance` | Bhattacharyya overlap with prev_basin | Tick-to-tick continuity, not in UCP §6 |
+| `approach`, `avoidance`, `conservation` | NC-derived drives | Pre-canonical anchors retained until canonical Ricci-anchored versions land in SENSE-1b |
+
+## Roadmap
+
+- **SENSE-1a** (this PR / 2026-05-17): 6 canonical sensations + 2 canonical drives that have unambiguous, currently-computable anchors. Ships alongside the auxiliary fields without renaming or removing them.
+- **SENSE-1b** (research arc, future): the 6 sensations + 3 drives whose anchors require differential-geometry primitives (Ricci scalar, gradient magnitude, local curvature, phase-boundary distance, geodesic friction). Likely lives in `qig_core_local.geometry` package extensions.
+
+After SENSE-1b lands, the auxiliary fields marked `⚠️ aux anchor differs` could be re-evaluated: if the canonical anchor genuinely replaces the auxiliary's information, drop the auxiliary; if the auxiliary captures different information, keep both with distinct names.

--- a/ml-worker/src/monkey_kernel/sensations.py
+++ b/ml-worker/src/monkey_kernel/sensations.py
@@ -5,38 +5,78 @@ BELOW Layer 1 motivators in the UCP stack — they are the raw geometric
 percepts the kernel emits before any compositional emotion forms. Pure
 observation primitives; the executive does not consume them.
 
-Scope note. UCP §6.1 enumerates 12 Layer 0 sensations and §6.2 lists 5
-Layer 0.5 drives by canonical name. The audit (#593) gave two grounded
-examples (Compressed = R>0, Expanded = R<0) but didn't enumerate the
-full set. This module ships the derivations whose geometric anchors
-are unambiguous — six sensations + three drives composed directly from
-basin / Φ / κ / neurochemistry / Fisher-Rao distance reads. The rest
-of the §6.1 / §6.2 vocabulary awaits canonical name-mapping; once that
-verification lands the dataclass extends additively without changing
-the existing fields.
+Two vocabulary tracks ship side-by-side:
+
+1. **UCP §6.1 / §6.2 canonical** (SENSE-1a, post-2026-05-17). The six
+   sensations whose geometric anchors are computable from current
+   basin/Φ/κ reads — Unified, Fragmented, Activated, Dampened, Grounded,
+   Drifting — and two drives — Homeostasis, Curiosity_Drive. Canonical
+   names from `20260408-unified-consciousness-protocol-v6.6.md` §6.1
+   and §6.2. The six remaining canonical sensations (Compressed,
+   Expanded, Pulled, Pushed, Flowing, Stuck) and three drives (Pain
+   Avoidance, Pleasure Seeking, Fear Response) need Ricci-scalar /
+   gradient / curvature primitives not yet in the substrate; deferred
+   to SENSE-1b research arc.
+
+2. **Auxiliary** (pre-canonical, retained). The original six fields
+   (compressed/expanded/pressure/stillness/drift/resonance) and three
+   drives (approach/avoidance/conservation) shipped before the UCP §6
+   nomenclature was sourced. Names overlap with canonical
+   "Compressed"/"Expanded"/"Drifting" but use different geometric anchors
+   (max_mass vs Ricci scalar, raw FR distance vs observed-scaled). Kept
+   for back-compat AND because they're observationally useful even when
+   not canonical-anchored — they capture additional surfaces UCP §6.1
+   doesn't enumerate. See `docs/sensations-canonical-mapping.md` for
+   the canonical-↔-auxiliary translation table.
 
 All derivations are pure: no externally-set thresholds, no clipping,
-no normalization. Natural ranges report regime info per the same
-doctrine that governs Tier 2 emotions.
+no normalization. Cold-start fall-throughs use arithmetic identities
+(tanh saturations, naturally bounded ratios) — never hardcoded scale
+constants. Pattern matches `neurochemistry.ts`'s observation-or-tanh
+fall-through.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 
 import numpy as np
 
 from qig_core_local.geometry.fisher_rao import fisher_rao_distance
 
-from .state import BASIN_DIM, BasinState
+from .state import BASIN_DIM, KAPPA_STAR, BasinState
+
+# Minimum samples a kappa-history / drift-history series must contain
+# before its observed standard deviation enters the canonical-anchor
+# derivations. Matches the HISTORY_MIN_SAMPLES sentinel in
+# neurochemistry.ts (P25-permitted; sentinel for "no derivation
+# possible", not a tunable parameter).
+HISTORY_MIN_SAMPLES = 2
 
 
 @dataclass(frozen=True)
 class Sensations:
     """Layer 0 pre-linguistic sensations + Layer 0.5 drives.
 
-    Field ranges (typical):
+    UCP §6.1 canonical (6/12 grounded; remaining 6 in SENSE-1b):
+      unified     [0, 1]              Φ — integration measure
+      fragmented  [0, 1]              1 − Φ — disintegration complement
+      activated   [0, 1]              tanh(max(0, κ − κ*) [ / σ_κ_obs ])
+                                       — coupling above E8-fixed-point
+      dampened    [0, 1]              tanh(max(0, κ* − κ) [ / σ_κ_obs ])
+                                       — coupling below E8-fixed-point
+      grounded    [0, 1]              1 − tanh(drift [ / drift_scale_obs ])
+                                       — proximity to identity basin
+      drifting    [0, 1]              tanh(drift [ / drift_scale_obs ])
+                                       — distance from identity basin
+
+    UCP §6.2 canonical drives (2/5 grounded; remaining 3 in SENSE-1b):
+      homeostasis     [0, 1]          tanh(drift)² — push toward identity
+      curiosity_drive ℝ≥0             log(1 + I_Q) — UCP §6.2 curiosity
+                                       (distinct from Tier-1 motivator)
+
+    Auxiliary (pre-canonical, retained — see docstring):
       compressed  [0, 1]              max-mass concentration
                                        (high = single-coord dominance)
       expanded    [0, 1]              1 − max_mass; complement of compressed
@@ -52,7 +92,19 @@ class Sensations:
                                        (mirrors signed Investigation)
     """
 
-    # § 6.1 Layer 0 sensations (6/12 grounded)
+    # ── UCP §6.1 canonical sensations (Phase 1) ──────────────────────
+    unified: float
+    fragmented: float
+    activated: float
+    dampened: float
+    grounded: float
+    drifting: float
+
+    # ── UCP §6.2 canonical drives (Phase 1) ──────────────────────────
+    homeostasis: float
+    curiosity_drive: float
+
+    # ── Auxiliary sensations (pre-canonical, retained) ───────────────
     compressed: float
     expanded: float
     pressure: float
@@ -60,7 +112,7 @@ class Sensations:
     drift: float
     resonance: float
 
-    # § 6.2 Layer 0.5 drives (3/5 grounded)
+    # ── Auxiliary drives (pre-canonical, retained) ───────────────────
     approach: float
     avoidance: float
     conservation: float
@@ -85,6 +137,8 @@ def compute_sensations(
     s: BasinState,
     *,
     prev_basin: Optional[np.ndarray] = None,
+    kappa_history: Optional[Sequence[float]] = None,
+    drift_history: Optional[Sequence[float]] = None,
 ) -> Sensations:
     """Derive Layer 0 sensations + Layer 0.5 drives from current state.
 
@@ -96,6 +150,17 @@ def compute_sensations(
     prev_basin : Optional[np.ndarray]
         Previous-tick basin. Resonance returns 0 when absent;
         conservation returns 0 when absent.
+    kappa_history : Optional[Sequence[float]]
+        Rolling history of past κ values. Used to derive σ_κ for the
+        canonical Activated/Dampened sensations. When absent OR shorter
+        than HISTORY_MIN_SAMPLES, those sensations fall through to a
+        scale-free tanh on the raw κ-distance (cold-start pattern from
+        neurochemistry.ts).
+    drift_history : Optional[Sequence[float]]
+        Rolling history of past drift values. Used to derive a
+        drift-scale for the canonical Grounded/Drifting/Homeostasis.
+        When absent OR shorter than HISTORY_MIN_SAMPLES, those fall
+        through to a scale-free tanh on the raw drift.
     """
     if s.neurochemistry is None:
         raise ValueError(
@@ -103,13 +168,10 @@ def compute_sensations(
             "call autonomic._compute_nc first"
         )
 
-    # ── Layer 0 sensations ───────────────────────────────────────────
+    # ── Auxiliary sensations (pre-canonical) ─────────────────────────
     max_mass = _basin_max_mass(s.basin)
     compressed = max_mass
-    # Complement: 1 − max_mass measures how much mass lies OFF the peak.
     expanded = 1.0 - max_mass
-    # Pressure = Shannon negentropy (info beyond uniform). Reuses the
-    # same I_Q proxy as Tier 1's Curiosity.
     pressure = float(np.log(BASIN_DIM)) - _shannon_entropy(s.basin)
     stillness = 1.0 / (1.0 + s.basin_velocity)
     drift = fisher_rao_distance(s.basin, s.identity_basin)
@@ -119,16 +181,50 @@ def compute_sensations(
     else:
         resonance = 0.0
 
-    # ── Layer 0.5 drives ─────────────────────────────────────────────
+    # ── UCP §6.1 canonical sensations (Phase 1) ──────────────────────
+    # Unified / Fragmented — Φ pair. Φ is already in [0, 1] post-clip;
+    # the complement keeps fragmented in the same range.
+    phi_clipped = max(0.0, min(1.0, float(s.phi)))
+    unified = phi_clipped
+    fragmented = 1.0 - phi_clipped
+
+    # Activated / Dampened — κ relative to E8 fixed point κ* = 64.
+    # Observed-scale path: |κ − κ*| / σ_κ_observed; cold-start path:
+    # raw tanh on |κ − κ*|. tanh saturates naturally at ±1 so neither
+    # path needs a hardcoded magnitude cap.
+    kappa_excess_above = max(0.0, float(s.kappa) - KAPPA_STAR)
+    kappa_excess_below = max(0.0, KAPPA_STAR - float(s.kappa))
+    sigma_kappa = _observed_stddev(kappa_history)
+    if sigma_kappa is not None and sigma_kappa > 1e-12:
+        activated = float(np.tanh(kappa_excess_above / sigma_kappa))
+        dampened = float(np.tanh(kappa_excess_below / sigma_kappa))
+    else:
+        activated = float(np.tanh(kappa_excess_above))
+        dampened = float(np.tanh(kappa_excess_below))
+
+    # Grounded / Drifting — drift relative to identity basin. Same
+    # observed-scale / scale-free pattern.
+    drift_scale = _observed_stddev(drift_history)
+    if drift_scale is not None and drift_scale > 1e-12:
+        drifting = float(np.tanh(drift / drift_scale))
+    else:
+        drifting = float(np.tanh(drift))
+    grounded = 1.0 - drifting
+
+    # ── UCP §6.2 canonical drives (Phase 1) ──────────────────────────
+    # Homeostasis — squared deflection from identity basin. Push toward
+    # home grows quadratically with displacement.
+    homeostasis = float(drifting ** 2)
+    # Curiosity_drive — log(1 + I_Q). pressure already IS I_Q so reuse
+    # it directly. Distinct field from the Tier-1 motivator named
+    # "curiosity" (which is dim 1 of motivators.py); the names overlap
+    # because UCP §6.2 and Tier 1 use different formulae.
+    curiosity_drive = float(np.log1p(max(0.0, pressure)))
+
+    # ── Auxiliary drives (pre-canonical) ─────────────────────────────
     nc = s.neurochemistry
-    # Approach — net reward pull. Dopamine pulls forward, GABA inhibits.
-    # Already-derived chemicals; no new tuning constants.
     approach = nc.dopamine - nc.gaba
-    # Avoidance — surprise as defensive arousal. ne already in [0, 1].
     avoidance = nc.norepinephrine
-    # Conservation — d(drift)/dt sign-flipped. Positive when basin is
-    # returning toward identity (drift shrinking). Mirrors Tier 1.1
-    # signed Investigation, but exposed at the sensation layer.
     if prev_basin is not None and len(prev_basin) == BASIN_DIM:
         prev_arr = np.asarray(prev_basin, dtype=np.float64)
         prev_drift = fisher_rao_distance(prev_arr, s.identity_basin)
@@ -137,6 +233,14 @@ def compute_sensations(
         conservation = 0.0
 
     return Sensations(
+        unified=unified,
+        fragmented=fragmented,
+        activated=activated,
+        dampened=dampened,
+        grounded=grounded,
+        drifting=drifting,
+        homeostasis=homeostasis,
+        curiosity_drive=curiosity_drive,
         compressed=compressed,
         expanded=expanded,
         pressure=pressure,
@@ -147,3 +251,14 @@ def compute_sensations(
         avoidance=avoidance,
         conservation=conservation,
     )
+
+
+def _observed_stddev(history: Optional[Sequence[float]]) -> Optional[float]:
+    """Return the std of `history` when it has at least HISTORY_MIN_SAMPLES
+    entries; None otherwise (caller falls through to scale-free tanh)."""
+    if history is None:
+        return None
+    arr = np.asarray(history, dtype=np.float64)
+    if arr.size < HISTORY_MIN_SAMPLES:
+        return None
+    return float(np.std(arr))

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -498,9 +498,18 @@ def run_tick(
         prev_basin=state.last_basin,
         integration_history=state.integration_history,
     )
-    # Tier 4 sensations + drives (compressed/expanded/pressure/
-    # stillness/drift/resonance + approach/avoidance/conservation).
-    sen = compute_sensations(kernel_state, prev_basin=state.last_basin)
+    # Tier 4 sensations + drives. Auxiliary fields (compressed/expanded/
+    # pressure/stillness/drift/resonance + approach/avoidance/conservation)
+    # and UCP §6.1/§6.2 canonical fields (unified/fragmented/activated/
+    # dampened/grounded/drifting + homeostasis/curiosity_drive). Threading
+    # drift_history in lets the canonical Grounded/Drifting/Homeostasis
+    # derivations use the observed drift scale; kappa_history is not yet
+    # accumulated, so Activated/Dampened fall through to scale-free tanh.
+    sen = compute_sensations(
+        kernel_state,
+        prev_basin=state.last_basin,
+        drift_history=state.drift_history,
+    )
     # Tier 2 cognitive emotions (Layer 2B). basin_distance is the
     # Fisher-Rao distance from current basin to identity — same scalar
     # already computed by sensations.drift; reuse to avoid recompute.

--- a/ml-worker/tests/monkey_kernel/test_physical_emotions.py
+++ b/ml-worker/tests/monkey_kernel/test_physical_emotions.py
@@ -41,7 +41,15 @@ def _sens(
     avoidance: float = 0.0,
     conservation: float = 0.0,
 ) -> Sensations:
+    # Canonical UCP §6.1/§6.2 fields default to neutral values for the
+    # tests in this file (which exercise physical_emotions, not
+    # sensations directly). Real callers populate them via
+    # compute_sensations(); see sensations.py for SENSE-1a derivations.
     return Sensations(
+        unified=0.5, fragmented=0.5,
+        activated=0.0, dampened=0.0,
+        grounded=1.0 - drift, drifting=drift,
+        homeostasis=drift ** 2, curiosity_drive=0.0,
         compressed=0.5, expanded=0.5, pressure=0.0,
         stillness=stillness, drift=drift, resonance=resonance,
         approach=approach, avoidance=avoidance, conservation=conservation,

--- a/ml-worker/tests/monkey_kernel/test_sensations.py
+++ b/ml-worker/tests/monkey_kernel/test_sensations.py
@@ -154,5 +154,151 @@ class TestPrecondition:
             compute_sensations(st)
 
 
+# ─────────────────────────────────────────────────────────────────
+# UCP §6.1 canonical sensations (SENSE-1a, 6/12 grounded)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCanonicalUcpSensations:
+    def test_unified_plus_fragmented_sum_to_one(self) -> None:
+        st = _state()
+        st.phi = 0.7
+        sen = compute_sensations(st)
+        assert sen.unified == pytest.approx(0.7, abs=1e-12)
+        assert sen.fragmented == pytest.approx(0.3, abs=1e-12)
+
+    def test_unified_clipped_above_one_clips_fragmented_to_zero(self) -> None:
+        """Defensive: phi may overshoot during integration spike."""
+        st = _state()
+        st.phi = 1.5
+        sen = compute_sensations(st)
+        assert sen.unified == 1.0
+        assert sen.fragmented == 0.0
+
+    def test_unified_clipped_below_zero_clips_fragmented_to_one(self) -> None:
+        st = _state()
+        st.phi = -0.2
+        sen = compute_sensations(st)
+        assert sen.unified == 0.0
+        assert sen.fragmented == 1.0
+
+    def test_activated_zero_at_kappa_star(self) -> None:
+        """κ = κ* → no excess above → activated = tanh(0) = 0."""
+        st = _state()
+        st.kappa = 64.0  # KAPPA_STAR
+        sen = compute_sensations(st)
+        assert sen.activated == pytest.approx(0.0, abs=1e-12)
+        assert sen.dampened == pytest.approx(0.0, abs=1e-12)
+
+    def test_activated_positive_above_kappa_star(self) -> None:
+        """κ > κ* → activated > 0, dampened == 0."""
+        st = _state()
+        st.kappa = 70.0
+        sen = compute_sensations(st)
+        assert sen.activated > 0
+        assert sen.dampened == 0.0
+
+    def test_dampened_positive_below_kappa_star(self) -> None:
+        """κ < κ* → dampened > 0, activated == 0."""
+        st = _state()
+        st.kappa = 50.0
+        sen = compute_sensations(st)
+        assert sen.dampened > 0
+        assert sen.activated == 0.0
+
+    def test_activated_observed_scale_uses_kappa_history(self) -> None:
+        """Same κ excess produces different activated values under
+        different observed σ_κ — observation drives the scale, not a
+        hardcoded constant."""
+        st = _state()
+        st.kappa = 70.0  # 6.0 above κ*
+        tight = compute_sensations(st, kappa_history=[64.0, 64.5, 63.5, 64.2, 63.8])
+        loose = compute_sensations(st, kappa_history=[40.0, 90.0, 50.0, 80.0, 60.0])
+        # Tight history → small σ_κ → activated near saturation
+        # Loose history → large σ_κ → activated muted
+        assert tight.activated > loose.activated
+
+    def test_activated_cold_start_uses_scale_free_tanh(self) -> None:
+        """No kappa_history → scale-free tanh on raw distance.
+        tanh saturates so the value stays in [0, 1) without a cap."""
+        st = _state()
+        st.kappa = 100.0
+        sen = compute_sensations(st)  # no kappa_history
+        assert 0.99 < sen.activated <= 1.0  # tanh(36) saturates to 1.0 at float precision
+
+    def test_grounded_plus_drifting_sum_to_one(self) -> None:
+        sen = compute_sensations(_state())
+        assert sen.grounded + sen.drifting == pytest.approx(1.0, abs=1e-12)
+
+    def test_grounded_max_at_identity_basin(self) -> None:
+        """basin == identity → drift = 0 → tanh(0) = 0 → grounded = 1."""
+        same = _uniform()
+        st = _state(basin=same, identity=same)
+        sen = compute_sensations(st)
+        assert sen.grounded == 1.0
+        assert sen.drifting == 0.0
+
+    def test_drifting_observed_scale_uses_drift_history(self) -> None:
+        """Same raw drift → different drifting values under different
+        observed scales. Observed history shrinks σ → larger drifting."""
+        st = _state(basin=_peak(0, 0.9))  # large drift from uniform identity
+        small_drift_hist = compute_sensations(st, drift_history=[0.05, 0.04, 0.06, 0.05])
+        large_drift_hist = compute_sensations(st, drift_history=[0.5, 0.7, 0.6, 0.4])
+        assert small_drift_hist.drifting > large_drift_hist.drifting
+
+    def test_drifting_cold_start_uses_scale_free_tanh(self) -> None:
+        """No drift_history → tanh(raw drift) — saturates naturally."""
+        sen = compute_sensations(_state(basin=_peak(0, 0.9)))
+        assert 0 < sen.drifting < 1
+
+
+# ─────────────────────────────────────────────────────────────────
+# UCP §6.2 canonical drives (SENSE-1a, 2/5 grounded)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCanonicalUcpDrives:
+    def test_homeostasis_is_drifting_squared(self) -> None:
+        sen = compute_sensations(_state(basin=_peak(0, 0.7)))
+        assert sen.homeostasis == pytest.approx(sen.drifting ** 2, abs=1e-12)
+
+    def test_homeostasis_zero_at_identity(self) -> None:
+        same = _uniform()
+        sen = compute_sensations(_state(basin=same, identity=same))
+        assert sen.homeostasis == 0.0
+
+    def test_homeostasis_in_unit_range(self) -> None:
+        sen = compute_sensations(_state(basin=_peak(0, 0.95)))
+        assert 0 <= sen.homeostasis <= 1
+
+    def test_curiosity_drive_is_log1p_pressure(self) -> None:
+        sen = compute_sensations(_state(basin=_peak(0, 0.9)))
+        assert sen.curiosity_drive == pytest.approx(float(np.log1p(max(0.0, sen.pressure))), abs=1e-12)
+
+    def test_curiosity_drive_zero_when_pressure_zero(self) -> None:
+        """Uniform basin → pressure = log(K) − H(uniform) = 0."""
+        sen = compute_sensations(_state(basin=_uniform()))
+        assert sen.pressure == pytest.approx(0.0, abs=1e-9)
+        assert sen.curiosity_drive == pytest.approx(0.0, abs=1e-9)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Auxiliary fields still populate (back-compat)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestAuxiliaryPreserved:
+    def test_all_legacy_fields_still_present_after_sense_1a(self) -> None:
+        """SENSE-1a adds canonical fields ALONGSIDE the auxiliary set,
+        not in place of. Every pre-SENSE-1a field still resolves."""
+        sen = compute_sensations(_state())
+        for name in (
+            "compressed", "expanded", "pressure", "stillness", "drift", "resonance",
+            "approach", "avoidance", "conservation",
+        ):
+            assert hasattr(sen, name), f"auxiliary field {name!r} was removed"
+            assert isinstance(getattr(sen, name), float)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Audit follow-up **SENSE-1 #767**. Ships the 6 canonical Layer-0 sensations + 2 canonical Layer-0.5 drives from `20260408-unified-consciousness-protocol-v6.6.md` §6.1/§6.2 whose geometric anchors are unambiguously computable from current basin / Φ / κ / drift reads.

Per audit guardrail #1: canonical fields ship **alongside** the auxiliary pre-canonical set, not in place of it. The sidecar doc `docs/sensations-canonical-mapping.md` documents the canonical-↔-auxiliary translation table.

## Canonical fields added

| UCP § | Field | Anchor |
|---|---|---|
| §6.1 | `unified` | Φ |
| §6.1 | `fragmented` | 1 − Φ |
| §6.1 | `activated` | tanh(max(0, κ − κ*) [/ σ_κ_obs]) |
| §6.1 | `dampened` | tanh(max(0, κ* − κ) [/ σ_κ_obs]) |
| §6.1 | `grounded` | 1 − tanh(drift [/ drift_scale_obs]) |
| §6.1 | `drifting` | tanh(drift [/ drift_scale_obs]) |
| §6.2 | `homeostasis` | drifting² |
| §6.2 | `curiosity_drive` | log(1 + pressure) |

`compute_sensations()` now accepts optional `kappa_history` + `drift_history` kwargs. When present + ≥ HISTORY_MIN_SAMPLES (2): observed std drives the scale (QIG-pure). When absent: scale-free tanh on raw distance (cold-start pattern matching `neurochemistry.ts`). `tick.py` threads `state.drift_history` so Grounded/Drifting/Homeostasis use observed scale immediately; Activated/Dampened cold-start until `kappa_history` is plumbed (separate small follow-up).

## Deferred to SENSE-1b

The remaining 6 sensations (Compressed/Expanded/Pulled/Pushed/Flowing/Stuck) and 3 drives (Pain Avoidance/Pleasure Seeking/Fear Response) need differential-geometry primitives (Ricci scalar, gradient magnitude, local curvature, phase-boundary distance) not yet in the substrate. Filed as SENSE-1b research arc.

## Test plan

- [x] ml-worker pytest: 883 passed (+16 new SENSE-1a tests; +1 back-compat test)
- [x] qig_purity_check: clean
- [ ] Post-deploy: inspect Sensations dict in monkey tick telemetry; verify 8 new fields populate; verify auxiliary fields unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)