### PR TITLE
fix(monkey): close orphan DB rows when LIMIT_MAKER cancels unfilled (ROOT CAUSE of 21002 storm)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1452,6 +1452,37 @@ export class MonkeyKernel extends EventEmitter {
             stale_ms: now - this.pendingLimitMakerOrders.get(s.orderId)!.placedAtMs,
             consecutiveStales: prev + 1,
           });
+          // CRITICAL: close the orphan DB row created at order placement.
+          //
+          // The entry INSERT (loop.ts ~line 6483) writes status='open' for
+          // BOTH MARKET and LIMIT_MAKER orders. When a LIMIT_MAKER cancels
+          // unfilled, the DB row stays 'open' forever — next tick reads it
+          // via findOpenMonkeyTrade and decides the bot has a position
+          // that the exchange knows nothing about. Close attempt → 21002
+          // "Position not enough" → retry storm → reconciler eventually
+          // mops up with "side mismatch with exchange".
+          //
+          // Confirmed via prod DB diagnostic 2026-05-19: 07:09-07:15 BTC
+          // window had 5 monkey rows with exit_reason="reconciliation:
+          // side mismatch" — all from unfilled-maker entries.
+          //
+          // Fix: pin the DB row closed AS SOON AS the cancel succeeds, so
+          // the next decision tick sees a clean slate (no phantom position).
+          try {
+            await pool.query(
+              `UPDATE autonomous_trades
+                  SET status='closed', exit_time=NOW(),
+                      exit_reason='maker_cancelled_unfilled',
+                      exit_order_id=$1, pnl=0
+                WHERE order_id=$1 AND status='open'`,
+              [s.orderId],
+            );
+          } catch (dbErr) {
+            logger.warn('[Monkey] LIMIT_MAKER stale: orphan DB row close failed', {
+              orderId: s.orderId,
+              err: dbErr instanceof Error ? dbErr.message : String(dbErr),
+            });
+          }
         }
       } catch (err) {
         // Non-11008 cancel error — still increment stale counter, the
@@ -1464,6 +1495,13 @@ export class MonkeyKernel extends EventEmitter {
           err: err instanceof Error ? err.message : String(err),
           consecutiveStales: prev + 1,
         });
+        // Cancel state ambiguous (could be 11008-as-fill or real error).
+        // If the order DID fill, the row should stay open and reconciler
+        // will catch any mismatch. If the order is genuinely gone but the
+        // DB row is still open, the reconciler will mark it closed
+        // with "side mismatch" within ~60s. We deliberately do NOT
+        // pin the row closed here — false-positive closes on a real
+        // fill would lose the position from the bot's view.
       } finally {
         this.pendingLimitMakerOrders.delete(s.orderId);
       }


### PR DESCRIPTION
## Definitive root cause of the 21002 retry storm

**Confirmed via production DB diagnostic 2026-05-19:** 5 monkey rows in the 07:09-07:15 BTC window had \`exit_reason=\"reconciliation: side mismatch with exchange\"\` — all preceded by LIMIT_MAKER stale-cancels minutes earlier.

The bug:

1. Entry decision → \`placeOrder\` (LIMIT_MAKER) returns orderId
2. DB INSERT (loop.ts:6483) writes \`status='open'\` for the row — same path as MARKET, no maker-aware branch
3. Order sits at best-bid, never fills
4. Stale cancel fires (45-120s later), exchange cancels the order
5. **DB row STAYS \`status='open'\`** — nothing in the cancel path clears it
6. Next decision tick: \`findOpenMonkeyTrade\` reads the row → bot thinks it has a position
7. Bot tries to close → exchange returns 21002 \"Position not enough\" (the maker never filled)
8. Retry storm for up to ~60s window
9. Reconciler eventually marks the row closed with \"side mismatch with exchange\"

**Why this only surfaced post-maker-rollout:** pre-maker, every entry was MARKET → always filled → row's \`status='open'\` was always correct. Post-maker (~80% of CHOP-cell entries), unfilled rate was high enough that orphan rows accumulated.

This is **the** root cause — neither C1 (UPDATE silently failed; ruled out by absence of ORPHAN RISK logs) nor C3-NULL (no NULL-lane rows in window per DB query) was the active mechanism. #828's defensive UPDATE-recovery and #829's defensive lane=NULL OR remain valid as belt-and-braces; this PR addresses the actual upstream cause.

## Fix

In \`cancelStaleLimitMakers\`, after the exchange cancel succeeds (i.e. NOT raceResolved — that case means the order filled, row should stay open), pin the corresponding DB row:

\`\`\`sql
UPDATE autonomous_trades
   SET status='closed', exit_time=NOW(),
       exit_reason='maker_cancelled_unfilled',
       exit_order_id=$1, pnl=0
 WHERE order_id=$1 AND status='open'
\`\`\`

Idempotent. If reconciler beat us to it or the row was already closed by another path, no-op.

The catch branch (non-11008 cancel error) deliberately does **not** pin the row closed — that path's terminal state is ambiguous (could be a fill that the cancel race-lost), and a false-positive close would lose the position from the bot's view. Reconciler still picks it up within ~60s if genuinely orphaned.

## Verification

- TypeScript: clean
- Suite: **1484/1484 passing**
- DB diagnostic confirmed the mechanism on production data

## Follow-up

Existing orphan rows on prod (pre-deploy) will continue to be swept by the reconciler. Post-deploy, new orphans should not be created. Could run a one-time cleanup SQL to mark any pre-existing orphans as \`maker_cancelled_unfilled\` instead of waiting for reconciler — track in a follow-up if needed.

🤖 Generated with Claude Code