### PR TITLE
fix(liveSignal): lower Monkey-disagreement threshold 0.15→0.10 (catch persistent mild lean)

### DIFF
--- a/apps/api/src/services/liveSignalEngine.ts
+++ b/apps/api/src/services/liveSignalEngine.ts
@@ -704,14 +704,30 @@ export class LiveSignalEngine extends EventEmitter {
       // closes the cross-engine blind spot where LiveSignal holds a stale
       // short while Monkey's basin already favors long.
       //
-      // Threshold: re-uses the SAME 0.15 SAFETY_BOUND as the existing
-      // ML-flip Monkey-agreement gate (line ~625). Required streak count
-      // bounds operator-observable risk: at the 60s LiveSignal tick
-      // cadence, 5 ticks ≈ 5 minutes of persistent disagreement before
-      // forced exit. Configurable via env for ops.
+      // Threshold semantics — DIFFERENT from the existing ML-flip
+      // agreement-block gate at line ~625:
+      //   - AGREEMENT-block (0.15): "Monkey must NOT strongly oppose
+      //     an ML-flip-driven exit" — high threshold = strict block.
+      //   - DISAGREEMENT-trigger (0.10, THIS one): "Persistent mild
+      //     Monkey opposition is enough to force-exit even without an
+      //     ML flip" — lower threshold catches the stale-direction-bleed
+      //     pattern where Monkey leans the opposite direction by
+      //     0.10-0.13 (real but mild) for many minutes while ML stays
+      //     at HOLD.
+      //
+      // Calibration: live tape 2026-05-17 showed BTC + ETH shorts
+      // bleeding for 4+ hours while Monkey basinDir = +0.10 to +0.13
+      // (long-leaning). The initial 0.15 threshold (PR #796) didn't
+      // catch this — same order-of-magnitude SAFETY_BOUND but tuned
+      // for "persistent mild disagreement" rather than "strong opposition."
+      //
+      // Required streak count bounds operator-observable risk: at the
+      // 60s LiveSignal tick cadence, 5 ticks ≈ 5 minutes of persistent
+      // disagreement before forced exit. Env-configurable for ops.
       const streakKey = `${symbol}|${existingPos.side}`;
       const monkeySnap = getFreshestMonkeyBasinSnapshot(symbol);
-      const MONKEY_DISAGREEMENT_THRESHOLD = 0.15;  // SAFETY_BOUND, matches existing gate
+      const MONKEY_DISAGREEMENT_THRESHOLD =
+        Number(process.env.LIVE_MONKEY_DISAGREEMENT_THRESHOLD) || 0.10;  // SAFETY_BOUND
       const MONKEY_DISAGREEMENT_TICKS_FOR_EXIT =
         Number(process.env.LIVE_MONKEY_DISAGREEMENT_TICKS) || 5;
       let strongDisagreeNow = false;


### PR DESCRIPTION
## Hotfix on #796

PR #796 deployed 5 min ago with \`MONKEY_DISAGREEMENT_THRESHOLD=0.15\`. Live tape post-deploy shows streak stuck at \`0/5\` — Monkey basinDir on BTC + ETH hovers at +0.10 to +0.13, just BELOW the 0.15 trigger.

## Why 0.15 was wrong

The 0.15 was inherited from the EXISTING agreement-BLOCK gate at line ~625, which has DIFFERENT semantics:

| Gate | Semantics | Right threshold |
|---|---|---|
| AGREEMENT-block (existing, 0.15) | Blocks an ML-flip exit when Monkey strongly opposes | High = strict (only block on STRONG opposition) |
| DISAGREEMENT-trigger (this PR, new) | Forces exit when Monkey persistently opposes | **Low** = catches mild persistent opposition |

The two gates are symmetric in form but asymmetric in intent — the agreement-block wants to be hard to block (only true strong opposition counts), while the disagreement-trigger wants to be easy to fire (persistent mild lean is enough).

## Calibration source

Live tape 2026-05-17 ~07:55Z: BTC + ETH shorts bleeding for 4+ hours while Monkey basinDir = +0.10 to +0.13 (long-leaning). The 0.15 threshold missed this exact pattern.

## Env override

\`LIVE_MONKEY_DISAGREEMENT_THRESHOLD=0.05\` (or any value) for ops calibration if 0.10 turns out too permissive.

## Verification

- TypeScript: clean
- Existing 0.15 agreement-BLOCK gate unchanged (different code path)
- Streak logic + close path unchanged from #796

## Test plan

- [ ] CI green
- [ ] After deploy: streak counter accumulates 1/5, 2/5... in production logs
- [ ] After 5 min of persistent opposition: \`Monkey-disagreement exit\` fires
- [ ] BTC + ETH bleeding shorts close
- [ ] Account upl trajectory improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>