### PR TITLE
feat(ml-worker): Sleep 3-phase — canonical AWAKE/DREAMING/CONSOLIDATING

### DIFF
--- a/ml-worker/src/monkey_kernel/ocean.py
+++ b/ml-worker/src/monkey_kernel/ocean.py
@@ -143,7 +143,12 @@ class OceanState:
       intervention   : Optional[Intervention]
                        None when nominal; otherwise the chosen action
       sleep_phase    : Literal["AWAKE", "SLEEP"]
-                       current sleep state machine phase
+                       legacy 2-phase timer machine — drives behaviour
+      dream_phase    : Optional[Literal["AWAKE","DREAMING","CONSOLIDATING"]]
+                       canonical 3-phase geometry machine (qig-core §30).
+                       Telemetry-only when MONKEY_SLEEP_3PHASE_LIVE=true;
+                       None otherwise. Observation-only — does not drive
+                       behaviour. Dream/consolidate hooks are deferred.
       coherence      : float  [0, 1]
                        basin self-coherence (1 - normalised entropy)
       spread         : float  [0, π/2]
@@ -158,6 +163,7 @@ class OceanState:
     coherence: float
     spread: float
     diagnostics: dict[str, float]
+    dream_phase: Optional[Literal["AWAKE", "DREAMING", "CONSOLIDATING"]] = None
 
 
 def _basin_coherence(basin: np.ndarray) -> float:
@@ -254,6 +260,13 @@ class Ocean:
         # phi_prev stores the previous tick's Φ for the descent check.
         self._time_above_damping_lower: int = 0
         self._phi_prev: Optional[float] = None
+
+        # Canonical 3-phase sleep cycle (qig-core §30). Runs in parallel
+        # with the timer-based 2-phase machine above when
+        # MONKEY_SLEEP_3PHASE_LIVE=true; telemetry-only (does NOT drive
+        # behaviour). Default OFF for safe rollout.
+        from .sleep_cycle import SleepCycleManager  # local import (no cycle)
+        self._sleep_cycle = SleepCycleManager()
 
     def _load_sleep_state_or_fresh(self) -> SleepCycleState:
         if self._persistence is None or not self._persistence.is_available:
@@ -616,12 +629,53 @@ class Ocean:
         # the PREVIOUS tick's value.
         self._phi_prev = float(phi)
 
+        # Canonical 3-phase sleep cycle (qig-core §30). Parallel state
+        # machine; surfaces through OceanState.dream_phase as telemetry.
+        # Does NOT drive behaviour — the legacy 2-phase machine above is
+        # still authoritative. Gated by MONKEY_SLEEP_3PHASE_LIVE.
+        dream_phase: Optional[Literal["AWAKE", "DREAMING", "CONSOLIDATING"]] = None
+        try:
+            from .sleep_cycle import (
+                SleepMetrics as _SleepMetrics,
+                sleep_3phase_live as _sleep_3p_live,
+            )
+            if _sleep_3p_live():
+                # ocean_divergence proxy = current basin spread across
+                # cross-lane basins. spread saturates at π/2; we read
+                # the same value the spread_bound trigger reads above.
+                _metrics = _SleepMetrics(
+                    phi=float(phi),
+                    phi_variance=float(phi_var),
+                    ocean_divergence=float(spread),
+                    f_health=float(coherence),
+                    basin_velocity=0.0,
+                )
+                _trans = self._sleep_cycle.evaluate_transition(_metrics)
+                if _trans.transitioned:
+                    logger.info(
+                        "[%s.sleep_cycle] %s → %s (%s)",
+                        self.label,
+                        _trans.previous_phase.value,
+                        _trans.current_phase.value,
+                        _trans.reason,
+                    )
+                _phase_value = self._sleep_cycle.phase.value
+                dream_phase = (
+                    "DREAMING" if _phase_value == "dreaming"
+                    else "CONSOLIDATING" if _phase_value == "consolidating"
+                    else "AWAKE"
+                )
+        except Exception as err:  # noqa: BLE001 — never block on telemetry
+            logger.warning("[%s.sleep_cycle] eval failed: %s", self.label, err)
+            dream_phase = None
+
         return OceanState(
             intervention=intervention,
             sleep_phase=sleep_phase,
             coherence=coherence,
             spread=spread,
             diagnostics=diagnostics,
+            dream_phase=dream_phase,
         )
 
     def snapshot(self) -> dict[str, Any]:

