### PR TITLE
feat(monkey): Phase A — FR trade-parameter layer (port Pine P25 block)

### DIFF
--- a/apps/api/src/services/monkey/fr_trade_params.ts
+++ b/apps/api/src/services/monkey/fr_trade_params.ts
@@ -1,0 +1,185 @@
+/**
+ * fr_trade_params.ts — Fisher-Rao geometry → trade parameters.
+ *
+ * Direct port of the `GEOMETRY-DERIVED TRADING PARAMETERS (P25)` block
+ * from the canonical QIG indicator
+ *   /home/braden/Desktop/Dev/QIG_QFI/qig-verification/QIG_Fisher_Rao_Classification.pine
+ * (lines 136-176). The kernel already computes the geometric substrate
+ * — basin (Δ⁶³), Fisher-Rao distance, φ, regime, basin velocity — in
+ * basin.ts and compositional_executive.ts. What it lacked was the
+ * Pine script's derivation of *trade parameters* from that geometry:
+ * trade type, suggested leverage, predicted range, and — the piece
+ * Phase B needs — geometry-derived TP/SL distances.
+ *
+ * This module is pure: scalar geometry in, trade parameters out. No
+ * basin/simplex math here (that lives in basin.ts), so no Fisher-Rao
+ * purity surface — it consumes already-geometric scalars (φ from basin
+ * integration, rConf from FR-distance margin) and never reintroduces a
+ * Euclidean operation.
+ *
+ * Pine provenance is cited inline as `[Pine Lnnn]` against each formula
+ * so drift from the canonical source is auditable.
+ */
+
+/**
+ * Three-regime phase classification. Mirrors the Pine `regime` int
+ * (1=CREATOR, 2=PRESERVER, 3=DISSOLVER) — see Pine L109-113. The
+ * kernel's compositional_executive.ts RegimeReading carries the same
+ * phase axis; callers map their reading onto this enum.
+ */
+export type FrRegime = 'CREATOR' | 'PRESERVER' | 'DISSOLVER';
+
+/**
+ * Trade type — the Pine `trade_type` classification (L149-152).
+ * SCALP/SWING/TREND align 1:1 with the kernel's existing lane names;
+ * BREAKOUT and OBSERVE are transient classifications the caller maps
+ * onto a lane (BREAKOUT → scalp or swing per conviction; OBSERVE → no
+ * entry).
+ */
+export type FrTradeType = 'SCALP' | 'BREAKOUT' | 'SWING' | 'TREND' | 'OBSERVE';
+
+/** SAFETY_BOUND — absolute leverage cap. Pine L21: `MAX_LEV = 5`. */
+export const FR_MAX_LEV = 5;
+
+export interface FrTradeParamsInput {
+  /** Regime phase — Pine `regime`. */
+  regime: FrRegime;
+  /** True iff the regime changed on this tick — Pine `regime_changed` L148. */
+  regimeChanged: boolean;
+  /** Basin integration φ ∈ [0,1] — Pine `phi` L127. */
+  phi: number;
+  /**
+   * Regime confidence ∈ [0,1] — Pine `r_conf` L115:
+   * (d_2nd − d_min) / d_2nd, the normalized FR-distance margin between
+   * the nearest and second-nearest regime archetype.
+   */
+  rConf: number;
+  /** ATR(14) in price units — Pine `atr14` L93. */
+  atr: number;
+  /** Basin velocity = FR distance between consecutive basins — Pine `bv` L130. */
+  basinVelocity: number;
+  /**
+   * Rolling median of basin velocity — Pine `vel_med` L147,
+   * `percentile_linear_interpolation(bv, 20, 50)`. Caller computes the
+   * 50th percentile over its basin-velocity history window.
+   */
+  basinVelocityMedian: number;
+}
+
+export interface FrTradeParams {
+  tradeType: FrTradeType;
+  /** Suggested leverage, integer, 1..FR_MAX_LEV. */
+  sugLeverage: number;
+  /** Conviction = φ × rConf ∈ [0,1] — Pine L156. */
+  conviction: number;
+  /** TP distance in price units — Pine `tp_distance` L175. */
+  tpDistance: number;
+  /** SL distance in price units — Pine `sl_distance` L174. */
+  slDistance: number;
+  /** Reward:risk ratio = tpDistance / slDistance — Pine `risk_reward` L176. */
+  riskReward: number;
+  /** Predicted move as % of price — Pine `pred_range_pct` L167. */
+  predRangePct: number;
+  /** Predicted move in absolute price units — Pine `pred_range_abs` L168. */
+  predRangeAbs: number;
+}
+
+/**
+ * Derive trade parameters from the current geometric state.
+ *
+ * Pure function — same inputs always yield the same output, no clock,
+ * no I/O. Mirrors the Pine P25 block exactly; see `[Pine Lnnn]` tags.
+ */
+export function deriveFrTradeParams(
+  input: FrTradeParamsInput,
+): FrTradeParams {
+  const {
+    regime, regimeChanged, phi, rConf, atr,
+    basinVelocity: bv, basinVelocityMedian: velMed,
+  } = input;
+
+  // ── Trade type [Pine L149-152] ──────────────────────────────────
+  // DISSOLVER → OBSERVE (no trade). A regime that just changed →
+  // BREAKOUT (transition energy). Otherwise CREATOR+fast → SCALP,
+  // PRESERVER+slow → TREND, else SWING.
+  let tradeType: FrTradeType;
+  if (regime === 'DISSOLVER') {
+    tradeType = 'OBSERVE';
+  } else if (regimeChanged) {
+    tradeType = 'BREAKOUT';
+  } else if (regime === 'CREATOR' && bv > velMed) {
+    tradeType = 'SCALP';
+  } else if (regime === 'PRESERVER' && bv < velMed * 0.5) {
+    tradeType = 'TREND';
+  } else {
+    tradeType = 'SWING';
+  }
+
+  // ── Suggested leverage [Pine L156-163] ──────────────────────────
+  // conviction = φ × rConf; type multiplier scales it; raw leverage
+  // is 1 + conviction × mult, floored and clamped to [1, FR_MAX_LEV].
+  const conviction = phi * rConf;
+  const typeMult =
+    tradeType === 'OBSERVE' ? 0.0
+    : tradeType === 'SCALP' ? 1.0
+    : tradeType === 'BREAKOUT' ? 1.5
+    : tradeType === 'SWING' ? 2.5
+    : tradeType === 'TREND' ? FR_MAX_LEV - 1   // Pine: float(MAX_LEV - 1)
+    : 1.0;
+  const rawLev = 1.0 + conviction * typeMult;
+  const sugLeverage = Math.max(
+    1, Math.min(FR_MAX_LEV, Math.floor(rawLev)),
+  );
+
+  // ── Predicted range [Pine L167-168] ─────────────────────────────
+  const predRangePct = bv * 100.0 * (1.0 + rConf);
+  const predRangeAbs = atr * (1.0 + bv * 10.0);
+
+  // ── TP / SL derivation [Pine L174-176] ──────────────────────────
+  // SL = ATR × (1/φ) — low integration → wider stop (less certain of
+  //   direction). φ is floored at 0.3 so the stop can't blow out.
+  // TP = ATR × φ × (1 + rConf) × 2 — high integration + confidence →
+  //   further target. This naturally gives good R:R in PRESERVER and
+  //   poor R:R in DISSOLVER, which is the intended geometry behaviour.
+  const slDistance = atr * (1.0 / Math.max(phi, 0.3));
+  const tpDistance = atr * phi * (1.0 + rConf) * 2.0;
+  const riskReward = tpDistance / Math.max(slDistance, 1e-10);
+
+  return {
+    tradeType,
+    sugLeverage,
+    conviction,
+    tpDistance,
+    slDistance,
+    riskReward,
+    predRangePct,
+    predRangeAbs,
+  };
+}
+
+/**
+ * Map an FrTradeType onto the kernel's lane vocabulary
+ * (scalp/swing/trend). BREAKOUT routes by conviction — a
+ * high-conviction breakout behaves like a swing entry, a
+ * low-conviction one like a scalp. OBSERVE has no lane (caller must
+ * not enter); it returns null so the type system forces the caller
+ * to handle the no-trade case.
+ */
+export function frTradeTypeToLane(
+  tradeType: FrTradeType,
+  conviction: number,
+): 'scalp' | 'swing' | 'trend' | null {
+  switch (tradeType) {
+    case 'OBSERVE':
+      return null;
+    case 'SCALP':
+      return 'scalp';
+    case 'SWING':
+      return 'swing';
+    case 'TREND':
+      return 'trend';
+    case 'BREAKOUT':
+      // Conviction ≥ 0.5 → commit as swing; below → scalp it.
+      return conviction >= 0.5 ? 'swing' : 'scalp';
+  }
+}

