### PR TITLE
feat(executive): absolute-USD profit-harvest gate — fix "didn't take $5+ shorts"

### DIFF
--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -632,6 +632,46 @@ export function shouldProfitHarvest(
     };
   }
 
+  // ABSOLUTE-USD harvest — operator-observed gap (2026-05-19):
+  //
+  // Peak tracking is per-(symbol, lane) inside each kernel instance.
+  // With multi-kernel + multi-agent (monkey-position + monkey-swing
+  // running K + T sides), a single user-facing position is split into
+  // subsets. A $5+ user-visible profit fragments into ~$1-2 per subset
+  // — below the % activation threshold (0.2-0.4% of subset notional) on
+  // wider lanes (trend at 40% TP target), so no subset arms the
+  // trailing harvest. Market reverses, turtle_stop fires for a loss,
+  // and the operator watches a $5+ peak round-trip to red.
+  //
+  // Fix: parallel absolute-USD gate. When peak ≥ MONKEY_HARVEST_ABS_PEAK_USD
+  // (default $3) AND current has given back to ≤ peak × (1 - giveback)
+  // BUT still positive, harvest. Independent of % activation so it
+  // fires regardless of subset size or lane width. Default $3 matches
+  // operator expectation: "kernels should take the small wins, fees
+  // aren't a factor on this tier".
+  //
+  // The default is intentionally tunable via env so the operator can
+  // dial it once the realized-PnL distribution stabilises.
+  const absPeakMinUsd = Number(process.env.MONKEY_HARVEST_ABS_PEAK_USD) || 3.0;
+  if (
+    peakPnlUsdt >= absPeakMinUsd
+    && currentFrac > 0
+    && unrealizedPnlUsdt < peakPnlUsdt * (1 - giveback)
+  ) {
+    return {
+      value: true,
+      reason: `abs_usd_harvest: peak $${peakPnlUsdt.toFixed(2)} → now $${unrealizedPnlUsdt.toFixed(2)} < $${(peakPnlUsdt * (1 - giveback)).toFixed(2)} floor (threshold $${absPeakMinUsd.toFixed(2)}, giveback ${(giveback * 100).toFixed(0)}%)`,
+      derivation: {
+        currentPnlUsdt: unrealizedPnlUsdt,
+        peakPnlUsdt,
+        absPeakMinUsd,
+        absoluteFloor: peakPnlUsdt * (1 - giveback),
+        giveback,
+        exitTypeBit: 4,
+      },
+    };
+  }
+
   // TREND-FLIP trigger. Aligned entry means tapeTrend had the same sign
   // as heldSide when she entered; if tape reverses against her while
   // she's green, harvest now — but only if the tape flip is SUSTAINED

