### PR TITLE
fix(monkey): LIMIT_MAKER orderbook parse — unwrap once not twice (the real maker bug)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -6119,10 +6119,17 @@ export class MonkeyKernel extends EventEmitter {
         let bestAsk: number | null = null;
         try {
           const ob = await poloniexFuturesService.getOrderBook(symbol, 5);
-          // v3 response shape: { data: { asks: [[price, sz], ...], bids: [[price, sz], ...] } }
-          const data = (ob as Record<string, unknown>)?.data as Record<string, unknown> | undefined;
-          const asks = Array.isArray(data?.asks) ? data!.asks as Array<Array<unknown>> : null;
-          const bids = Array.isArray(data?.bids) ? data!.bids as Array<Array<unknown>> : null;
+          // Poloniex v3 raw response: { code: 200, data: { asks, bids, s, ts }, msg }
+          // BUT poloniexFuturesService.makePublicRequest already UNWRAPS
+          // the `data` field (see line 887). So ob === {asks, bids, s, ts}
+          // directly, NOT { data: {...} }. Diagnosed 2026-05-19 from live
+          // log: `limit_maker pre-check failed bestBid=null bestAsk=null`
+          // — my prior `ob.data.asks` access was undefined → MARKET
+          // fallback → 100% taker fills despite the cell-conditional
+          // routing being correct in #817.
+          const rec = ob as Record<string, unknown>;
+          const asks = Array.isArray(rec.asks) ? rec.asks as Array<Array<unknown>> : null;
+          const bids = Array.isArray(rec.bids) ? rec.bids as Array<Array<unknown>> : null;
           if (asks && asks.length > 0 && Number.isFinite(Number(asks[0]?.[0]))) {
             bestAsk = Number(asks[0]![0]);
           }


### PR DESCRIPTION
## Root cause

\`poloniexFuturesService.makePublicRequest\` already unwraps the \`data\` field at lines 886-887 before returning:
\`\`\`js
// Poloniex V3 API returns: { code: 200, data: [...], msg: 'Success' }
if (response.data && typeof response.data === 'object' && 'data' in response.data) {
  result = response.data.data;
}
\`\`\`

My LIMIT_MAKER code in \`loop.ts\` expected double-wrap (\`ob.data.asks\`), got undefined, fell through to MARKET fallback. Every \`getOrderBook\` → \`LIMIT_MAKER\` attempt has silently degraded since #793 originally shipped.

Symptom in logs:
\`\`\`
[Monkey] limit_maker pre-check failed — falling back to market
{symbol:ETH_USDT_PERP, bestBid:null, bestAsk:null}
\`\`\`

## Fix

Read \`ob.asks\` / \`ob.bids\` directly (single unwrap, matches the service's actual return shape).

\`\`\`ts
// BEFORE (buggy — double-unwraps)
const data = (ob as Record<string, unknown>)?.data as Record<string, unknown> | undefined;
const asks = Array.isArray(data?.asks) ? data!.asks as Array<Array<unknown>> : null;

// AFTER (correct — matches makePublicRequest behavior)
const rec = ob as Record<string, unknown>;
const asks = Array.isArray(rec.asks) ? rec.asks as Array<Array<unknown>> : null;
\`\`\`

## Verification

- tsc clean
- 1481/1481 tests passing
- Combined with #817 (cell-conditional routing) and #819 (cooldown calibration), the maker-fill path should finally fire on the next CHOP-cell entry post-deploy.

## Why this matters

claude.ai's 13:32 snapshot: 0/30 maker fills, net realized -\$0.50, fee drag dominates trade-edge. Maker-fill rebate is the sign-flip lever.

🤖 Generated with Claude Code