### PR TITLE
feat(monkey): REGIME-2 #800 — regime-aware held-position exit on cell degradation

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2442,6 +2442,71 @@ export class MonkeyKernel extends EventEmitter {
         }
         derivation.rejustification = rejust;
 
+        // REGIME-2 #800 — regime-aware held-position exit on cell degradation.
+        // When REGIME_HELD_EXIT_LIVE=true AND the current compositional cell
+        // is a preservation-mandate cell (harvestTightness === 'tight':
+        // DISSOLVER × any, CREATOR × CHOP) AND we hold a profitable position,
+        // take the profit immediately rather than waiting for the regime-blind
+        // TP threshold that the existing trailing harvest gate enforces.
+        //
+        // This is the operator-stated doctrine "sell in profit not eat equity"
+        // expressed as a cell-conditional rule. The compositional executive
+        // (PR #792) governs entry posture; this rule governs the symmetric
+        // exit posture on held positions when the regime has degraded toward
+        // preservation-mandate cells.
+        //
+        // Threshold: any positive ROI (currentRoi > 0). The cell-tightness
+        // signal is qualitative ("the regime says preserve") — once any
+        // profit exists, take it rather than risk it evaporating into the
+        // bleeding chop. This is structurally distinct from the trailing
+        // harvest (giveback-based) and stale-bleed (negative-ROI duration)
+        // gates that operate without regime context.
+        if (
+          !exitFired
+          && process.env.REGIME_HELD_EXIT_LIVE === 'true'
+          && cellAction !== null
+          && cellAction.harvestTightness === 'tight'
+          && currentRoi !== undefined
+          && currentRoi > 0
+        ) {
+          const roiPct = (currentRoi * 100).toFixed(3);
+          action = 'scalp_exit';
+          reason =
+            `regime_held_exit: cell ${cellAction.label}, ROI ${roiPct}% — `
+            + `preservation-mandate cell + profitable position → take profit now`;
+          exitFired = true;
+          derivation.scalp = {
+            exitTypeBit: 6,  // REGIME-2 regime-aware held exit
+            unrealizedPnl,
+            markPrice: lastPrice,
+            tradeId,
+            lane: heldLane,
+          };
+          derivation.regime2HeldExit = {
+            fired: true,
+            cellLabel: cellAction.label,
+            cellHarvestTightness: cellAction.harvestTightness,
+            currentRoi,
+            unrealizedPnl,
+          };
+        } else if (cellAction !== null) {
+          // Telemetry — record the would-fire condition each tick so the
+          // operator can grep `regime2HeldExit.fired` for both true (exit
+          // executed) and false (would not have exited) over time.
+          derivation.regime2HeldExit = {
+            fired: false,
+            cellLabel: cellAction.label,
+            cellHarvestTightness: cellAction.harvestTightness,
+            currentRoi: currentRoi ?? null,
+            reason:
+              process.env.REGIME_HELD_EXIT_LIVE !== 'true' ? 'flag_off'
+              : cellAction.harvestTightness !== 'tight' ? 'cell_not_tight'
+              : currentRoi === undefined ? 'roi_unknown'
+              : currentRoi <= 0 ? 'not_profitable'
+              : 'unknown',
+          };
+        }
+
         // 3. Profit harvest — trailing stop + trend-flip, only while green.
         if (!exitFired) {
           const harvest = shouldProfitHarvest(


### PR DESCRIPTION
## Closes #800

Compositional executive (#792) governs **entry posture**. This PR adds the symmetric **exit posture**: when current cell is preservation-mandate (`harvestTightness === 'tight'`: DISSOLVER × any OR CREATOR × CHOP) AND a held position is profitable, take the profit immediately rather than waiting for the regime-blind trailing-harvest gate.

Operator-stated doctrine: "sell in profit, not eat equity" — expressed as a cell-conditional rule.

## Trigger

```ts
if (
  !exitFired
  && process.env.REGIME_HELD_EXIT_LIVE === 'true'  // operator already set
  && cellAction !== null
  && cellAction.harvestTightness === 'tight'
  && currentRoi !== undefined
  && currentRoi > 0
) {
  // → scalp_exit with reason=regime_held_exit
}
```

## Cells that trigger

| Cell | Triggers? |
|---|---|
| CREATOR × TREND_UP/DOWN | No (normal harvest — let it run) |
| CREATOR × CHOP | **Yes** (tight) |
| PRESERVER × TREND_UP/DOWN | No (loose harvest — let winners run) |
| PRESERVER × CHOP | No (normal harvest) |
| DISSOLVER × * | **Yes** (tight — sit out posture) |

## Composes with existing exit ladder

| Order | Gate | Purpose |
|---|---|---|
| 1 | rejustification (regime_change, phi_collapse, conviction_failed, stale_bleed, directional_disagreement) | broad held-position exits |
| 2 | **REGIME-2 (this PR)** | cell-degradation → preserve profit |
| 3 | shouldProfitHarvest (trailing + trend-flip) | giveback-based |
| 4 | scalp TP | mode profile threshold |
| 5 | scalp SL | downside cap |

## Telemetry

`derivation.regime2HeldExit` always populated when cellAction exists:
- `fired=true` with cell label when triggered
- `fired=false` with reason (`flag_off | cell_not_tight | roi_unknown | not_profitable`) when not

## QIG purity

- No tunable knobs — categorical trigger (cell label + sign of ROI)
- Cell labels derive from observer-driven CAL-3 + TrajectoryObserver
- ExitTypeBit=6 is a bound-not-tune constant

## Verification

- TypeScript: clean
- Full test suite: 1462/1462 passing
- AST purity scan: clean
- Operator already has `REGIME_HELD_EXIT_LIVE=true` set in Railway env

## Test plan

- [ ] CI green
- [ ] After deploy: monitor for `regime_held_exit` log lines firing
- [ ] Verify `derivation.regime2HeldExit.fired=true` events in monkey_decisions
- [ ] Net upl improvement over 30 min as held profitable positions close on DISSOLVER × CHOP cells

🤖 Generated with Claude Code

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>