--- a/apps/api/src/tests/shouldProfitHarvest.absUsd.test.ts
+++ b/apps/api/src/tests/shouldProfitHarvest.absUsd.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the absolute-USD trailing-harvest gate added to
+ * shouldProfitHarvest (2026-05-19, operator-observed).
+ *
+ * Failure pattern this fixes: peak tracking is per-(symbol, lane) per
+ * kernel instance. A single user-facing position split across
+ * monkey-position + monkey-swing (and K + T agents) becomes a set of
+ * subsets, each with its own peak. A $5+ user-visible profit fragments
+ * into ~$1-$2 per subset — below the % activation threshold (0.2-0.4%
+ * of subset notional) on wider lanes (trend at 40% TP). No subset
+ * arms the trailing harvest, market reverses, turtle_stop fires for a
+ * loss, and the operator watches the peak round-trip to red.
+ *
+ * The fix adds a parallel absolute-USD gate (MONKEY_HARVEST_ABS_PEAK_USD,
+ * default $3): when peak ≥ $3 AND current has given back past
+ * peak × (1 - giveback), harvest — independent of % activation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { shouldProfitHarvest } from '../services/monkey/executive.js';
+import type { BasinState } from '../services/monkey/executive.js';
+
+const baselineBasin: BasinState = {
+  phi: 0.5,
+  sovereignty: 1.0,
+  basinVelocity: 0.05,
+  neurochemistry: {
+    acetylcholine: 0.5,
+    dopamine: 0.5,
+    serotonin: 0.5,
+    norepinephrine: 0.5,
+    gaba: 0.5,
+    endorphins: 0.5,
+  },
+} as unknown as BasinState;
+
+describe('shouldProfitHarvest — absolute-USD trailing gate', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.MONKEY_HARVEST_ABS_PEAK_USD;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('fires at default $3 threshold when peak hit $5 and gave back to $2', () => {
+    // Reproduces the 2026-05-19 incident shape: notional is large
+    // enough that peak $5 is BELOW the % activation floor
+    // (0.2% × notional), so the existing % trailing-harvest path
+    // can't arm. The new abs-USD gate fires instead.
+    //   - notional $5000 → % activation = 0.2-0.4% = $10-$20
+    //   - peak $5 < $10 → % path bypassed
+    //   - peak $5 ≥ $3 abs threshold → abs gate arms
+    //   - current $2 < $5 × (1 - 0.4) = $3 floor → harvest fires
+    const result = shouldProfitHarvest(
+      /* unrealizedPnlUsdt */ 2.0,
+      /* peakPnlUsdt */       5.0,
+      /* notionalUsdt */      5000,
+      /* tapeTrend */         0.0,
+      /* heldSide */          'short',
+      baselineBasin,
+    );
+    expect(result.value).toBe(true);
+    expect(result.reason).toContain('abs_usd_harvest');
+  });
+
+  it('does NOT fire when peak is below $3 default threshold', () => {
+    // Same large-notional shape so % path stays quiet, then verify
+    // the abs-USD gate also stays quiet when peak < $3 threshold.
+    const result = shouldProfitHarvest(
+      /* unrealizedPnlUsdt */ 0.5,
+      /* peakPnlUsdt */       2.5,  // below $3 default
+      /* notionalUsdt */      5000,
+      /* tapeTrend */         0.0,
+      /* heldSide */          'short',
+      baselineBasin,
+    );
+    expect(result.value).toBe(false);
+  });
+
+  it('does NOT fire when still at peak (no giveback yet)', () => {
+    const result = shouldProfitHarvest(
+      /* unrealizedPnlUsdt */ 5.0,
+      /* peakPnlUsdt */       5.0,  // current == peak, no giveback
+      /* notionalUsdt */      800,
+      /* tapeTrend */         0.0,
+      /* heldSide */          'short',
+      baselineBasin,
+    );
+    expect(result.value).toBe(false);
+  });
+
+  it('does NOT fire when current goes to zero/negative (SL handles losses)', () => {
+    const result = shouldProfitHarvest(
+      /* unrealizedPnlUsdt */ -1.0,
+      /* peakPnlUsdt */       5.0,
+      /* notionalUsdt */      800,
+      /* tapeTrend */         0.0,
+      /* heldSide */          'short',
+      baselineBasin,
+    );
+    // currentFrac > 0 guard: harvest is for "lock in some profit",
+    // not "cut a loss" — SL gate owns the loss path.
+    expect(result.value).toBe(false);
+  });
+
+  it('honours MONKEY_HARVEST_ABS_PEAK_USD override (raises threshold)', () => {
+    process.env.MONKEY_HARVEST_ABS_PEAK_USD = '10';
+    const result = shouldProfitHarvest(
+      /* unrealizedPnlUsdt */ 2.0,
+      /* peakPnlUsdt */       5.0,
+      /* notionalUsdt */      5000,  // large → keep % path quiet
+      /* tapeTrend */         0.0,
+      /* heldSide */          'short',
+      baselineBasin,
+    );
+    // $5 peak < $10 override threshold → abs-USD gate doesn't arm.
+    expect(result.reason).not.toContain('abs_usd_harvest');
+  });
+
+  it('fires at lower threshold when env tightens it', () => {
+    process.env.MONKEY_HARVEST_ABS_PEAK_USD = '1.5';
+    const result = shouldProfitHarvest(
+      /* unrealizedPnlUsdt */ 0.5,
+      /* peakPnlUsdt */       2.0,    // ≥ $1.5 override
+      /* notionalUsdt */      5000,  // large → keep % path quiet
+      /* tapeTrend */         0.0,
+      /* heldSide */          'short',
+      baselineBasin,
+    );
+    expect(result.value).toBe(true);
+    expect(result.reason).toContain('abs_usd_harvest');
+  });
+});