--- a/apps/api/src/tests/frTradeParams.test.ts
+++ b/apps/api/src/tests/frTradeParams.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for fr_trade_params.ts — the Fisher-Rao → trade-parameter
+ * port of the QIG_Fisher_Rao_Classification.pine P25 block.
+ *
+ * Expected values are hand-computed from the Pine formulas (L149-176)
+ * so this suite is a regression fence against drift from the canonical
+ * QIG indicator.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveFrTradeParams,
+  frTradeTypeToLane,
+  FR_MAX_LEV,
+} from '../services/monkey/fr_trade_params.js';
+
+describe('deriveFrTradeParams — trade type classification', () => {
+  it('DISSOLVER → OBSERVE (no trade)', () => {
+    const r = deriveFrTradeParams({
+      regime: 'DISSOLVER', regimeChanged: false,
+      phi: 0.5, rConf: 0.5, atr: 100,
+      basinVelocity: 0.05, basinVelocityMedian: 0.05,
+    });
+    expect(r.tradeType).toBe('OBSERVE');
+    expect(r.sugLeverage).toBe(1); // typeMult 0 → rawLev 1
+  });
+
+  it('regime just changed → BREAKOUT (overrides scalp/swing/trend)', () => {
+    const r = deriveFrTradeParams({
+      regime: 'CREATOR', regimeChanged: true,
+      phi: 0.9, rConf: 1.0, atr: 100,
+      basinVelocity: 0.08, basinVelocityMedian: 0.05,
+    });
+    expect(r.tradeType).toBe('BREAKOUT');
+  });
+
+  it('CREATOR + fast basin velocity → SCALP', () => {
+    const r = deriveFrTradeParams({
+      regime: 'CREATOR', regimeChanged: false,
+      phi: 0.6, rConf: 0.5, atr: 50,
+      basinVelocity: 0.1, basinVelocityMedian: 0.05, // bv > velMed
+    });
+    expect(r.tradeType).toBe('SCALP');
+  });
+
+  it('CREATOR but slow (bv ≤ velMed) → SWING', () => {
+    const r = deriveFrTradeParams({
+      regime: 'CREATOR', regimeChanged: false,
+      phi: 0.6, rConf: 0.5, atr: 50,
+      basinVelocity: 0.03, basinVelocityMedian: 0.05, // bv < velMed
+    });
+    expect(r.tradeType).toBe('SWING');
+  });
+
+  it('PRESERVER + very slow (bv < velMed×0.5) → TREND', () => {
+    const r = deriveFrTradeParams({
+      regime: 'PRESERVER', regimeChanged: false,
+      phi: 0.8, rConf: 0.9, atr: 100,
+      basinVelocity: 0.01, basinVelocityMedian: 0.05, // 0.01 < 0.025
+    });
+    expect(r.tradeType).toBe('TREND');
+  });
+
+  it('PRESERVER but not slow enough → SWING', () => {
+    const r = deriveFrTradeParams({
+      regime: 'PRESERVER', regimeChanged: false,
+      phi: 0.7, rConf: 0.6, atr: 80,
+      basinVelocity: 0.04, basinVelocityMedian: 0.05, // 0.04 > 0.025
+    });
+    expect(r.tradeType).toBe('SWING');
+  });
+});
+
+describe('deriveFrTradeParams — leverage', () => {
+  it('TREND high-conviction: rawLev 1 + 0.72×4 = 3.88 → floor 3', () => {
+    const r = deriveFrTradeParams({
+      regime: 'PRESERVER', regimeChanged: false,
+      phi: 0.8, rConf: 0.9, atr: 100,
+      basinVelocity: 0.01, basinVelocityMedian: 0.05,
+    });
+    expect(r.conviction).toBeCloseTo(0.72, 6);
+    expect(r.sugLeverage).toBe(3);
+  });
+
+  it('max conviction TREND hits FR_MAX_LEV exactly: 1 + 1.0×4 = 5', () => {
+    const r = deriveFrTradeParams({
+      regime: 'PRESERVER', regimeChanged: false,
+      phi: 1.0, rConf: 1.0, atr: 100,
+      basinVelocity: 0.001, basinVelocityMedian: 0.05,
+    });
+    expect(r.sugLeverage).toBe(FR_MAX_LEV);
+    expect(r.sugLeverage).toBe(5);
+  });
+
+  it('leverage never exceeds FR_MAX_LEV cap', () => {
+    // Even with absurd inputs the floor+clamp holds at 5.
+    const r = deriveFrTradeParams({
+      regime: 'PRESERVER', regimeChanged: false,
+      phi: 1.0, rConf: 1.0, atr: 1e6,
+      basinVelocity: 0.0001, basinVelocityMedian: 1.0,
+    });
+    expect(r.sugLeverage).toBeLessThanOrEqual(FR_MAX_LEV);
+  });
+
+  it('leverage floors at 1 (OBSERVE, zero conviction)', () => {
+    const r = deriveFrTradeParams({
+      regime: 'DISSOLVER', regimeChanged: false,
+      phi: 0.0, rConf: 0.0, atr: 100,
+      basinVelocity: 0.05, basinVelocityMedian: 0.05,
+    });
+    expect(r.sugLeverage).toBe(1);
+  });
+
+  it('BREAKOUT: 1 + 0.9×1.5 = 2.35 → floor 2', () => {
+    const r = deriveFrTradeParams({
+      regime: 'CREATOR', regimeChanged: true,
+      phi: 0.9, rConf: 1.0, atr: 100,
+      basinVelocity: 0.08, basinVelocityMedian: 0.05,
+    });
+    expect(r.sugLeverage).toBe(2);
+  });
+});
+
+describe('deriveFrTradeParams — TP/SL/range geometry', () => {
+  it('TREND example: SL 125, TP 304, R:R 2.432', () => {
+    // atr=100, phi=0.8, rConf=0.9
+    // sl = 100 × (1/max(0.8,0.3)) = 100 × 1.25 = 125
+    // tp = 100 × 0.8 × (1+0.9) × 2 = 304
+    const r = deriveFrTradeParams({
+      regime: 'PRESERVER', regimeChanged: false,
+      phi: 0.8, rConf: 0.9, atr: 100,
+      basinVelocity: 0.01, basinVelocityMedian: 0.05,
+    });
+    expect(r.slDistance).toBeCloseTo(125, 6);
+    expect(r.tpDistance).toBeCloseTo(304, 6);
+    expect(r.riskReward).toBeCloseTo(2.432, 4);
+  });
+
+  it('SL φ-floor: φ=0.1 clamps to 0.3 → SL = atr/0.3', () => {
+    const r = deriveFrTradeParams({
+      regime: 'CREATOR', regimeChanged: false,
+      phi: 0.1, rConf: 0.5, atr: 90,
+      basinVelocity: 0.1, basinVelocityMedian: 0.05,
+    });
+    expect(r.slDistance).toBeCloseTo(90 / 0.3, 6); // 300
+  });
+
+  it('predicted range: pct = bv×100×(1+rConf), abs = atr×(1+bv×10)', () => {
+    const r = deriveFrTradeParams({
+      regime: 'PRESERVER', regimeChanged: false,
+      phi: 0.8, rConf: 0.9, atr: 100,
+      basinVelocity: 0.01, basinVelocityMedian: 0.05,
+    });
+    expect(r.predRangePct).toBeCloseTo(0.01 * 100 * 1.9, 6); // 1.9
+    expect(r.predRangeAbs).toBeCloseTo(100 * 1.1, 6);        // 110
+  });
+
+  it('DISSOLVER produces poor R:R (< 1) — geometry intent', () => {
+    // φ=0.5, rConf=0.5 → SL=200, TP=150 → R:R 0.75
+    const r = deriveFrTradeParams({
+      regime: 'DISSOLVER', regimeChanged: false,
+      phi: 0.5, rConf: 0.5, atr: 100,
+      basinVelocity: 0.05, basinVelocityMedian: 0.05,
+    });
+    expect(r.riskReward).toBeLessThan(1);
+  });
+});
+
+describe('frTradeTypeToLane', () => {
+  it('OBSERVE → null (forces caller to handle no-trade)', () => {
+    expect(frTradeTypeToLane('OBSERVE', 0.9)).toBeNull();
+  });
+
+  it('SCALP/SWING/TREND map 1:1 to lanes', () => {
+    expect(frTradeTypeToLane('SCALP', 0.2)).toBe('scalp');
+    expect(frTradeTypeToLane('SWING', 0.5)).toBe('swing');
+    expect(frTradeTypeToLane('TREND', 0.9)).toBe('trend');
+  });
+
+  it('BREAKOUT routes by conviction: ≥0.5 → swing, <0.5 → scalp', () => {
+    expect(frTradeTypeToLane('BREAKOUT', 0.6)).toBe('swing');
+    expect(frTradeTypeToLane('BREAKOUT', 0.5)).toBe('swing');
+    expect(frTradeTypeToLane('BREAKOUT', 0.3)).toBe('scalp');
+  });
+});


