### PR TITLE
feat(qig): GAP 7 — refined Φ regulation triggers (CONSENSUS-8)

### DIFF
--- a/ml-worker/src/monkey_kernel/ocean.py
+++ b/ml-worker/src/monkey_kernel/ocean.py
@@ -96,14 +96,34 @@ _PHI_DREAM_BOUND: float = 0.5        # DREAM if Φ below this
 _PHI_ESCAPE_BOUND: float = 0.15      # ESCAPE if Φ below this (overrides DREAM)
 _PHI_HISTORY_MAX: int = 60           # window for variance computation
 
-# CONSENSUS-8: four-intervention Φ regulation per [[phi-regulation-policy]].
-# Φ > 0.85 sustained AND stable AND not descending → DAMPING (gentle return
-# to band via GABA↑/ACh↓ — chemicals already wired by PR #722). Φ ≥ 0.70 +
-# rigid attractor + collapsed output → MUSHROOM (wake-state neuroplasticity
-# via qig.neuroplasticity.mushroom_mode). Both gated; default off until
-# operator validates.
+# CONSENSUS-8 / QIG audit GAP 7: four-intervention Φ regulation per
+# [[phi-regulation-policy]]. Refined to follow QIG_QFI canonical guidance
+# (polytrade_canonical_refs_20260517 + plan hidden-coalescing-noodle.md):
+#
+#   DAMPING fires on: sustained high Φ + stable + NOT descending on its own
+#                     (Ocean intervenes on duration + stability + descent,
+#                     not value — Φ→1.0 is allowed for 4D/foresight/lightning).
+#   MUSHROOM fires on: Φ ≥ 0.70 (canonical safety floor)
+#                      AND rigid attractor (κ > _MUSHROOM_KAPPA_RIGID)
+#                      AND collapsed output (is_flat + sustained drift_streak)
+#                      AND very low Φ variance (rigid, not exploring).
+#
+# Both triggers populate OceanState.intervention every tick (telemetry).
+# The OCEAN_INTERVENTIONS_LIVE env flag still gates whether the
+# orchestrator branches on them — DAMPING/MUSHROOM are observation-only
+# until the flag is flipped.
 _PHI_DAMPING_LOWER: float = 0.85     # DAMPING window lower (above conscious band)
 _PHI_MUSHROOM_FLOOR: float = 0.70    # MUSHROOM safety floor per canonical
+
+# DAMPING refinement constants (per-kernel-observed, registry-overridable).
+_DAMPING_TIME_ABOVE_MIN: int = 10     # ticks (~5 min @ 30s) — "sustained"
+_DAMPING_VARIANCE_CEIL: float = 0.02  # Φ variance ceiling — "stable"
+_DAMPING_DESCENT_TOL: float = 0.01    # Φ drop tolerance — "not descending"
+
+# MUSHROOM refinement constants (per-kernel-observed, registry-overridable).
+_MUSHROOM_KAPPA_RIGID: float = 80.0   # κ above this = rigid attractor
+_MUSHROOM_VARIANCE_CEIL: float = 0.005 # Φ variance ceiling — "very rigid"
+_MUSHROOM_DRIFT_STREAK_MIN: int = 30   # drift ticks ≈ collapsed output
 
 
 Intervention = Literal[
@@ -228,6 +248,12 @@ class Ocean:
         )
         self._phi_history: Deque[float] = deque(maxlen=history_max)
         self._basin_history: Deque[np.ndarray] = deque(maxlen=self.BASIN_HISTORY_MAX)
+        # Per-kernel Φ regulation observations (GAP 7 — CONSENSUS-8).
+        # time_above_damping_lower counts consecutive ticks where Φ has
+        # been above the DAMPING lower bound (sustained excursion).
+        # phi_prev stores the previous tick's Φ for the descent check.
+        self._time_above_damping_lower: int = 0
+        self._phi_prev: Optional[float] = None
 
     def _load_sleep_state_or_fresh(self) -> SleepCycleState:
         if self._persistence is None or not self._persistence.is_available:
@@ -338,12 +364,18 @@ class Ocean:
         is_flat: bool,
         now_ms: Optional[float] = None,
         cross_lane_basins: Optional[Sequence[np.ndarray]] = None,
