### PR TITLE
fix(cors): add PATCH to allowed methods

### DIFF
--- a/apps/api/src/config/security.ts
+++ b/apps/api/src/config/security.ts
@@ -115,7 +115,7 @@ export function createCorsOptions(): CorsOptions {
       return callback(null, false);
     },
     credentials: true,
-    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: [
       'Origin',
       'X-Requested-With',


### PR DESCRIPTION
Browser console showed:
```
CORS blocked: Method PATCH is not allowed by Access-Control-Allow-Methods
in preflight response (autonomous-agent page → PATCH /api/autonomous/config)
```

The CORS allowed-methods list was missing PATCH. The route `router.patch('/config', ...)` at `apps/api/src/routes/autonomousTrader.ts:251` existed and worked server-side, but the CORS preflight OPTIONS response told the browser PATCH wasn't allowed → request never reached the route → autonomous-agent config UI couldn't update settings.

The downstream 503 in the console is likely a dependent request triggered by the PATCH failing.

## Fix
One-line: add `'PATCH'` to the methods list in `security.ts:118`.

## Verification
- TypeScript: clean
- Config + route test suites: 292/292 passing

🤖 Generated with Claude Code

## Summary by Sourcery

Bug Fixes:
- Include PATCH in the list of allowed CORS HTTP methods to unblock browser PATCH requests to the API.