### PR TITLE
fix(monkey): fee-aware REGIME-2 + maker latency knobs + sibling-close race window

### DIFF
--- a/apps/api/src/services/monkey/__tests__/closeCoordinator.test.ts
+++ b/apps/api/src/services/monkey/__tests__/closeCoordinator.test.ts
@@ -53,13 +53,14 @@ describe('close_coordinator', () => {
     expect(sibling).toEqual({ ok: true });
   });
 
-  it('lifts the cooldown once it expires (2s window)', () => {
+  it('lifts the cooldown once it expires (60s default window)', () => {
     const t0 = 1_700_000_000_000;
     tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
     releaseClose('ETH_USDT_PERP', 'long', 'monkey-position', true, t0 + 100);
 
-    // Just after the 2000ms cooldown
-    const sibling = tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 2200);
+    // Just after the 60_000ms cooldown (was 2_000ms — bumped to 60s in
+    // 2026-05-19 after 4-min cross-kernel close race went unhandled).
+    const sibling = tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 60_500);
     expect(sibling).toEqual({ ok: true });
   });
 
@@ -109,13 +110,26 @@ describe('close_coordinator', () => {
     expect(race).toEqual({ raced: false });
   });
 
-  it('isLikelyRaceLoss does NOT flag once cooldown expires', () => {
+  it('isLikelyRaceLoss does NOT flag once cooldown expires (60s default)', () => {
     const t0 = 1_700_000_000_000;
     tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
     releaseClose('ETH_USDT_PERP', 'long', 'monkey-position', true, t0 + 100);
 
-    const race = isLikelyRaceLoss('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 2_500);
+    // 60_001ms after release — just past the 60s cooldown.
+    const race = isLikelyRaceLoss('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 60_500);
     expect(race).toEqual({ raced: false });
+  });
+
+  it('isLikelyRaceLoss flags closes up to 60s after sibling close (was 2s)', () => {
+    const t0 = 1_700_000_000_000;
+    tryAcquireClose('ETH_USDT_PERP', 'long', 'monkey-position', t0);
+    releaseClose('ETH_USDT_PERP', 'long', 'monkey-position', true, t0 + 100);
+
+    // 45s after release — this was the failure mode in the 07:07/07:11
+    // BTC retry storm. Pre-fix this returned raced=false → bot logged
+    // close_exchange_rejected and kept retrying for 4 min.
+    const race = isLikelyRaceLoss('ETH_USDT_PERP', 'long', 'monkey-swing', t0 + 45_000);
+    expect(race).toEqual({ raced: true, siblingId: 'monkey-position', ageMs: 44_900 });
   });
 
   it('release without holding the lock is a no-op (does not crash)', () => {

--- a/apps/api/src/services/monkey/close_coordinator.ts
+++ b/apps/api/src/services/monkey/close_coordinator.ts
@@ -50,10 +50,23 @@ interface RecentClose {
 const inFlight = new Map<string, InFlight>();
 const recentlyClosed = new Map<string, RecentClose>();
 
-/** Cooldown window after a successful close. Sized to comfortably exceed
- *  the observed prod race window (~280ms) while staying short enough that
- *  a legitimate re-entry isn't blocked perceptibly. */
-const RECENT_CLOSE_COOLDOWN_MS = 2000;
+/** Cooldown window for treating a 21002 ("Position not enough") as a
+ *  race-loss against a sibling close (rather than a real error).
+ *
+ *  Originally 2s — sized for the simultaneous-tick race. But 2026-05-19
+ *  07:07/07:11 prod log showed a 4-min gap: monkey-position closed BTC
+ *  successfully at 07:07:11, then monkey-swing's separate tick decided
+ *  to close at 07:11:14 (its tracked DB row was still status='open',
+ *  but the merged exchange position was already gone). The 21002 fell
+ *  outside this 2s window so it was logged as a real error and the DB
+ *  row stayed open for the reconciler to mop up — 4 minutes of bogus
+ *  retry storms in between.
+ *
+ *  60s is long enough to cover normal cross-kernel decision lag (tick
+ *  cadence + processing). Operator override:
+ *  MONKEY_RECENT_CLOSE_COOLDOWN_MS. */
+const RECENT_CLOSE_COOLDOWN_MS =
+  Number(process.env.MONKEY_RECENT_CLOSE_COOLDOWN_MS) || 60_000;
 
 /** Defensive max — an in-flight close should never take longer than this.
  *  If the lock holder crashes mid-close, the next caller after this window

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -765,7 +765,39 @@ export class MonkeyKernel extends EventEmitter {
     side: 'long' | 'short';
     lane: 'scalp' | 'swing' | 'trend';
   }> = new Map();
-  private static readonly LIMIT_MAKER_STALE_MS = 120_000;  // SAFETY_BOUND: 2 min
+  // SAFETY_BOUND tunable via env. Default 45s — long enough for normal
+  // fills on liquid pairs (BTC/ETH typical fill < 15s), short enough
+  // that post-only orders don't sit through a regime change. 120s
+  // (prior default) was visibly sluggish under broad cell routing
+  // because every CHOP cell now posts maker; multiplying issuers ×
+  // 2-min hold made entry latency blow up (0/12 fill rate observed
+  // 2026-05-19 07:00-07:18). Operator override: MONKEY_LIMIT_MAKER_STALE_MS.
+  private static readonly LIMIT_MAKER_STALE_MS =
+    Number(process.env.MONKEY_LIMIT_MAKER_STALE_MS) || 45_000;
+  /**
+   * LIMIT_MAKER fallback counter — tracks consecutive stale-cancels
+   * (orders that posted but never filled) per (symbol, side). When this
+   * crosses the MAX_CONSECUTIVE_STALES threshold, the next entry attempt
+   * for that key uses MARKET (taker) instead of LIMIT_MAKER, so the bot
+   * isn't paralyzed by a market state where its bid sits at the back of
+   * the queue and never gets hit.
+   *
+   * Reset on any successful MARKET placement (we know it filled because
+   * the placeOrder call returned an orderId without throwing). Maker
+   * fills don't reset the counter explicitly — they implicitly clear
+   * via the next MARKET success after the fall-back threshold is hit.
+   *
+   * Diagnosed 2026-05-19 07:14: 0/12 maker fills in a 15-min window —
+   * every order timed out at the 120s stale boundary. User-visible
+   * symptom: "much slower to respond since we changed to maker."
+   *
+   * Key format: `${symbol}|${side}`.
+   */
+  private makerStaleCountByKey: Map<string, number> = new Map();
+  /** SAFETY_BOUND: 2 consecutive stale-cancels before falling back to
+   *  MARKET for the next entry. Operator can override via
+   *  MAKER_MAX_CONSECUTIVE_STALES env. */
+  private static readonly MAX_CONSECUTIVE_STALES_DEFAULT = 2;
   /**
    * Funding-arb #794 — latest funding rate per symbol with timestamp.
    * Populated by processSymbol after each funding-rate fetch; consumed
@@ -1398,15 +1430,39 @@ export class MonkeyKernel extends EventEmitter {
         // call shape was (creds, orderId) which sent body {orderId: …}
         // (wrong field name) and no symbol → 401. See cancelOrder
         // signature in poloniexFuturesService.js for the write-up.
-        await poloniexFuturesService.cancelOrder(creds, s.symbol, s.orderId);
-        logger.info('[Monkey] LIMIT_MAKER cancelled (stale)', {
-          symbol: s.symbol, side: s.side, orderId: s.orderId,
-          stale_ms: now - this.pendingLimitMakerOrders.get(s.orderId)!.placedAtMs,
-        });
+        const cancelResult = await poloniexFuturesService.cancelOrder(creds, s.symbol, s.orderId);
+        // raceResolved sentinel from #826: order filled before our cancel
+        // arrived. That's a SUCCESSFUL maker fill, not a stale — don't
+        // increment the fallback counter (the entry path worked).
+        const raceResolved = cancelResult && cancelResult.raceResolved === true;
+        if (raceResolved) {
+          logger.info('[Monkey] LIMIT_MAKER fill detected (cancel race) — resetting stale counter', {
+            symbol: s.symbol, side: s.side, orderId: s.orderId,
+          });
+          this.makerStaleCountByKey.set(`${s.symbol}|${s.side}`, 0);
+        } else {
+          // True stale: order sat in queue and never filled. Bump the
+          // counter so the next entry attempt on this (symbol, side)
+          // knows to fall back to MARKET if maker keeps missing.
+          const key = `${s.symbol}|${s.side}`;
+          const prev = this.makerStaleCountByKey.get(key) ?? 0;
+          this.makerStaleCountByKey.set(key, prev + 1);
+          logger.info('[Monkey] LIMIT_MAKER cancelled (stale)', {
+            symbol: s.symbol, side: s.side, orderId: s.orderId,
+            stale_ms: now - this.pendingLimitMakerOrders.get(s.orderId)!.placedAtMs,
+            consecutiveStales: prev + 1,
+          });
+        }
       } catch (err) {
+        // Non-11008 cancel error — still increment stale counter, the
+        // order's terminal state is uncertain but it didn't fill cleanly.
+        const key = `${s.symbol}|${s.side}`;
+        const prev = this.makerStaleCountByKey.get(key) ?? 0;
+        this.makerStaleCountByKey.set(key, prev + 1);
         logger.warn('[Monkey] LIMIT_MAKER cancel failed (may have already filled)', {
           symbol: s.symbol, orderId: s.orderId,
           err: err instanceof Error ? err.message : String(err),
+          consecutiveStales: prev + 1,
         });
       } finally {
         this.pendingLimitMakerOrders.delete(s.orderId);
@@ -2563,6 +2619,27 @@ export class MonkeyKernel extends EventEmitter {
         // bleeding chop. This is structurally distinct from the trailing
         // harvest (giveback-based) and stale-bleed (negative-ROI duration)
         // gates that operate without regime context.
+        // Fee-aware floor — REGIME-2 must clear round-trip taker on the
+        // realized close (close uses MARKET, so taker on at least the
+        // exit; assume taker on both legs as conservative baseline when
+        // entry routing isn't known here). Poloniex futures taker = 0.075%
+        // notional one-side. Threshold = notional × (2 × taker + 3bps slip).
+        //
+        // Diagnosed 2026-05-19 from user-reported "~$1 loss" on a BTC
+        // close kernel-reported as +$0.168: at $2300 notional (post-deposit
+        // scale-up), the dollar fee was ~$3.45 round-trip + ~$0.69 slip =
+        // $4.14 needed to clear. Kernel mark PnL of $0.168 < $4.14 → fired
+        // anyway and netted as a loss. Dollar-based (not percentage-based)
+        // is the right unit because fees are dollar-amount per notional,
+        // not ROI on margin.
+        const TAKER_FEE_FRAC = 0.00075;
+        const FEE_SAFETY_BPS = 0.0003;  // 3 bps slip + price-impact buffer
+        const minProfitablePnl =
+          positionNotional > 0
+            ? positionNotional * (2 * TAKER_FEE_FRAC + FEE_SAFETY_BPS)
+            : Number.POSITIVE_INFINITY;
+        const profitClearsFees =
+          unrealizedPnl !== undefined && unrealizedPnl > minProfitablePnl;
         if (
           !exitFired
           && process.env.REGIME_HELD_EXIT_LIVE === 'true'
@@ -2570,12 +2647,14 @@ export class MonkeyKernel extends EventEmitter {
           && cellAction.harvestTightness === 'tight'
           && currentRoi !== undefined
           && currentRoi > 0
+          && profitClearsFees
         ) {
           const roiPct = (currentRoi * 100).toFixed(3);
           action = 'scalp_exit';
           reason =
             `regime_held_exit: cell ${cellAction.label}, ROI ${roiPct}% — `
-            + `preservation-mandate cell + profitable position → take profit now`;
+            + `preservation-mandate cell + profitable position → take profit now `
+            + `(pnl=$${unrealizedPnl?.toFixed(4)} > fees=$${minProfitablePnl.toFixed(4)})`;
           exitFired = true;
           derivation.scalp = {
             exitTypeBit: 6,  // REGIME-2 regime-aware held exit
@@ -5675,6 +5754,24 @@ export class MonkeyKernel extends EventEmitter {
       logger.error('[Monkey] close DB update failed — ORPHAN RISK (reconciler will catch)', {
         tradeId, err: err instanceof Error ? err.message : String(err),
       });
+      // Defensive single-row close so subsequent ticks don't re-decide
+      // on this position. The bulk per-row UPDATE above failed; this
+      // pins at least the primary tradeId row to closed, breaking the
+      // 21002-retry loop. Reconciler still picks up any siblings.
+      try {
+        await pool.query(
+          `UPDATE autonomous_trades
+              SET status='closed', exit_price=$1, exit_time=NOW(),
+                  exit_reason=$2, exit_order_id=$3, pnl=$4
+            WHERE id=$5 AND status='open'`,
+          [markPrice, `${exitReason}__db_recovery`, orderId, pnlAtDecision, tradeId],
+        );
+      } catch (recoveryErr) {
+        logger.error('[Monkey] close DB recovery also failed — full reconciler dependency', {
+          tradeId,
+          recoveryErr: recoveryErr instanceof Error ? recoveryErr.message : String(recoveryErr),
+        });
+      }
     }
 
     logger.info('[Monkey] POSITION CLOSED', {
@@ -6200,12 +6297,38 @@ export class MonkeyKernel extends EventEmitter {
     // Why no TREND cells: directional moves require instant fill or the
     // move gets away. Trend lane SHOULD pay taker fees — the TP/SL is
     // wider (0.4%) so fee impact is proportionally smaller.
+    // Operator-toggleable scope: SCALP_LIMIT_MAKER_BROAD=false reverts
+    // to the original scalp-lane-only routing if broad-CHOP routing's
+    // latency outweighs the rebate on the current symbol mix. The PR
+    // #817 counterfactual was a single window; this lever lets you A/B
+    // without a redeploy.
+    const broadMakerRouting = process.env.SCALP_LIMIT_MAKER_BROAD !== 'false';
     const cellIsChop = req.cellDirection === 'CHOP';
     const laneIsScalp = (req.lane ?? 'swing') === 'scalp';
+    // Fallback after consecutive stale-cancels: when maker has failed
+    // to fill N times in a row on this (symbol, side), the next entry
+    // uses MARKET. Without this gate, a market state where our post-only
+    // bid sits at the back of the queue produces 0% fill rate and the
+    // bot can't enter at all (observed 2026-05-19 07:00-07:18 window:
+    // 0/12 maker fills — every order timed out at 120s STALE_MS).
+    // Counter resets to 0 on successful MARKET fill (placeOrder returns
+    // an orderId), so the next attempt after fallback retries maker.
+    const makerKey = `${symbol}|${side}`;
+    const maxStales =
+      Number(process.env.MAKER_MAX_CONSECUTIVE_STALES)
+      || MonkeyKernel.MAX_CONSECUTIVE_STALES_DEFAULT;
+    const consecutiveStales = this.makerStaleCountByKey.get(makerKey) ?? 0;
+    const makerCircuitOpen = consecutiveStales >= maxStales;
+    if (makerCircuitOpen) {
+      logger.info('[Monkey] LIMIT_MAKER circuit open — using MARKET for this entry', {
+        symbol, side, consecutiveStales, maxStales,
+      });
+    }
     const useLimitMaker =
       process.env.SCALP_LIMIT_MAKER_LIVE === 'true'
-      && (cellIsChop || laneIsScalp)
-      && !req.isDCAAdd;
+      && (laneIsScalp || (broadMakerRouting && cellIsChop))
+      && !req.isDCAAdd
+      && !makerCircuitOpen;
 
     let orderId: string | null = null;
     let limitMakerPriceUsed: number | null = null;
@@ -6283,6 +6406,13 @@ export class MonkeyKernel extends EventEmitter {
         orderId =
           exchangeOrder?.ordId ?? exchangeOrder?.orderId ??
           exchangeOrder?.id ?? exchangeOrder?.clientOid ?? null;
+        if (orderId) {
+          // MARKET fills immediately (or rejects). Reset the maker
+          // stale-counter so the next entry on this (symbol, side)
+          // can retry maker — we don't want to stay on taker forever
+          // just because maker missed twice in a row.
+          this.makerStaleCountByKey.set(makerKey, 0);
+        }
       }
       if (!orderId) {
         logger.warn('[Monkey] exchange placed but no orderId returned', {


### PR DESCRIPTION
## Three convergent issues from 2026-05-19 07:00-07:18 production window

### A. REGIME-2 fired below break-even fee threshold

User-observed **\"~\$1 loss\"** on a BTC close kernel-reported as +\$0.168.

REGIME-2 #800 fires take-profit on ANY `currentRoi > 0`. After the \$900 deposit scaled notional to ~\$2,300, round-trip taker fees (2 × 0.075% = 0.15%) + slippage routinely eat any kernel-mark ROI below ~0.25%. Kernel said +0.393% gross → Polo realized as net loss.

**Fix:** dollar-based fee floor —
\`unrealizedPnl > positionNotional × (2 × taker_fee + 3 bps slip)\`.

At \$2,300 notional, minimum profit = **\$4.14 before take-profit fires**. Doctrine preserved (\"preservation-mandate cell + profitable position → take profit now\"), just gates on net-profitable instead of gross-profitable.

### B. Maker latency (0/12 fill rate) + staleness window too long

User: *\"it's much slower to respond since we changed to maker.\"*

Every LIMIT_MAKER order posted at best-bid sat in the queue, timed out at \`LIMIT_MAKER_STALE_MS = 120s\`, got cancelled, was re-placed at the new best-bid (price had moved). **0 entries in 18 min** on broad CHOP-cell routing.

**Three env-tunable knobs:**

| Var | Default | Effect |
|---|---|---|
| `MONKEY_LIMIT_MAKER_STALE_MS` | **45_000** (was 120_000) | Fail-fast on missed fills |
| `SCALP_LIMIT_MAKER_BROAD` | `true` | Set `false` to revert to scalp-lane-only routing |
| `MAKER_MAX_CONSECUTIVE_STALES` | `2` | Per-(symbol,side) circuit breaker → MARKET fallback |

Circuit breaker resets on MARKET fill OR on 11008 race sentinel from #826 (which is actually a successful maker fill, mis-identified as a stale).

### C. Sibling-close race window too short (21002 retry storm)

Production timeline:
- `07:07:11` monkey-position closes BTC (+\$0.168) — recorded in `recentlyClosed` map
- `07:11:14` monkey-swing's separate tick decides to close — its DB row was status='open' but exchange position was gone. 21002 \"Position not enough\" fell **outside** the **2s** `RECENT_CLOSE_COOLDOWN_MS` window → logged as real error → bot retried 3× over 4 min until reconciler swept phantom rows

**Fix:** `RECENT_CLOSE_COOLDOWN_MS` 2s → **60s default** (`MONKEY_RECENT_CLOSE_COOLDOWN_MS`). Covers normal cross-kernel decision lag.

### D. Defensive DB recovery on close failure (belt-and-braces)

If the bulk per-row UPDATE in the close path fails (catch-all surfaces as \"ORPHAN RISK\"), add a single-row UPDATE for the primary tradeId so subsequent ticks don't re-decide on that position. Reconciler still picks up siblings.

## Verification

- TypeScript: clean
- Suite: **1484/1484 passing** (+1 new test for 60s sibling-close window)
- All behavior gated by existing or new env flags (conservative defaults)

## Operator levers (no redeploy required)

```
MONKEY_LIMIT_MAKER_STALE_MS=45000          # default — bump to 60-90 for less liquid symbols
MONKEY_LIMIT_MAKER_PREEMPT_MIN_MS=8000     # reserved (C.2 not shipped this PR)
SCALP_LIMIT_MAKER_BROAD=false              # revert to scalp-only if latency bites
MAKER_MAX_CONSECUTIVE_STALES=2             # taker fallback aggressiveness
MONKEY_RECENT_CLOSE_COOLDOWN_MS=60000      # sibling-close race window
REGIME_HELD_EXIT_MIN_ROI_PCT=...           # NOT WIRED — fee formula uses notional, more rigorous
```

## Risks / follow-ups (deliberately out of scope)

- Taker fee constant hardcoded at 0.075%. Future work: read tier from `getAccountInfo`.
- C.2 (pre-empt cancel on cell direction change) requires new `lastCellDirectionBySymbol` state — separate PR.
- Maker-rebate-vs-latency tradeoff is continuous; worth A/B with `SCALP_LIMIT_MAKER_BROAD=false` for a week to measure.

🤖 Generated with Claude Code