### PR TITLE
feat(monkey): bump position sizing knobs (sizeFraction + CHOP cell multipliers)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/compositionalExecutive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/compositionalExecutive.test.ts
@@ -43,18 +43,22 @@ describe('evaluateCell — 3×3 compositional matrix coverage', () => {
     }
   });
 
-  it('CREATOR + CHOP → scalp bias, tight harvest, half size', () => {
+  it('CREATOR + CHOP → scalp bias, tight harvest, 0.75x size (env-tunable)', () => {
     const cell = evaluateCell('CREATOR', 'CHOP');
     expect(cell.laneBias).toBe('scalp');
     expect(cell.harvestTightness).toBe('tight');
-    expect(cell.sizeMultiplier).toBe(0.5);
+    // 0.75 default (bumped from 0.5 in 2026-05-19 sizing-knobs pass per
+    // user report "small positions, low leverage, tiny wins").
+    // Env override: REGIME_CREATOR_CHOP_SIZE_MULT.
+    expect(cell.sizeMultiplier).toBe(0.75);
   });
 
-  it('PRESERVER + CHOP → swing (mean-revert), normal harvest, 0.7x size', () => {
+  it('PRESERVER + CHOP → swing (mean-revert), normal harvest, 0.85x size (env-tunable)', () => {
     const cell = evaluateCell('PRESERVER', 'CHOP');
     expect(cell.laneBias).toBe('swing');
     expect(cell.harvestTightness).toBe('normal');
-    expect(cell.sizeMultiplier).toBe(0.7);
+    // 0.85 default (bumped from 0.7). Env: REGIME_PRESERVER_CHOP_SIZE_MULT.
+    expect(cell.sizeMultiplier).toBe(0.85);
   });
 
   it('CREATOR + TREND_UP and CREATOR + TREND_DOWN → trend lane, full size', () => {

--- a/apps/api/src/services/monkey/compositional_executive.ts
+++ b/apps/api/src/services/monkey/compositional_executive.ts
@@ -64,9 +64,16 @@ export function evaluateCell(
       harvestTightness: 'normal',
       label: 'CREATOR×TREND_DOWN: aggressive trend-follow (short)',
     };
-    // CHOP within CREATOR — symmetry-breaking imminent, trade lightly
+    // CHOP within CREATOR — symmetry-breaking imminent, trade lightly.
+    // 2026-05-19: sizeMultiplier bumped 0.5 → 0.75 per user report
+    // "small positions, low leverage, tiny wins." Doctrine preserved
+    // (still "lightly" — full size = 1.0 for trending cells, 0.75 here)
+    // but the prior 0.5 compounded with sizeFraction 0.5 to leave bot
+    // at 0.25× equity per side — entries were structurally too small
+    // to produce meaningful absolute wins. Env-tunable for operator tuning.
     return {
-      phase, direction, laneBias: 'scalp', sizeMultiplier: 0.5,
+      phase, direction, laneBias: 'scalp',
+      sizeMultiplier: Number(process.env.REGIME_CREATOR_CHOP_SIZE_MULT) || 0.75,
       harvestTightness: 'tight',
       label: 'CREATOR×CHOP: trade lightly, expect breakout',
     };
@@ -84,9 +91,13 @@ export function evaluateCell(
       harvestTightness: 'loose',
       label: 'PRESERVER×TREND_DOWN: ride established short',
     };
-    // CHOP within PRESERVER — consolidating before continuation, mean-revert
+    // CHOP within PRESERVER — consolidating before continuation, mean-revert.
+    // sizeMultiplier env-tunable (default 0.85, bumped from 0.7 in 2026-05-19
+    // sizing-knobs pass — preservation cells still get full conviction since
+    // continuation is the likely outcome).
     return {
-      phase, direction, laneBias: 'swing', sizeMultiplier: 0.7,
+      phase, direction, laneBias: 'swing',
+      sizeMultiplier: Number(process.env.REGIME_PRESERVER_CHOP_SIZE_MULT) || 0.85,
       harvestTightness: 'normal',
       label: 'PRESERVER×CHOP: mean-revert (consolidating)',
     };

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -7243,12 +7243,25 @@ export class MonkeyKernel extends EventEmitter {
 // both are open on the same symbol; the risk kernel's 5× blast door
 // still enforces the hard ceiling.
 
+// User report 2026-05-19 09:53: "taking up pretty small positions compared
+// to the equity. very low leverage. all wins are tiny."
+//
+// Sizing compounds three throttles:
+//   1. sizeFraction per kernel — was 0.5 each = 1.0 combined
+//   2. CREATOR_CHOP cellSizeMultiplier 0.5 (compositional_executive.ts)
+//   3. phi-derived rawFrac (~0.2 typical) inside computeSize
+//
+// Net: 0.5 × 0.5 × 0.2 = 0.05 × bank — positions ~5% of equity.
+//
+// Defaults bumped to 0.7 per kernel (combined 1.4× when same-direction).
+// CREATOR_CHOP raised in compositional_executive.ts companion change.
+// All env-tunable for operator-driven tuning per [[feedback-standing-env-flip-auth]].
 export const monkeyKernel = new MonkeyKernel({
   instanceId: 'monkey-position',
   timeframe: '15m',
   tickMs: 30_000,
   label: 'Monkey.Position',
-  sizeFraction: 0.5,
+  sizeFraction: Number(process.env.MONKEY_POSITION_SIZE_FRACTION) || 0.7,
 });
 
 export const swingMonkey = new MonkeyKernel({
@@ -7256,7 +7269,7 @@ export const swingMonkey = new MonkeyKernel({
   timeframe: '5m',
   tickMs: 30_000,
   label: 'Monkey.Swing',
-  sizeFraction: 0.5,
+  sizeFraction: Number(process.env.MONKEY_SWING_SIZE_FRACTION) || 0.7,
 });
 
 export const allMonkeyKernels: readonly MonkeyKernel[] = [


### PR DESCRIPTION
User: "small positions, low leverage, tiny wins." Diagnosis: 3 compounding throttles produce 5% × equity per position. Bump sizeFraction 0.5→0.7 + CREATOR_CHOP 0.5→0.75 + PRESERVER_CHOP 0.7→0.85. All env-tunable. ~2.1× larger positions. Doctrine preserved (CHOP still trades lightly, DISSOLVER still suppresses). 1484/1484 tests.