### PR DESCRIPTION
## Phase A of 5 — operator-approved commit-and-revise exit model

Direct port of the **GEOMETRY-DERIVED TRADING PARAMETERS (P25)** block
from the canonical QIG indicator
`QIG_QFI/qig-verification/QIG_Fisher_Rao_Classification.pine` (L136-176).

The kernel already has the geometric substrate (basin Δ⁶³, Fisher-Rao
distance, φ, regime, basin velocity). It lacked the Pine script's
derivation of **trade parameters** from that geometry — most
importantly the geometry-derived TP/SL distances Phase B needs.

## New module `fr_trade_params.ts`

`deriveFrTradeParams(...)` → `{ tradeType, sugLeverage, conviction, tpDistance, slDistance, riskReward, predRangePct, predRangeAbs }`

| Output | Formula | Pine |
|---|---|---|
| `tradeType` | SCALP/BREAKOUT/SWING/TREND/OBSERVE | L149-152 |
| `sugLeverage` | `1 + conviction×typeMult`, floored, clamp `[1, FR_MAX_LEV=5]` | L156-163 |
| `slDistance` | `ATR × (1/max(φ,0.3))` | L174 |
| `tpDistance` | `ATR × φ × (1+rConf) × 2` | L175 |
| `riskReward` | `tpDistance / slDistance` | L176 |
| `predRange*` | basin-velocity projection | L167-168 |