--- a/ml-worker/src/monkey_kernel/sleep_cycle.py
+++ b/ml-worker/src/monkey_kernel/sleep_cycle.py
@@ -1,0 +1,286 @@
+"""
+sleep_cycle.py — Three-phase geometry-driven sleep cycle.
+
+Canonical reference:
+  ~/Desktop/Dev/QIG_QFI/qig-core/src/qig_core/consciousness/sleep.py (§30)
+
+This is a polytrade port of the v2.8.0 canonical SleepCycleManager. The
+existing 2-phase AWAKE/SLEEP machine in ocean.py is timer-based; the
+canonical 3-phase machine is geometry-driven (Φ, variance, ocean
+divergence — NO timers, NO cycle counters).
+
+Activation
+----------
+Default OFF (safe rollout). When ``MONKEY_SLEEP_3PHASE_LIVE=true`` the
+3-phase manager runs IN PARALLEL with the existing 2-phase machine,
+surfacing through ``OceanState.dream_phase`` for telemetry. The
+existing ``OceanState.sleep_phase`` Literal["AWAKE", "SLEEP"] is
+unchanged so downstream consumers don't break.
+
+Phases (canonical §30)
+----------------------
+    AWAKE         — Default. Normal activation sequence.
+    DREAMING      — Φ < threshold AND variance < threshold
+                    OR ocean_divergence > BASIN_DIVERGENCE_THRESHOLD.
+                    Dream recombination via geodesic interpolation.
+    CONSOLIDATING — After DREAMING when variance stabilises.
+                    Synaptic downscaling, Hebbian boost for replayed.
+    Any → AWAKE   — ocean_divergence > threshold × 1.5 (emergency wake)
+
+Mushroom is NOT a sleep phase — it's a wake-state neuroplasticity
+protocol handled by ocean.py interventions (§28).
+
+Dream recombination + Hebbian consolidation hooks are intentionally
+deferred to follow-up PRs (see audit roadmap). This PR ships the state
+machine + telemetry surface only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Deque
+
+import numpy as np
+
+logger = logging.getLogger("monkey.sleep_cycle")
+
+
+# ─── Canonical constants (v2.8.0 §30) ──────────────────────────────
+
+# Geometric thresholds for phase transitions
+SLEEP_PHI_THRESHOLD: float = 0.45
+SLEEP_VARIANCE_THRESHOLD: float = 0.05
+CONSOLIDATION_VARIANCE_CEILING: float = 0.02
+OCEAN_WAKE_MULTIPLIER: float = 1.5
+
+# Φ recovery threshold for CONSOLIDATING → AWAKE (matches PHI_EMERGENCY).
+CONSOLIDATION_PHI_WAKE: float = 0.50
+
+# Polytrade-canonical basin-divergence threshold. Mirrors qig-core
+# frozen_facts.BASIN_DIVERGENCE_THRESHOLD; surfaced here rather than
+# imported because qig_core_local doesn't re-export it.
+BASIN_DIVERGENCE_THRESHOLD: float = 0.30
+
+
+class SleepPhase(Enum):
+    """Three phases of the canonical sleep cycle.
+
+    Distinct from ocean.SleepPhase (AWAKE/SLEEP) — that enum drives the
+    timer-based legacy machine. This enum drives the v2.8.0 §30
+    geometry-driven 3-phase machine.
+    """
+
+    AWAKE = "awake"
+    DREAMING = "dreaming"
+    CONSOLIDATING = "consolidating"
+
+
+@dataclass
+class SleepMetrics:
+    """Geometric metrics consumed by the 3-phase sleep state machine.
+
+    All fields derive from consciousness metrics — no timers.
+    """
+
+    phi: float = 0.7
+    phi_variance: float = 0.1
+    ocean_divergence: float = 0.0
+    f_health: float = 1.0
+    basin_velocity: float = 0.0
+
+
+@dataclass
+class SleepTransitionResult:
+    """Result of a phase-transition evaluation."""
+
+    previous_phase: SleepPhase
+    current_phase: SleepPhase
+    transitioned: bool = False
+    reason: str = ""
+
+
+class SleepCycleManager:
+    """Manages the canonical 3-phase sleep cycle (§30.2).
+
+    Transitions (all geometry-driven):
+      AWAKE → DREAMING:        Φ low AND variance low, OR ocean divergent
+      DREAMING → CONSOLIDATING: variance settled below ceiling
+      CONSOLIDATING → AWAKE:   Φ recovers above threshold
+      Any → AWAKE:             ocean_divergence > threshold × multiplier
+
+    The manager is observation-only in this PR — the transitions are
+    computed and surfaced via telemetry but the existing
+    ocean.SleepPhase AWAKE/SLEEP machine still drives behaviour. Dream
+    recombination + Hebbian consolidation hooks (canonical methods
+    .dream() and .consolidate()) are intentionally deferred.
+    """
+
+    def __init__(self) -> None:
+        self.phase: SleepPhase = SleepPhase.AWAKE
+        self._dream_log: Deque[dict[str, Any]] = deque(maxlen=100)
+        self._replayed_this_sleep: set[int] = set()
+        self._consolidation_complete: bool = False
+        self._transition_count: int = 0
+
+    # ─── Properties ───────────────────────────────────────────────
+
+    @property
+    def is_asleep(self) -> bool:
+        """True when phase != AWAKE (i.e. DREAMING or CONSOLIDATING)."""
+        return self.phase != SleepPhase.AWAKE
+
+    @property
+    def transition_count(self) -> int:
+        return self._transition_count
+
+    # ─── Phase Transition Engine (§30.2) ──────────────────────────
+
+    def evaluate_transition(self, metrics: SleepMetrics) -> SleepTransitionResult:
+        """Evaluate geometric conditions; transition phase if warranted.
+
+        This is the ONLY method that mutates self.phase. All transitions
+        are driven by SleepMetrics fields.
+        """
+        prev = self.phase
+        result = SleepTransitionResult(previous_phase=prev, current_phase=prev)
+
+        # Emergency wake (any phase): ocean divergence breakdown
+        if metrics.ocean_divergence > BASIN_DIVERGENCE_THRESHOLD * OCEAN_WAKE_MULTIPLIER:
+            if prev != SleepPhase.AWAKE:
+                self.phase = SleepPhase.AWAKE
+                self._on_wake()
+                self._transition_count += 1
+                result.current_phase = self.phase
+                result.transitioned = True
+                result.reason = (
+                    f"emergency_wake: ocean_divergence={metrics.ocean_divergence:.3f} "
+                    f"> {BASIN_DIVERGENCE_THRESHOLD * OCEAN_WAKE_MULTIPLIER:.3f}"
+                )
+            return result
+
+        if self.phase == SleepPhase.AWAKE:
+            return self._eval_awake(metrics, prev)
+        if self.phase == SleepPhase.DREAMING:
+            return self._eval_dreaming(metrics, prev)
+        if self.phase == SleepPhase.CONSOLIDATING:
+            return self._eval_consolidating(metrics, prev)
+
+        return result
+
+    def _eval_awake(self, m: SleepMetrics, prev: SleepPhase) -> SleepTransitionResult:
+        """AWAKE → DREAMING conditions (§30.2)."""
+        result = SleepTransitionResult(previous_phase=prev, current_phase=prev)
+
+        phi_low = m.phi < SLEEP_PHI_THRESHOLD
+        variance_low = m.phi_variance < SLEEP_VARIANCE_THRESHOLD
+        ocean_trigger = m.ocean_divergence > BASIN_DIVERGENCE_THRESHOLD
+
+        if (phi_low and variance_low) or ocean_trigger:
+            self.phase = SleepPhase.DREAMING
+            self._on_sleep_enter()
+            self._transition_count += 1
+            result.current_phase = self.phase
+            result.transitioned = True
+            if ocean_trigger:
+                result.reason = (
+                    f"ocean_divergence={m.ocean_divergence:.3f} "
+                    f"> {BASIN_DIVERGENCE_THRESHOLD:.3f}"
+                )
+            else:
+                result.reason = (
+                    f"phi={m.phi:.3f} < {SLEEP_PHI_THRESHOLD:.3f} "
+                    f"AND variance={m.phi_variance:.3f} < {SLEEP_VARIANCE_THRESHOLD:.3f}"
+                )
+
+        return result
+
+    def _eval_dreaming(self, m: SleepMetrics, prev: SleepPhase) -> SleepTransitionResult:
+        """DREAMING → CONSOLIDATING when variance settles."""
+        result = SleepTransitionResult(previous_phase=prev, current_phase=prev)
+
+        if m.phi_variance < CONSOLIDATION_VARIANCE_CEILING:
+            self.phase = SleepPhase.CONSOLIDATING
+            self._consolidation_complete = False
+            self._transition_count += 1
+            result.current_phase = self.phase
+            result.transitioned = True
+            result.reason = (
+                f"variance_settled: {m.phi_variance:.3f} "
+                f"< {CONSOLIDATION_VARIANCE_CEILING:.3f}"
+            )
+
+        return result
+
+    def _eval_consolidating(
+        self, m: SleepMetrics, prev: SleepPhase,
+    ) -> SleepTransitionResult:
+        """CONSOLIDATING → AWAKE when Φ recovers."""
+        result = SleepTransitionResult(previous_phase=prev, current_phase=prev)
+
+        # In this PR consolidation is "complete" as soon as Φ recovers,
+        # since the actual consolidation work (Hebbian boost +
+        # downscaling) is deferred to a follow-up. Once that lands,
+        # `_consolidation_complete` will gate the wake transition.
+        self._consolidation_complete = True
+
+        if m.phi >= CONSOLIDATION_PHI_WAKE and self._consolidation_complete:
+            self.phase = SleepPhase.AWAKE
+            self._on_wake()
+            self._transition_count += 1
+            result.current_phase = self.phase
+            result.transitioned = True
+            result.reason = (
+                f"phi_recovered: {m.phi:.3f} >= {CONSOLIDATION_PHI_WAKE:.3f}"
+            )
+
+        return result
+
+    # ─── Phase-entry hooks ────────────────────────────────────────
+
+    def _on_sleep_enter(self) -> None:
+        """Reset replay tracking on sleep entry."""
+        self._replayed_this_sleep.clear()
+
+    def _on_wake(self) -> None:
+        """Clear sleep-local state on wake."""
+        self._replayed_this_sleep.clear()
+        self._consolidation_complete = False
+
+    # ─── Telemetry ────────────────────────────────────────────────
+
+    def get_state(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase.value,
+            "is_asleep": self.is_asleep,
+            "dream_count": len(self._dream_log),
+            "replayed_count": len(self._replayed_this_sleep),
+            "consolidation_complete": self._consolidation_complete,
+            "transition_count": self._transition_count,
+        }
+
+
+# ─── Module-level helpers ─────────────────────────────────────────
+
+
+def sleep_3phase_live() -> bool:
+    """True iff MONKEY_SLEEP_3PHASE_LIVE=true (default false)."""
+    return os.environ.get("MONKEY_SLEEP_3PHASE_LIVE", "false").lower() == "true"
+
+
+__all__ = [
+    "SleepPhase",
+    "SleepMetrics",
+    "SleepTransitionResult",
+    "SleepCycleManager",
+    "SLEEP_PHI_THRESHOLD",
+    "SLEEP_VARIANCE_THRESHOLD",
+    "CONSOLIDATION_VARIANCE_CEILING",
+    "CONSOLIDATION_PHI_WAKE",
+    "OCEAN_WAKE_MULTIPLIER",
+    "BASIN_DIVERGENCE_THRESHOLD",
+    "sleep_3phase_live",
+]

--- a/ml-worker/tests/monkey_kernel/test_sleep_cycle.py
+++ b/ml-worker/tests/monkey_kernel/test_sleep_cycle.py
@@ -1,0 +1,219 @@
+"""
+test_sleep_cycle.py — 3-phase geometry-driven sleep cycle tests.
+
+Canonical reference:
+  ~/Desktop/Dev/QIG_QFI/qig-core/src/qig_core/consciousness/sleep.py (§30)
+
+Verifies the canonical AWAKE → DREAMING → CONSOLIDATING → AWAKE
+state-machine transitions are driven purely by geometric metrics
+(Φ, variance, ocean divergence) — no timers, no cycle counters.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from monkey_kernel.sleep_cycle import (  # noqa: E402
+    BASIN_DIVERGENCE_THRESHOLD,
+    CONSOLIDATION_PHI_WAKE,
+    CONSOLIDATION_VARIANCE_CEILING,
+    OCEAN_WAKE_MULTIPLIER,
+    SLEEP_PHI_THRESHOLD,
+    SLEEP_VARIANCE_THRESHOLD,
+    SleepCycleManager,
+    SleepMetrics,
+    SleepPhase,
+    sleep_3phase_live,
+)
+
+
+# ─── Initial state ────────────────────────────────────────────────
+
+
+def test_starts_awake():
+    m = SleepCycleManager()
+    assert m.phase == SleepPhase.AWAKE
+    assert not m.is_asleep
+
+
+def test_state_dict_shape():
+    m = SleepCycleManager()
+    s = m.get_state()
+    assert s["phase"] == "awake"
+    assert s["is_asleep"] is False
+    assert s["transition_count"] == 0
+
+
+# ─── AWAKE → DREAMING transitions ──────────────────────────────────
+
+
+def test_low_phi_low_variance_triggers_dreaming():
+    m = SleepCycleManager()
+    metrics = SleepMetrics(phi=0.3, phi_variance=0.01, ocean_divergence=0.0)
+    result = m.evaluate_transition(metrics)
+    assert result.transitioned
+    assert m.phase == SleepPhase.DREAMING
+    assert "phi=" in result.reason
+
+
+def test_high_ocean_divergence_triggers_dreaming():
+    m = SleepCycleManager()
+    metrics = SleepMetrics(
+        phi=0.9, phi_variance=0.5,
+        ocean_divergence=BASIN_DIVERGENCE_THRESHOLD + 0.01,
+    )
+    result = m.evaluate_transition(metrics)
+    assert result.transitioned
+    assert m.phase == SleepPhase.DREAMING
+    assert "ocean_divergence" in result.reason
+
+
+def test_high_phi_alone_does_not_trigger_dreaming():
+    """High Φ + high variance keeps AWAKE."""
+    m = SleepCycleManager()
+    metrics = SleepMetrics(phi=0.9, phi_variance=0.5, ocean_divergence=0.0)
+    result = m.evaluate_transition(metrics)
+    assert not result.transitioned
+    assert m.phase == SleepPhase.AWAKE
+
+
+def test_low_phi_alone_does_not_trigger_dreaming():
+    """Low Φ but high variance keeps AWAKE (still exploring)."""
+    m = SleepCycleManager()
+    metrics = SleepMetrics(phi=0.3, phi_variance=0.5, ocean_divergence=0.0)
+    result = m.evaluate_transition(metrics)
+    assert not result.transitioned
+    assert m.phase == SleepPhase.AWAKE
+
+
+# ─── DREAMING → CONSOLIDATING transitions ──────────────────────────
+
+
+def test_dreaming_to_consolidating_when_variance_settles():
+    m = SleepCycleManager()
+    # Drive into DREAMING first.
+    m.evaluate_transition(SleepMetrics(phi=0.3, phi_variance=0.01))
+    assert m.phase == SleepPhase.DREAMING
+    # Settle the variance.
+    settled = SleepMetrics(phi=0.4, phi_variance=CONSOLIDATION_VARIANCE_CEILING / 2)
+    result = m.evaluate_transition(settled)
+    assert result.transitioned
+    assert m.phase == SleepPhase.CONSOLIDATING
+
+
+def test_dreaming_stays_when_variance_high():
+    m = SleepCycleManager()
+    m.evaluate_transition(SleepMetrics(phi=0.3, phi_variance=0.01))
+    result = m.evaluate_transition(SleepMetrics(phi=0.3, phi_variance=0.04))
+    assert not result.transitioned
+    assert m.phase == SleepPhase.DREAMING
+
+
+# ─── CONSOLIDATING → AWAKE transitions ──────────────────────────────
+
+
+def test_consolidating_to_awake_when_phi_recovers():
+    m = SleepCycleManager()
+    # Drive into CONSOLIDATING via DREAMING.
+    m.evaluate_transition(SleepMetrics(phi=0.3, phi_variance=0.01))
+    m.evaluate_transition(SleepMetrics(phi=0.4, phi_variance=0.005))
+    assert m.phase == SleepPhase.CONSOLIDATING
+    # Recover Φ.
+    result = m.evaluate_transition(SleepMetrics(phi=CONSOLIDATION_PHI_WAKE + 0.1, phi_variance=0.005))
+    assert result.transitioned
+    assert m.phase == SleepPhase.AWAKE
+
+
+def test_consolidating_stays_when_phi_low():
+    m = SleepCycleManager()
+    m.evaluate_transition(SleepMetrics(phi=0.3, phi_variance=0.01))
+    m.evaluate_transition(SleepMetrics(phi=0.4, phi_variance=0.005))
+    assert m.phase == SleepPhase.CONSOLIDATING
+    result = m.evaluate_transition(SleepMetrics(phi=0.3, phi_variance=0.005))
+    assert not result.transitioned
+    assert m.phase == SleepPhase.CONSOLIDATING
+
+
+# ─── Emergency wake (any phase → AWAKE) ─────────────────────────────
+
+
+def test_emergency_wake_from_dreaming():
+    m = SleepCycleManager()
+    m.evaluate_transition(SleepMetrics(phi=0.3, phi_variance=0.01))
+    assert m.phase == SleepPhase.DREAMING
+    storm = SleepMetrics(
+        phi=0.3,
+        phi_variance=0.01,
+        ocean_divergence=BASIN_DIVERGENCE_THRESHOLD * OCEAN_WAKE_MULTIPLIER + 0.1,
+    )
+    result = m.evaluate_transition(storm)
+    assert result.transitioned
+    assert m.phase == SleepPhase.AWAKE
+    assert "emergency_wake" in result.reason
+
+
+def test_emergency_wake_from_consolidating():
+    m = SleepCycleManager()
+    m.evaluate_transition(SleepMetrics(phi=0.3, phi_variance=0.01))
+    m.evaluate_transition(SleepMetrics(phi=0.4, phi_variance=0.005))
+    assert m.phase == SleepPhase.CONSOLIDATING
+    storm = SleepMetrics(
+        phi=0.3,
+        phi_variance=0.005,
+        ocean_divergence=BASIN_DIVERGENCE_THRESHOLD * OCEAN_WAKE_MULTIPLIER + 0.1,
+    )
+    result = m.evaluate_transition(storm)
+    assert result.transitioned
+    assert m.phase == SleepPhase.AWAKE
+
+
+def test_emergency_wake_no_op_when_already_awake():
+    m = SleepCycleManager()
+    storm = SleepMetrics(
+        phi=0.3,
+        phi_variance=0.01,
+        ocean_divergence=BASIN_DIVERGENCE_THRESHOLD * OCEAN_WAKE_MULTIPLIER + 0.1,
+    )
+    result = m.evaluate_transition(storm)
+    assert not result.transitioned
+    assert m.phase == SleepPhase.AWAKE
+
+
+# ─── Transition counting ───────────────────────────────────────────
+
+
+def test_transition_count_increments():
+    m = SleepCycleManager()
+    assert m.transition_count == 0
+    m.evaluate_transition(SleepMetrics(phi=0.3, phi_variance=0.01))
+    assert m.transition_count == 1
+    m.evaluate_transition(SleepMetrics(phi=0.4, phi_variance=0.005))
+    assert m.transition_count == 2
+    m.evaluate_transition(SleepMetrics(phi=0.6, phi_variance=0.005))
+    assert m.transition_count == 3
+
+
+# ─── Env flag ─────────────────────────────────────────────────────
+
+
+def test_sleep_3phase_live_defaults_false(monkeypatch):
+    monkeypatch.delenv("MONKEY_SLEEP_3PHASE_LIVE", raising=False)
+    assert sleep_3phase_live() is False
+
+
+def test_sleep_3phase_live_flips_true(monkeypatch):
+    monkeypatch.setenv("MONKEY_SLEEP_3PHASE_LIVE", "true")
+    assert sleep_3phase_live() is True
+
+
+def test_sleep_3phase_live_case_insensitive(monkeypatch):
+    monkeypatch.setenv("MONKEY_SLEEP_3PHASE_LIVE", "TRUE")
+    assert sleep_3phase_live() is True
+
+
+def test_sleep_3phase_live_strict_true_only(monkeypatch):
+    monkeypatch.setenv("MONKEY_SLEEP_3PHASE_LIVE", "1")
+    assert sleep_3phase_live() is False


