### PR TITLE
feat(monkey): emit chosenLane in per-tick log (LIMIT_MAKER routing observability)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -4147,6 +4147,14 @@ export class MonkeyKernel extends EventEmitter {
       mode,
       cell: cellToken,
       cellLive: process.env.REGIME_COMPOSITIONAL_LIVE === 'true',
+      // chosenLane surfaces the lane chooseLane picked this tick (after
+      // simplex projection + cellLaneBias + SENSE-2c prior). Critical
+      // observability for LIMIT_MAKER routing: scalp lane routes to
+      // post-only entries, trend/swing route to MARKET. If chosenLane
+      // stays at swing/trend even when cell=CREATOR_CHOP (laneBias=scalp),
+      // that surfaces a routing bug — grep `chosenLane=swing` with
+      // `cell=CREATOR_CHOP` to find mismatches.
+      chosenLane,
       phi: phi.toFixed(3),
       kappa: state.kappa.toFixed(2),
       nc: summarizeNC(nc),


### PR DESCRIPTION
Per claude.ai cross-session diagnostic: CSV shows 30 fills all taker over a 2hr window despite `SCALP_LIMIT_MAKER_LIVE=true`. Code-path tracing confirms the LIMIT_MAKER routing is plumbed correctly (`chooseLane → positionLane → executeEntry.useLimitMaker` check), but we can't verify the live behaviour without seeing what lane chooseLane actually picks per tick.

## Change

Adds `chosenLane` field to the existing per-tick log:
```
cell: 'CREATOR_CHOP' | 'CREATOR_TREND_UP' | ...
chosenLane: 'scalp' | 'swing' | 'trend' | 'observe'
```

## What this enables

If `chosenLane='swing'` while `cell='CREATOR_CHOP'` (which has `laneBias='scalp'`), that surfaces a routing bug. Grep:
```bash
railway logs | grep 'cell.*CREATOR_CHOP' | grep -oE 'chosenLane:"[a-z]+"' | sort | uniq -c
```

## Verification

- TypeScript: clean
- Full suite: 1481/1481 passing
- Zero new log lines (additive to existing)

🤖 Generated with Claude Code

## Summary by Sourcery

Enhancements:
- Extend the existing monkey per-tick logging payload with a chosenLane field reflecting the lane selected for that tick.