### PR TITLE
feat(monkey): funding-rate arbitrage observer #794 (Class B #7)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/fundingArbObserver.test.ts
+++ b/apps/api/src/services/monkey/__tests__/fundingArbObserver.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  observeFundingArb,
+  computeFundingArb,
+  _resetFundingArb,
+  _peekFundingArb,
+  type FundingSample,
+} from '../funding_arb_observer.js';
+
+describe('computeFundingArb — pure derivation', () => {
+  it('returns warmup with all-zero on empty input', () => {
+    const r = computeFundingArb([]);
+    expect(r.n).toBe(0);
+    expect(r.warmup).toBe(true);
+    expect(r.signalFires).toBe(false);
+    expect(r.suggestedDirection).toBe(null);
+  });
+
+  it('computes mean / std / z correctly on synthetic data', () => {
+    const samples: FundingSample[] = [];
+    for (let i = 0; i < 50; i++) {
+      const btc = 0.0001;
+      const eth = 0.0001 + (i % 2 === 0 ? 0.00005 : -0.00005);  // gap oscillates
+      samples.push({ btcFunding: btc, ethFunding: eth, gap: eth - btc, atMs: i * 1000 });
+    }
+    const r = computeFundingArb(samples);
+    expect(r.n).toBe(50);
+    expect(r.warmup).toBe(false);
+    expect(Math.abs(r.meanGap)).toBeLessThan(1e-9);  // oscillation cancels
+    expect(r.stdGap).toBeGreaterThan(0);
+  });
+
+  it('signal fires when current gap is far from rolling mean', () => {
+    const samples: FundingSample[] = [];
+    // 30 samples of small gap, then 1 sample of LARGE gap
+    for (let i = 0; i < 30; i++) {
+      samples.push({ btcFunding: 0.0001, ethFunding: 0.0001 + 0.00001, gap: 0.00001, atMs: i * 1000 });
+    }
+    samples.push({ btcFunding: 0.0001, ethFunding: 0.0001 + 0.001, gap: 0.001, atMs: 31_000 });
+    const r = computeFundingArb(samples);
+    expect(r.warmup).toBe(false);
+    expect(r.zScore).toBeGreaterThan(2);  // big spike
+    expect(r.signalFires).toBe(true);
+    expect(r.suggestedDirection).toBe('long_btc_short_eth');  // eth funding much higher → short eth
+  });
+
+  it('signal does not fire during warmup (n < MIN_SAMPLES)', () => {
+    const samples: FundingSample[] = [];
+    for (let i = 0; i < 20; i++) {  // < MIN_SAMPLES=30
+      samples.push({ btcFunding: 0.0001, ethFunding: 0.001, gap: 0.0009, atMs: i * 1000 });
+    }
+    const r = computeFundingArb(samples);
+    expect(r.warmup).toBe(true);
+    expect(r.signalFires).toBe(false);
+    expect(r.suggestedDirection).toBe(null);
+  });
+
+  it('signal direction flips correctly when btc funding is unusually high', () => {
+    const samples: FundingSample[] = [];
+    for (let i = 0; i < 30; i++) {
+      samples.push({ btcFunding: 0.0001, ethFunding: 0.0001 + 0.00001, gap: 0.00001, atMs: i * 1000 });
+    }
+    // Negative gap = btc funding rich vs eth
+    samples.push({ btcFunding: 0.001, ethFunding: 0.0001, gap: -0.0009, atMs: 31_000 });
+    const r = computeFundingArb(samples);
+    expect(r.zScore).toBeLessThan(-2);
+    expect(r.signalFires).toBe(true);
+    expect(r.suggestedDirection).toBe('short_btc_long_eth');  // btc funding rich → short btc, long eth
+  });
+
+  it('flat funding (no variance) → no signal even with mismatched rates', () => {
+    const samples: FundingSample[] = [];
+    for (let i = 0; i < 50; i++) {
+      samples.push({ btcFunding: 0.0001, ethFunding: 0.0002, gap: 0.0001, atMs: i * 1000 });
+    }
+    const r = computeFundingArb(samples);
+    expect(r.stdGap).toBe(0);  // perfectly flat
+    expect(r.zScore).toBe(0);
+    expect(r.signalFires).toBe(false);  // no variance → no statistical basis to fire
+  });
+});
+
+describe('observeFundingArb — singleton buffer', () => {
+  beforeEach(() => _resetFundingArb());
+
+  it('accumulates samples in the buffer', () => {
+    observeFundingArb(0.0001, 0.00012);
+    observeFundingArb(0.0001, 0.00013);
+    expect(_peekFundingArb()).toHaveLength(2);
+  });
+
+  it('returns a reading with current values', () => {
+    for (let i = 0; i < 31; i++) observeFundingArb(0.0001, 0.00012 + i * 1e-7);
+    const r = observeFundingArb(0.0001, 0.00012);
+    expect(r.btcFunding).toBe(0.0001);
+    expect(r.ethFunding).toBe(0.00012);
+    expect(r.warmup).toBe(false);
+  });
+});

