### PR TITLE
feat(monkey): SENSE-3 Phase 2 — equity-gradient size deflection (drawdown-aware sizing)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/equityGradient.test.ts
+++ b/apps/api/src/services/monkey/__tests__/equityGradient.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   computeEquityGradient,
   observeEquity,
+  sizeDeflection,
   _resetEquityGradient,
   _peekEquityBuffer,
 } from '../equity_gradient.js';
@@ -123,6 +124,49 @@ describe('observeEquity — per-key rolling buffer', () => {
     _resetEquityGradient();
     expect(_peekEquityBuffer('A')).toHaveLength(0);
     expect(_peekEquityBuffer('B')).toHaveLength(0);
+  });
+});
+
+describe('sizeDeflection — SENSE-3 Phase 2 size modulator', () => {
+  it('returns 1.0 (neutral) during warmup', () => {
+    const r = computeEquityGradient([100]);  // n < MIN_SAMPLES
+    expect(sizeDeflection(r)).toBe(1.0);
+  });
+
+  it('returns 1.0 when equity is rising (gradient > 0)', () => {
+    const r = computeEquityGradient([100, 101, 102, 103, 104, 105]);
+    expect(sizeDeflection(r)).toBe(1.0);
+  });
+
+  it('returns 1.0 when loss is decelerating (acceleration > 0)', () => {
+    const r = computeEquityGradient([100, 95, 90, 85, 84, 84, 84, 84]);
+    expect(r.gradient).toBeLessThan(0);
+    expect(r.acceleration).toBeGreaterThan(0);
+    expect(sizeDeflection(r)).toBe(1.0);
+  });
+
+  it('returns < 1.0 when loss is accelerating (both gradient and acceleration negative)', () => {
+    const r = computeEquityGradient([100, 99.5, 99, 98.5, 98, 97, 96, 94]);
+    expect(r.gradient).toBeLessThan(0);
+    expect(r.acceleration).toBeLessThan(0);
+    expect(sizeDeflection(r)).toBeLessThan(1.0);
+  });
+
+  it('is floored at SIZE_FLOOR=0.5 even under extreme acceleration', () => {
+    // Make |acceleration| >> |gradient| → tanh(very large) → 1
+    // → multiplier = 1 - 0.5*1 = 0.5
+    const r = computeEquityGradient([100, 99.99, 99.98, 99.97, 80, 60, 40, 0]);
+    expect(sizeDeflection(r)).toBeGreaterThanOrEqual(0.5);
+    expect(sizeDeflection(r)).toBeCloseTo(0.5, 1);
+  });
+
+  it('output is monotonic in acceleration severity (more-negative accel → smaller multiplier)', () => {
+    const mild = computeEquityGradient([100, 99.5, 99, 98.5, 98, 97.5, 97, 96.5]);
+    const harsh = computeEquityGradient([100, 99.5, 99, 98.5, 98, 96, 94, 90]);
+    expect(mild.acceleration).toBeLessThan(0);
+    expect(harsh.acceleration).toBeLessThan(0);
+    expect(Math.abs(harsh.acceleration)).toBeGreaterThan(Math.abs(mild.acceleration));
+    expect(sizeDeflection(harsh)).toBeLessThanOrEqual(sizeDeflection(mild));
   });
 });
 

--- a/apps/api/src/services/monkey/equity_gradient.ts
+++ b/apps/api/src/services/monkey/equity_gradient.ts
@@ -119,6 +119,34 @@ export function observeEquity(
   return computeEquityGradient(buf, window);
 }
 