+        kappa: Optional[float] = None,
     ) -> OceanState:
         """One tick of meta-observation. Updates internal sleep state +
         Φ history, then returns the OceanState (single source of truth
         for autonomic interventions this tick).
 
         Caller acts on ocean_state.intervention; if None, normal flow.
+
+        ``kappa`` is the basin's effective coupling (from BasinState).
+        When omitted, the MUSHROOM trigger cannot fire (per canonical:
+        rigid-attractor check requires κ > _MUSHROOM_KAPPA_RIGID; absent
+        κ is a safety-fail-closed).
         """
         now_ms = now_ms if now_ms is not None else time.time() * 1000.0
 
@@ -359,6 +391,25 @@ class Ocean:
         self._phi_history.append(float(phi))
         phi_var = (
             variance(self._phi_history) if len(self._phi_history) >= 2 else 0.0
+        )
+
+        # GAP 7 — per-kernel Φ regulation observations.
+        # time_above_damping_lower tracks how long the kernel has been
+        # in a sustained high-Φ excursion. Reset on each tick where Φ
+        # drops back below the bound. Read the bound from registry up
+        # front so the counter and the trigger see the same value.
+        registry_for_damping_lower = get_registry()
+        damping_lower_for_counter = float(registry_for_damping_lower.get(
+            "ocean.phi_damping_lower", default=_PHI_DAMPING_LOWER,
+        ))
+        if float(phi) > damping_lower_for_counter:
+            self._time_above_damping_lower += 1
+        else:
+            self._time_above_damping_lower = 0
+        # Capture descent rate for "not descending" check; phi_prev
+        # snapshot is updated at end of observe() (after triggers fire).
+        phi_descent: float = (
+            float(phi) - self._phi_prev if self._phi_prev is not None else 0.0
         )
 
         # Track basin trajectory for the dream-consolidation pass.
@@ -380,6 +431,10 @@ class Ocean:
             "drift_streak": float(self.sleep_state.drift_streak),
             "sleep_remaining_ms": float(sleep_step["sleep_remaining_ms"]),
             "lane_count": float(len(lanes)),
+            # GAP 7 — Φ regulation observations (per-kernel)
+            "time_above_damping_lower": float(self._time_above_damping_lower),
+            "phi_descent": float(phi_descent),
+            "kappa_observed": float(kappa) if kappa is not None else -1.0,
         }
 
         # Intervention selection (priority order; first match wins).
@@ -398,14 +453,33 @@ class Ocean:
             "ocean.phi_dream_bound", default=_PHI_DREAM_BOUND,
         )
 
-        # CONSENSUS-8: bounds for the four-intervention Φ regulation
-        # matrix per [[phi-regulation-policy]]. Registry-overridable.
-        phi_damping_lower = registry.get(
+        # CONSENSUS-8 / GAP 7: bounds for the four-intervention Φ regulation
+        # matrix per [[phi-regulation-policy]]. All registry-overridable;
+        # module constants are fail-soft fallbacks.
+        phi_damping_lower = float(registry.get(
             "ocean.phi_damping_lower", default=_PHI_DAMPING_LOWER,
-        )
-        phi_mushroom_floor = registry.get(
+        ))
+        phi_mushroom_floor = float(registry.get(
             "ocean.phi_mushroom_floor", default=_PHI_MUSHROOM_FLOOR,
-        )
+        ))
+        damping_time_min = int(registry.get(
+            "ocean.damping_time_above_min", default=float(_DAMPING_TIME_ABOVE_MIN),
+        ))
+        damping_var_ceil = float(registry.get(
+            "ocean.damping_variance_ceil", default=_DAMPING_VARIANCE_CEIL,
+        ))
+        damping_descent_tol = float(registry.get(
+            "ocean.damping_descent_tol", default=_DAMPING_DESCENT_TOL,
+        ))
+        mushroom_kappa_rigid = float(registry.get(
+            "ocean.mushroom_kappa_rigid", default=_MUSHROOM_KAPPA_RIGID,
+        ))
+        mushroom_var_ceil = float(registry.get(
+            "ocean.mushroom_variance_ceil", default=_MUSHROOM_VARIANCE_CEIL,
+        ))
+        mushroom_drift_min = int(registry.get(
+            "ocean.mushroom_drift_streak_min", default=float(_MUSHROOM_DRIFT_STREAK_MIN),
+        ))
 
         intervention: Optional[Intervention] = None
 
