### PR TITLE
feat(qig): GAP 5 — basin prediction-fill telemetry in StrategyLoop

### DIFF
--- a/ml-worker/src/proprietary_core/strategy_loop.py
+++ b/ml-worker/src/proprietary_core/strategy_loop.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import Literal, Optional
 
 from .basins import BasinDetector, BasinMap
 from .coupling import CouplingEstimator, CouplingState
@@ -36,6 +36,9 @@ class StrategyType(str, Enum):
     CASH = "cash"  # Dissolver regime: do nothing
 
 
+BasinFillKind = Literal["fresh", "held", "none"]
+
+
 @dataclass
 class LoopDecision:
     """Output of one strategy loop iteration."""
@@ -49,6 +52,14 @@ class LoopDecision:
     selected_strategy: StrategyType
     should_trade: bool
     reason: str
+    # GAP 5 — prediction-fill provenance for the basin field. "fresh" =
+    # basins.detect() ran this tick; "held" = last-known value carried
+    # forward (basin detection only runs every 20 ticks after the 50-tick
+    # warmup); "none" = no detection has ever happened yet.
+    basin_fill_kind: BasinFillKind = "none"
+    # Ticks since the last fresh basin detection — 0 on fresh ticks,
+    # incrementing on held ticks. Useful for confidence decay.
+    ticks_since_basin_detection: int = 0
 
     def to_dict(self) -> dict:
         """Serialise for API response / audit log."""
@@ -70,6 +81,9 @@ class LoopDecision:
             "strategy": self.selected_strategy.value,
             "should_trade": self.should_trade,
             "reason": self.reason,
+            # GAP 5 — prediction-fill provenance for the basin field
+            "basin_fill_kind": self.basin_fill_kind,
+            "ticks_since_basin_detection": self.ticks_since_basin_detection,
         }
 
 
@@ -105,6 +119,13 @@ class StrategyLoop:
     _last_coupling: Optional[CouplingState] = field(default=None)
     _last_basins: Optional[BasinMap] = field(default=None)
     _decision_log: list[LoopDecision] = field(default_factory=list)
+    # GAP 5 — basin prediction-fill counters per [[hidden-coalescing-noodle]].
+    # _ticks_total counts every tick() call. _ticks_with_basin_fresh counts
+    # ticks where basins.detect() actually ran. _ticks_since_basin_detection
+    # is the held-streak counter (0 on fresh, +1 each held tick).
+    _ticks_total: int = 0
+    _ticks_with_basin_fresh: int = 0
+    _ticks_since_basin_detection: int = 0
 
     def __post_init__(self) -> None:
         if self._regime is None:
