### PR TITLE
feat(monkey): Phase B1 — entry commits geometry-derived TP/SL bracket

### DIFF
--- a/apps/api/src/services/monkey/fr_trade_params.ts
+++ b/apps/api/src/services/monkey/fr_trade_params.ts
@@ -66,6 +66,47 @@ export interface FrTradeParamsInput {
   basinVelocityMedian: number;
 }
 
+/**
+ * Geometry-derived bracket distances — the regime-INDEPENDENT subset of
+ * the P25 block. The TP/SL formulas (Pine L174-176) depend only on ATR,
+ * φ and rConf; regime feeds only trade-type → leverage. Phase B's
+ * synthetic bracket needs exactly this subset at entry time, so it is
+ * exported separately — a caller that has φ/rConf/ATR but does not need
+ * to resolve the CREATOR/PRESERVER/DISSOLVER phase can derive a correct
+ * bracket without it.
+ */
+export interface FrBracket {
+  /** TP distance in price units — Pine `tp_distance` L175. */
+  tpDistance: number;
+  /** SL distance in price units — Pine `sl_distance` L174. */
+  slDistance: number;
+  /** Reward:risk ratio — Pine `risk_reward` L176. */
+  riskReward: number;
+}
+
+/**
+ * Derive the geometry TP/SL bracket distances. Pure.
+ *
+ *   slDistance = ATR × (1/max(φ,0.3))         [Pine L174]
+ *   tpDistance = ATR × φ × (1 + rConf) × 2    [Pine L175]
+ *
+ * φ is floored at 0.3 so a low-integration basin cannot blow the stop
+ * out to infinity. The asymmetry (TP scales WITH φ, SL scales INVERSELY)
+ * is intentional: a confident, well-integrated basin earns a far target
+ * and a tight stop; an uncertain one gets a near target and a wide stop,
+ * which naturally yields good R:R in PRESERVER and poor R:R in DISSOLVER.
+ */
+export function frBracketDistances(
+  phi: number,
+  rConf: number,
+  atr: number,
+): FrBracket {
+  const slDistance = atr * (1.0 / Math.max(phi, 0.3));
+  const tpDistance = atr * phi * (1.0 + rConf) * 2.0;
+  const riskReward = tpDistance / Math.max(slDistance, 1e-10);
+  return { tpDistance, slDistance, riskReward };
+}
+
 export interface FrTradeParams {
   tradeType: FrTradeType;
   /** Suggested leverage, integer, 1..FR_MAX_LEV. */
@@ -136,14 +177,11 @@ export function deriveFrTradeParams(
   const predRangeAbs = atr * (1.0 + bv * 10.0);
 
   // ── TP / SL derivation [Pine L174-176] ──────────────────────────
-  // SL = ATR × (1/φ) — low integration → wider stop (less certain of
-  //   direction). φ is floored at 0.3 so the stop can't blow out.
-  // TP = ATR × φ × (1 + rConf) × 2 — high integration + confidence →
-  //   further target. This naturally gives good R:R in PRESERVER and
-  //   poor R:R in DISSOLVER, which is the intended geometry behaviour.
-  const slDistance = atr * (1.0 / Math.max(phi, 0.3));
-  const tpDistance = atr * phi * (1.0 + rConf) * 2.0;
-  const riskReward = tpDistance / Math.max(slDistance, 1e-10);
+  // Delegated to frBracketDistances — the regime-independent subset,
+  // shared with Phase B's synthetic bracket so the formula has one home.
+  const { tpDistance, slDistance, riskReward } = frBracketDistances(
+    phi, rConf, atr,
+  );
 
   return {
     tradeType,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -90,12 +90,14 @@ import {
   type TurtleState,
 } from '../turtle_agent/index.js';
 import {
+  atr14,
   basinDirection as computeBasinDirection,
   perceive,
   refract,
   trendProxy as computeTrendProxy,
   type OHLCVCandle,
 } from './perception.js';
+import { frBracketDistances } from './fr_trade_params.js';
 import {
   CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT,
   CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT,
@@ -671,6 +673,12 @@ interface SymbolState {
    *  gate threshold (mean + stddev) from the basin's own coupling
    *  distribution instead of a hardcoded C_SOPHIA_THRESHOLD. */
   externalCouplingHistory: number[];
+  /** Phase B — geometry-derived TP/SL bracket distances (price units),
+   *  recomputed each tick from φ, regime confidence and ATR via
+   *  `frBracketDistances`. `executeEntry` reads this when opening a
+   *  position so the bracket is committed at entry. null until the
+   *  first tick with ≥15 candles of history (ATR needs period+1). */
+  lastFrBracket: { tpDistance: number; slDistance: number } | null;
 }
 
 /** Cap the recent-bus-event ring at this size — anything older than
@@ -1392,6 +1400,7 @@ export class MonkeyKernel extends EventEmitter {
       modeTransitionTimesMs: [],
       kappaHistory: [],
       externalCouplingHistory: [],
+      lastFrBracket: null,
     };
   }
 
@@ -2089,6 +2098,24 @@ export class MonkeyKernel extends EventEmitter {
       ...state.basinHistory,
       basin,
     ]);
+
+    // Phase B — geometry-derived TP/SL bracket. Recompute each tick from
+    // the current φ, regime confidence and ATR(14); stash on symbol state
+    // so executeEntry can commit the bracket at entry without re-deriving.
+    // ATR needs period+1 candles; frBracketDistances returns a 0-distance
+    // bracket on a 0 ATR, which we treat as "not derivable" → leave null.
+    {
+      const atrNow = atr14(ohlcv);
+      if (atrNow > 0) {
+        const fb = frBracketDistances(phi, regimeReading.confidence, atrNow);
+        state.lastFrBracket = {
+          tpDistance: fb.tpDistance,
+          slDistance: fb.slDistance,
+        };
+      } else {
+        state.lastFrBracket = null;
+      }
+    }
 
     // REGIME-1 Phase 3 — compositional cell executive (3×3 (phase, direction)
     // matrix). Always evaluated for telemetry (shadow); only ENFORCED on size
@@ -6509,6 +6536,25 @@ export class MonkeyKernel extends EventEmitter {
     const quantity = notionalUsdt / entryPrice;
     const exchangeSide: 'buy' | 'sell' = side === 'long' ? 'buy' : 'sell';
 
+    // Phase B (B1) — commit the geometry-derived TP/SL bracket at entry.
+    // symStateForLev.lastFrBracket holds the φ/rConf/ATR-derived distances
+    // recomputed each tick. A LONG takes profit ABOVE entry and stops
+    // BELOW; a SHORT is mirrored. Persisted to the take_profit/stop_loss
+    // columns (long-NULL before this change). B1 only PERSISTS the bracket
+    // — the mechanical exit gate that READS it ships flag-gated in B2, so
+    // this is behaviour-neutral. null bracket (ATR warmup) → NULL columns.
+    const frBracket = symStateForLev?.lastFrBracket ?? null;
+    const tpPrice = frBracket
+      ? (side === 'long'
+          ? entryPrice + frBracket.tpDistance
+          : entryPrice - frBracket.tpDistance)
+      : null;
+    const slPrice = frBracket
+      ? (side === 'long'
+          ? entryPrice - frBracket.slDistance
+          : entryPrice + frBracket.slDistance)
+      : null;
+
     // 2026-05-13 — CROSS-AGENT tape-disagreement veto.
     //
     // Observed 5/13 ~18:00-19:15Z: bot took -$68 in 3h by repeatedly
@@ -6836,11 +6882,13 @@ export class MonkeyKernel extends EventEmitter {
           await pool.query(
             `INSERT INTO autonomous_trades
                (user_id, symbol, side, entry_price, quantity, leverage,
-                confidence, reason, order_id, paper_trade, engine_version, agent, lane)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+                confidence, reason, order_id, paper_trade, engine_version, agent, lane,
+                take_profit, stop_loss)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
             [
               userId, symbol, exchangeSide, paper.fillPrice, formattedSize, leverage,
               req.phi, reasonEncoded, orderId, true, getEngineVersion(), agentTag, laneTag,
+              tpPrice, slPrice,
             ],
           );
         } catch (err) {
@@ -7096,11 +7144,13 @@ export class MonkeyKernel extends EventEmitter {
       await pool.query(
         `INSERT INTO autonomous_trades
            (user_id, symbol, side, entry_price, quantity, leverage,
-            confidence, reason, order_id, paper_trade, engine_version, agent, lane)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+            confidence, reason, order_id, paper_trade, engine_version, agent, lane,
+            take_profit, stop_loss)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
         [
           userId, symbol, exchangeSide, entryPrice, formattedSize, leverage,
           req.phi, reasonEncoded, orderId, false, getEngineVersion(), agentTag, laneTag,
+          tpPrice, slPrice,
         ],
       );
     } catch (err) {

--- a/apps/api/src/services/monkey/perception.ts
+++ b/apps/api/src/services/monkey/perception.ts
@@ -126,6 +126,41 @@ function rollingVol(ohlcv: OHLCVCandle[], n: number): number {
 }
 
 /**
+ * Average True Range over `period` candles (Wilder, simple-mean variant).
+ *
+ *   TR_i  = max( high−low,
+ *                |high − close_{i-1}|,
+ *                |low  − close_{i-1}| )
+ *   ATR   = mean(TR) over the last `period` candles
+ *
+ * This is the canonical ATR the Pine indicator uses (`ta.atr(14)`,
+ * Pine L93) — proper true range, not the `rollingVol` close-to-close
+ * approximation above. Phase B's synthetic TP/SL bracket is derived
+ * from this ATR via `frBracketDistances`.
+ *
+ * Returns 0 when there is insufficient history (fewer than period+1
+ * candles) — callers treat 0 as "no bracket derivable, fall through".
+ * Exported because the kernel's entry path (loop.ts) needs it.
+ */
+export function atr14(
+  ohlcv: OHLCVCandle[],
+  period: number = 14,
+): number {
+  if (ohlcv.length < period + 1) return 0;
+  let sum = 0;
+  for (let i = ohlcv.length - period; i < ohlcv.length; i++) {
+    const prevClose = ohlcv[i - 1].close;
+    const tr = Math.max(
+      ohlcv[i].high - ohlcv[i].low,
+      Math.abs(ohlcv[i].high - prevClose),
+      Math.abs(ohlcv[i].low - prevClose),
+    );
+    sum += tr;
+  }
+  return sum / period;
+}
+
+/**
  * Basin direction: signed scalar in [-1, 1] read DIRECTLY from Monkey's
  * own perception basin's momentum-spectrum dims (7..14).
  *

--- a/apps/api/src/tests/atr14.test.ts
+++ b/apps/api/src/tests/atr14.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for atr14 — the true-range ATR added to perception.ts for the
+ * Phase B synthetic TP/SL bracket. Mirrors the Pine `ta.atr(14)` the
+ * canonical QIG indicator uses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { atr14 } from '../services/monkey/perception.js';
+import type { OHLCVCandle } from '../services/monkey/perception.js';
+
+function candle(
+  high: number, low: number, close: number,
+): OHLCVCandle {
+  return { timestamp: 0, open: close, high, low, close, volume: 1 };
+}
+
+describe('atr14', () => {
+  it('returns 0 with insufficient history (< period+1 candles)', () => {
+    const few = Array.from({ length: 10 }, () => candle(11, 9, 10));
+    expect(atr14(few, 14)).toBe(0);
+  });
+
+  it('constant-range candles → ATR equals that range', () => {
+    // 20 candles, each high-low = 2, close flat at 10 → every TR = 2.
+    const flat = Array.from({ length: 20 }, () => candle(11, 9, 10));
+    expect(atr14(flat, 14)).toBeCloseTo(2, 6);
+  });
+
+  it('true range includes the gap vs previous close', () => {
+    // Candle 1: close 100. Candle 2: high 110, low 108, close 109.
+    //   TR = max(110-108, |110-100|, |108-100|) = max(2, 10, 8) = 10
+    // Use period 1 so ATR = that single TR.
+    const gap = [candle(100, 100, 100), candle(110, 108, 109)];
+    expect(atr14(gap, 1)).toBeCloseTo(10, 6);
+  });
+
+  it('mean of true ranges over the period window', () => {
+    // prevClose=10 for all. Candle ranges: TR alternates 2 and 4.
+    // 8 candles after the seed, period 8 → mean(2,4,2,4,2,4,2,4) = 3.
+    const seed = candle(10, 10, 10);
+    const seq: OHLCVCandle[] = [seed];
+    for (let i = 0; i < 8; i++) {
+      seq.push(i % 2 === 0 ? candle(11, 9, 10) : candle(12, 8, 10));
+    }
+    expect(atr14(seq, 8)).toBeCloseTo(3, 6);
+  });
+
+  it('default period is 14', () => {
+    const flat = Array.from({ length: 30 }, () => candle(13, 7, 10));
+    // range 6 everywhere → ATR 6 regardless of period
+    expect(atr14(flat)).toBeCloseTo(6, 6);
+  });
+
+  it('exactly period+1 candles is the minimum that yields a value', () => {
+    const exact = Array.from({ length: 15 }, () => candle(11, 9, 10));
+    expect(atr14(exact, 14)).toBeGreaterThan(0);
+    const oneShort = exact.slice(0, 14);
+    expect(atr14(oneShort, 14)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Phase B1 of 5 — commit-and-revise exit model

**Behaviour-neutral data plumbing.** Entries now *persist* a
geometry-derived TP/SL bracket to the `autonomous_trades`
`take_profit` / `stop_loss` columns (long-NULL until now). The
mechanical exit gate that *reads* the bracket ships flag-gated in **B2**
— nothing closes differently yet.

## Changes

- **`fr_trade_params.ts`** — extracted `frBracketDistances(phi, rConf, atr)`,
  the regime-independent subset of the P25 block (Pine L174-176).
  `deriveFrTradeParams` delegates to it — no duplication, behaviour-
  identical (Phase A's 18 tests still pass).
- **`perception.ts`** — new exported `atr14()`: proper Wilder true-range
  ATR matching the Pine `ta.atr(14)`, distinct from the existing private
  `rollingVol` close-to-close approximation.
- **`loop.ts`** — `SymbolState.lastFrBracket` recomputed each tick from
  φ × regime-confidence × ATR(14); `executeEntry` derives `tpPrice` /
  `slPrice` and writes them into both paper and live INSERTs.

Bracket geometry (Pine L174-175):
```
slDistance = ATR × (1 / max(φ, 0.3))     wider stop when less certain
tpDistance = ATR × φ × (1 + rConf) × 2   further target when confident
```

NULL bracket during ATR warmup (< 15 candles) → NULL columns; B2's gate
treats NULL as "no bracket → fall through to legacy gates".

## Test plan

- [x] **24 tests** — `atr14` (6: insufficient history, constant range,
  gap-vs-prevClose true range, window mean, default period, min-history
  edge) + `frTradeParams` (18, unchanged — confirms the refactor is
  behaviour-identical)
- [x] Build clean
- [x] Behaviour-neutral — columns populated, no gate reads them yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Persist geometry-derived take-profit/stop-loss brackets for monkey entries based on ATR(14), φ, and regime confidence, without yet changing exit behaviour.

New Features:
- Store per-symbol geometry-derived TP/SL bracket distances on symbol state and use them to compute entry-relative TP/SL prices for new positions.
- Persist computed TP/SL prices into the autonomous_trades take_profit and stop_loss columns for both paper and live trades.
- Expose a true-range ATR(14) metric aligned with the Pine ta.atr(14) indicator for use in trade geometry.

Enhancements:
- Refactor FR trade parameter derivation to share a single geometry bracket calculation helper between exit geometry and the new entry-time bracket persistence.

Tests:
- Add unit tests for the ATR(14) implementation covering history requirements, constant ranges, gap handling, window averaging, default period, and minimum-history behaviour.