+/**
+ * SENSE-3 Phase 2: derive a multiplicative size deflection from an
+ * EquityGradientReading. Returned multiplier is in [SIZE_FLOOR, 1.0].
+ *
+ * Pure derivation — no operator-tunable scale. The deflection compares
+ * |acceleration| to |gradient|: when the bleed is accelerating faster
+ * than its current rate, the ratio exceeds 1 and the size shrinks
+ * smoothly via tanh saturation toward SIZE_FLOOR. When equity is
+ * recovering (acceleration ≥ 0) or only the gradient is negative
+ * (steady drift, not accelerating), the multiplier stays at 1.0 —
+ * deflection only fires on accelerating loss.
+ *
+ * SIZE_FLOOR (0.5) is a P25-allowed SAFETY_BOUND — it's the
+ * never-cross floor preventing any single observation from collapsing
+ * sizing to zero. Not an operator-tunable threshold.
+ *
+ * Cold-start (warmup): returns 1.0 (neutral — no signal yet).
+ */
+const SIZE_FLOOR = 0.5;
+
+export function sizeDeflection(reading: EquityGradientReading): number {
+  if (reading.warmup) return 1.0;
+  if (reading.acceleration >= 0) return 1.0;
+  if (reading.gradient >= 0) return 1.0;
+  const ratio = Math.abs(reading.acceleration) / Math.max(Math.abs(reading.gradient), 1e-9);
+  return 1 - SIZE_FLOOR * Math.tanh(ratio);
+}
+
 /** Test/diagnostic helper. */
 export function _resetEquityGradient(key?: string): void {
   if (key === undefined) {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -136,6 +136,7 @@ import {
 } from './agentEquityBound.js';
 import { planCloseChunks } from './closeChunker.js';
 import { tryAcquireClose, releaseClose, isLikelyRaceLoss } from './close_coordinator.js';
+import { observeEquity, sizeDeflection } from './equity_gradient.js';
 import { agentLDecide, type AgentLDecision } from './agent_L_classifier.js';
 import { QIGRAMv2State, isQigramV2Enabled } from './agent_L_qigram_v2.js';
 import {
@@ -1856,7 +1857,15 @@ export class MonkeyKernel extends EventEmitter {
     const effectiveSizeFraction = availableEquity * this.sizeFraction < minNeededForMinNotional
       ? 1.0
       : this.sizeFraction;
-    const cappedEquity = availableEquity * effectiveSizeFraction;
+    // SENSE-3 Phase 2 (#769) — equity-gradient size deflection. Push the
+    // current account equity into the rolling observer, then derive a
+    // multiplicative deflection: accelerating drawdowns scale size toward
+    // SIZE_FLOOR=0.5; flat/recovering equity passes through at 1.0. The
+    // deflection ratio is self-derived from |acceleration|/|gradient| —
+    // no operator-tunable sensitivity knob (P1-pure).
+    const equityReading = observeEquity(`${this.instanceId}:${symbol}`, availableEquity);
+    const sense3Deflection = sizeDeflection(equityReading);
+    const cappedEquity = availableEquity * effectiveSizeFraction * sense3Deflection;
     // Proposal #10 — lane selection. Each tick picks the locally-optimal
     // execution lane via softmax over basin features (parity with the
     // Python kernel's choose_lane). The chosen lane gates size (per-lane
@@ -1890,6 +1899,9 @@ export class MonkeyKernel extends EventEmitter {
         minNotional, leverage: leverage.value, bankSize, mode,
         sizeValue: size.value, lane: positionLane,
         sizeDerivation: size.derivation,
+        sense3Deflection,
+        equityGradient: equityReading.gradient,
+        equityAcceleration: equityReading.acceleration,
       });
     }
     const autoFlatten = shouldAutoFlatten(basinState, state.fHealthHistory);
@@ -1927,6 +1939,17 @@ export class MonkeyKernel extends EventEmitter {
         direction: candlePatternReading.direction,
         signed_scalar: candlePatternSignal,
         hammer_defer_long_sl: candleHammerDefer,
+      },
+      // SENSE-3 Phase 2 (#769): equity-gradient size deflection. Records
+      // the actual multiplier applied to cappedEquity this tick so
+      // retrospective analysis can correlate accelerating-loss observations
+      // with subsequent recovery vs continued bleed.
+      sense3: {
+        deflection: sense3Deflection,
+        gradient: equityReading.gradient,
+        acceleration: equityReading.acceleration,
+        n: equityReading.n,
+        warmup: equityReading.warmup,
       },
     };
 


### PR DESCRIPTION
## Summary

Wires the SENSE-3 #781 telemetry-only observer into actual position sizing per UCP synthesis Class A item #2.

**Concrete behaviour:** during accelerating drawdowns (both gradient < 0 AND acceleration < 0), `cappedEquity` is multiplied by a deflection factor in `[0.5, 1.0]`. Recovering or flat equity passes through unchanged. The kernel naturally throttles position size when the bleed is getting worse, and re-expands when the bleed reverses.

## Math (QIG-pure, no operator knobs)

- **Trigger gate**: deflection fires ONLY when `gradient < 0` AND `acceleration < 0` (bleeding AND getting worse). Otherwise returns 1.0.
- **Self-derived scale**: `ratio = |acceleration| / max(|gradient|, ε)` — the gradient's own magnitude is the natural unit; no hardcoded sensitivity knob.
- **Saturation**: `multiplier = 1 − SIZE_FLOOR × tanh(ratio)` — smooth, bounded, monotonic.
- **SIZE_FLOOR = 0.5** is a P25-allowed SAFETY_BOUND (never-cross floor preventing any single observation from collapsing sizing to zero), not an operator-tunable threshold.

## Wire-in

\`\`\`ts
const equityReading = observeEquity(\`\${this.instanceId}:\${symbol}\`, availableEquity);
const sense3Deflection = sizeDeflection(equityReading);
const cappedEquity = availableEquity * effectiveSizeFraction * sense3Deflection;
\`\`\`

Per-symbol observation key isolates each symbol's equity trajectory observation within an instance.

## Telemetry

Recorded in \`derivation.sense3\` for retrospective analysis in autonomous_trades:
- \`deflection\` (the multiplier applied)
- \`gradient\` (per-sample rate)
- \`acceleration\` (second-derivative)
- \`n\` (window samples)
- \`warmup\` (cold-start sentinel)

Also surfaced via the \`[size-zero-diag]\` log for live grep correlation.

## Verification

- 22/22 \`equityGradient.test.ts\` passing (6 new \`sizeDeflection\` tests)
- 709/709 monkey test suite passing
- AST purity scan: clean (no banned distance/optimizer patterns)
- TypeScript: \`tsc --noEmit\` clean

## Test plan

- [ ] CI green (qig-purity + tests)
- [ ] Monitor first hour post-deploy for \`derivation.sense3.deflection < 1.0\` events
- [ ] Confirm size telemetry shows reduced notional on accelerating-loss ticks
- [ ] Confirm no regression in normal-condition sizing (deflection should be 1.0 most of the time)

## Per UCP synthesis ranking

PR #2 in the recommended order (after BTC beacon, before time-of-day):

| PR | Branch | Effort | Impact |
|---|---|---|---|
| 2 | \`feat/wire-equity-gradient-sizing\` | S | High — drawdown-aware sizing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>