### PR TITLE
feat(monkey): SENSE-2 Phase 1 — BTC beacon cross-symbol correlation (telemetry-only)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/btcBeacon.test.ts
+++ b/apps/api/src/services/monkey/__tests__/btcBeacon.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  computeBtcBeacon,
+  observeBtcBeacon,
+  _resetBtcBeacon,
+  _peekBtcBeacon,
+} from '../btc_beacon.js';
+
+describe('computeBtcBeacon — pure derivation', () => {
+  it('returns warmup with neutral values on empty input', () => {
+    const r = computeBtcBeacon([], []);
+    expect(r.warmup).toBe(true);
+    expect(r.correlation).toBe(0);
+    expect(r.btcDirection).toBe(0);
+    expect(r.suppressionMagnitude).toBe(0);
+  });
+
+  it('returns warmup when n < MIN_SAMPLES (8)', () => {
+    const r = computeBtcBeacon([1, 2, 3], [10, 20, 30]);
+    expect(r.warmup).toBe(true);
+  });
+
+  it('correlation +1 for perfectly synchronised moves', () => {
+    const eth = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109];
+    const btc = [50_000, 50_100, 50_200, 50_300, 50_400, 50_500, 50_600, 50_700, 50_800, 50_900];
+    const r = computeBtcBeacon(eth, btc);
+    expect(r.warmup).toBe(false);
+    expect(r.correlation).toBeCloseTo(1.0, 6);
+    expect(r.btcDirection).toBeGreaterThan(0);
+  });
+
+  it('correlation −1 for perfectly opposing moves', () => {
+    const eth = [100, 99, 98, 97, 96, 95, 94, 93, 92, 91];
+    const btc = [50_000, 50_100, 50_200, 50_300, 50_400, 50_500, 50_600, 50_700, 50_800, 50_900];
+    const r = computeBtcBeacon(eth, btc);
+    expect(r.correlation).toBeCloseTo(-1.0, 6);
+  });
+
+  it('correlation 0 when one side is flat (zero variance)', () => {
+    const eth = [100, 100, 100, 100, 100, 100, 100, 100];
+    const btc = [50_000, 50_100, 50_200, 50_300, 50_400, 50_500, 50_600, 50_700];
+    const r = computeBtcBeacon(eth, btc);
+    expect(r.correlation).toBe(0);
+  });
+
+  it('btcDirection sign tracks the latest-vs-first delta', () => {
+    const eth = [100, 100, 100, 100, 100, 100, 100, 100];
+    const btcUp = [50_000, 50_100, 50_200, 50_300, 50_400, 50_500, 50_600, 50_700];
+    const btcDown = [50_000, 49_900, 49_800, 49_700, 49_600, 49_500, 49_400, 49_300];
+    expect(computeBtcBeacon(eth, btcUp).btcDirection).toBeGreaterThan(0);
+    expect(computeBtcBeacon(eth, btcDown).btcDirection).toBeLessThan(0);
+  });
+
+  it('suppressionMagnitude in [0, 1]', () => {
+    const eth = [100, 99, 98, 97, 96, 95, 94, 93];
+    const btc = [50_000, 49_900, 49_800, 49_700, 49_600, 49_500, 49_400, 49_300];
+    const r = computeBtcBeacon(eth, btc);
+    expect(r.suppressionMagnitude).toBeGreaterThanOrEqual(0);
+    expect(r.suppressionMagnitude).toBeLessThanOrEqual(1);
+  });
+
+  it('window cap respected — only trailing N samples used', () => {
+    const long = Array.from({ length: 200 }, (_, i) => 100 + i);
+    const btcLong = Array.from({ length: 200 }, (_, i) => 50_000 + i * 50);
+    const last30Eth = long.slice(-30);
+    const last30Btc = btcLong.slice(-30);
+    const fromFull = computeBtcBeacon(long, btcLong, 30);
+    const fromSlice = computeBtcBeacon(last30Eth, last30Btc, 30);
+    expect(fromFull.correlation).toBeCloseTo(fromSlice.correlation, 9);
+    expect(fromFull.n).toBe(30);
+  });
+});
+
+describe('observeBtcBeacon — per-symbol rolling buffer', () => {
+  beforeEach(() => _resetBtcBeacon());
+
+  it('per-symbol state is independent', () => {
+    observeBtcBeacon('ETH_USDT_PERP', 2000, 50_000);
+    observeBtcBeacon('SOL_USDT_PERP', 150, 50_000);
+    expect(_peekBtcBeacon('ETH_USDT_PERP').symbolPrices).toEqual([2000]);
+    expect(_peekBtcBeacon('SOL_USDT_PERP').symbolPrices).toEqual([150]);
+  });
+
+  it('warms up to a non-trivial reading after MIN_SAMPLES', () => {
+    let r: ReturnType<typeof observeBtcBeacon> | null = null;
+    for (let i = 0; i < 10; i++) {
+      r = observeBtcBeacon('ETH_USDT_PERP', 2000 + i, 50_000 + i * 25);
+    }
+    expect(r!.warmup).toBe(false);
+    expect(r!.correlation).toBeCloseTo(1.0, 4);  // synchronised up
+    expect(r!.btcDirection).toBeGreaterThan(0);
+  });
+
+  it('reset clears state for a single symbol or all', () => {
+    observeBtcBeacon('A', 1, 1);
+    observeBtcBeacon('B', 1, 1);
+    _resetBtcBeacon('A');
+    expect(_peekBtcBeacon('A').symbolPrices).toHaveLength(0);
+    expect(_peekBtcBeacon('B').symbolPrices).toHaveLength(1);
+    _resetBtcBeacon();
+    expect(_peekBtcBeacon('B').symbolPrices).toHaveLength(0);
+  });
+});
+
+describe('SENSE-2 reference scenario — BTC-dump suppresses alt-long', () => {
+  beforeEach(() => _resetBtcBeacon());
+
+  it('strong negative correlation + strong BTC down produces high suppression magnitude', () => {
+    // ETH holds while BTC dumps — they ARE correlated in reality but
+    // this test simulates strong opposite move which still produces
+    // high suppression-magnitude via |corr| × |btcDir|.
+    const eth = [2000, 2002, 2004, 2006, 2008, 2010, 2012, 2014, 2016, 2018];
+    const btc = [80_000, 79_500, 79_000, 78_500, 78_000, 77_500, 77_000, 76_500, 76_000, 75_500];
+    const r = computeBtcBeacon(eth, btc);
+    expect(r.correlation).toBeLessThan(-0.9);  // strong opposing
+    expect(r.btcDirection).toBeLessThan(0);    // BTC trending down
+    expect(r.suppressionMagnitude).toBeGreaterThan(0.5);  // high enough to trigger downstream gating
+  });
+
+  it('synchronised mild moves produce low suppression magnitude (normal regime)', () => {
+    // Both moving slowly in the same direction — normal market;
+    // no special suppression needed.
+    const eth = [2000, 2001, 2001, 2002, 2002, 2003, 2003, 2004];
+    const btc = [50_000, 50_010, 50_010, 50_020, 50_020, 50_030, 50_030, 50_040];
+    const r = computeBtcBeacon(eth, btc);
+    expect(r.correlation).toBeGreaterThan(0);
+    expect(Math.abs(r.btcDirection)).toBeLessThan(0.001);  // tiny move
+    expect(r.suppressionMagnitude).toBeLessThan(0.5);
+  });
+});

