### PR TITLE
fix(monkey): wire pendingLimitMakerOrders entry-gate + defensive lane=NULL on close

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -5338,11 +5338,19 @@ export class MonkeyKernel extends EventEmitter {
         return { executed: false, orderId: null, reason: 'paper_mode_invalid_mark_price' };
       }
       try {
+        // Defensive `lane IS NULL` — picks up legacy rows (pre-migration
+        // 042 backfill) and any row inserted by a code path that didn't
+        // set lane explicitly. Without this, a NULL-lane row whose logical
+        // lane is `swing` gets silently skipped by `AND lane = 'swing'`
+        // (SQL: NULL = anything is UNKNOWN, not true), leaves status='open',
+        // and the next decision tick re-finds it → 21002 retry storm.
+        // The reason filter still scopes to this kernel instance so we
+        // don't accidentally close LiveSignal rows.
         const openRows = closeLane
           ? await pool.query(
               `SELECT id, quantity, agent, order_id FROM autonomous_trades
                 WHERE reason LIKE $1 AND status = 'open' AND symbol = $2
-                  AND lane = $3
+                  AND (lane = $3 OR lane IS NULL)
                 ORDER BY entry_time ASC`,
               [`monkey|kernel=${this.instanceId}|%`, symbol, closeLane],
             )
@@ -5670,11 +5678,16 @@ export class MonkeyKernel extends EventEmitter {
       // Proposal #10 — when a lane is scoped, only close that lane's
       // open rows. Other lanes (e.g. swing-long while we're closing a
       // scalp-short) keep their bookkeeping intact.
+      //
+      // Defensive `lane IS NULL` — same reasoning as paper-mode SELECT
+      // above. Without it, NULL-lane Monkey rows get silently skipped
+      // by `AND lane = X`, stay status='open', and the next decision
+      // tick re-fires close → 21002 retry storm.
       const openRows = closeLane
         ? await pool.query(
             `SELECT id, quantity, agent FROM autonomous_trades
               WHERE reason LIKE $1 AND status = 'open' AND symbol = $2
-                AND lane = $3
+                AND (lane = $3 OR lane IS NULL)
               ORDER BY entry_time ASC`,
             [`monkey|kernel=${this.instanceId}|%`, symbol, closeLane],
           )
@@ -6297,6 +6310,33 @@ export class MonkeyKernel extends EventEmitter {
     // Why no TREND cells: directional moves require instant fill or the
     // move gets away. Trend lane SHOULD pay taker fees — the TP/SL is
     // wider (0.4%) so fee impact is proportionally smaller.
+    // M.1 — entry gate against stacked makers on the same (symbol, side, lane).
+    // Pre-fix, the entry path never read pendingLimitMakerOrders before
+    // placing — each 30s tick could post a fresh maker order even with
+    // one already resting at the same price (observed in prod logs
+    // 07:09:43/07:09:44/07:09:46: three placements within 3s). This
+    // amplified the cancel-and-replace cycle and worsened latency. The
+    // tracker Map was design-documented as a double-queue guard (loop.ts
+    // class field comment) but the read was never wired. Wiring it now.
+    //
+    // DCA adds bypass — they intentionally stack onto an existing pending
+    // entry to defend a position.
+    if (!req.isDCAAdd) {
+      const targetLane = (req.lane ?? 'swing') as 'scalp' | 'swing' | 'trend';
+      for (const info of this.pendingLimitMakerOrders.values()) {
+        if (info.symbol === symbol && info.side === side && info.lane === targetLane) {
+          const ageMs = Date.now() - info.placedAtMs;
+          logger.debug('[Monkey] skipping entry — maker already pending', {
+            symbol, side, lane: targetLane, pendingOrderId: info.orderId, ageMs,
+          });
+          return {
+            executed: false, orderId: null,
+            reason: `maker_already_pending: orderId=${info.orderId} age=${(ageMs / 1000).toFixed(1)}s`,
+          };
+        }
+      }
+    }
+
     // Operator-toggleable scope: SCALP_LIMIT_MAKER_BROAD=false reverts
     // to the original scalp-lane-only routing if broad-CHOP routing's
     // latency outweighs the rebate on the current symbol mix. The PR


### PR DESCRIPTION
## Gap-fills from claude.ai's deeper trace post-#828

### M.1 — entry gate against stacked maker orders

The \`pendingLimitMakerOrders\` Map was **design-documented as a double-queue guard but the read was never wired into the entry path**. Each 30s tick could post a fresh maker order even with one already resting on the same \`(symbol, side, lane)\`.

Observed in prod 2026-05-19:
\`\`\`
07:09:43  LIMIT_MAKER scalp placed  BTC long
07:09:44  LIMIT_MAKER scalp placed  ETH long
07:09:46  LIMIT_MAKER scalp placed  ETH long  ← stacked on top of 07:09:44
\`\`\`

**Fix:** scan \`pendingLimitMakerOrders\` before placing. If a maker is already pending for \`(symbol, side, lane)\`, skip with reason \`maker_already_pending: orderId=… age=…s\`. DCA adds bypass — they intentionally stack onto an existing entry to defend a position.

### C3 — defensive \`lane = NULL\` on close SELECTs

Both lane-scoped close SELECTs filter \`AND lane = \$3\`. If a Monkey row has \`lane=NULL\` (legacy row pre-migration 042, or any code path that doesn't set lane), \`lane = 'swing'\` silently excludes the row (SQL: \`NULL = X\` is UNKNOWN, not true). The row stays \`status='open'\`, the next decision tick re-finds it via \`findOpenMonkeyTrade\` (no lane filter), tries to close → **21002 \"Position not enough\" → retry storm**.

**Fix:** \`AND (lane = \$3 OR lane IS NULL)\` on both close SELECTs (paper-mode line 5345 + live line 5688). Reason filter still scopes to this kernel instance — does **not** accidentally catch LiveSignal rows (different reason prefix \`live_signal|...\` vs \`monkey|kernel=...\`).

## Investigation provenance (verified, not memory)

- **C1 candidate** (bulk UPDATE silently failed): catch-all defensive recovery already shipped in #828
- **C2 candidate** (stale exchange-position cache): **ruled out** — \`findOpenMonkeyTrade\` at \`loop.ts:4528\` reads only \`autonomous_trades\`, no exchange call
- **C3-NULL candidate** (lane filter exclusion): this PR
- **B.1 diagnostic query** (DB-side): not yet run; safe to ship these defensive patches first

## Verification

- TypeScript: clean
- Suite: **1484/1484 passing**
- All changes are defensive — fail-safe regardless of which retry-storm root cause is active

## Risks / follow-ups (deliberately out of scope)

- **C2 maker-close on preservation-mandate exits** — when REGIME-2 / trailing_harvest fires, the doctrine is \"we have time\" — closing as LIMIT_MAKER would close the rebate-asymmetry gap. Risk: price moves while waiting. Separate PR.
- **trailing_harvest fee floor extension** — same pattern as REGIME-2 #828 but with peak-tracking guards. Less urgent. Separate PR.
- **WebSocket fills** — \`wsTrade\` / \`wsOrders\` channels would eliminate the stale-window concept entirely for makers. v0.9 work.

🤖 Generated with Claude Code