### PR TITLE
feat(monkey): emit cell=PHASE_DIRECTION token in per-tick hold log

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -4129,8 +4129,17 @@ export class MonkeyKernel extends EventEmitter {
     }
 
     // Info-level log — the user asked for end-to-end observability.
+    // REGIME-1 #792 cell token added: emit `cell=PHASE_DIRECTION` per
+    // tick so the operator can grep `cell=` for distribution histograms
+    // without DB queries. Format matches the operator-stated convention
+    // `(DISSOLVER|PRESERVER|CREATOR)_(TREND_UP|CHOP|TREND_DOWN)`.
+    const cellToken = cellAction !== null
+      ? `${cellAction.phase}_${cellAction.direction}`
+      : 'CELL_UNRESOLVED';
     logger.info(`[Monkey] ${symbol} [${mode}] ${action}${executed ? ' EXECUTED' : ''}`, {
       mode,
+      cell: cellToken,
+      cellLive: process.env.REGIME_COMPOSITIONAL_LIVE === 'true',
       phi: phi.toFixed(3),
       kappa: state.kappa.toFixed(2),
       nc: summarizeNC(nc),


### PR DESCRIPTION
Per operator directive — currently regime1_cell info is only in DB derivation, so operator can't grep stdout for cell-distribution histogram. Adds two fields to the existing per-tick log line:

```
cell: 'DISSOLVER_CHOP' | 'PRESERVER_TREND_UP' | ... | 'CELL_UNRESOLVED'
cellLive: true | false
```

Zero new log lines — additive to existing one. Operator can now `grep -oE 'cell=(DISSOLVER|PRESERVER|CREATOR)_[A-Z_]+'` production logs.

🤖 Generated with Claude Code

## Summary by Sourcery

Log the selected regime-1 cell phase/direction for each tick in the monkey kernel info log to support operator-side distribution analysis without DB access.

New Features:
- Include a per-tick cell token field in monkey kernel info logs indicating the current phase and direction or unresolved state.
- Add a cellLive flag to monkey kernel info logs to indicate whether compositional regime mode is active based on configuration.