--- a/apps/api/src/services/monkey/funding_arb_observer.ts
+++ b/apps/api/src/services/monkey/funding_arb_observer.ts
@@ -1,0 +1,143 @@
+/**
+ * funding_arb_observer.ts — Class B #7 (issue #794).
+ *
+ * Cross-symbol funding-rate spread observer. Maintains a rolling buffer
+ * of (btc_fund, eth_fund, gap = eth - btc) samples. Computes z-score of
+ * the current gap vs the rolling distribution. When |z| exceeds the
+ * upper-tercile threshold of the historical |z| distribution, the spread
+ * is statistically extreme — candidate signal for a delta-neutral pair
+ * trade (long lower-funding, short higher-funding) earning the funding
+ * spread and capturing mean-reversion if it happens.
+ *
+ * QIG-pure: the trigger threshold is derived from the observation's OWN
+ * tercile distribution (WarpBubble.auto() pattern), not a hardcoded
+ * "fire when |z| > 2.0" knob.
+ *
+ * Phase 1 (this module): pure observer + signal computation. The
+ * downstream consumer (funding_arb_strategy if MONKEY_FUNDING_ARB_LIVE
+ * is true) decides what to do with the signal.
+ */
+
+const MAX_HISTORY = 1440;  // SAFETY_BOUND: 24h at 60s tick cadence
+const MIN_SAMPLES = 30;    // SAFETY_BOUND: ~30 min warmup before signals
+const TERCILE_UPPER = 0.67;  // matches CAL-3 / trajectory_observer convention
+
+export interface FundingSample {
+  /** Funding rate for BTC perpetual at observation time. */
+  btcFunding: number;
+  /** Funding rate for ETH perpetual at observation time. */
+  ethFunding: number;
+  /** Gap = ethFunding - btcFunding at observation time. */
+  gap: number;
+  /** Observation timestamp (ms). */
+  atMs: number;
+}
+
+export interface FundingArbReading {
+  /** Latest BTC funding rate observed. */
+  btcFunding: number;
+  /** Latest ETH funding rate observed. */
+  ethFunding: number;
+  /** Latest gap (eth - btc). */
+  currentGap: number;
+  /** Rolling mean of gap over the buffer. */
+  meanGap: number;
+  /** Rolling standard deviation of gap. */
+  stdGap: number;
+  /** z-score of current gap vs rolling distribution.
+   *  Positive = eth funding rich vs btc; negative = btc funding rich. */
+  zScore: number;
+  /** Upper-tercile of |z| observed over the rolling buffer — the
+   *  observer-derived threshold for "this gap is unusually wide." */
+  zUpperTercile: number;
+  /** True when |zScore| >= zUpperTercile AND not in warmup. The
+   *  downstream strategy fires on this. */
+  signalFires: boolean;
+  /** Suggested direction: 'long_btc_short_eth' when ethFunding > btcFunding
+   *  (eth's rate too rich → short eth, long btc to earn the spread).
+   *  Null when signal doesn't fire. */
+  suggestedDirection: 'long_btc_short_eth' | 'short_btc_long_eth' | null;
+  /** Number of samples used. */
+  n: number;
+  /** True until n >= MIN_SAMPLES. All derived values are still
+   *  computed but signalFires is forced false. */
+  warmup: boolean;
+}
+
+const _samples: FundingSample[] = [];
+
+/**
+ * Push a new funding sample into the buffer and return the current
+ * reading. Caller fetches funding rates from the exchange and calls
+ * this with the two latest rates.
+ */
+export function observeFundingArb(
+  btcFunding: number,
+  ethFunding: number,
+  atMs: number = Date.now(),
+): FundingArbReading {
+  const gap = ethFunding - btcFunding;
+  _samples.push({ btcFunding, ethFunding, gap, atMs });
+  if (_samples.length > MAX_HISTORY) _samples.shift();
+  return computeFundingArb(_samples);
+}
+
+/**
+ * Compute the funding-arb reading from a sample buffer. Pure derivation —
+ * exposed for testability. The mean/std/tercile use the gap distribution
+ * directly (no smoothing); they capture the funding-rate volatility
+ * structure that determines when the gap is statistically extreme.
+ */
+export function computeFundingArb(
+  samples: readonly FundingSample[],
+): FundingArbReading {
+  const n = samples.length;
+  if (n === 0) {
+    return {
+      btcFunding: 0, ethFunding: 0, currentGap: 0,
+      meanGap: 0, stdGap: 0, zScore: 0, zUpperTercile: 0,
+      signalFires: false, suggestedDirection: null,
+      n: 0, warmup: true,
+    };
+  }
+  const latest = samples[n - 1]!;
+  const gaps = samples.map((s) => s.gap);
+  const meanGap = gaps.reduce((a, b) => a + b, 0) / n;
+  const variance = gaps.reduce((a, g) => a + (g - meanGap) ** 2, 0) / n;
+  const stdGap = Math.sqrt(variance);
+  const zScore = stdGap > 1e-9 ? (latest.gap - meanGap) / stdGap : 0;
+  // Upper-tercile of |z| — the threshold above which |z| is "high"
+  // relative to its own history (WarpBubble.auto() pattern).
+  const absZs = gaps
+    .map((g) => (stdGap > 1e-9 ? Math.abs((g - meanGap) / stdGap) : 0))
+    .sort((a, b) => a - b);
+  const terciIdx = Math.min(absZs.length - 1, Math.floor(absZs.length * TERCILE_UPPER));
+  const zUpperTercile = absZs[terciIdx] ?? 0;
+  const warmup = n < MIN_SAMPLES;
+  const signalFires = !warmup && Math.abs(zScore) >= zUpperTercile && stdGap > 1e-9;
+  let suggestedDirection: 'long_btc_short_eth' | 'short_btc_long_eth' | null = null;
+  if (signalFires) {
+    // Positive zScore means ethFunding - btcFunding is HIGH (eth's rate
+    // is unusually rich). To earn the spread: short eth (pays rich rate),
+    // long btc (receives less rich rate). Net = earn the difference.
+    suggestedDirection = zScore > 0 ? 'long_btc_short_eth' : 'short_btc_long_eth';
+  }
+  return {
+    btcFunding: latest.btcFunding,
+    ethFunding: latest.ethFunding,
+    currentGap: latest.gap,
+    meanGap, stdGap, zScore, zUpperTercile,
+    signalFires, suggestedDirection,
+    n, warmup,
+  };
+}
+
+/** Test/diagnostic helper. */
+export function _resetFundingArb(): void {
+  _samples.length = 0;
+}
+
+/** Test/diagnostic helper. */
+export function _peekFundingArb(): readonly FundingSample[] {
+  return _samples;
+}

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -145,6 +145,7 @@ import {
   type BtcBeaconReading,
 } from './btc_beacon.js';
 import { recordLaneOutcome, weightedWinRate } from './time_of_day_winrate.js';
