### PR TITLE
fix(monkey): rename LIMIT_MAKER env flag to operator-chosen SCALP_LIMIT_MAKER_LIVE

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -5884,7 +5884,7 @@ export class MonkeyKernel extends EventEmitter {
     }
 
     // LIMIT_MAKER #793 (Class B #5) — scalp lane post-only entry path.
-    // When MONKEY_SCALP_LIMIT_MAKER=true AND lane='scalp' AND not a DCA add:
+    // When SCALP_LIMIT_MAKER_LIVE=true AND lane='scalp' AND not a DCA add:
     // fetch the order book, post at best-bid (long) or best-ask (short).
     // The post-only flag means the order is rejected if it would cross
     // the spread — so the exchange enforces the maker-rebate guarantee.
@@ -5898,7 +5898,7 @@ export class MonkeyKernel extends EventEmitter {
     // Why not DCA: DCA-adds are reactive to adverse price moves, often
     // need immediate fill to defend the position; can't wait for maker.
     const useLimitMaker =
-      process.env.MONKEY_SCALP_LIMIT_MAKER === 'true'
+      process.env.SCALP_LIMIT_MAKER_LIVE === 'true'
       && (req.lane ?? 'swing') === 'scalp'
       && !req.isDCAAdd;
 


### PR DESCRIPTION
Hotfix on #798. Operator set `SCALP_LIMIT_MAKER_LIVE=true` in Railway env (canonical naming pattern matching MONKEY_SHORTS_LIVE / REGIME_COMPOSITIONAL_LIVE). My PR #798 used `MONKEY_SCALP_LIMIT_MAKER` — flag-name mismatch meant the LIMIT_MAKER path wasn't firing despite the flag being on.

This 2-line rename makes the operator's flag actually engage the code.

🤖 Generated with Claude Code