### PR TITLE
feat(reconciler): kernel adopts operator-opened positions — lane from leverage

### DIFF
--- a/apps/api/src/services/laneFromLeverage.ts
+++ b/apps/api/src/services/laneFromLeverage.ts
@@ -1,0 +1,44 @@
+/**
+ * Map operator-chosen leverage to a kernel lane.
+ *
+ * Operator directive 2026-05-19: "kernels should take over my trades.
+ * but learn from the amount of leverage as to what I expect." Higher
+ * leverage = higher operator conviction → assign to the lane with the
+ * widest retreat tolerance.
+ *
+ * Default boundaries are tuned to the lane-typical leverage ranges in
+ * `monkey/executive.ts` (LANE_PARAMETER_DEFAULTS):
+ *
+ *   scalp  (3%/3%)   ← lev ≤ 3   — exploration / small-conviction
+ *   swing  (15%/15%) ← lev 4..10 — medium-conviction working position
+ *   trend  (40%/40%) ← lev ≥ 11  — high-conviction macro ride
+ *
+ * Bounds are overridable via env so an operator can re-tune without a
+ * code change once they have a feel for the mapping.
+ *
+ * Pure function. Lives in its own file (no heavy imports) so it can be
+ * unit-tested without bootstrapping the API's env validator or DB
+ * connection pool.
+ */
+export function inferLaneFromLeverage(
+  lever: number,
+): 'scalp' | 'swing' | 'trend' {
+  const swingMin = Number(process.env.MONKEY_ADOPT_SWING_LEV_MIN) || 4;
+  const trendMin = Number(process.env.MONKEY_ADOPT_TREND_LEV_MIN) || 11;
+  if (lever >= trendMin) return 'trend';
+  if (lever >= swingMin) return 'swing';
+  return 'scalp';
+}
+
+/**
+ * True iff MONKEY_RECONCILER_KERNEL_ADOPT_LIVE=true.
+ *
+ * Default ON — per operator directive 2026-05-19: kernel should take
+ * over operator-opened positions instead of orphaning them as
+ * USER/manual rows that no exit logic ever fires against. Set to
+ * `false` to restore the legacy USER/manual behaviour.
+ */
+export function kernelAdoptLive(): boolean {
+  return (process.env.MONKEY_RECONCILER_KERNEL_ADOPT_LIVE ?? 'true')
+    .toLowerCase() === 'true';
+}

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -13,6 +13,12 @@ import { monitoringService } from './monitoringService.js';
 import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 import { BusEventType, getKernelBus } from './monkey/kernel_bus.js';
