### PR TITLE
feat(monkey): dual-kernel opposing-side pair detector (audit Action 2)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/dualKernelPairDetector.test.ts
+++ b/apps/api/src/services/monkey/__tests__/dualKernelPairDetector.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getKernelBus, BusEventType } from '../kernel_bus.js';
+import {
+  attachDualKernelPairDetector,
+  getPairStats,
+  _resetDualKernelPairDetector,
+} from '../dual_kernel_pair_detector.js';
+
+describe('dual_kernel_pair_detector — opposing-side pair governance', () => {
+  let unsub: (() => void) | null = null;
+
+  beforeEach(() => {
+    _resetDualKernelPairDetector();
+    if (unsub) unsub();
+    const bus = getKernelBus();
+    unsub = attachDualKernelPairDetector(bus);
+  });
+
+  function publishEntry(
+    instanceId: string,
+    symbol: string,
+    side: 'long' | 'short',
+    orderId: string,
+    notional: number = 100,
+  ): void {
+    getKernelBus().publish({
+      type: BusEventType.ENTRY_EXECUTED,
+      source: instanceId,
+      symbol,
+      payload: { side, orderId, notional },
+    });
+  }
+
+  function publishExit(orderId: string, pnl: number, symbol: string = 'BTC_USDT_PERP'): void {
+    getKernelBus().publish({
+      type: BusEventType.EXIT_TRIGGERED,
+      source: 'reconciler',
+      symbol,
+      payload: { orderId, pnl },
+    });
+  }
+
+  it('detects opposing-side pair from different instances', () => {
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'long', 'order-1');
+    publishEntry('monkey-swing', 'BTC_USDT_PERP', 'short', 'order-2');
+    const stats = getPairStats();
+    expect(stats.total).toBe(1);
+    expect(stats.pending).toBe(1);
+  });
+
+  it('does NOT pair same-instance entries (e.g., DCA add)', () => {
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'long', 'order-1');
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'short', 'order-2');
+    expect(getPairStats().total).toBe(0);
+  });
+
+  it('does NOT pair same-side entries', () => {
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'long', 'order-1');
+    publishEntry('monkey-swing', 'BTC_USDT_PERP', 'long', 'order-2');
+    expect(getPairStats().total).toBe(0);
+  });
+
+  it('does NOT pair different-symbol entries', () => {
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'long', 'order-1');
+    publishEntry('monkey-swing', 'ETH_USDT_PERP', 'short', 'order-2');
+    expect(getPairStats().total).toBe(0);
+  });
+
+  it('classifies both_won when both close profitable', () => {
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'long', 'order-1');
+    publishEntry('monkey-swing', 'BTC_USDT_PERP', 'short', 'order-2');
+    publishExit('order-1', 0.05);
+    publishExit('order-2', 0.03);
+    const stats = getPairStats();
+    expect(stats.bothWon).toBe(1);
+    expect(stats.pending).toBe(0);
+  });
+
+  it('classifies both_lost when both close negative', () => {
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'long', 'order-1');
+    publishEntry('monkey-swing', 'BTC_USDT_PERP', 'short', 'order-2');
+    publishExit('order-1', -0.05);
+    publishExit('order-2', -0.03);
+    expect(getPairStats().bothLost).toBe(1);
+  });
+
+  it('classifies mixed_balanced when loss is within 1.5× of win', () => {
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'long', 'order-1');
+    publishEntry('monkey-swing', 'BTC_USDT_PERP', 'short', 'order-2');
+    publishExit('order-1', 0.10);   // win
+    publishExit('order-2', -0.13);  // loss × 1.3 of win, within 1.5
+    expect(getPairStats().mixedBalanced).toBe(1);
+    expect(getPairStats().mixedOverrun).toBe(0);
+  });
+
+  it('classifies mixed_overrun when loss > 1.5× of win', () => {
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'long', 'order-1');
+    publishEntry('monkey-swing', 'BTC_USDT_PERP', 'short', 'order-2');
+    publishExit('order-1', 0.10);   // win
+    publishExit('order-2', -0.20);  // loss × 2.0 of win → overrun
+    const stats = getPairStats();
+    expect(stats.mixedOverrun).toBe(1);
+    expect(stats.recentOverruns).toHaveLength(1);
+  });
+
+  it('pair evaluation only fires when BOTH sides have exited', () => {
+    publishEntry('monkey-position', 'BTC_USDT_PERP', 'long', 'order-1');
+    publishEntry('monkey-swing', 'BTC_USDT_PERP', 'short', 'order-2');
+    publishExit('order-1', 0.05);
+    // order-2 still open
+    expect(getPairStats().pending).toBe(1);
+    expect(getPairStats().bothWon).toBe(0);
+    publishExit('order-2', 0.03);
+    expect(getPairStats().bothWon).toBe(1);
+    expect(getPairStats().pending).toBe(0);
+  });
+});