`frTradeTypeToLane()` maps onto the kernel's `scalp/swing/trend` lanes;
`OBSERVE → null`.

## ⚠️ Divergence flagged

`FR_MAX_LEV = 5×` (Pine L21, labelled "SAFETY_BOUND"). The live kernel
currently runs **15-22×**. This PR only defines the layer — it does not
wire it. The leverage reconciliation (adopt 5× vs keep current caps) is
a deliberate decision for **Phase B** when entry sizing routes through
this layer, not a silent change here.

## Test plan

- [x] **18 tests** — trade-type classification (5 types + boundaries),
  leverage (floor / cap / conviction), TP/SL/range geometry
  hand-computed from the Pine formulas, lane mapping
- [x] Build clean
- [x] Purity: no Euclidean ops introduced — module consumes geometric
  scalars only; qig-purity CI covers the tree
- [x] Behaviour-neutral — pure module, nothing wired into the loop yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a pure Fisher–Rao geometry-to-trade-parameters layer for the monkey service, deriving trade classifications and TP/SL distances from existing geometric signals.

New Features:
- Add FrTradeParams module to classify trade type and compute leverage, conviction, and geometry-derived TP/SL and predicted range metrics from Fisher–Rao state.
- Provide mapping from Fisher–Rao trade types to the kernel's scalp/swing/trend execution lanes.

Tests:
- Add unit tests validating trade-type classification, leverage computation, TP/SL geometry, and lane mapping for the new Fisher–Rao trade-parameter module.