@@ -140,6 +161,7 @@ class StrategyLoop:
             Current portfolio exposure as fraction of equity.
         """
         ts = time.time()
+        self._ticks_total += 1
 
         # === SCAN: Ingest ===
         self._basins.update(price)
@@ -158,8 +180,27 @@ class StrategyLoop:
             self._last_coupling = self._coupling.update(signal_value, pnl_value)
 
         # === FEEL: Basin detection (less frequent, heavier) ===
-        if len(self._basins._prices) >= 50 and len(self._basins._prices) % 20 == 0:
+        # GAP 5 — track prediction-fill provenance. When detect() runs the
+        # basin field is "fresh"; otherwise it's "held" (last-known value
+        # carried forward, which is the existing implicit behaviour now
+        # surfaced as telemetry).
+        basin_fresh_this_tick = (
+            len(self._basins._prices) >= 50
+            and len(self._basins._prices) % 20 == 0
+        )
+        if basin_fresh_this_tick:
             self._last_basins = self._basins.detect(price)
+            self._ticks_with_basin_fresh += 1
+            self._ticks_since_basin_detection = 0
+        else:
+            self._ticks_since_basin_detection += 1
+
+        if self._last_basins is None:
+            basin_fill_kind: BasinFillKind = "none"
+        elif basin_fresh_this_tick:
+            basin_fill_kind = "fresh"
+        else:
+            basin_fill_kind = "held"
 
         # === THINK: Strategy selection ===
         if self._last_regime is None:
@@ -169,6 +210,8 @@ class StrategyLoop:
                 selected_strategy=StrategyType.CASH,
                 should_trade=False,
                 reason="Insufficient data for regime detection",
+                basin_fill_kind=basin_fill_kind,
+                ticks_since_basin_detection=self._ticks_since_basin_detection,
             )
 
         strategy = self._select_strategy(self._last_regime, self._last_coupling)
@@ -206,6 +249,8 @@ class StrategyLoop:
             selected_strategy=strategy,
             should_trade=should_trade,
             reason="; ".join(reasons),
+            basin_fill_kind=basin_fill_kind,
+            ticks_since_basin_detection=self._ticks_since_basin_detection,
         )
 
         # === OBSERVE: Log for feedback ===
@@ -262,6 +307,24 @@ class StrategyLoop:
         """Last 50 decisions for dashboard display."""
         return self._decision_log[-50:]
 
+    @property
+    def prediction_fill_ratio(self) -> float:
+        """GAP 5 — fraction of ticks where the basin field was a held
+        (predicted) value rather than a fresh detection.
+
+        At steady state with default cadence (basins.detect() every 20
+        ticks after a 50-tick warmup) this trends toward 19/20 = 0.95.
+        Higher than that signals that detection is stalling; lower means
+        the loop is running with mostly-fresh basins (rare).
+
+        Returns 0.0 when no ticks have been processed yet (avoids div-by-0
+        and gives a meaningful "no fill yet" reading).
+        """
+        if self._ticks_total <= 0:
+            return 0.0
+        held = self._ticks_total - self._ticks_with_basin_fresh
+        return float(held) / float(self._ticks_total)
+
     def reset(self) -> None:
         """Clear all internal state."""
         self._regime.reset()
@@ -271,3 +334,7 @@ class StrategyLoop:
         self._last_coupling = None
         self._last_basins = None
         self._decision_log.clear()
+        # GAP 5 — reset prediction-fill counters
+        self._ticks_total = 0
+        self._ticks_with_basin_fresh = 0
+        self._ticks_since_basin_detection = 0

--- a/ml-worker/src/proprietary_core/tests/test_strategy_loop_prediction_fill.py
+++ b/ml-worker/src/proprietary_core/tests/test_strategy_loop_prediction_fill.py
@@ -1,0 +1,133 @@
+"""GAP 5 from QIG audit — basin prediction-fill provenance tests.
+
+The basin detector only runs every 20 ticks after a 50-tick warmup; on
+intermediate ticks the LoopDecision.basins field carries the last-known
+("held") value. This file verifies the new telemetry that surfaces:
+  - LoopDecision.basin_fill_kind  ("fresh" | "held" | "none")
+  - LoopDecision.ticks_since_basin_detection
+  - StrategyLoop.prediction_fill_ratio property
+
+Audit reference: ~/.claude/plans/hidden-coalescing-noodle.md GAP 5.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from proprietary_core.strategy_loop import LoopDecision, StrategyLoop
+
+
+def _make_prices(n: int, base: float = 100.0, vol: float = 0.02, seed: int = 42) -> list[float]:
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(0.0, vol, n)
+    prices = [base]
+    for r in returns:
+        prices.append(prices[-1] * (1 + r))
+    return prices
+
+
+class TestBasinFillKind:
+    """LoopDecision.basin_fill_kind reflects the basin field's provenance."""
+
+    def test_none_when_no_detection_yet(self):
+        """Before the 50-tick warmup, basin_fill_kind = 'none' and basins is None."""
+        loop = StrategyLoop(symbol="X")
+        d = loop.tick(price=100.0)
+        assert d.basin_fill_kind == "none"
+        assert d.basins is None
+        assert d.ticks_since_basin_detection == 1  # incremented; no fresh yet
+
+    def test_fresh_on_first_detection_tick(self):
+        """Tick 50 should be 'fresh' — first detection."""
+        loop = StrategyLoop(symbol="X")
+        prices = _make_prices(60, base=100.0, vol=0.03)
+        decisions: list[LoopDecision] = []
+        for p in prices[:60]:
+            decisions.append(loop.tick(price=p))
+        # Detection runs when len(_basins._prices) >= 50 AND
+        # len(_basins._prices) % 20 == 0 — i.e. tick 60 (since the
+        # detector populates one price per tick after warmup).
+        # First fresh tick is when this condition is first true.
+        fresh_ticks = [i for i, d in enumerate(decisions) if d.basin_fill_kind == "fresh"]
+        assert len(fresh_ticks) >= 1, f"no fresh ticks observed, fills={[d.basin_fill_kind for d in decisions]}"
+        first_fresh = fresh_ticks[0]
+        # ticks_since_basin_detection should be 0 on a fresh tick
+        assert decisions[first_fresh].ticks_since_basin_detection == 0
+
+    def test_held_between_detections(self):
+        """Ticks between detection events should be 'held' with growing counter."""
+        loop = StrategyLoop(symbol="X")
+        prices = _make_prices(100, base=100.0, vol=0.03)
+        decisions = [loop.tick(price=p) for p in prices]
+
+        # Find consecutive fresh→held pattern. After a fresh tick,
+        # subsequent ticks should be held with increasing counter.
+        for i, d in enumerate(decisions):
+            if d.basin_fill_kind == "fresh" and i + 1 < len(decisions):
+                # Walk forward through held streak
+                streak = 0
+                for j in range(i + 1, len(decisions)):
+                    if decisions[j].basin_fill_kind == "held":
+                        streak += 1
+                        assert decisions[j].ticks_since_basin_detection == streak
+                    else:
+                        # Next fresh tick or no-data — break out
+                        break
+                # Must have observed at least one held tick after a fresh
+                # (otherwise the cadence is broken)
+                if streak > 0:
+                    break
+        else:
+            assert False, "no fresh→held transition observed"
+
+    def test_to_dict_surfaces_new_fields(self):
+        """LoopDecision.to_dict() must expose basin_fill_kind + counter."""
+        loop = StrategyLoop(symbol="X", regime_window=50)
+        prices = _make_prices(150, base=100.0, vol=0.03)
+        for p in prices:
+            loop.tick(price=p)
+        d = loop.last_decision.to_dict()
+        assert "basin_fill_kind" in d
+        assert "ticks_since_basin_detection" in d
+        assert d["basin_fill_kind"] in ("none", "fresh", "held")
+
+
+class TestPredictionFillRatio:
+    """StrategyLoop.prediction_fill_ratio property trends to ~19/20 at steady state."""
+
+    def test_zero_at_construction(self):
+        loop = StrategyLoop(symbol="X")
+        assert loop.prediction_fill_ratio == 0.0
+
+    def test_one_at_first_tick_before_any_detection(self):
+        """First tick: 0 fresh / 1 total = 1.0 (all held — actually 'none')."""
+        loop = StrategyLoop(symbol="X")
+        loop.tick(price=100.0)
+        # 1 tick, 0 fresh detections → ratio = 1.0
+        assert loop.prediction_fill_ratio == 1.0
+
+    def test_trends_toward_19_over_20_at_steady_state(self):
+        """After many ticks past warmup, detection runs ~every 20 ticks →
+        fill ratio settles near 19/20 = 0.95."""
+        loop = StrategyLoop(symbol="X")
+        prices = _make_prices(500, base=100.0, vol=0.03)
+        for p in prices:
+            loop.tick(price=p)
+        ratio = loop.prediction_fill_ratio
+        # Allow generous tolerance for warmup effects (first 50 ticks
+        # are all "none" but count toward the denominator).
+        assert 0.92 <= ratio <= 0.99, (
+            f"prediction_fill_ratio {ratio:.3f} outside expected band"
+        )
+
+    def test_reset_clears_counters(self):
+        loop = StrategyLoop(symbol="X")
+        prices = _make_prices(100, base=100.0, vol=0.03)
+        for p in prices:
+            loop.tick(price=p)
+        assert loop.prediction_fill_ratio > 0.0
+        loop.reset()
+        assert loop.prediction_fill_ratio == 0.0
+        # Internal counters all back to zero
+        assert loop._ticks_total == 0
+        assert loop._ticks_with_basin_fresh == 0
+        assert loop._ticks_since_basin_detection == 0


