### PR TITLE
fix(monkey): tape-override on DRIFT mode gate (parallel to #841)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1946,6 +1946,11 @@ export class MonkeyKernel extends EventEmitter {
     const driftNow = fisherRao(basin, state.identityBasin);
     state.driftHistory.push(driftNow);
     if (state.driftHistory.length > HISTORY_MAX) state.driftHistory.shift();
+    // 2026-05-19: compute tapeTrend HERE so detectMode can gate DRIFT
+    // on tape direction (parallel to #841 cellDirection fix). Same
+    // computation runs again later at line ~2005 for basin snapshot
+    // and entry-decision — idempotent (pure derivation from ohlcv).
+    const tapeTrendForMode = computeTrendProxy(ohlcv);
     const modeDecision = detectMode({
       basin,
       identityBasin: state.identityBasin,
@@ -1956,6 +1961,7 @@ export class MonkeyKernel extends EventEmitter {
       phiHistory: state.phiHistory,
       fHealthHistory: state.fHealthHistory,
       driftHistory: state.driftHistory,
+      tapeTrend: tapeTrendForMode,
     });
     const mode = modeDecision.value;
     if (state.lastMode !== null && state.lastMode !== mode) {

--- a/apps/api/src/services/monkey/modes.ts
+++ b/apps/api/src/services/monkey/modes.ts
@@ -158,6 +158,21 @@ export interface ModeInputs {
   fHealthHistory: number[];
   /** Recent identity-drift history (Fisher-Rao, last N, newest last). */
   driftHistory: number[];
+  /**
+   * Optional tape-trend signal from the price OHLCV (computeTrendProxy).
+   * Used to gate DRIFT mode — when tape is strongly directional but
+   * basin happens to be quiet, the kernel was perceiving "nothing
+   * happening" while market was clearly active.
+   *
+   * Parallel to #841's cellDirection tape-override fix. Same lag class:
+   * basin-derived metrics (curiosity = ΔΦ, basinDir) can stay flat
+   * during steady-rate moves because Φ tracks integration of the
+   * already-stable regime; price IS moving but the regime isn't
+   * changing.
+   *
+   * Optional for back-compat with existing tests that don't pass tape.
+   */
+  tapeTrend?: number;
 }
 
 /**
@@ -237,15 +252,46 @@ export function detectMode(inp: ModeInputs): ExecutiveDecision<MonkeyMode> {
   const basinDir = basinDirection(inp.basin);
   const hasDirection = Math.abs(basinDir) > 0.30;
 
+  // 2026-05-19 (parallel to #841): tape-trend ALSO gates DRIFT.
+  //
+  // User report 11:54: "why is curiosity 0.00" — log showed kernel
+  // transitioning to DRIFT with curiosity=0.0000 flat, bv=0.005,
+  // basinDir=0.04. All basin-derived metrics flat, but tape may have
+  // been clearly directional at that moment.
+  //
+  // Root cause: same lag class as cellDirection's CHOP mis-read
+  // (fixed by #841). Basin signals (curiosity = ΔΦ, basinDir) track
+  // INTERNAL state evolution; on a steady-rate price move, basin can
+  // stay flat because the regime isn't CHANGING — only the price is.
+  // The kernel reads "quiet" and drops to DRIFT, blocking entries that
+  // tape conviction would otherwise support.
+  //
+  // Threshold MONKEY_MODE_TAPE_OVERRIDE_THRESHOLD (default 0.30, same
+  // magnitude as basinDir's hasDirection gate). When `|tape| > threshold`,
+  // hasTapeDirection blocks the DRIFT gate even on flat basin.
+  const tapeOverrideThreshold = (() => {
+    const raw = process.env.MONKEY_MODE_TAPE_OVERRIDE_THRESHOLD;
+    if (raw === undefined || raw === '') return 0.30;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : 0.30;
+  })();
+  const hasTapeDirection =
+    inp.tapeTrend !== undefined && Math.abs(inp.tapeTrend) > tapeOverrideThreshold;
+
   if (
     fHealthNow > 0.97 &&
     Math.abs(mot.curiosity) < 0.005 &&
     inp.basinVelocity < 0.015 &&
-    !hasDirection
+    !hasDirection &&
+    !hasTapeDirection
   ) {
     // DRIFT: diffuse basin + no curiosity + slow change + no direction
+    // (basin AND tape).
     mode = MonkeyMode.DRIFT;
-    reason = `fh=${fHealthNow.toFixed(3)} diffuse, curiosity=${mot.curiosity.toFixed(4)} flat, bv=${inp.basinVelocity.toFixed(3)}, basinDir=${basinDir.toFixed(2)} flat`;
+    const tapeReport = inp.tapeTrend !== undefined
+      ? `, tape=${inp.tapeTrend.toFixed(2)} flat`
+      : '';
+    reason = `fh=${fHealthNow.toFixed(3)} diffuse, curiosity=${mot.curiosity.toFixed(4)} flat, bv=${inp.basinVelocity.toFixed(3)}, basinDir=${basinDir.toFixed(2)} flat${tapeReport}`;
   } else if (driftNow > 0.30 && mot.curiosity > 0.002) {
     // EXPLORATION: high drift + expanding perception volume
     mode = MonkeyMode.EXPLORATION;


### PR DESCRIPTION
User: "why is curiosity 0.00?" Same bug class as #841 cellDirection mis-read at a different layer. Basin-derived metrics (curiosity=ΔΦ, basinDir, bv) all stay flat on steady-rate price moves because they track regime integration, not price. When tape is clearly directional but internal metrics flat, DRIFT mode fires → blocks all entries. Fix: tape gates DRIFT (|tape| > 0.30). Env: MONKEY_MODE_TAPE_OVERRIDE_THRESHOLD. 1484/1484 tests.