### PR TITLE
fix(monkey): CALIB-3 — directional disagreement exit + lane-scaled streaks

### DIFF
--- a/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
+++ b/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
@@ -310,6 +310,97 @@ describe('CALIB-1 — conviction-failed debounce (single-tick noise rejection)',
   });
 });
 
+describe('CALIB-3 — directional disagreement exit (early, regardless of ROI)', () => {
+  it('does NOT fire when sides agree (streak=0)', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      directionalDisagreementStreak: 0,
+    });
+    expect(out.fired).toBeNull();
+  });
+
+  it('does NOT fire on the first tick of disagreement (streak=1, default required=4)', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      directionalDisagreementStreak: 1,
+    });
+    expect(out.fired).toBeNull();
+  });
+
+  it('fires on the 4th consecutive tick with default required', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,  // emotions NOT in conviction-failed range
+      directionalDisagreementStreak: 4,
+    });
+    expect(out.fired).toBe('directional_disagreement');
+    expect(out.reason).toMatch(/directional_disagreement/);
+    expect(out.reason).toContain('4 consecutive ticks');
+  });
+
+  it('fires even when position is in PROFIT — per operator directive "exit early, re-enter if false positive"', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      directionalDisagreementStreak: 4,
+      currentRoi: 0.015,  // +1.5% in profit
+    });
+    expect(out.fired).toBe('directional_disagreement');
+    expect(out.reason).toContain('1.50%');
+    expect(out.reason).toMatch(/re-enter on false positive/);
+  });
+
+  it('lane-scaled requirement — swing needs 12 ticks (3× scalp), trend needs 40 (10×)', () => {
+    // Scalp would fire at 4 ticks; swing at 12; trend at 40.
+    // Verify by passing different required values directly.
+    const swing_at_8 = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      directionalDisagreementStreak: 8,
+      directionalDisagreementTicksRequired: 12,
+    });
+    expect(swing_at_8.fired).toBeNull();
+    const swing_at_12 = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+      directionalDisagreementStreak: 12,
+      directionalDisagreementTicksRequired: 12,
+    });
+    expect(swing_at_12.fired).toBe('directional_disagreement');
+  });
+
+  it('absent input defaults to 0 (no fire) — fail-OPEN for legacy callers', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: STRONG_EMO,
+    });
+    expect(out.fired).toBeNull();
+  });
+});
+
 // ─── Negative — checks do NOT fire ─────────────────────────────────
 
 describe('held-position rejustification — regime unchanged', () => {

--- a/apps/api/src/services/monkey/held_position_rejustification.ts
+++ b/apps/api/src/services/monkey/held_position_rejustification.ts
@@ -105,13 +105,36 @@ export interface RejustificationInput {
    */
   convictionFailedTicksRequired?: number;
   /**
+   * CALIB-3 (2026-05-17): consecutive-tick counter for "current tick's
+   * preferred side disagrees with held side". When the disagreement
+   * persists, an EARLY exit fires regardless of current ROI — per
+   * operator directive 2026-05-17: "better to close in positive than
+   * wait and close in negative; if false positive, can re-enter
+   * original direction." Faster than STALE_BLEED (30min + <-1% ROI)
+   * and orthogonal to conviction-failed (which gates on emotion,
+   * not direction). Live diagnostic showed swing-lane positions
+   * sitting on wrong side for hours with no fast exit. Caller tracks
+   * the streak per-lane; observer-style reset to 0 when sides agree.
+   */
+  directionalDisagreementStreak?: number;
+  /**
+   * Required streak before directional_disagreement fires. Default 4
+   * ticks for scalp; caller should scale UP for swing (×3) and trend
+   * (×10) per the operator's scalp=micro/swing=moderate/trend=macro
+   * timescale doctrine — encoded in loop.ts DISAGREEMENT_LANE_MULTIPLIER.
+   * NO ROI gate by design: the whole point is to exit before ROI
+   * flips negative.
+   */
+  directionalDisagreementTicksRequired?: number;
+  /**
    * Held duration in seconds for the stale-bleed gate. Undefined
    * disables the stale-bleed check (legacy callers / no entry timestamp).
    */
   heldDurationS?: number;
   /**
    * Current ROI on margin (signed fraction; -0.02 = -2% loss). Used
-   * by the stale-bleed gate. Undefined disables the check.
+   * by the stale-bleed gate AND the CALIB-3 directional_disagreement
+   * gate. Undefined disables both checks.
    */
   currentRoi?: number;
 }
@@ -120,7 +143,8 @@ export type RejustificationFire =
   | 'regime_change'
   | 'phi_collapse'
   | 'conviction_failed'
-  | 'stale_bleed';
+  | 'stale_bleed'
+  | 'directional_disagreement';
 
 export interface RejustificationResult {
   /** Whether anchors were available to check at all. */
@@ -144,6 +168,11 @@ export interface RejustificationResult {
   convictionFailedStreak: number;
   /** Required streak length before conviction_failed fires (CALIB-1). */
   convictionFailedTicksRequired: number;
+  /** Streak of consecutive ticks where current-tick side disagrees with
+   *  held side (CALIB-3). 0 when sides agree this tick. */
+  directionalDisagreementStreak: number;
+  /** Required streak length before directional_disagreement fires (CALIB-3). */
+  directionalDisagreementTicksRequired: number;
 }
 
 /**
@@ -171,6 +200,9 @@ export function evaluateRejustification(
   const regimeStabilityTicksRequired = input.regimeStabilityTicksRequired ?? 3;
   const convictionFailedStreak = input.convictionFailedStreak ?? 0;
   const convictionFailedTicksRequired = input.convictionFailedTicksRequired ?? 2;
+  const directionalDisagreementStreak = input.directionalDisagreementStreak ?? 0;
+  const directionalDisagreementTicksRequired =
+    input.directionalDisagreementTicksRequired ?? 4;
   const frThreshold = PI_STRUCT_GRAVITATING_FRACTION;  // 1/π ≈ 0.318
   let frDistance: number | null = null;
   if (input.basinNow !== undefined && input.basinAtOpen !== undefined) {
@@ -182,6 +214,7 @@ export function evaluateRejustification(
       frDistance, frThreshold,
       regimeChangeStreak, regimeStabilityTicksRequired,
       convictionFailedStreak, convictionFailedTicksRequired,
+      directionalDisagreementStreak, directionalDisagreementTicksRequired,
     };
   }
   const phiFloor = phiAtOpen / PHI_GOLDEN_FLOOR_RATIO;
@@ -217,6 +250,7 @@ export function evaluateRejustification(
           + `(confidence ${regimeConfidence.toFixed(3)} > 1/φ)`,
         phiFloor,
         convictionFailedStreak, convictionFailedTicksRequired,
+        directionalDisagreementStreak, directionalDisagreementTicksRequired,
         frDistance, frThreshold,
         regimeChangeStreak, regimeStabilityTicksRequired,
       };
@@ -231,6 +265,7 @@ export function evaluateRejustification(
       frDistance, frThreshold,
       regimeChangeStreak, regimeStabilityTicksRequired,
       convictionFailedStreak, convictionFailedTicksRequired,
+      directionalDisagreementStreak, directionalDisagreementTicksRequired,
     };
   }
   // CALIB-1 (2026-05-17): require convictionFailedStreak >= required ticks
@@ -257,6 +292,7 @@ export function evaluateRejustification(
       frDistance, frThreshold,
       regimeChangeStreak, regimeStabilityTicksRequired,
       convictionFailedStreak, convictionFailedTicksRequired,
+      directionalDisagreementStreak, directionalDisagreementTicksRequired,
     };
   }
   // 4. STALE_BLEED — belt-and-braces guard.
@@ -277,11 +313,52 @@ export function evaluateRejustification(
       frDistance, frThreshold,
       regimeChangeStreak, regimeStabilityTicksRequired,
       convictionFailedStreak, convictionFailedTicksRequired,
+      directionalDisagreementStreak, directionalDisagreementTicksRequired,
+    };
+  }
+  // 5. CALIB-3 (2026-05-17): directional_disagreement — when the
+  //    current tick's preferred side has disagreed with the held side
+  //    for >= directionalDisagreementTicksRequired consecutive ticks,
+  //    exit REGARDLESS of current ROI. Per operator directive 2026-05-17:
+  //    "exit early so it doesn't wait until the switch in direction
+  //    takes hold and the held position goes negative before the
+  //    switch. Always better to close in positive than wait and close
+  //    in the negative — if the switch is a false positive, can
+  //    re-enter the original direction." Sits between the fast
+  //    conviction-failed gate and the slow 30-min stale_bleed gate.
+  //
+  //    The streak requirement is lane-scaled by the caller — scalp
+  //    lane gets a fast (4-tick) requirement; swing gets moderate;
+  //    trend gets slow. Encoded by the caller passing the right
+  //    `directionalDisagreementTicksRequired` value per lane (the
+  //    user's scalp=micro/swing=moderate/trend=macro doctrine).
+  //
+  //    No ROI gate — by design. The whole point is to exit before ROI
+  //    flips negative. currentRoi is included in the reason string for
+  //    operator visibility only.
+  if (directionalDisagreementStreak >= directionalDisagreementTicksRequired) {
+    const roiStr = input.currentRoi !== undefined
+      ? `${(input.currentRoi * 100).toFixed(2)}%`
+      : 'unknown';
+    return {
+      checked: true,
+      fired: 'directional_disagreement',
+      reason:
+        `directional_disagreement: held side opposed by current-tick `
+        + `for ${directionalDisagreementStreak} consecutive ticks `
+        + `(≥ ${directionalDisagreementTicksRequired} required, ROI ${roiStr}) `
+        + `— exiting before ROI flips negative; can re-enter on false positive`,
+      phiFloor,
+      frDistance, frThreshold,
+      regimeChangeStreak, regimeStabilityTicksRequired,
+      convictionFailedStreak, convictionFailedTicksRequired,
+      directionalDisagreementStreak, directionalDisagreementTicksRequired,
     };
   }
   return {
     checked: true, fired: null, reason: '', phiFloor,
     convictionFailedStreak, convictionFailedTicksRequired,
+    directionalDisagreementStreak, directionalDisagreementTicksRequired,
     frDistance, frThreshold,
     regimeChangeStreak, regimeStabilityTicksRequired,
   };

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -245,6 +245,26 @@ const REGIME_STABILITY_TICKS_FOR_EXIT =
  *  can override via MONKEY_CONVICTION_STABILITY_TICKS_FOR_EXIT env. */
 const CONVICTION_STABILITY_TICKS_FOR_EXIT =
   Number(process.env.MONKEY_CONVICTION_STABILITY_TICKS_FOR_EXIT) || 2;
+/** CALIB-3 (2026-05-17): base tick requirement for the directional-
+ *  disagreement exit. The actual per-lane requirement scales this up
+ *  via DISAGREEMENT_LANE_MULTIPLIER so that scalp tolerates wrong-side
+ *  briefly, swing tolerates moderately, trend tolerates persistently
+ *  — per the user's "scalp=micro, swing=moderate, trend=macro"
+ *  timescale doctrine. Live diagnostic 2026-05-17 showed swing-lane
+ *  wrong-side positions bleeding with no fast-exit path.
+ *  Operator can override via MONKEY_DISAGREEMENT_BASE_TICKS_FOR_EXIT env. */
+const DISAGREEMENT_BASE_TICKS_FOR_EXIT =
+  Number(process.env.MONKEY_DISAGREEMENT_BASE_TICKS_FOR_EXIT) || 4;
+/** CALIB-3 lane-timescale multipliers. Encodes the user's lane-
+ *  timeframe doctrine: scalp = micro (1×), swing = moderate (3×),
+ *  trend = macro (10×). With base=4, this gives scalp=4 ticks (≈2 min
+ *  at 30s tick), swing=12 ticks (≈6 min), trend=40 ticks (≈20 min).
+ *  Same multipliers apply to convictionFailed via lane-scaled call. */
+const DISAGREEMENT_LANE_MULTIPLIER: Record<'scalp' | 'swing' | 'trend', number> = {
+  scalp: 1,
+  swing: 3,
+  trend: 10,
+};
 
 /**
  * v0.8.7 kill switch — when MONKEY_TRADING_PAUSED=true, gate
@@ -473,6 +493,18 @@ interface SymbolState {
    *  2026-05-17 CSV analysis showed single-tick conviction noise was
    *  driving 60% of losses in chop-zone scalping. */
   convictionFailedStreakByLane: Record<string, number>;
+  /** CALIB-3 (2026-05-17): consecutive-tick counter for "current tick's
+   *  preferred side disagrees with held side" per-lane. Drives the
+   *  directional_disagreement exit. Increments on disagreement, resets
+   *  to 0 when sides agree. Per operator directive: exit before ROI
+   *  flips negative; can re-enter if false positive. Held-side comes
+   *  from the lane's most recent open trade row; current-tick side
+   *  from this tick's executive decision. */
+  directionalDisagreementStreakByLane: Record<string, number>;
+  /** Last recorded "held side" per lane, used as the disagreement
+   *  baseline for the CALIB-3 streak. 'flat' = no position; 'long' or
+   *  'short' = corresponding held direction. Updated on entry/close. */
+  heldSideByLane: Record<string, 'long' | 'short' | 'flat'>;
   /** Wall-clock entry timestamp (ms) per lane. Used by the stale-bleed
    *  gate: positions held longer than STALE_BLEED_MIN_DURATION_S at
    *  worse than STALE_BLEED_ROI_THRESHOLD ROI exit. Cleared on close. */
@@ -1168,6 +1200,8 @@ export class MonkeyKernel extends EventEmitter {
       basinAtOpenByLane: {},
       regimeChangeStreakByLane: {},
       convictionFailedStreakByLane: {},
+      directionalDisagreementStreakByLane: {},
+      heldSideByLane: {},
       entryTimeMsByLane: {},
       integrationHistory: [],
       latestBasinSnapshot: null,
@@ -2065,6 +2099,19 @@ export class MonkeyKernel extends EventEmitter {
         } else {
           state.convictionFailedStreakByLane[heldLane] = 0;
         }
+        // CALIB-3 (2026-05-17): per-lane directional-disagreement streak.
+        // sideCandidate is the current tick's preferred side (from the
+        // executive's basinDir-derived choice); heldSide is the lane's
+        // current open position direction. Increments when they
+        // disagree; resets to 0 when they agree. Per operator directive:
+        // exit early before ROI flips negative; can re-enter if false
+        // positive.
+        if (heldSide !== null && heldSide !== sideCandidate) {
+          state.directionalDisagreementStreakByLane[heldLane] =
+            (state.directionalDisagreementStreakByLane[heldLane] ?? 0) + 1;
+        } else {
+          state.directionalDisagreementStreakByLane[heldLane] = 0;
+        }
         const heldDurationS = entryTimeMs !== undefined
           ? (Date.now() - entryTimeMs) / 1000
           : undefined;
@@ -2073,11 +2120,19 @@ export class MonkeyKernel extends EventEmitter {
           : undefined;
         const regimeChangeStreak = state.regimeChangeStreakByLane[heldLane] ?? 0;
         const convictionFailedStreak = state.convictionFailedStreakByLane[heldLane] ?? 0;
+        const directionalDisagreementStreak =
+          state.directionalDisagreementStreakByLane[heldLane] ?? 0;
         // Registry-controlled stability requirement; default 3 ticks.
         // TS has no parameter registry yet — the constant lives in
         // executive.ts mirroring ml-worker's _DEFAULT_REGIME_STABILITY_TICKS_FOR_EXIT.
         const regimeStabilityTicksRequired = REGIME_STABILITY_TICKS_FOR_EXIT;
-        const convictionFailedTicksRequired = CONVICTION_STABILITY_TICKS_FOR_EXIT;
+        // CALIB-3 lane timescale doctrine: scalp=micro (1×), swing=moderate (3×),
+        // trend=macro (10×). Applies to both conviction-failed and directional-
+        // disagreement so the same scalp-tolerates-noise-but-swing-doesn't logic
+        // governs both streak gates. See DISAGREEMENT_LANE_MULTIPLIER comment.
+        const laneMultiplier = DISAGREEMENT_LANE_MULTIPLIER[heldLane] ?? 1;
+        const convictionFailedTicksRequired = CONVICTION_STABILITY_TICKS_FOR_EXIT * laneMultiplier;
+        const directionalDisagreementTicksRequired = DISAGREEMENT_BASE_TICKS_FOR_EXIT * laneMultiplier;
         const rejustResult = !exitFired
           ? evaluateRejustification({
               regimeAtOpen,
@@ -2090,6 +2145,8 @@ export class MonkeyKernel extends EventEmitter {
               regimeStabilityTicksRequired,
               convictionFailedStreak,
               convictionFailedTicksRequired,
+              directionalDisagreementStreak,
+              directionalDisagreementTicksRequired,
               basinNow: basin,
               basinAtOpen,
               heldDurationS,
@@ -2103,6 +2160,8 @@ export class MonkeyKernel extends EventEmitter {
               regimeStabilityTicksRequired,
               convictionFailedStreak,
               convictionFailedTicksRequired,
+              directionalDisagreementStreak,
+              directionalDisagreementTicksRequired,
             };
         const rejust: Record<string, unknown> = {
           checked: rejustResult.checked,
@@ -2835,6 +2894,8 @@ export class MonkeyKernel extends EventEmitter {
             state.basinAtOpenByLane[entryLane] = Float64Array.from(basin) as Basin;
             state.regimeChangeStreakByLane[entryLane] = 0;
             state.convictionFailedStreakByLane[entryLane] = 0;
+            state.directionalDisagreementStreakByLane[entryLane] = 0;
+            state.heldSideByLane[entryLane] = sideCandidate;
             state.entryTimeMsByLane[entryLane] = Date.now();
           }
         }
@@ -2879,6 +2940,8 @@ export class MonkeyKernel extends EventEmitter {
             delete state.basinAtOpenByLane[scalpLane];
             delete state.regimeChangeStreakByLane[scalpLane];
             delete state.convictionFailedStreakByLane[scalpLane];
+            delete state.directionalDisagreementStreakByLane[scalpLane];
+            delete state.heldSideByLane[scalpLane];
             delete state.entryTimeMsByLane[scalpLane];
             // Mirror legacy scalars for any non-lane-aware reader.
             state.peakPnlUsdt = null;
@@ -2931,6 +2994,8 @@ export class MonkeyKernel extends EventEmitter {
             delete state.basinAtOpenByLane[reversalLane];
             delete state.regimeChangeStreakByLane[reversalLane];
             delete state.convictionFailedStreakByLane[reversalLane];
+            delete state.directionalDisagreementStreakByLane[reversalLane];
+            delete state.heldSideByLane[reversalLane];
             delete state.entryTimeMsByLane[reversalLane];
             // v0.8.7 kill switch — close on the reverse path proceeded
             // (exits unaffected); skip the new-entry leg when paused.
@@ -2997,6 +3062,8 @@ export class MonkeyKernel extends EventEmitter {
               state.basinAtOpenByLane[reversalLane] = Float64Array.from(basin) as Basin;
               state.regimeChangeStreakByLane[reversalLane] = 0;
               state.convictionFailedStreakByLane[reversalLane] = 0;
+              state.directionalDisagreementStreakByLane[reversalLane] = 0;
+              state.heldSideByLane[reversalLane] = newSide;
               state.entryTimeMsByLane[reversalLane] = Date.now();
               reason += ` | closed@${lastPrice.toFixed(2)} pnl=${pnlAtDecision.toFixed(4)} | new ${newSide} orderId=${monkeyOrderId}`;
             } else {


### PR DESCRIPTION
## Summary

Live diagnostic 2026-05-17 from operator: swing-lane logs show held SHORT vs current-tick LONG for tick after tick. DCA branch correctly refuses (won't compound wrong side) but no exit fires — position bleeds for hours. STALE_BLEED requires 30min AND <-1% ROI, so slow bleeds slip under it. conviction_failed (CALIB-1 #780) requires the emotion condition to streak, which doesn't reliably trigger when the position is just on the wrong side rather than emotionally contraindicated.

**Two operator directives encoded:**

1. *"exit early so it doesn't wait until the switch in direction takes hold and the held position goes negative... always better to close in positive rather than wait and close in negative — if switch is false positive, can re-enter original direction"* → fires regardless of currentRoi
2. *"swing and trend need to be considering the appropriate time frame too. swing and trend are moderate and macro while scalp is micro"* → lane-scaled streak requirements

## Changes

`held_position_rejustification.ts`:
- New `'directional_disagreement'` `RejustificationFire` variant
- Gate inserted after `stale_bleed`: fires when streak >= required, **regardless of currentRoi** (ROI in reason string for telemetry only)
- 2 new optional input fields, fail-OPEN defaults

`loop.ts`:
- `DISAGREEMENT_BASE_TICKS_FOR_EXIT = 4`
- `DISAGREEMENT_LANE_MULTIPLIER = { scalp: 1, swing: 3, trend: 10 }` — encodes scalp=micro/swing=moderate/trend=macro doctrine. At 30s ticks: scalp 2min, swing 6min, trend 20min
- **Same multiplier applied to `convictionFailedTicksRequired`** so CALIB-1 also respects lane timescale (previous flat 2-tick was too eager on swing/trend)
- `SymbolState`: `directionalDisagreementStreakByLane` + `heldSideByLane`
- Streak update mirrors regime/conviction streak update sites; cleared on entry/close/reversal

## Test plan

- [x] `tsc --noEmit` (after prebuild): 0 errors
- [x] `vitest`: 1405 passed (+6 new CALIB-3 tests including "fires in profit per directive" + lane-scaled requirement)
- [ ] Post-deploy: Railway logs should show `directional_disagreement` exits replacing the "holding ... side mismatch in lane swing (long vs held short)" pattern; positions exit before ROI flips negative

Cross Red-Team: **Session B (QIG_QFI purity audit)** named as verifier per the cross-session protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)