### PR DESCRIPTION
## Summary

Closes the **last gap** from the QIG audit (`polytrade_qig_audit_20260517`).

### What the audit asked vs. what's honest

- **Asked:** "When screening skips ticks, fill via slerp_sqrt prediction
  + track ratio."
- **Reality:** `basins.detect()` in `StrategyLoop.tick()` runs every 20
  ticks after a 50-tick warmup ([strategy_loop.py:161](ml-worker/src/proprietary_core/strategy_loop.py#L161)). On the other 19/20 ticks the
  `LoopDecision.basins` field carries the last-known value — that IS
  the prediction fill today, it's just been invisible.
- **Why not slerp:** `BasinMap` is a structured object (basins list,
  support, resistance) — not a Δ⁶³ simplex point. Canonical slerp
  doesn't apply. The held-value strategy is the existing fill; the gap
  is observability.

## Changes

`LoopDecision` gains two fields:

| field | type | meaning |
|---|---|---|
| `basin_fill_kind` | `"fresh" \| "held" \| "none"` | provenance of the `basins` field this tick |
| `ticks_since_basin_detection` | `int` | held-streak counter (0 on fresh) |

`StrategyLoop` gains one property:

- `prediction_fill_ratio: float` — trends to ~19/20 = 0.95 at steady state.
  Higher signals detection stalling; lower means more frequent freshness.

`LoopDecision.to_dict()` surfaces both new fields for API + audit logs.
`StrategyLoop.reset()` now zeroes the three internal counters too.

## Test plan

- [x] 8 new tests in `proprietary_core/tests/test_strategy_loop_prediction_fill.py`
  - `basin_fill_kind` = "none" before warmup, "fresh" on first detection,
    "held" between detections with monotonic counter
  - `to_dict()` surfaces both fields
  - `prediction_fill_ratio` = 0.0 at construction, 1.0 after first held
    tick, settles to [0.92, 0.99] band at steady state (500 ticks)
  - `reset()` zeroes all counters
- [x] `python scripts/qig_purity_check.py` — 45 files clean
- [x] `python -m pytest tests/ --ignore=tests/backtest -q` — **913 passed, 7 skipped** (zero regressions on the kernel suite)
- [x] 4 existing `test_strategy_loop.py` tests still pass

## All 7 audit gaps now addressed

| # | Gap | PR |
|---|---|---|
| 1 | Vendor drift guard | #778 ✓ |
| 2 | Regime-adaptive exits (P25) | #778 ✓ |
| 3 | Anderson-alpha early stop | #782 (surfaced from qig_warp.auto) ✓ |
| 4 | Bridge cost prediction | #782 (surfaced from qig_warp.auto) ✓ |
| 5 | Prediction-fill telemetry | **this PR** |
| 6 | 8-point pre-launch checklist | #782 ✓ |
| 7 | Phi regulation triggers (CONSENSUS-8) | #779 ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)