### PR TITLE
feat(monkey): SENSE-2c — time-of-day phase observer (UTC sin/cos basin dims)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/timeOfDay.test.ts
+++ b/apps/api/src/services/monkey/__tests__/timeOfDay.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { observeTimeOfDay, hourCycleDistance } from '../time_of_day.js';
+
+describe('observeTimeOfDay — pure derivation', () => {
+  it('midnight UTC has hourSin=0, hourCos=1 (the 0-radian point on unit circle)', () => {
+    const r = observeTimeOfDay(new Date('2026-05-17T00:00:00.000Z'));
+    expect(r.hourSin).toBeCloseTo(0, 9);
+    expect(r.hourCos).toBeCloseTo(1, 9);
+    expect(r.hourUtc).toBeCloseTo(0, 6);
+  });
+
+  it('06:00 UTC has hourSin=1, hourCos=0 (quarter-cycle)', () => {
+    const r = observeTimeOfDay(new Date('2026-05-17T06:00:00.000Z'));
+    expect(r.hourSin).toBeCloseTo(1, 9);
+    expect(r.hourCos).toBeCloseTo(0, 9);
+  });
+
+  it('noon UTC has hourSin=0, hourCos=-1 (half-cycle)', () => {
+    const r = observeTimeOfDay(new Date('2026-05-17T12:00:00.000Z'));
+    expect(r.hourSin).toBeCloseTo(0, 9);
+    expect(r.hourCos).toBeCloseTo(-1, 9);
+  });
+
+  it('18:00 UTC has hourSin=-1, hourCos=0 (three-quarter-cycle)', () => {
+    const r = observeTimeOfDay(new Date('2026-05-17T18:00:00.000Z'));
+    expect(r.hourSin).toBeCloseTo(-1, 9);
+    expect(r.hourCos).toBeCloseTo(0, 9);
+  });
+
+  it('day-of-week sine/cosine reflect ISO weekday (Mon=0, Sun=6)', () => {
+    // 2026-05-17 is a Sunday → ISO day 6
+    const sun = observeTimeOfDay(new Date('2026-05-17T00:00:00.000Z'));
+    expect(sun.dayOfWeek).toBe(6);
+    // 2026-05-18 Monday → ISO day 0 → daySin = sin(0) = 0, dayCos = cos(0) = 1
+    const mon = observeTimeOfDay(new Date('2026-05-18T00:00:00.000Z'));
+    expect(mon.dayOfWeek).toBe(0);
+    expect(mon.daySin).toBeCloseTo(0, 9);
+    expect(mon.dayCos).toBeCloseTo(1, 9);
+  });
+
+  it('values stay in [-1, +1]', () => {
+    for (let h = 0; h < 24; h++) {
+      const d = new Date(Date.UTC(2026, 4, 17, h, 0, 0));
+      const r = observeTimeOfDay(d);
+      expect(r.hourSin).toBeGreaterThanOrEqual(-1);
+      expect(r.hourSin).toBeLessThanOrEqual(1);
+      expect(r.hourCos).toBeGreaterThanOrEqual(-1);
+      expect(r.hourCos).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('hourCycleDistance — wraparound-safe time distance', () => {
+  it('distance from self is 0', () => {
+    const a = observeTimeOfDay(new Date('2026-05-17T12:00:00.000Z'));
+    expect(hourCycleDistance(a, a)).toBeCloseTo(0, 6);
+  });
+
+  it('distance from opposite times is 1.0 (full π apart)', () => {
+    const midnight = observeTimeOfDay(new Date('2026-05-17T00:00:00.000Z'));
+    const noon = observeTimeOfDay(new Date('2026-05-17T12:00:00.000Z'));
+    expect(hourCycleDistance(midnight, noon)).toBeCloseTo(1, 6);
+  });
+
+  it('23:59 and 00:01 are ADJACENT despite raw-hour values being far apart', () => {
+    // Naive raw-hour encoding: |23.98 − 0.02| = 23.97 (looks maximally distant)
+    // Sin/cos cycle encoding: ~0.001 cycle distance (correct: they're 2 min apart)
+    const lateA = observeTimeOfDay(new Date('2026-05-17T23:59:00.000Z'));
+    const earlyB = observeTimeOfDay(new Date('2026-05-18T00:01:00.000Z'));
+    expect(hourCycleDistance(lateA, earlyB)).toBeLessThan(0.01);
+  });
+
+  it('quarter-cycle distance is 0.5', () => {
+    const midnight = observeTimeOfDay(new Date('2026-05-17T00:00:00.000Z'));
+    const six = observeTimeOfDay(new Date('2026-05-17T06:00:00.000Z'));
+    expect(hourCycleDistance(midnight, six)).toBeCloseTo(0.5, 6);
+  });
+});

--- a/apps/api/src/services/monkey/time_of_day.ts
+++ b/apps/api/src/services/monkey/time_of_day.ts
@@ -1,0 +1,87 @@
+/**
+ * time_of_day.ts — SENSE-2c (telemetry-only).
+ *
+ * Markets aren't time-stationary. Asian, EU, and US sessions have
+ * different liquidity, volatility, and participant composition. The
+ * kernel currently has no temporal sensation — every tick looks like
+ * every other tick from the substrate's point of view.
+ *
+ * Per the audit's QIG-pure framing: encode time as a continuous,
+ * rotationally-continuous pair (sine, cosine) of UTC hour-of-day and
+ * day-of-week. Session bucketing (Asian/EU/US) is DOWNSTREAM of these
+ * continuous values — the executive decides what to do with the
+ * (sin, cos) pair; this module just surfaces the observation.
+ *
+ * Why sine/cosine (not raw hour): the encoding is rotationally
+ * continuous. Midnight (h=0) and 23:59 (h=23.98) are 1 minute apart in
+ * reality, but raw-hour encoding makes them maximally distant (0 vs
+ * 23.98). The (sin, cos) pair on a unit circle puts them adjacent.
+ * Same trick applied to day-of-week.
+ *
+ * Phase 1 (this module): pure derivation + telemetry. No decision path
+ * consumes it yet.
+ *
+ * Phase 2 (follow-up): expose as basin dimensions or as session-context
+ * features the executive folds into entry-threshold gating.
+ */
+
+export interface TimeOfDayReading {
+  /** UTC hour-of-day as a sine on a 24-hour cycle. */
+  hourSin: number;
+  /** UTC hour-of-day as a cosine on a 24-hour cycle. */
+  hourCos: number;
+  /** UTC day-of-week as a sine on a 7-day cycle. */
+  daySin: number;
+  /** UTC day-of-week as a cosine on a 7-day cycle. */
+  dayCos: number;
+  /** Hour-of-day as a float in [0, 24) — surfaced for telemetry
+   *  readability; downstream should use hourSin/Cos. */
+  hourUtc: number;
+  /** Day-of-week as int in [0, 6] (Mon=0, Sun=6) — same purpose. */
+  dayOfWeek: number;
+}
+
+/**
+ * Compute the time-of-day phase observation. Accepts an explicit Date
+ * for testability; defaults to now.
+ *
+ * Pure derivation: sine and cosine of normalized cycle position.
+ * No state, no buffer, no thresholds.
+ */
+export function observeTimeOfDay(now: Date = new Date()): TimeOfDayReading {
+  const ms = now.getTime();
+  // UTC seconds since midnight.
+  const utcMs = ms % (24 * 60 * 60 * 1000);
+  const hourUtc = utcMs / (60 * 60 * 1000);  // 0..24
+
+  // ISO day-of-week: Mon=0, Sun=6. JS getUTCDay() returns Sun=0; remap.
+  const jsDay = now.getUTCDay();  // 0..6 with Sun=0
+  const dayOfWeek = (jsDay + 6) % 7;  // shift so Mon=0, Sun=6
+
+  const hourAngle = (hourUtc / 24) * 2 * Math.PI;
+  const dayAngle = (dayOfWeek / 7) * 2 * Math.PI;
+
+  return {
+    hourSin: Math.sin(hourAngle),
+    hourCos: Math.cos(hourAngle),
+    daySin: Math.sin(dayAngle),
+    dayCos: Math.cos(dayAngle),
+    hourUtc,
+    dayOfWeek,
+  };
+}
+
+/**
+ * Distance on the time-of-day cycle between two readings, in unit-cycle
+ * units [0, 1]. 0 = same hour-of-day; 0.5 = opposite side of the
+ * 24-hour clock. Useful for "are these two events at similar times of
+ * day" queries without dealing with the wraparound at midnight.
+ */
+export function hourCycleDistance(a: TimeOfDayReading, b: TimeOfDayReading): number {
+  // dot product on the unit circle = cos(angular distance)
+  const dot = a.hourSin * b.hourSin + a.hourCos * b.hourCos;
+  // clamp dot to [-1, 1] in case of float noise
+  const clamped = Math.max(-1, Math.min(1, dot));
+  // angular distance in radians, normalised to [0, 1] over [0, π]
+  return Math.acos(clamped) / Math.PI;
+}


### PR DESCRIPTION
Per audit roadmap SENSE-2 #768. Markets aren't time-stationary — Asian/EU/US sessions differ. The kernel currently has no temporal sensation. Sin/cos encoding of UTC hour + day-of-week is rotationally continuous (23:59 and 00:01 land adjacent, not maximally distant).

Phase 1 (this PR): pure derivation + telemetry. 10 tests including the critical wraparound test.

Cross Red-Team: Session B verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)