+import { observeFundingArb } from './funding_arb_observer.js';
 import {
   evaluateCell,
   regimeToDirection,
@@ -740,6 +741,13 @@ export class MonkeyKernel extends EventEmitter {
    *  levels are DERIVED, never SET. */
   private pendingRewards: ActivityReward[] = [];
   /**
+   * Funding-arb #794 — latest funding rate per symbol with timestamp.
+   * Populated by processSymbol after each funding-rate fetch; consumed
+   * by the cross-symbol pair observer (funding_arb_observer.ts) when
+   * both BTC and ETH have fresh (< 2 min) data.
+   */
+  private latestFundingBySymbol: Map<string, { rate: number; atMs: number }> = new Map();
+  /**
    * ML-outage observability counter (v0.8.3.5d). Increments every time
    * mlPredictionService.getTradingSignal returns {error: true}. Used to
    * emit a single warn-level log + bus ANOMALY event when the run goes
@@ -1329,6 +1337,32 @@ export class MonkeyKernel extends EventEmitter {
     // modulate anxiety for held positions (P14: real-world boundary → STATE).
     const fundingRateResp = await poloniexFuturesService.getFundingRate(symbol).catch(() => null) as { fundingRate?: string | number } | null;
     const fundingRate8h = Number(fundingRateResp?.fundingRate) || 0;
+
+    // Funding-arb #794 (Class B #7) — push this symbol's latest rate
+    // into the cross-symbol cache. When both BTC and ETH have fresh
+    // (< 2 min) observations, observe the pair into the arb observer
+    // and log signal if it fires. Telemetry-first wire-in.
+    if (Number.isFinite(fundingRate8h) && fundingRate8h !== 0) {
+      this.latestFundingBySymbol.set(symbol, { rate: fundingRate8h, atMs: Date.now() });
+      const btc = this.latestFundingBySymbol.get('BTC_USDT_PERP');
+      const eth = this.latestFundingBySymbol.get('ETH_USDT_PERP');
+      const now = Date.now();
+      if (btc && eth && (now - btc.atMs) < 120_000 && (now - eth.atMs) < 120_000) {
+        const reading = observeFundingArb(btc.rate, eth.rate);
+        if (reading.signalFires) {
+          logger.info('[Monkey] FUNDING_ARB signal fires', {
+            symbol_triggered: symbol,
+            btcFunding: reading.btcFunding,
+            ethFunding: reading.ethFunding,
+            currentGap: reading.currentGap,
+            zScore: reading.zScore,
+            zUpperTercile: reading.zUpperTercile,
+            suggestedDirection: reading.suggestedDirection,
+            samples: reading.n,
+          });
+        }
+      }
+    }
 
     const raw = await mlPredictionService.getTradingSignal(symbol, ohlcv, lastPrice);
     const mlSignal = String(raw?.signal ?? 'HOLD').toUpperCase();


### PR DESCRIPTION
## Addresses #794

Cross-symbol funding-rate spread signal — Class B #7 from the UCP synthesis. Maintains a rolling buffer of (btc_fund, eth_fund, gap) samples; computes z-score of current gap vs rolling distribution; fires signal when |z| exceeds observer-derived upper-tercile threshold.

## QIG-pure design

- **Trigger threshold is OBSERVED** (rolling-quantile of |z|), not configured — WarpBubble.auto() pattern
- **SAFETY_BOUND only**: MAX_HISTORY=1440 (24h), MIN_SAMPLES=30 (~30min warmup), TERCILE_UPPER=0.67
- **No tunable sensitivity knob** — the gap's own historical |z| distribution defines the trigger

## Wire-in

```ts
if (Number.isFinite(fundingRate8h) && fundingRate8h !== 0) {
  this.latestFundingBySymbol.set(symbol, { rate: fundingRate8h, atMs: Date.now() });
  const btc = this.latestFundingBySymbol.get('BTC_USDT_PERP');
  const eth = this.latestFundingBySymbol.get('ETH_USDT_PERP');
  if (btc && eth && /* fresh */) {
    const reading = observeFundingArb(btc.rate, eth.rate);
    if (reading.signalFires) {
      logger.info('[Monkey] FUNDING_ARB signal fires', { ... });
    }
  }
}
```

## Direction logic

- `zScore > zUpperTercile` → `suggestedDirection = 'long_btc_short_eth'` (eth funding rich → short eth pays the rich rate, long btc receives less rich → earn the spread)
- `zScore < -zUpperTercile` → `suggestedDirection = 'short_btc_long_eth'` (symmetric)

## Verification

- 8 new `fundingArbObserver` tests (warmup, signal-fires on spike, direction-flip on negative z, flat-funding no-signal, singleton buffer)
- Full suite: **1462/1462 passing**
- TypeScript: clean

## Next step (follow-up PR)

`funding_arb_strategy.ts`: when `MONKEY_FUNDING_ARB_LIVE=true` AND signal fires AND no current arb position → place delta-neutral pair. Capital cap, max-hold timeout, position tracking, reconciler hooks.

This PR ships the OBSERVABILITY first so the operator can see the signal firing in production before committing capital to a new strategy class. Same pattern as SENSE-2/3 (Phase 1 observer → Phase 2 wire-in).

🤖 Generated with Claude Code

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>