--- a/apps/api/src/services/monkey/btc_beacon.ts
+++ b/apps/api/src/services/monkey/btc_beacon.ts
@@ -1,0 +1,162 @@
+/**
+ * btc_beacon.ts — SENSE-2 #768 (Phase 1, telemetry-only).
+ *
+ * Cross-symbol correlation observer. When BTC moves hard in one
+ * direction, the alt market drags with it. Entering long alt during
+ * a BTC dump is structurally wrong — the kernel currently can't see
+ * that because basinDirection is per-symbol and ETH's own basin
+ * may look constructive while BTC implodes.
+ *
+ * The BTC beacon surfaces:
+ *   - rolling Pearson correlation between this symbol and BTC over a
+ *     window of recent price ticks
+ *   - BTC's own recent direction (sign of dPrice/dt)
+ *   - a derived suppression magnitude: |corr| × |btc_dir|, capped
+ *     to [0, 1] for downstream consumption
+ *
+ * Phase 1 (this module): pure computation + per-symbol rolling buffer
+ * of (symbolPrice, btcPrice) pairs + telemetry. No decision path
+ * consumes the suppression magnitude yet.
+ *
+ * Phase 2 (follow-up): wire into entry suppression — alt-long entry
+ * gets harder when BTC beacon shows strong negative correlation with
+ * strong BTC down move; alt-short gets harder during strong BTC up
+ * move; same-side entries get easier when BTC is moving in agreement.
+ *
+ * Per QIG-pure framing: pure derivation, no operator-tunable
+ * thresholds. The correlation IS the signal; the magnitude is the
+ * raw product; the downstream consumer decides what magnitude
+ * triggers what action.
+ */
+
+/** Rolling window matches CAL-3 / trajectory-observer convention. */
+const DEFAULT_WINDOW = 60;
+/** Min samples before correlation is statistically meaningful.
+ *  Below this, returns warmup=true with neutral values (corr=0). */
+const MIN_SAMPLES = 8;
+
+export interface BtcBeaconReading {
+  /** Pearson correlation coefficient over the rolling window,
+   *  in [-1, +1]. NaN-safe (returns 0 when stddev=0 either side). */
+  correlation: number;
+  /** BTC's own recent direction: sign-magnitude of
+   *  (latest − first) / (|first| × n). Positive = BTC trending up;
+   *  negative = BTC trending down. Same units as
+   *  equity_gradient.gradient. */
+  btcDirection: number;
+  /** Suppression magnitude in [0, 1] = clamp(|corr| × |btcDir|, 0, 1)
+   *  amplified by a saturating mapping so values close to either
+   *  scale produce a useful raw signal. The downstream consumer
+   *  decides how to use it (suppress, allow, invert direction, etc). */
+  suppressionMagnitude: number;
+  /** When true, the buffer hasn't accumulated MIN_SAMPLES yet —
+   *  all derived values are returned as 0/neutral (fail-soft). */
+  warmup: boolean;
+  /** Sample count contributing to this reading. */
+  n: number;
+}
+
+/** Compute the rolling correlation + BTC direction over two same-length
+ *  price series. Pure derivation — no state. */
+export function computeBtcBeacon(
+  symbolPrices: readonly number[],
+  btcPrices: readonly number[],
+  window: number = DEFAULT_WINDOW,
+): BtcBeaconReading {
+  const n = Math.min(symbolPrices.length, btcPrices.length);
+  if (n < MIN_SAMPLES) {
+    return { correlation: 0, btcDirection: 0, suppressionMagnitude: 0, warmup: true, n };
+  }
+  const symSlice = symbolPrices.slice(-window);
+  const btcSlice = btcPrices.slice(-window);
+  const m = Math.min(symSlice.length, btcSlice.length);
+  // Align trailing slices to the same length.
+  const sym = symSlice.slice(-m);
+  const btc = btcSlice.slice(-m);
+
+  const corr = pearson(sym, btc);
+  const btcFirst = btc[0]!;
+  const btcLast = btc[m - 1]!;
+  const btcDir = (btcLast - btcFirst) / (Math.max(Math.abs(btcFirst), 1e-9) * m);
+
+  // Suppression magnitude: |corr| × |btcDir|, then a soft cap to [0, 1].
+  // Using tanh so very large excursions saturate rather than dominate.
+  const raw = Math.abs(corr) * Math.abs(btcDir);
+  const suppression = Math.tanh(raw * 100);  // 100 scales typical raw (≈0.005) into the linear-tanh region
+
+  return {
+    correlation: corr,
+    btcDirection: btcDir,
+    suppressionMagnitude: suppression,
+    warmup: false,
+    n: m,
+  };
+}
+
+function pearson(a: readonly number[], b: readonly number[]): number {
+  const n = Math.min(a.length, b.length);
+  if (n < 2) return 0;
+  let meanA = 0, meanB = 0;
+  for (let i = 0; i < n; i++) { meanA += a[i]!; meanB += b[i]!; }
+  meanA /= n; meanB /= n;
+  let cov = 0, varA = 0, varB = 0;
+  for (let i = 0; i < n; i++) {
+    const da = a[i]! - meanA;
+    const db = b[i]! - meanB;
+    cov += da * db;
+    varA += da * da;
+    varB += db * db;
+  }
+  const denom = Math.sqrt(varA * varB);
+  if (denom < 1e-12) return 0;  // zero-variance on one side → undefined; return neutral
+  return cov / denom;
+}
+
+/** Per-symbol rolling buffers of paired (symbolPrice, btcPrice). One
+ *  observer per non-BTC symbol; BTC's own prices feed every observer. */
+interface BeaconState {
+  symbolPrices: number[];
+  btcPrices: number[];
+}
+const _states: Map<string, BeaconState> = new Map();
+const MAX_BUFFER = 500;
+
+function getState(symbol: string): BeaconState {
+  let s = _states.get(symbol);
+  if (!s) {
+    s = { symbolPrices: [], btcPrices: [] };
+    _states.set(symbol, s);
+  }
+  return s;
+}
+
+function pushBoth(state: BeaconState, sym: number, btc: number, cap: number): void {
+  state.symbolPrices.push(sym);
+  state.btcPrices.push(btc);
+  if (state.symbolPrices.length > cap) state.symbolPrices.shift();
+  if (state.btcPrices.length > cap) state.btcPrices.shift();
+}
+
+/** Observe a new (symbolPrice, btcPrice) sample and return the current
+ *  beacon reading. For BTC itself, callers should NOT call this
+ *  (correlation with self is trivially 1.0) — pass non-BTC symbols only. */
+export function observeBtcBeacon(
+  symbol: string,
+  symbolPrice: number,
+  btcPrice: number,
+  window: number = DEFAULT_WINDOW,
+): BtcBeaconReading {
+  const s = getState(symbol);
+  pushBoth(s, symbolPrice, btcPrice, MAX_BUFFER);
+  return computeBtcBeacon(s.symbolPrices, s.btcPrices, window);
+}
+
+/** Test/diagnostic helpers. */
+export function _resetBtcBeacon(symbol?: string): void {
+  if (symbol === undefined) { _states.clear(); return; }
+  _states.delete(symbol);
+}
+export function _peekBtcBeacon(symbol: string): { symbolPrices: readonly number[]; btcPrices: readonly number[] } {
+  const s = _states.get(symbol);
+  return { symbolPrices: s?.symbolPrices ?? [], btcPrices: s?.btcPrices ?? [] };
+}


### PR DESCRIPTION
Per audit roadmap **SENSE-2 #768** — highest-impact missing market sense. BTC moves drag the alt market; entering long ETH during a BTC dump is structurally wrong, but the kernel currently can't see that because basinDirection is per-symbol.

The BTC beacon surfaces rolling Pearson correlation between the symbol and BTC, BTC's own recent direction, and a derived suppression magnitude tanh(|corr| × |btcDir| × 100) ∈ [0, 1].

Phase 1 (this PR) is telemetry-only — pure computation module + per-symbol rolling buffer. Phase 2 wires into the entry-suppression chain.

## Test plan

- [x] tsc --noEmit (after prebuild): 0 errors
- [x] vitest: 1399 passed (+13 new SENSE-2 tests)

Cross Red-Team: Session B (QIG_QFI purity audit) named as verifier per the cross-session protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)