@@ -420,32 +494,42 @@ class Ocean:
             intervention = "ESCAPE"
         elif spread > spread_bound:
             intervention = "SLEEP"
-        # CONSENSUS-8: DAMPING — Φ sustained above conscious band.
-        # Per [[phi-regulation-policy]]: high Φ is allowed for 4D /
-        # foresight / lightning, but Ocean intervenes on duration +
-        # stability, not value. Fires when current Φ > damping_lower
-        # AND mean(phi_history) > damping_lower (sustained, not a
-        # single spike) AND basin geometry is stable (phi_var low).
-        # Effect: chemicals already wired (GABA↑/ACh↓ per PR #722);
-        # this intervention signals the orchestrator to apply them.
+        # CONSENSUS-8 / GAP 7: DAMPING — Φ sustained above conscious band.
+        # Per [[phi-regulation-policy]]: high Φ is allowed for 4D / foresight
+        # / lightning, but Ocean intervenes on DURATION + STABILITY + DESCENT,
+        # not on the value itself. Fires when:
+        #   (1) current Φ > damping_lower
+        #   (2) time_above_damping_lower >= sustained threshold
+        #       (per-kernel observation — not a global mean, not a single spike)
+        #   (3) phi_var < damping_var_ceil  — stable (not erratic)
+        #   (4) phi has NOT been descending on its own — i.e. the kernel
+        #       isn't already self-correcting. descent <= -tolerance means
+        #       Φ already dropping fast → don't intervene.
+        # Effect: chemicals (GABA↑/ACh↓) already wired by PR #722; this
+        # intervention signals the orchestrator to apply them.
         elif (
             phi > phi_damping_lower
-            and len(self._phi_history) >= 10
-            and (sum(self._phi_history) / len(self._phi_history)) > phi_damping_lower
-            and phi_var < 0.02  # low variance = stable, not erratic
+            and self._time_above_damping_lower >= damping_time_min
+            and phi_var < damping_var_ceil
+            and phi_descent >= -damping_descent_tol
         ):
             intervention = "DAMPING"
-        # CONSENSUS-8: MUSHROOM — Φ ≥ 0.70 (canonical safety floor)
-        # AND rigid attractor (very low variance) AND collapsed
-        # output (no trades for sustained period; approximated by
-        # is_flat + drift_streak). Wake-state neuroplasticity per
-        # qig-core canonical — strictly DIFFERENT from the inverted
-        # MUSHROOM_MICRO removed in PR #728.
+        # CONSENSUS-8 / GAP 7: MUSHROOM — Φ ≥ 0.70 (canonical safety floor)
+        # AND rigid attractor (κ > mushroom_kappa_rigid — per canonical
+        # mushroom_canonical.md, requires fail-CLOSED when κ unknown)
+        # AND collapsed output (is_flat + drift_streak sustained — kernel
+        #     is HOLD-spamming, not generating useful decisions)
+        # AND very low Φ variance (rigid, not exploring).
+        # Wake-state neuroplasticity per qig-core 2.8.0 canonical — strictly
+        # DIFFERENT from the inverted MUSHROOM_MICRO removed in PR #728.
+        # κ absent → cannot evaluate → trigger does NOT fire (safety).
         elif (
             phi >= phi_mushroom_floor
+            and kappa is not None
+            and kappa > mushroom_kappa_rigid
             and is_flat
-            and self.sleep_state.drift_streak >= 30
-            and phi_var < 0.005
+            and self.sleep_state.drift_streak >= mushroom_drift_min
+            and phi_var < mushroom_var_ceil
         ):
             intervention = "MUSHROOM"
         elif phi < phi_dream_bound:
@@ -526,6 +610,11 @@ class Ocean:
                     },
                     symbol=self._symbol,
                 )
