### PR TITLE
fix(reconciler): orphan rows wrote entry_price=0 — Poloniex v3 field names

### DIFF
--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -180,7 +180,29 @@ class StateReconciliationService {
         );
 
         if (!matched) {
-          const entryPrice = parseFloat(exPos.avgPrice ?? exPos.entryPrice ?? '0');
+          // Poloniex v3 /trade/position/opens emits `openAvgPx`
+          // (camelCase) or `avg_open_price` (snake-case) for the
+          // position's average entry price. Earlier versions of this
+          // file used `avgPrice ?? entryPrice` — neither field exists
+          // on v3 responses, so orphans were always inserted with
+          // entry_price=0, which broke every downstream check that
+          // gates on entry_price > 0 (ROI %, TP/SL calc, exit logic).
+          // Same un-normalized-v3-response bug class as
+          // exchangePositionSide.ts. Field order matches the v3
+          // canonical preference; legacy aliases at the tail are
+          // defensive in case the response shape changes again.
+          const entryPrice = parseFloat(
+            exPos.openAvgPx
+            ?? exPos.avg_open_price
+            ?? exPos.avgEntryPrice
+            ?? exPos.avgPrice
+            ?? exPos.entryPrice
+            ?? '0',
+          );
+          const leverFromExchange = parseInt(
+            String(exPos.lever ?? exPos.leverage ?? '1'),
+            10,
+          );
           const orphan: OrphanedPosition = {
             symbol,
             side,
@@ -203,15 +225,16 @@ class StateReconciliationService {
             }|src=reconciler`;
             await pool.query(
               `INSERT INTO autonomous_trades
-               (user_id, symbol, side, entry_price, quantity, reason, status,
-                engine_version, agent, lane)
-               VALUES ($1, $2, $3, $4, $5, $6, 'open', $7, 'USER', 'manual')`,
+               (user_id, symbol, side, entry_price, quantity, leverage, reason,
+                status, engine_version, agent, lane)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, 'open', $8, 'USER', 'manual')`,
               [
                 userId,
                 symbol,
                 side,
                 entryPrice,
                 size,
+                leverFromExchange > 0 ? leverFromExchange : 1,
                 userReason,
                 getEngineVersion(),
               ]


### PR DESCRIPTION
## Summary

Operator reported a bleed: two SHORTs (BTC @22×, ETH @22×) held without
exit logic firing. DB rows: `agent='USER'`, `lane='manual'`,
`entry_price=0`.

## Root cause

[stateReconciliationService.ts:183](apps/api/src/services/stateReconciliationService.ts#L183)
read the exchange position's average entry price via
\`exPos.avgPrice ?? exPos.entryPrice ?? '0'\`. **Neither field exists**
on Poloniex v3 \`/trade/position/opens\` responses — the v3-canonical
names are:

| Caller | Field used |
|---|---|
| `fullyAutonomousTrader.ts` (line 1499) | `openAvgPx` ✅ |
| `poloniexFuturesService.js` (line 1530) | `avg_open_price` ✅ |
| `stateReconciliationService.ts:183` | `avgPrice` / `entryPrice` ❌ |

So every orphan position the reconciler tracked got `entry_price=0`
inserted, breaking:
- Dashboard ROI %, TP/SL UI calculations
- Any downstream check filtering on `entry_price > 0`
- Position-management heuristics that rely on the real entry

Compounded by: leverage was always defaulted to 1 (column DEFAULT),
ignoring the actual exchange leverage. The two orphans this morning
were running at 22× on the exchange while the DB said 1×.

Same un-normalized-v3-response bug class as
[exchangePositionSide.ts](apps/api/src/services/exchangePositionSide.ts)
(2026-05-14 qty/posSide / im×lever fixes).

## Fix

- Field-name order in entry_price parsing matches v3 reality:
  `openAvgPx ?? avg_open_price ?? avgEntryPrice` first; the prior
  `avgPrice ?? entryPrice` retained at the tail as defensive aliases.
- Parse `lever ?? leverage` from the exchange position and pass it
  into the INSERT, so the DB column reflects the actual margin
  multiplier instead of column-default 1.

## Manual repair (already applied)

The two existing orphan rows were updated via direct SQL alongside
this PR — entry_price + leverage now match the FAT-observed values
so dashboards work for them immediately, without waiting for redeploy.

## Out of scope (deliberate)

USER/manual orphans still aren't subject to kernel exit logic.
Activating exits on USER rows is a separate decision — current
behaviour (operator manages USER positions manually) is preserved.

## Test plan

- [x] Build clean (yarn build)
- [x] Field-order matches v3 reality (verified against
  fullyAutonomousTrader.ts + poloniexFuturesService.js conventions)
- [x] Manual DB repair confirmed (both orphan rows now show correct
  entry_price + leverage=22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix reconciliation of orphaned Poloniex v3 positions so stored entry price and leverage reflect the actual exchange position state.

Bug Fixes:
- Correct parsing of Poloniex v3 position entry price fields to avoid inserting orphaned trades with entry_price=0.
- Populate leverage for reconciled orphan positions from the exchange response instead of defaulting to 1× in the database.