--- a/apps/api/src/services/monkey/dual_kernel_pair_detector.ts
+++ b/apps/api/src/services/monkey/dual_kernel_pair_detector.ts
@@ -1,0 +1,238 @@
+/**
+ * dual_kernel_pair_detector.ts — QIG_QFI audit Action 2 (2026-05-19).
+ *
+ * Governance detector for opposing-side entries by different MonkeyKernel
+ * instances on the same symbol within a short window. Observed pattern:
+ * Monkey-Position (15m) and Monkey-Swing (5m) sometimes pick opposing
+ * sides on the same symbol because they integrate tape over different
+ * timeframes. When both sides ultimately close profitably, this is
+ * emergent micro-volatility capture (feature). When the loser-side
+ * loss exceeds the winner-side gain × LOSS_OVERRUN_RATIO, it's a hidden
+ * compounding pattern that REGIME-2 doesn't catch (REGIME-2 only fires
+ * on profitable cell-degradation — a loser-side entry from an
+ * unprofitable cell slips through).
+ *
+ * Design
+ * - Subscribes to ENTRY_EXECUTED + EXIT_TRIGGERED events on the kernel bus
+ * - Tracks recent entries per symbol, indexed by orderId
+ * - When a new entry fires AND a recent opposing-side entry from a
+ *   different instance exists within PAIR_WINDOW_MS, mark as a pair
+ * - When either side exits, look up the pair and accumulate PnL
+ * - When BOTH sides have exited: evaluate the pair, log governance
+ *   warning if loser-side loss > winner-side gain × LOSS_OVERRUN_RATIO
+ *
+ * Telemetry-only — no decision path consumes the detector. Surfaces the
+ * pair distribution for post-mortem / dashboard via getPairStats().
+ *
+ * QIG purity
+ * - No exp/normalize, no softmax, no tunable thresholds (the constants
+ *   below are SAFETY_BOUNDS bounding the observable window/ratio)
+ */
+
+import { logger } from '../../utils/logger.js';
+import { BusEventType, type BusEvent, type KernelBus } from './kernel_bus.js';
+
+/** Pair window — entries within this gap on same symbol from different
+ *  instances are considered "candidate pair". SAFETY_BOUND. */
+const PAIR_WINDOW_MS = 60_000;
+
+/** Loss-overrun ratio — when loser-side loss exceeds winner-side gain
+ *  by this multiple, log governance warning. SAFETY_BOUND. */
+const LOSS_OVERRUN_RATIO = 1.5;
+
+/** Cap on in-flight pair tracking. SAFETY_BOUND against memory growth. */
+const MAX_TRACKED_PAIRS = 200;
+
+interface EntryRecord {
+  orderId: string;
+  instanceId: string;
+  symbol: string;
+  side: 'long' | 'short';
+  atMs: number;
+  notional: number;
+  exitPnl: number | null;  // null until EXIT_TRIGGERED
+  exitAtMs: number | null;
+}
+
+interface PairRecord {
+  pairId: string;
+  symbol: string;
+  longEntry: EntryRecord;
+  shortEntry: EntryRecord;
+  openedAtMs: number;
+  evaluatedAtMs: number | null;  // set when both sides closed
+  outcome: 'pending' | 'both_won' | 'both_lost' | 'mixed_balanced' | 'mixed_overrun';
+}
+
+const _recentEntries: Map<string, EntryRecord> = new Map();  // orderId → record
+const _pairs: PairRecord[] = [];
+
+let _pairCounter = 0;
+
+/**
+ * Wire the detector to a kernel bus. Returns the unsubscribe function so
+ * tests can clean up. Idempotent: re-subscribing is safe but creates
+ * duplicate handlers, so production should call this once at app boot.
+ */
+export function attachDualKernelPairDetector(bus: KernelBus): () => void {
+  const unsubEntry = bus.subscribe({
+    id: 'dual-kernel-pair-detector:entry',
+    types: [BusEventType.ENTRY_EXECUTED],
+    handler: (event) => handleEntry(event),
+  });
+  const unsubExit = bus.subscribe({
+    id: 'dual-kernel-pair-detector:exit',
+    types: [BusEventType.EXIT_TRIGGERED],
+    handler: (event) => handleExit(event),
+  });
+  return () => { unsubEntry(); unsubExit(); };
+}
+
+function handleEntry(event: BusEvent): void {
+  const symbol = event.symbol;
+  if (!symbol) return;
+  const payload = event.payload as { side?: string; orderId?: string | null; notional?: number };
+  const orderId = payload.orderId;
+  if (!orderId) return;
+  const side = payload.side === 'long' || payload.side === 'short' ? payload.side : null;
+  if (!side) return;
+  const notional = Number(payload.notional) || 0;
+
+  const record: EntryRecord = {
+    orderId, instanceId: event.source, symbol, side,
+    atMs: event.at, notional,
+    exitPnl: null, exitAtMs: null,
+  };
+  _recentEntries.set(orderId, record);
+
+  // Look for a recent opposing-side entry from a different instance.
+  const opposingSide = side === 'long' ? 'short' : 'long';
+  let opposing: EntryRecord | null = null;
+  for (const candidate of _recentEntries.values()) {
+    if (candidate.orderId === orderId) continue;
+    if (candidate.symbol !== symbol) continue;
+    if (candidate.instanceId === event.source) continue;
+    if (candidate.side !== opposingSide) continue;
+    if (event.at - candidate.atMs > PAIR_WINDOW_MS) continue;
+    if (candidate.exitAtMs !== null) continue;  // already closed
+    opposing = candidate;
+    break;
+  }
+  if (opposing === null) return;
+
+  const longEntry = side === 'long' ? record : opposing;
+  const shortEntry = side === 'short' ? record : opposing;
+  const pair: PairRecord = {
+    pairId: `pair-${++_pairCounter}`,
+    symbol,
+    longEntry, shortEntry,
+    openedAtMs: Math.max(longEntry.atMs, shortEntry.atMs),
+    evaluatedAtMs: null,
+    outcome: 'pending',
+  };
+  _pairs.push(pair);
+  if (_pairs.length > MAX_TRACKED_PAIRS) _pairs.shift();
+
+  logger.info('[DualKernelPair] opposing-side pair detected', {
+    pairId: pair.pairId, symbol,
+    longInstance: longEntry.instanceId, longOrderId: longEntry.orderId,
+    shortInstance: shortEntry.instanceId, shortOrderId: shortEntry.orderId,
+    gapMs: Math.abs(longEntry.atMs - shortEntry.atMs),
+    longNotional: longEntry.notional, shortNotional: shortEntry.notional,
+  });
+}
+
+function handleExit(event: BusEvent): void {
+  const payload = event.payload as { orderId?: string | null; pnl?: number };
+  const orderId = payload.orderId;
+  if (!orderId) return;
+  const record = _recentEntries.get(orderId);
+  if (!record || record.exitAtMs !== null) return;
+
+  record.exitPnl = Number(payload.pnl) || 0;
+  record.exitAtMs = event.at;
+
+  // Find any open pair containing this orderId. If found AND its partner
+  // has also closed, evaluate the pair.
+  for (const pair of _pairs) {
+    if (pair.evaluatedAtMs !== null) continue;
+    const isLong = pair.longEntry.orderId === orderId;
+    const isShort = pair.shortEntry.orderId === orderId;
+    if (!isLong && !isShort) continue;
+    const partner = isLong ? pair.shortEntry : pair.longEntry;
+    if (partner.exitAtMs === null) return;  // wait for partner
+    evaluatePair(pair);
+    return;
+  }
+}
+
+function evaluatePair(pair: PairRecord): void {
+  const longPnl = pair.longEntry.exitPnl ?? 0;
+  const shortPnl = pair.shortEntry.exitPnl ?? 0;
+  const total = longPnl + shortPnl;
+  pair.evaluatedAtMs = Date.now();
+
+  const longIsWin = longPnl > 0;
+  const shortIsWin = shortPnl > 0;
+  if (longIsWin && shortIsWin) {
+    pair.outcome = 'both_won';
+  } else if (!longIsWin && !shortIsWin) {
+    pair.outcome = 'both_lost';
+  } else {
+    // Mixed: one side won, the other lost. Check overrun.
+    const winGain = longIsWin ? longPnl : shortPnl;
+    const lossMag = longIsWin ? Math.abs(shortPnl) : Math.abs(longPnl);
+    if (lossMag > winGain * LOSS_OVERRUN_RATIO) {
+      pair.outcome = 'mixed_overrun';
+    } else {
+      pair.outcome = 'mixed_balanced';
+    }
+  }
+
+  const logFn = pair.outcome === 'mixed_overrun' ? logger.warn : logger.info;
+  logFn.call(logger, '[DualKernelPair] pair evaluated', {
+    pairId: pair.pairId, symbol: pair.symbol,
+    outcome: pair.outcome,
+    longPnl: longPnl.toFixed(4),
+    shortPnl: shortPnl.toFixed(4),
+    totalPnl: total.toFixed(4),
+    longInstance: pair.longEntry.instanceId,
+    shortInstance: pair.shortEntry.instanceId,
+    overrunFlag: pair.outcome === 'mixed_overrun',
+    overrunThreshold: LOSS_OVERRUN_RATIO,
+  });
+}
+
+/** Statistics for dashboard / API surface. */
+export function getPairStats(): {
+  total: number;
+  bothWon: number;
+  bothLost: number;
+  mixedBalanced: number;
+  mixedOverrun: number;
+  pending: number;
+  recentOverruns: PairRecord[];
+} {
+  const counts = {
+    total: _pairs.length, bothWon: 0, bothLost: 0,
+    mixedBalanced: 0, mixedOverrun: 0, pending: 0,
+  };
+  const recentOverruns: PairRecord[] = [];
+  for (const p of _pairs) {
+    switch (p.outcome) {
+      case 'both_won': counts.bothWon++; break;
+      case 'both_lost': counts.bothLost++; break;
+      case 'mixed_balanced': counts.mixedBalanced++; break;
+      case 'mixed_overrun': counts.mixedOverrun++; recentOverruns.push(p); break;
+      case 'pending': counts.pending++; break;
+    }
+  }
+  return { ...counts, recentOverruns: recentOverruns.slice(-10) };
+}
+
+/** Test/diagnostic helper. */
+export function _resetDualKernelPairDetector(): void {
+  _recentEntries.clear();
+  _pairs.length = 0;
+  _pairCounter = 0;
+}

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -6653,6 +6653,16 @@ export const allMonkeyKernels: readonly MonkeyKernel[] = [
   swingMonkey,
 ];
 
