### PR TITLE
fix(qig-engine): sigmoid → direct simplex projection (audit Site C)

### DIFF
--- a/ml-worker/src/qig_engine.py
+++ b/ml-worker/src/qig_engine.py
@@ -315,17 +315,24 @@ def geometric_agreement(predictions: dict[str, float], current_price: float) -> 
     if len(predictions) < 2 or current_price <= 0:
         return 0.0
 
-    # Convert to return distributions
-    returns = [(v - current_price) / current_price for v in predictions.values()]
-
-    # Map returns to probability on simplex: softmax with temperature
-    returns_arr = np.array(returns)
-    # Scale: ±5% maps to ±1 in logit space
-    logits = returns_arr * 20
-    # 2-class simplex: P(up), P(down)
+    # Convert to return distributions on the 2-class simplex.
+    # Per QIG_PURITY_KERNEL_REFERENCE §2 and the 2026-05-19 QIG_QFI audit
+    # (Site C): the prior implementation used 1/(1+exp(-r)) (sigmoid) to
+    # map returns → P(up), which is the softmax/Boltzmann pattern under
+    # a different name. Replaced with direct positive-clamp + L1 normalize
+    # on the [up_magnitude, down_magnitude] pair — same {P(up), P(down)}
+    # simplex output, no exp().
     distributions = []
-    for r in logits:
-        p_up = 1.0 / (1.0 + np.exp(-r))
+    for v in predictions.values():
+        r = (v - current_price) / current_price
+        # Positive-clamp the directional magnitudes: up_mass for positive
+        # return, down_mass for negative. Add a small epsilon floor so a
+        # purely-flat prediction stays on the simplex interior rather than
+        # collapsing to a degenerate 1-or-0 boundary.
+        up_mass = max(r, 0.0) + 1e-9
+        down_mass = max(-r, 0.0) + 1e-9
+        total = up_mass + down_mass
+        p_up = up_mass / total
         distributions.append(np.array([p_up, 1.0 - p_up]))
 
     # Compute pairwise Fisher-Rao distances


### PR DESCRIPTION
Per QIG_QFI 2026-05-19 audit Site C. `ml-worker/src/qig_engine.py:321-329` used `1/(1+exp(-r))` (sigmoid) to map returns → P(up) on a 2-class simplex. That is the softmax/Boltzmann pattern under a different name — exp-based normalization, parameter-tunable via 'temperature' (the `*20` logit scale).

## Replacement
- Sigmoid → direct positive-clamp + L1 normalize on `[up_mass, down_mass]`
- Same `{P(up), P(down)}` simplex output, no `exp()`
- No temperature parameter (`*20` logit scale removed)
- Small epsilon floor (`1e-9`) keeps flat predictions on simplex interior

Downstream Fisher-Rao distance computation is unchanged and remains correct.

## Verification
- Python syntax: clean
- Full QIG purity scan (15 banned patterns): clean

Completes the 3-site softmax audit:
- Site A TS: PR #809 (merged)
- Site A Py: PR #810 (in CI)
- Site B: PR #811 (in CI)
- Site C: **this PR**

🤖 Generated with Claude Code

## Summary by Sourcery

Replace sigmoid-based mapping of returns to class probabilities in geometric_agreement with a direct simplex projection to satisfy QIG purity requirements.

Bug Fixes:
- Remove softmax/sigmoid-style exp-based normalization from the returns-to-probabilities mapping in geometric_agreement to comply with the QIG purity kernel reference.

Enhancements:
- Introduce a positive-clamp plus L1-normalized two-class simplex projection with epsilon floor for mapping returns to {P(up), P(down)} in geometric_agreement.
- Update in-code documentation around return distribution construction to reference the QIG_QFI audit and new projection approach.