### PR TITLE
fix(orders): idempotent cancel on 11008 race (TS + Py mirror)

### DIFF
--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -730,7 +730,34 @@ class PoloniexFuturesService {
     if (resolvedOrderId) body.ordId = resolvedOrderId;
     if (clientOid) body.clOrdId = clientOid;
 
-    const result = await this.makeRequest(credentials, 'DELETE', '/trade/order', body);
+    let result;
+    try {
+      result = await this.makeRequest(credentials, 'DELETE', '/trade/order', body);
+    } catch (err) {
+      // 11008 = "The order does not exist". Stale-cancel race: order
+      // filled (or cancelled by another path) between our stale-decision
+      // and the DELETE arriving. The desired terminal state — no live
+      // order with that id — is already true, so treat as success and
+      // force a fills/positions resync so the ledger picks up the fill
+      // before the next decision tick.
+      //
+      // Observed live 2026-05-19 06:39:26 + 06:47:04 post-PR #824:
+      //   [Poloniex] /v3/trade/order returned code=11008 …
+      //   [Monkey]   LIMIT_MAKER cancel failed (may have already filled)
+      // Local state stayed 'cancelling' until the next poll resynced,
+      // which created a window where the engine could double-act on the
+      // (already-filled) leg.
+      if (err && (err.poloniexCode === 11008 || String(err.poloniexCode) === '11008')) {
+        logger.info('[cancelOrder] 11008 race — order already terminal; treating as success', {
+          symbol, ordId: resolvedOrderId, clOrdId: clientOid,
+        });
+        apiCache.invalidatePrefix('GET:/trade/order');
+        apiCache.invalidatePrefix('GET:/trade/position');
+        apiCache.invalidatePrefix('GET:/account/balance');
+        return { ok: true, raceResolved: true, code: 11008 };
+      }
+      throw err;
+    }
     apiCache.invalidatePrefix('GET:/account/balance');
     apiCache.invalidatePrefix('GET:/trade/position');
     apiCache.invalidatePrefix('GET:/trade/order');

--- a/apps/api/src/tests/poloniexFuturesService.test.js
+++ b/apps/api/src/tests/poloniexFuturesService.test.js
@@ -298,6 +298,32 @@ describe('PoloniexFuturesService', () => {
       expect(axios).toHaveBeenCalled();
     });
 
+    it('should swallow code=11008 (order already terminal — stale-cancel race)', async () => {
+      // Simulate the race: order filled between our stale-decision and
+      // the DELETE arriving. Poloniex returns {code: 11008, msg: "The
+      // order does not exist"}; makeRequest throws an Error with
+      // err.poloniexCode = 11008. cancelOrder must catch and return a
+      // raceResolved sentinel so callers can advance their state-machine.
+      axios.mockResolvedValueOnce({
+        data: { code: 11008, msg: 'The order does not exist' },
+      });
+      const result = await poloniexFuturesService.cancelOrder(
+        mockCredentials, 'BTC_USDT_PERP', '579679007277432832',
+      );
+      expect(result).toEqual({ ok: true, raceResolved: true, code: 11008 });
+    });
+
+    it('should rethrow non-11008 errors from cancelOrder', async () => {
+      axios.mockResolvedValueOnce({
+        data: { code: 10001, msg: 'Invalid signature' },
+      });
+      await expect(
+        poloniexFuturesService.cancelOrder(
+          mockCredentials, 'BTC_USDT_PERP', '999',
+        ),
+      ).rejects.toThrow(/code=10001/);
+    });
+
     it('should get current orders', async () => {
       const symbol = 'BTC_USDT_PERP';
       const result = await poloniexFuturesService.getCurrentOrders(mockCredentials, symbol);

--- a/ml-worker/src/exchange/poloniex_v3.py
+++ b/ml-worker/src/exchange/poloniex_v3.py
@@ -382,11 +382,34 @@ class PoloniexV3Client:
         return await self._request("POST", "/trade/orders", body={"orders": orders})
 
     async def cancel_order(self, order_id: str, symbol: str) -> Any:
-        """DELETE /v3/trade/order."""
-        return await self._request(
-            "DELETE", "/trade/order",
-            body={"symbol": symbol, "orderId": order_id},
-        )
+        """DELETE /v3/trade/order.
+
+        Body field is ``ordId`` (camelCase v3), not ``orderId``. The TS
+        client got this wrong historically and produced 401s (signature
+        validation against the wire body); matching the corrected form
+        from PR #824 here so flipping TRADING_ENGINE_PY=true doesn't
+        reintroduce the bug.
+
+        Idempotent on code=11008 ("The order does not exist"). Race
+        where the order filled or cancelled between our decision and
+        the DELETE arriving — the desired terminal state already holds,
+        so return a synthetic success and let the caller advance its
+        state-machine to reconcile from the next fills poll.
+        """
+        try:
+            return await self._request(
+                "DELETE", "/trade/order",
+                body={"symbol": symbol, "ordId": order_id},
+            )
+        except PoloniexV3Error as err:
+            if err.poloniex_code == 11008 or str(err.poloniex_code) == "11008":
+                logger.info(
+                    "cancel_order 11008 race — order already terminal; "
+                    "treating as success (symbol=%s ordId=%s)",
+                    symbol, order_id,
+                )
+                return {"ok": True, "raceResolved": True, "code": 11008}
+            raise
 
     async def cancel_all_orders(self, symbol: Optional[str] = None) -> Any:
         """DELETE /v3/trade/allOrders."""

--- a/ml-worker/tests/exchange/test_poloniex_v3_cancel_race.py
+++ b/ml-worker/tests/exchange/test_poloniex_v3_cancel_race.py
@@ -1,0 +1,90 @@
+"""
+test_poloniex_v3_cancel_race.py — idempotent cancel_order on code=11008.
+
+When the order has already filled (or been cancelled by another path)
+between the bot's stale-decision and the DELETE arriving, the exchange
+returns {code: 11008, msg: "The order does not exist"}. The desired
+terminal state — no live order with that id — is already true, so
+cancel_order must catch and return a raceResolved sentinel so callers
+can advance their state-machine to reconcile from the next poll.
+
+Mirrors the TS swallow path in apps/api/src/services/poloniexFuturesService.js.
+
+Uses asyncio.run directly — no pytest-asyncio dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from exchange.poloniex_v3 import PoloniexV3Client, PoloniexV3Error
+
+
+def _client() -> PoloniexV3Client:
+    # Credentials can be None — _request is mocked, signing is not exercised.
+    return PoloniexV3Client()
+
+
+def test_cancel_order_swallows_11008_race() -> None:
+    async def _run() -> Any:
+        client = _client()
+        err = PoloniexV3Error(
+            endpoint="/trade/order",
+            code=11008,
+            msg="The order does not exist",
+        )
+        client._request = AsyncMock(side_effect=err)  # type: ignore[method-assign]
+        return await client.cancel_order(
+            order_id="579679007277432832", symbol="BTC_USDT_PERP",
+        )
+
+    result = asyncio.run(_run())
+    assert result == {"ok": True, "raceResolved": True, "code": 11008}
+
+
+def test_cancel_order_rethrows_non_11008() -> None:
+    async def _run() -> None:
+        client = _client()
+        err = PoloniexV3Error(
+            endpoint="/trade/order",
+            code=10001,
+            msg="Invalid signature",
+        )
+        client._request = AsyncMock(side_effect=err)  # type: ignore[method-assign]
+        await client.cancel_order(order_id="999", symbol="BTC_USDT_PERP")
+
+    try:
+        asyncio.run(_run())
+    except PoloniexV3Error as exc:
+        assert exc.poloniex_code == 10001
+    else:
+        raise AssertionError("expected PoloniexV3Error to propagate, got none")
+
+
+def test_cancel_order_uses_v3_ordId_field_name() -> None:
+    """Regression: the TS client got `orderId` vs `ordId` wrong historically.
+
+    Python was sending {orderId: ...} which would fail with 401 once the
+    flag flipped. PR #826 corrects to {ordId: ...} matching v3 spec +
+    the TS cancelOrder body.
+    """
+    captured: dict[str, Any] = {}
+
+    async def _run() -> None:
+        client = _client()
+        mock_request = AsyncMock(return_value={"ok": True})
+        client._request = mock_request  # type: ignore[method-assign]
+        await client.cancel_order(order_id="abc123", symbol="ETH_USDT_PERP")
+        captured["call"] = mock_request.await_args
+
+    asyncio.run(_run())
+    call = captured["call"]
+    body = call.kwargs["body"]
+    assert body == {"symbol": "ETH_USDT_PERP", "ordId": "abc123"}
+    assert "orderId" not in body


### PR DESCRIPTION
## Observed

Post-#824 (401 fix) the cancel path WAS reaching the exchange — and immediately surfaced the actual race condition:

\`\`\`
2026-05-19T06:39:26  /v3/trade/order returned code=11008 \"The order does not exist\"
2026-05-19T06:47:04  same — back-to-back BTC + ETH stale-cancel races
\`\`\`

## Root cause

\`makeRequest\` throws on any non-200 body code. \`cancelOrder\` had no catch for 11008, so the stale-cancel race (order filled or cancelled between our decision and the DELETE arriving) bubbled up as an unhandled error. Local state stayed \`cancelling\` until the next poll resynced — window in which the engine could double-act on the already-filled leg.

## Fix

### TS (live path)

\`apps/api/src/services/poloniexFuturesService.js\` — catch \`err.poloniexCode === 11008\`, log info, return \`{ok: true, raceResolved: true, code: 11008}\`, invalidate \`/trade/order\` + \`/trade/position\` + \`/account/balance\` caches so the next decision-tick picks up the maker fill before acting.

### Py mirror (dormant until \`TRADING_ENGINE_PY=true\`)

\`ml-worker/src/exchange/poloniex_v3.py\` — same swallow + **corrected body field name** \`ordId\` (was \`orderId\`). Without this correction, flipping \`TRADING_ENGINE_PY=true\` later would have reproduced the 401 storm #824 fixed.

## Tests

- **TS**: 1483/1483 passing (+2 new — swallow + non-11008 rethrow)
- **Py**: 9/9 passing — 3 new tests including a regression assertion that body uses \`ordId\` not \`orderId\`

## Risks (deliberately out of scope)

- **11008 hides \"ordId we never sent\" failures.** Mitigated by the info log + forced cache invalidation; next poll resyncs from exchange truth. If the same ordId 11008s twice without intervening fill confirmation, that's a separate alarm worth adding later.
- **ETH symbol asymmetry** (-\$0.10x tail losses recurring across 3 snapshots) — separate issue, evidence-gathering required, not bundled.

🤖 Generated with Claude Code