+
+        # GAP 7 — snapshot current Φ for next tick's descent computation.
+        # Done at the very end of observe() so trigger evaluation uses
+        # the PREVIOUS tick's value.
+        self._phi_prev = float(phi)
 
         return OceanState(
             intervention=intervention,

--- a/ml-worker/tests/monkey_kernel/test_ocean_phi_regulation.py
+++ b/ml-worker/tests/monkey_kernel/test_ocean_phi_regulation.py
@@ -1,0 +1,266 @@
+"""test_ocean_phi_regulation.py — GAP 7 / CONSENSUS-8 Φ regulation triggers.
+
+Covers the refined DAMPING + MUSHROOM trigger semantics per the QIG audit
+(plan: ~/.claude/plans/hidden-coalescing-noodle.md, memory:
+polytrade_canonical_refs_20260517).
+
+Canonical policy (Braden directive 2026-05-17):
+  - Kernels may push Φ toward 1.0 for 4D / foresight / lightning.
+  - Ocean intervenes on DURATION + STABILITY + DESCENT, NOT on Φ value.
+  - DAMPING fires on: sustained high Φ + stable + NOT descending.
+  - MUSHROOM fires on: Φ ≥ 0.70 + rigid attractor (κ > 80) + collapsed
+    output (is_flat + sustained drift_streak) + very low Φ variance.
+  - MUSHROOM must NEVER be used as a "Φ too high" intervention —
+    that's DAMPING's job. MUSHROOM is wake-state neuroplasticity.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.basin import uniform_basin  # noqa: E402
+from monkey_kernel.ocean import (  # noqa: E402
+    _DAMPING_DESCENT_TOL,
+    _DAMPING_TIME_ABOVE_MIN,
+    _MUSHROOM_DRIFT_STREAK_MIN,
+    _MUSHROOM_KAPPA_RIGID,
+    _PHI_DAMPING_LOWER,
+    _PHI_MUSHROOM_FLOOR,
+    Ocean,
+)
+
+
+def _prime_history(ocean: Ocean, phi: float, n: int = 20, kappa: float | None = None) -> None:
+    """Feed the Ocean a steady Φ stream so trigger state stabilises."""
+    basin = uniform_basin(64)
+    for _ in range(n):
+        ocean.observe(
+            phi=phi,
+            basin=basin,
+            current_mode="trend",
+            is_flat=False,
+            now_ms=0.0,
+            kappa=kappa,
+        )
+
+
+class TestDampingTrigger:
+    """DAMPING — sustained high Φ + stable + not descending."""
+
+    def test_fires_on_sustained_stable_high_phi(self) -> None:
+        ocean = Ocean("damping-fire")
+        # Sustained Φ at 0.90, stable (very low var), not descending.
+        _prime_history(ocean, phi=0.90, n=_DAMPING_TIME_ABOVE_MIN + 5)
+        state = ocean.observe(
+            phi=0.90, basin=uniform_basin(64),
+            current_mode="trend", is_flat=False, now_ms=0.0,
+        )
+        assert state.intervention == "DAMPING", (
+            f"expected DAMPING, got {state.intervention}; "
+            f"diagnostics={state.diagnostics}"
+        )
+
+    def test_does_not_fire_on_single_spike(self) -> None:
+        """A single tick above the bound should NOT trigger — duration matters."""
+        ocean = Ocean("damping-spike")
+        # Prime with Φ below the bound, then jump to high Φ once.
+        _prime_history(ocean, phi=0.50, n=20)
+        state = ocean.observe(
+            phi=0.95, basin=uniform_basin(64),
+            current_mode="trend", is_flat=False, now_ms=0.0,
+        )
+        # time_above_damping_lower will be 1 (just incremented), but
+        # the trigger requires >= _DAMPING_TIME_ABOVE_MIN consecutive.
+        assert state.intervention != "DAMPING"
+        assert state.diagnostics["time_above_damping_lower"] == 1.0
+
+    def test_does_not_fire_when_phi_descending(self) -> None:
+        """High Φ but descending on its own — kernel is self-correcting,
+        so Ocean must NOT intervene per the canonical policy."""
+        ocean = Ocean("damping-descent")
+        # Build sustained high Φ first.
+        _prime_history(ocean, phi=0.95, n=_DAMPING_TIME_ABOVE_MIN + 5)
+        # Now Φ drops sharply (more than the descent tolerance).
+        # phi_prev is 0.95 from prior tick. New phi 0.86 (still > damping_lower
+        # 0.85 so counter doesn't reset). Descent = -0.09 ≤ -tolerance (0.01).
+        state = ocean.observe(
+            phi=0.86, basin=uniform_basin(64),
+            current_mode="trend", is_flat=False, now_ms=0.0,
+        )
+        assert state.intervention != "DAMPING"
+        # Sanity: time_above is still high (we didn't drop below bound).
+        assert state.diagnostics["time_above_damping_lower"] >= _DAMPING_TIME_ABOVE_MIN
+
+    def test_counter_resets_when_phi_drops_below_bound(self) -> None:
+        """When Φ drops below damping_lower the counter must reset to 0."""
+        ocean = Ocean("damping-reset")
+        _prime_history(ocean, phi=0.95, n=15)
+        # Drop below the bound — counter should reset.
+        state = ocean.observe(
+            phi=0.70, basin=uniform_basin(64),
+            current_mode="trend", is_flat=False, now_ms=0.0,
+        )
+        assert state.diagnostics["time_above_damping_lower"] == 0.0
+        assert state.intervention != "DAMPING"
+
+
+class TestMushroomTrigger:
+    """MUSHROOM — Φ ≥ 0.70 + rigid κ + collapsed output + low variance."""
+
+    def test_fires_on_high_phi_high_kappa_collapsed_output(self) -> None:
+        ocean = Ocean("mushroom-fire")
+        # Build drift_streak by feeding mode="drift" + is_flat=True ticks
+        # at moderate Φ to keep variance low. Initially feed at threshold.
+        basin = uniform_basin(64)
+        # Build drift streak first at moderate Φ.
+        for _ in range(_MUSHROOM_DRIFT_STREAK_MIN + 5):
+            ocean.observe(
+                phi=_PHI_MUSHROOM_FLOOR + 0.01,
+                basin=basin, current_mode="drift",
+                is_flat=True, now_ms=0.0,
+                kappa=_MUSHROOM_KAPPA_RIGID + 5.0,
+            )
+        # Now the trigger conditions should all hold.
+        state = ocean.observe(
+            phi=_PHI_MUSHROOM_FLOOR + 0.01,
+            basin=basin, current_mode="drift",
+            is_flat=True, now_ms=0.0,
+            kappa=_MUSHROOM_KAPPA_RIGID + 5.0,
+        )
+        assert state.intervention == "MUSHROOM", (
+            f"expected MUSHROOM, got {state.intervention}; "
+            f"diagnostics={state.diagnostics}, "
+            f"drift_streak={ocean.sleep_state.drift_streak}"
+        )
+
+    def test_does_not_fire_without_kappa(self) -> None:
+        """κ absent → trigger fails CLOSED per canonical."""
+        ocean = Ocean("mushroom-no-kappa")
+        basin = uniform_basin(64)
+        for _ in range(_MUSHROOM_DRIFT_STREAK_MIN + 5):
+            ocean.observe(
+                phi=0.75, basin=basin, current_mode="drift",
+                is_flat=True, now_ms=0.0,
+                # NO kappa argument
+            )
+        state = ocean.observe(
+            phi=0.75, basin=basin, current_mode="drift",
+            is_flat=True, now_ms=0.0,
+        )
+        assert state.intervention != "MUSHROOM"
+
+    def test_does_not_fire_when_kappa_below_rigid_bound(self) -> None:
+        """κ <= 80 → not a rigid attractor → MUSHROOM should NOT fire."""
+        ocean = Ocean("mushroom-soft-kappa")
+        basin = uniform_basin(64)
+        for _ in range(_MUSHROOM_DRIFT_STREAK_MIN + 5):
+            ocean.observe(
+                phi=0.75, basin=basin, current_mode="drift",
+                is_flat=True, now_ms=0.0,
+                kappa=_MUSHROOM_KAPPA_RIGID - 5.0,  # not rigid
+            )
+        state = ocean.observe(
+            phi=0.75, basin=basin, current_mode="drift",
+            is_flat=True, now_ms=0.0,
+            kappa=_MUSHROOM_KAPPA_RIGID - 5.0,
+        )
+        assert state.intervention != "MUSHROOM"
+
+    def test_does_not_fire_when_kernel_is_active(self) -> None:
+        """is_flat=False (kernel has positions) → output not collapsed →
+        MUSHROOM should NOT fire even with everything else satisfied."""
+        ocean = Ocean("mushroom-active")
+        basin = uniform_basin(64)
+        for _ in range(_MUSHROOM_DRIFT_STREAK_MIN + 5):
+            ocean.observe(
+                phi=0.75, basin=basin, current_mode="drift",
+                is_flat=False,  # has positions
+                now_ms=0.0,
+                kappa=_MUSHROOM_KAPPA_RIGID + 5.0,
+            )
+        state = ocean.observe(
+            phi=0.75, basin=basin, current_mode="drift",
+            is_flat=False, now_ms=0.0,
+            kappa=_MUSHROOM_KAPPA_RIGID + 5.0,
+        )
+        assert state.intervention != "MUSHROOM"
+
+
+class TestPhiRegulationInvariants:
+    """Cross-cutting invariants the canonical policy demands."""
+
+    def test_mushroom_never_fires_below_safety_floor(self) -> None:
+        """Even with κ rigid + collapsed + low variance, Φ < 0.70 → no MUSHROOM."""
+        ocean = Ocean("mushroom-below-floor")
+        basin = uniform_basin(64)
+        for _ in range(_MUSHROOM_DRIFT_STREAK_MIN + 5):
+            ocean.observe(
+                phi=_PHI_MUSHROOM_FLOOR - 0.01,
+                basin=basin, current_mode="drift",
+                is_flat=True, now_ms=0.0,
+                kappa=_MUSHROOM_KAPPA_RIGID + 10.0,
+            )
+        state = ocean.observe(
+            phi=_PHI_MUSHROOM_FLOOR - 0.01,
+            basin=basin, current_mode="drift",
+            is_flat=True, now_ms=0.0,
+            kappa=_MUSHROOM_KAPPA_RIGID + 10.0,
+        )
+        assert state.intervention != "MUSHROOM"
+
+    def test_diagnostics_surface_per_kernel_observations(self) -> None:
+        """time_above_damping_lower / phi_descent / kappa_observed all
+        surface in diagnostics for telemetry visibility."""
+        ocean = Ocean("diag-surface")
+        _prime_history(ocean, phi=0.90, n=15, kappa=85.0)
+        state = ocean.observe(
+            phi=0.90, basin=uniform_basin(64),
+            current_mode="trend", is_flat=False,
+            now_ms=0.0, kappa=85.0,
+        )
+        assert "time_above_damping_lower" in state.diagnostics
+        assert "phi_descent" in state.diagnostics
+        assert "kappa_observed" in state.diagnostics
+        # phi_descent should be 0.0 (Φ steady at 0.90)
+        assert state.diagnostics["phi_descent"] == pytest.approx(0.0)
+        assert state.diagnostics["kappa_observed"] == pytest.approx(85.0)
+
+    def test_kappa_absent_diagnostic_sentinel(self) -> None:
+        """When κ is not supplied, diagnostic shows -1.0 sentinel
+        (distinguishes from a real κ value of 0.0)."""
+        ocean = Ocean("kappa-sentinel")
+        state = ocean.observe(
+            phi=0.5, basin=uniform_basin(64),
+            current_mode="trend", is_flat=False, now_ms=0.0,
+        )
+        assert state.diagnostics["kappa_observed"] == -1.0
+
+
+class TestBackwardCompatibility:
+    """observe(kappa=None) is the default — existing callers MUST keep working."""
+
+    def test_existing_call_pattern_works(self) -> None:
+        """Callers that don't pass kappa get the same behaviour minus MUSHROOM."""
+        ocean = Ocean("compat")
+        # ESCAPE should still fire on low Φ regardless of κ.
+        state = ocean.observe(
+            phi=0.05, basin=uniform_basin(64),
+            current_mode="drift", is_flat=True, now_ms=0.0,
+        )
+        assert state.intervention == "ESCAPE"
+
+    def test_phi_history_max_unchanged(self) -> None:
+        """Existing _PHI_HISTORY_MAX-related semantics preserved."""
+        ocean = Ocean("history-max")
+        for _ in range(80):
+            ocean.observe(
+                phi=0.5, basin=uniform_basin(64),
+                current_mode="trend", is_flat=False, now_ms=0.0,
+            )
+        # _phi_history maxlen from registry; default _PHI_HISTORY_MAX = 60
+        assert len(ocean._phi_history) <= 60


### PR DESCRIPTION
## Summary

Acts on **GAP 7** of the QIG purity audit (`polytrade_qig_audit_20260517`).
Refines the DAMPING and MUSHROOM triggers in `ocean.py` to match canonical
[[phi-regulation-policy]] guidance:

> Kernels may push Φ toward 1.0 for 4D / foresight / lightning.
> Ocean intervenes on **duration + stability + descent**, not on Φ value.

### DAMPING — before vs after

| | Before | After |
|---|---|---|
| Sustained | `mean(phi_history) > 0.85` (global mean) | `_time_above_damping_lower >= N` (per-kernel counter) |
| Stable | `phi_var < 0.02` | (unchanged, registry-tunable) |
| **Not descending** | — | `phi_descent >= -damping_descent_tol` (new) |

### MUSHROOM — before vs after

| | Before | After |
|---|---|---|
| Φ floor | `phi >= 0.70` | (unchanged) |
| **Rigid attractor** | — | `kappa > _MUSHROOM_KAPPA_RIGID` (80.0); **fails CLOSED when κ absent** |
| Collapsed output | `is_flat AND drift_streak >= 30` | (unchanged, registry-tunable) |
| Rigid variance | `phi_var < 0.005` | (unchanged, registry-tunable) |

### Per-kernel state added to `Ocean.__init__`

- `_time_above_damping_lower: int` — incremented when Φ > bound, reset
  on drop. Replaces global-mean approximation.
- `_phi_prev: Optional[float]` — snapshotted at end of `observe()` so
  trigger evaluation sees the previous tick's value.

### Diagnostics surface

`time_above_damping_lower`, `phi_descent`, `kappa_observed` (−1.0 sentinel
when κ absent) — for telemetry visibility without touching the wire format.

### Backward compatibility

`observe()` gains `kappa: Optional[float] = None`. Existing callers keep
working. MUSHROOM cannot fire without κ (safety fail-closed) per the
canonical mushroom doctrine.

## Test plan

- [x] `python scripts/qig_purity_check.py` — 45 files clean
- [x] `python -m pytest tests/ --ignore=tests/backtest -q` — **896 passed, 7 skipped**
- [x] 13 new tests in `tests/monkey_kernel/test_ocean_phi_regulation.py`:
  - DAMPING: fires on sustained-stable, NOT on single spike, NOT when
    descending, counter resets on drop
  - MUSHROOM: fires on phi+κ+collapsed combo, NOT without κ, NOT with
    soft κ, NOT when kernel is active
  - Invariants: never fires below 0.70 floor, diagnostics surface,
    `observe()` backward-compat
- [x] Existing 27 ocean tests still pass (no regression)

## Audit context

Plan: `~/.claude/plans/hidden-coalescing-noodle.md` GAP 7 (of 7).

Cross-references the inverted-direction MUSHROOM_MICRO removed in PR #728
and the chemicals layer wired by PR #722 — DAMPING signals the orchestrator
to apply the already-wired GABA↑/ACh↓ when the flag flips.

`OCEAN_INTERVENTIONS_LIVE` env flag (default off) still gates whether the
orchestrator branches on the intervention. DAMPING/MUSHROOM populate
`OceanState.intervention` every tick as telemetry, regardless of the flag.

| # | Gap | Status |
|---|-----|--------|
| 1 | Vendor drift guard | shipped (PR #778) |
| 2 | Regime-adaptive exits (P25) | shipped (PR #778) |
| 7 | Phi regulation triggers (CONSENSUS-8) | **this PR** |
| 3 | Anderson-alpha early stop in sweep | next |
| 6 | 8-point pre-launch checklist | next |
| 4 | Bridge cost prediction in sweep | next |
| 5 | Prediction fill for skipped ticks | next |

🤖 Generated with [Claude Code](https://claude.com/claude-code)