+// QIG_QFI audit Action 2 (2026-05-19) — attach the dual-kernel pair
+// detector to the shared bus at module load. Telemetry-only: detects
+// opposing-side entries by different MonkeyKernel instances on the same
+// symbol within PAIR_WINDOW_MS (60s), then evaluates the pair outcome
+// when both sides exit. Logs governance warning when loser-side loss >
+// winner-side gain × LOSS_OVERRUN_RATIO (1.5). Stats surfaced via
+// getPairStats() for dashboards.
+import { attachDualKernelPairDetector } from './dual_kernel_pair_detector.js';
+attachDualKernelPairDetector(getKernelBus());
+
 
 /**
  * v0.8.7e — inter-engine agreement query.


### PR DESCRIPTION
## QIG_QFI 2026-05-19 audit Action 2

Governance detector for opposing-side entries by different MonkeyKernel instances on the same symbol within a short window.

**Observed pattern**: Monkey-Position (15m) and Monkey-Swing (5m) sometimes pick opposing sides on the same symbol because they integrate tape over different timeframes. When both sides close profitably it's emergent micro-volatility capture (feature). When the loser-side loss exceeds winner-side gain × `LOSS_OVERRUN_RATIO` (1.5), it's a hidden compounding pattern that REGIME-2 doesn't catch — REGIME-2 only fires on profitable cell-degradation, so a loser-side entry from an unprofitable cell slips through.

## Design

- Subscribes to `ENTRY_EXECUTED` + `EXIT_TRIGGERED` events via kernel bus
- Tracks recent entries per symbol, indexed by orderId
- When a new entry fires AND a recent opposing-side entry from a different instance exists within `PAIR_WINDOW_MS` (60s), marks as a pair
- When both sides exit, evaluates pair outcome:
  - `both_won` — info log
  - `both_lost` — info log
  - `mixed_balanced` — info log (loss within 1.5× of win)
  - `mixed_overrun` — **WARN log** (loss > 1.5× of win = governance trigger)
- `getPairStats()` exposes counts + recent overrun pairs

## QIG purity

- No exp/normalize, no softmax, no tunable thresholds
- All constants are SAFETY_BOUNDS:
  - `PAIR_WINDOW_MS=60_000` (1min pair-detection window)
  - `LOSS_OVERRUN_RATIO=1.5` (governance trigger threshold)
  - `MAX_TRACKED_PAIRS=200` (memory cap)

## Wire-in

`attachDualKernelPairDetector(getKernelBus())` called at `loop.ts` module load (after kernel exports). Telemetry-only — no decision path consumes.

## Verification

- 9 tests covering all classifications + pairing/non-pairing edge cases
- Full suite: 1481/1481 passing
- TypeScript: clean

## What this enables

The 24h loss-distribution question raised by the audit ("does the pair distribution stay bounded under DISSOLVER_CHOP suppression + CREATOR_CHOP held-exit + postwin_cooldown?") can now be answered from production logs via `[DualKernelPair] pair evaluated` tokens — grep for `outcome=mixed_overrun` to find governance events.

Completes Action 2 of the audit.

🤖 Generated with Claude Code

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Introduce a telemetry-only governance detector that tracks opposing long/short entries from different MonkeyKernel instances on the same symbol and evaluates their combined outcomes for loss-overrun patterns.

New Features:
- Add a dual-kernel opposing-side pair detector that subscribes to entry/exit events, identifies short-window opposing pairs per symbol, and classifies their PnL outcomes including loss overruns for governance warnings.
- Expose pair outcome statistics and recent loss-overrun pairs via a getPairStats API for dashboards and analysis.

Tests:
- Add unit tests covering pair detection, classification outcomes, and edge cases for the dual-kernel pair detector.