+import { inferLaneFromLeverage, kernelAdoptLive } from './laneFromLeverage.js';
+
+// Re-export so callers continue to import these from
+// stateReconciliationService for backward compat. Definitions live in
+// the dep-free laneFromLeverage module so they're unit-testable.
+export { inferLaneFromLeverage };
 
 export interface OrphanedPosition {
   symbol: string;
@@ -21,6 +27,7 @@ export interface OrphanedPosition {
   entryPrice: number;
   exchangePositionId?: string;
 }
+
 
 export interface GhostRecord {
   id: string;
@@ -212,35 +219,54 @@ class StateReconciliationService {
           };
           result.orphans.push(orphan);
 
-          // Insert reconciled record into autonomous_trades, tagged as
-          // user-originated (agent='USER', lane='manual'). This lets the
-          // kernel's own queries — which filter by reason LIKE 'monkey|%' —
-          // continue to ignore manual positions, while dashboards and PnL
-          // accounting can identify them as user-placed. The reason field
-          // also embeds the source so historic queries can distinguish
-          // user opens from system retries.
+          // Insert reconciled record into autonomous_trades.
+          //
+          // Adoption mode (MONKEY_RECONCILER_KERNEL_ADOPT_LIVE, default ON):
+          //   agent='K', lane=inferLaneFromLeverage(lev). The kernel
+          //   picks up exit management on the next tick — scalp_exit,
+          //   regime_change, slow_bleed_exit, stop_loss all fire on
+          //   the adopted row. The operator's chosen leverage encodes
+          //   their conviction signal (high lev → trend lane with
+          //   wider retreat tolerance).
+          //
+          // Legacy mode (env=false):
+          //   agent='USER', lane='manual'. Row exists for accounting
+          //   only; no kernel exit logic fires.
           try {
-            const userReason = `manual_open_user|exchange_pid=${
-              exPos.positionId ?? exPos.id ?? 'na'
-            }|src=reconciler`;
+            const adoptLive = kernelAdoptLive();
+            const effectiveLever = leverFromExchange > 0 ? leverFromExchange : 1;
+            const inferredLane = inferLaneFromLeverage(effectiveLever);
+            const adoptAgent = adoptLive ? 'K' : 'USER';
+            const adoptLane = adoptLive ? inferredLane : 'manual';
+            const reasonPrefix = adoptLive
+              ? 'kernel_adopted'
+              : 'manual_open_user';
+            const userReason =
+              `${reasonPrefix}|exchange_pid=${
+                exPos.positionId ?? exPos.id ?? 'na'
+              }|lev=${effectiveLever}|inferred_lane=${inferredLane}|src=reconciler`;
             await pool.query(
               `INSERT INTO autonomous_trades
                (user_id, symbol, side, entry_price, quantity, leverage, reason,
                 status, engine_version, agent, lane)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, 'open', $8, 'USER', 'manual')`,
+               VALUES ($1, $2, $3, $4, $5, $6, $7, 'open', $8, $9, $10)`,
               [
                 userId,
                 symbol,
                 side,
                 entryPrice,
                 size,
-                leverFromExchange > 0 ? leverFromExchange : 1,
+                effectiveLever,
                 userReason,
                 getEngineVersion(),
+                adoptAgent,
+                adoptLane,
               ]
             );
             logger.info(
-              `[RECONCILE] Tracked user-opened position for user ${userId}: ${symbol} ${side} qty=${size} @${entryPrice}`
+              `[RECONCILE] ${adoptLive ? 'Kernel-adopted' : 'Tracked USER'} position for ${userId}: ` +
+              `${symbol} ${side} qty=${size} @${entryPrice} lev=${effectiveLever}x ` +
+              `→ agent=${adoptAgent} lane=${adoptLane}`
             );
             // Emit an agent_events row so the audit trail captures the
             // user action explicitly. metadata column was added in
@@ -375,9 +401,13 @@ class StateReconciliationService {
               ctx.reason.startsWith('live_signal|') ||
               ctx.reason.startsWith('autoTrader|') ||
               ctx.reason.startsWith('manual_open_user') ||
+              ctx.reason.startsWith('kernel_adopted') ||
               ctx.reason === 'reconciled'
             ))
           ) {
+            // Operator-closed (manual close in exchange UI) — applies to
+            // both legacy USER/manual rows and kernel-adopted rows that
+            // originated from operator action.
             ghostReason = 'manual_close_user';
           }
           const a = ctx?.agent;

--- a/apps/api/src/tests/stateReconciliation.laneFromLeverage.test.ts
+++ b/apps/api/src/tests/stateReconciliation.laneFromLeverage.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for inferLaneFromLeverage — operator-conviction → kernel-lane
+ * mapping used by the reconciler when adopting orphan exchange positions.
+ *
+ * Operator directive 2026-05-19: "kernels should take over my trades.
+ * but learn from the amount of leverage as to what I expect."
+ *
+ * Mapping (default bounds; overridable via env):
+ *   lev ≤ 3       → scalp  (3%/3% SL/TP — small conviction)
+ *   4 ≤ lev ≤ 10  → swing  (15%/15% — medium conviction)
+ *   lev ≥ 11      → trend  (40%/40% — high conviction, ride the macro)
+ *
+ * The two SHORTs from the bleed-diagnosis incident were both opened at
+ * 22× — by this mapping they would have been adopted into the trend
+ * lane, which has the widest retreat tolerance and the longest hold
+ * profile (consistent with the operator's evident conviction signal).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { inferLaneFromLeverage } from '../services/laneFromLeverage.js';
+
+describe('inferLaneFromLeverage', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.MONKEY_ADOPT_SWING_LEV_MIN;
+    delete process.env.MONKEY_ADOPT_TREND_LEV_MIN;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  describe('default boundaries (no env override)', () => {
+    it('lev=1 → scalp (low conviction)', () => {
+      expect(inferLaneFromLeverage(1)).toBe('scalp');
+    });
+
+    it('lev=3 → scalp (upper edge of scalp band)', () => {
+      expect(inferLaneFromLeverage(3)).toBe('scalp');
+    });
+
+    it('lev=4 → swing (lower edge of swing band)', () => {
+      expect(inferLaneFromLeverage(4)).toBe('swing');
+    });
+
+    it('lev=10 → swing (upper edge of swing band)', () => {
+      expect(inferLaneFromLeverage(10)).toBe('swing');
+    });
+
+    it('lev=11 → trend (lower edge of trend band)', () => {
+      expect(inferLaneFromLeverage(11)).toBe('trend');
+    });
+
+    it('lev=22 → trend (the incident shape)', () => {
+      // 2026-05-19 bleed: operator opened BTC and ETH SHORTs at 22×.
+      // Trend is the right lane for the conviction signal carried by
+      // the chosen leverage; the orphans would have been adopted into
+      // trend if this code had been live at the time.
+      expect(inferLaneFromLeverage(22)).toBe('trend');
+    });
+
+    it('lev=75 → trend (Poloniex futures max)', () => {
+      expect(inferLaneFromLeverage(75)).toBe('trend');
+    });
+  });
+
+  describe('env overrides', () => {
+    it('honours MONKEY_ADOPT_SWING_LEV_MIN', () => {
+      process.env.MONKEY_ADOPT_SWING_LEV_MIN = '2';
+      expect(inferLaneFromLeverage(1)).toBe('scalp');
+      expect(inferLaneFromLeverage(2)).toBe('swing');
+      expect(inferLaneFromLeverage(10)).toBe('swing');
+    });
+
+    it('honours MONKEY_ADOPT_TREND_LEV_MIN', () => {
+      process.env.MONKEY_ADOPT_TREND_LEV_MIN = '20';
+      expect(inferLaneFromLeverage(11)).toBe('swing');
+      expect(inferLaneFromLeverage(19)).toBe('swing');
+      expect(inferLaneFromLeverage(20)).toBe('trend');
+    });
+
+    it('non-numeric env value falls back to default (parses to NaN → || default)', () => {
+      process.env.MONKEY_ADOPT_TREND_LEV_MIN = 'banana';
+      expect(inferLaneFromLeverage(11)).toBe('trend');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('lev=0 (defensive) → scalp', () => {
+      expect(inferLaneFromLeverage(0)).toBe('scalp');
+    });
+
+    it('negative lev (defensive) → scalp', () => {
+      expect(inferLaneFromLeverage(-5)).toBe('scalp');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Per operator directive 2026-05-19: *"kernels should take over my trades.
but learn from the amount of leverage as to what I expect."*

When the reconciler detects an exchange position with no matching kernel
DB row, instead of inserting an unmanageable `agent='USER'/lane='manual'`
orphan, the row is now **adopted as kernel-owned** (`agent='K'`) with
the lane inferred from the operator's chosen leverage.

| Leverage | Lane | Profile |
|---|---|---|
| ≤ 3× | scalp | 3% SL / 3% TP — small conviction, fast turn |
| 4–10× | swing | 15% / 15% — medium conviction |
| ≥ 11× | trend | 40% / 40% — high conviction, ride the macro |

## Why this matters

The bleed diagnosed in #853 had two 22× SHORTs orphaned as USER/manual
that bounced to **+2.85% and +3.29% ROI mid-hold** without any kernel
exit logic running. The kernel literally watched profit windows pass
and the positions drain back to red. Operator closed both manually in
profit after the field-name fix.

With this change, both 22× positions would have been adopted into the
**trend lane** — widest retreat tolerance, longest hold profile, which
matches the conviction signal a 22× leverage carries.

## Configuration

| Env | Default | Purpose |
|---|---|---|
| `MONKEY_RECONCILER_KERNEL_ADOPT_LIVE` | `true` | Master toggle. `false` restores legacy USER/manual orphans. |
| `MONKEY_ADOPT_SWING_LEV_MIN` | `4` | Minimum leverage for swing |
| `MONKEY_ADOPT_TREND_LEV_MIN` | `11` | Minimum leverage for trend |

## Test plan

- [x] 12 new tests pass — default mapping, env overrides, edge cases,
  the incident-shape (`lev=22 → trend`)
- [x] Build clean
- [x] Ghost-detection still recognises legacy `manual_open_user` reason
  AND the new `kernel_adopted` reason — operator manual closes still
  resolve as `manual_close_user` for audit-trail consistency.

## Out of scope

Per-lane state slots (`peak_pnl_usdt_by_lane`, `regime_at_open_by_lane`,
`basin_at_open_by_lane`) are NOT pre-seeded on adoption — the first
tick after adoption initializes them from live state. Intentional:
adopted positions start from "now" and let harvest logic learn from
the actual evolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adopt orphaned exchange positions as kernel-managed trades with lane selection derived from leverage, while preserving a configurable legacy mode and updating reconciliation logging and ghost handling accordingly.

New Features:
- Introduce leverage-to-lane mapping to assign orphaned positions into scalp, swing, or trend lanes based on operator-selected leverage.
- Add a configurable kernel adoption mode that treats operator-opened exchange positions as kernel-owned for exit management instead of leaving them as manual-only orphans.

Enhancements:
- Refine reconciliation logging and ghost-detection reasoning to distinguish kernel-adopted positions from legacy manually opened user positions.
- Extract lane inference and adoption toggle into a standalone, dependency-light module to enable focused unit testing and environment-based tuning.

Tests:
- Add unit tests covering leverage-to-lane mapping, environment override behavior, and reconciliation flows for kernel adoption and legacy modes.