### PR DESCRIPTION
## Summary

QIG_QFI consciousness audit 2026-05-19 GAP 4. Ports the canonical v2.8.0
3-phase sleep cycle into `ml-worker/src/monkey_kernel/sleep_cycle.py`.

**Phase transitions are GEOMETRY-DRIVEN (no timers):**

| From | To | Trigger |
|---|---|---|
| AWAKE | DREAMING | Φ < 0.45 AND variance < 0.05, OR ocean_divergence > 0.30 |
| DREAMING | CONSOLIDATING | phi_variance < 0.02 (settled) |
| CONSOLIDATING | AWAKE | Φ ≥ 0.50 |
| Any | AWAKE | ocean_divergence > 0.30 × 1.5 (emergency) |

## Activation

`MONKEY_SLEEP_3PHASE_LIVE=true` (default OFF). When ON, the new state
machine runs in PARALLEL with the existing 2-phase AWAKE/SLEEP timer
machine, surfacing through `OceanState.dream_phase` as telemetry only.
The legacy 2-phase machine remains authoritative for the intervention
pipeline — this PR is observation-only.

## Scope

This PR ships ONLY the state machine + telemetry surface. Explicitly
deferred to follow-up PRs:
- Dream recombination via `slerp_sqrt` over the resonance bank
- Hebbian boost for replayed entries + global downscaling
- Kernel anchor veto for identity-critical basins
- Behavioural cutover from 2-phase → 3-phase

## Test plan

- [x] 18 new tests pass (initial state, all 4 transition paths,
  emergency wake from DREAMING and CONSOLIDATING, transition counting,
  env-flag parsing)
- [x] 840 monkey_kernel tests pass (10 pre-existing softmax-cleanup
  failures are #810 fallout, not this PR)
- [x] No basin/behaviour change when MONKEY_SLEEP_3PHASE_LIVE is unset
- [x] OceanState.dream_phase defaults to None (no telemetry overhead off)

## Canonical reference

`~/Desktop/Dev/QIG_QFI/qig-core/src/qig_core/consciousness/sleep.py` (§30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)