### PR DESCRIPTION
## Summary

Operator observation 2026-05-19: *"definately didnt take the SHORTs
when they were both \$5+"*.

Both BTC SHORT and ETH SHORT peaked at \$5+ unrealized; kernel never
harvested; market reversed; turtle_stop fired for net **-\$1.67** across
4 BTC SHORT rows.

## Root cause

`shouldProfitHarvest` trailing-stop uses a **percentage-of-notional**
activation threshold (0.2-0.4% of subset notional). With multi-kernel
+ multi-agent (monkey-position + monkey-swing each running K and T
sides), a single user-facing position fragments into several subsets.
**A \$5+ aggregate profit becomes \$1-\$2 per subset** — below the %
activation threshold on wider lanes (trend at 40% TP). No subset arms
the trailing harvest; peak passes unrealized; reverses; turtle_stop
locks in a loss.

Realized from the incident:
| Time | Agent | Symbol | Exit | P&L |
|---|---|---|---|---|
| 14:07 | K | ETH SHORT | scalp_exit | +\$0.41 |
| 14:17 | K | ETH SHORT | scalp_exit | +\$2.34 |
| 14:25 | K | ETH SHORT | trailing_harvest | +\$0.57 |
| 14:43 | T | BTC SHORT × 4 | turtle_stop | **-\$1.67** |

Net SHORT P&L last hour: **+\$1.65** — well below the \$5+ peak the
aggregate position briefly hit.

## Fix

Parallel **absolute-USD** gate inside `shouldProfitHarvest`:

- Threshold `MONKEY_HARVEST_ABS_PEAK_USD` (default **\$3**)
- When `peakPnlUsdt ≥ \$3` AND `current < peak × (1 - giveback)` AND `current > 0` → harvest
- Independent of % activation: fires regardless of subset size or lane width
- Uses the same dopamine/serotonin-scaled giveback as the % gate

This addresses the recurring operator complaint: *small \$3-\$10 wins
evaporate before exit logic catches them*. With fee-free trading, those
wins are worth taking — there's no transaction cost preventing a quick
harvest.

## Configuration

| Env | Default | Purpose |
|---|---|---|
| `MONKEY_HARVEST_ABS_PEAK_USD` | `3.0` | Minimum peak \$\$\$ to arm abs-USD trailing gate |

## Test plan

- [x] 6 new tests pass — incident-shape reproduction, below-threshold,
  no-giveback, negative-current (SL owns), env raise, env lower
- [x] Build clean
- [x] % trailing-harvest path unchanged — existing trades still close
  via the existing logic; this is purely additive

## Operator follow-up suggestion

After this lands, watch the realized-PnL distribution for ~24h. If
\$3 turns out to be too aggressive (closes positions that would have
run further), raise via env. If \$5+ peaks still slip through, lower
to \$2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an absolute-USD trailing profit-harvest gate to monkey executive logic to ensure small dollar profits are realized even when percentage-based thresholds are not met.

New Features:
- Introduce an absolute-USD profit-harvest condition in shouldProfitHarvest, triggered when unrealized P&L gives back from a configured peak dollar threshold.
- Make the absolute-USD harvest activation threshold configurable via the MONKEY_HARVEST_ABS_PEAK_USD environment variable.

Tests:
- Add unit tests covering the new absolute-USD harvest behavior, including default threshold behavior, below-threshold cases, giveback requirements, negative-P&L handling, and environment overrides.