### PR TITLE
fix(monkey): funding rate response uses abbreviated v3 field names (fR, nFT)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1476,15 +1476,31 @@ export class MonkeyKernel extends EventEmitter {
     // Non-blocking: fetch failure → rate=0 → no drag perturbation this tick.
     // The rate is forwarded to the Python kernel so compute_funding_drag can
     // modulate anxiety for held positions (P14: real-world boundary → STATE).
+    //
+    // Poloniex v3 /v3/market/fundingRate returns ABBREVIATED field names:
+    //   { s: symbol, fR: fundingRate, fT: fundingTime,
+    //                 nFR: nextFundingRate, nFT: nextFundingTime }
+    // Verified 2026-05-19 14:30 via curl against the public endpoint.
+    // The full-name fields (.fundingRate, .nextFundingTime) used here
+    // pre-fix were silently returning undefined → coerced to 0 →
+    // funding-arb observer #794 + funding-gate #823 were both dead-code
+    // in production. Read .fR first (abbreviated, canonical); fall back
+    // to .fundingRate for back-compat with the WS shape in
+    // websocketData.ts:80 where the WS feed does include the full name.
     const fundingRateResp = await poloniexFuturesService.getFundingRate(symbol).catch(() => null) as {
+      fR?: string | number;
+      nFT?: string | number;
       fundingRate?: string | number;
       nextFundingTime?: string | number;
     } | null;
-    const fundingRate8h = Number(fundingRateResp?.fundingRate) || 0;
-    // Poloniex v3 returns nextFundingTime as ms epoch on the futures
-    // /v3/market/fundingRate response. Coerce defensively — absent/0
-    // means "unknown" and the entry-side funding gate falls open.
-    const nextFundingTimeMs = Number(fundingRateResp?.nextFundingTime) || undefined;
+    const fundingRate8h =
+      Number(fundingRateResp?.fR)
+      || Number(fundingRateResp?.fundingRate)
+      || 0;
+    const nextFundingTimeMs =
+      Number(fundingRateResp?.nFT)
+      || Number(fundingRateResp?.nextFundingTime)
+      || undefined;
 
     // Funding-arb #794 (Class B #7) — push this symbol's latest rate
     // into the cross-symbol cache. When both BTC and ETH have fresh


### PR DESCRIPTION
## Discovery

User asked \"next funding event?\". Direct curl against the public endpoint to confirm:

\`\`\`
curl https://api.poloniex.com/v3/market/fundingRate?symbol=BTC_USDT_PERP
{
  \"s\": \"BTC_USDT_PERP\",
  \"fR\": \"0.0001\",
  \"fT\": \"1779148800000\",
  \"nFR\": \"0.0001\",
  \"nFT\": \"1779177600000\"
}
\`\`\`

Poloniex v3 REST returns ABBREVIATED field names (\`fR\`, \`fT\`, \`nFR\`, \`nFT\`). loop.ts was reading \`.fundingRate\` and \`.nextFundingTime\` — silently undefined → 0.

## Pre-fix impact (since 2026-05-19)

| Consumer | What it saw | Effect |
| --- | --- | --- |
| Funding-arb observer #794 | rate=0 always | \`signalFires\` gated on \`stdGap > 1e-9\`, perma-false. Telemetry dead. |
| Funding gate #823 | nextFundingTimeMs undefined | Fail-open path always taken. Gate dead-code even when LIVE=true. |
| Py kernel \`compute_funding_drag\` | rate=0 | Anxiety carry modulation for held positions inert. |

## Fix

Read \`.fR\` first (canonical v3 REST shape), \`.fundingRate\` as fallback for the WS feed (per \`websocketData.ts:80\` the WS does include the full name).

\`\`\`ts
const fundingRate8h =
  Number(fundingRateResp?.fR)
  || Number(fundingRateResp?.fundingRate)
  || 0;
const nextFundingTimeMs =
  Number(fundingRateResp?.nFT)
  || Number(fundingRateResp?.nextFundingTime)
  || undefined;
\`\`\`

## Out of scope

\`confidenceScoringService.js:436\` + \`futuresWebSocket.ts:473-474\` read \`.fundingRate\` from TICKER responses. The ticker endpoint doesn't include fundingRate at all — those have returned 0/null forever. Dashboard/WS path, not trading path. Separate cleanup.

## Side note: next event

\`nFT = 1779177600000\` decodes to **2026-05-19 12:00 UTC** — 8h cycle (04:00 → 12:00 → 20:00 UTC).

## Verification

- TypeScript: clean
- Tests pass
- Live curl confirms response shape

🤖 Generated with Claude Code