### PR TITLE
feat(monkey): Phase B2 — synthetic bracket exit gate (commit-and-revise)

### DIFF
--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -561,6 +561,69 @@ export function shouldDCAAdd(req: {
 }
 
 /**
+ * shouldBracketExit — mechanical synthetic-bracket exit (Phase B2).
+ *
+ * The commit-and-revise exit model: at entry the kernel commits a
+ * geometry-derived TP/SL bracket (Phase B1 persists tpPrice/slPrice on
+ * the trade row). This gate is the *mechanical enforcer* — no
+ * discretion, no per-tick judgement: has the mark price crossed the
+ * committed level? Poloniex v3 has no native TP/SL order, so the
+ * kernel watches the price and fires the close itself; the decision
+ * was already made at entry.
+ *
+ * When this gate is live (MONKEY_BRACKET_EXIT_LIVE) and a row carries a
+ * bracket, it REPLACES the discretionary profit-take path
+ * (shouldProfitHarvest / shouldAggregateHarvest / scalp-TP). The
+ * loss-side time/tape safety gates (slow-bleed, fast-adverse) still run
+ * — a bracket SL is a price stop, not a time stop.
+ *
+ * LONG: TP above entry, SL below. SHORT mirrored. A null level is
+ * simply not checked (ATR-warmup entries have NULL columns); null on
+ * BOTH → no_bracket, caller falls through to the legacy gates.
+ *
+ * exitTypeBit 11 = BRACKET_TP, 12 = BRACKET_SL.
+ */
+export function shouldBracketExit(
+  markPrice: number,
+  heldSide: 'long' | 'short',
+  tpPrice: number | null,
+  slPrice: number | null,
+): ExecutiveDecision<boolean> {
+  if (tpPrice === null && slPrice === null) {
+    return { value: false, reason: 'no_bracket', derivation: {} };
+  }
+  const tpHit = tpPrice !== null && (
+    heldSide === 'long' ? markPrice >= tpPrice : markPrice <= tpPrice
+  );
+  if (tpHit) {
+    return {
+      value: true,
+      reason: `bracket_tp: mark ${markPrice} ${heldSide === 'long' ? '>=' : '<='} TP ${tpPrice}`,
+      derivation: { markPrice, tpPrice: tpPrice as number, exitTypeBit: 11 },
+    };
+  }
+  const slHit = slPrice !== null && (
+    heldSide === 'long' ? markPrice <= slPrice : markPrice >= slPrice
+  );
+  if (slHit) {
+    return {
+      value: true,
+      reason: `bracket_sl: mark ${markPrice} ${heldSide === 'long' ? '<=' : '>='} SL ${slPrice}`,
+      derivation: { markPrice, slPrice: slPrice as number, exitTypeBit: 12 },
+    };
+  }
+  return {
+    value: false,
+    reason: 'within_bracket',
+    derivation: {
+      markPrice,
+      ...(tpPrice !== null ? { tpPrice } : {}),
+      ...(slPrice !== null ? { slPrice } : {}),
+    },
+  };
+}
+
+/**
  * shouldProfitHarvest — early-exit WHILE IN PROFIT (v0.6.1).
  *
  * Runs BEFORE shouldScalpExit. When a trade has been in profit, the peak

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -123,6 +123,7 @@ import {
   shouldAutoFlatten,
   shouldAggregateBleedExit,
   shouldAggregateHarvest,
+  shouldBracketExit,
   shouldDCAAdd,
   shouldExit,
   shouldProfitHarvest,
@@ -2583,6 +2584,42 @@ export class MonkeyKernel extends EventEmitter {
         const lanePeak = state.peakPnlUsdtByLane[heldLane] ?? 0;
         const laneStreak = state.tapeFlipStreakByLane[heldLane] ?? 0;
 
+        // ── Gate 0: synthetic bracket exit (Phase B2) ────────────────
+        // Commit-and-revise model: when MONKEY_BRACKET_EXIT_LIVE and the
+        // row carries a geometry-derived bracket (Phase B1 populates
+        // take_profit/stop_loss), the mechanical TP/SL check OWNS
+        // profit-taking. It runs before every discretionary gate; when
+        // active, the discretionary PROFIT gates below (profit-harvest,
+        // aggregate-harvest, scalp-TP) are skipped via `bracketActive`.
+        // The loss-side safety gates (hard SL, fast-adverse, slow-bleed)
+        // still run — a price stop is not a time/tape stop. Default OFF;
+        // ships dark, flipped after observation.
+        const bracketExitLive = process.env.MONKEY_BRACKET_EXIT_LIVE === 'true';
+        const hasBracket = (openRow.take_profit ?? null) !== null
+          || (openRow.stop_loss ?? null) !== null;
+        const bracketActive = bracketExitLive && hasBracket;
+        if (!exitFired && bracketActive) {
+          const bracket = shouldBracketExit(
+            lastPrice, heldSide,
+            openRow.take_profit ?? null, openRow.stop_loss ?? null,
+          );
+          derivation.bracketExit = {
+            ...bracket.derivation, fired: bracket.value, tradeId, lane: heldLane,
+          };
+          if (bracket.value) {
+            action = 'scalp_exit';
+            reason = bracket.reason;
+            exitFired = true;
+            derivation.scalp = {
+              exitTypeBit: bracket.derivation.exitTypeBit,
+              unrealizedPnl,
+              markPrice: lastPrice,
+              tradeId,
+              lane: heldLane,
+            };
+          }
+        }
+
         // 1. Hard SL pre-check (SAFETY_BOUND) — must precede the
         // rejustification block so a position bleeding hard against
         // the kernel always closes on price before the kernel re-reads
@@ -3097,7 +3134,9 @@ export class MonkeyKernel extends EventEmitter {
         }
 
         // 3. Profit harvest — trailing stop + trend-flip, only while green.
-        if (!exitFired) {
+        // Phase B2: skipped when bracketActive — the synthetic bracket
+        // (Gate 0) owns profit-taking under the commit-and-revise model.
+        if (!exitFired && !bracketActive) {
           const harvest = shouldProfitHarvest(
             unrealizedPnl,
             lanePeak,
@@ -3129,7 +3168,8 @@ export class MonkeyKernel extends EventEmitter {
         //     kernel running this evaluates the SAME aggregate state and
         //     closes its own subset; total realized ≈ aggregate current
         //     at firing time. See aggregate_peak.ts for the rationale.
-        if (!exitFired) {
+        // Phase B2: skipped when bracketActive — bracket owns profit-take.
+        if (!exitFired && !bracketActive) {
           const aggPeak = aggregatePeakTracker.getPeak(symbol, heldSide);
           const aggCurrent = aggregatePeakTracker.getLastPnl(symbol, heldSide);
           const aggHarvest = shouldAggregateHarvest(
@@ -3158,7 +3198,10 @@ export class MonkeyKernel extends EventEmitter {
 
         // 4. Scalp TP — only TP can reach here (SL was returned above
         // unless deferred; rejustification and harvest also returned).
-        if (!exitFired && scalp.value && !isStopLoss) {
+        // Phase B2: skipped when bracketActive — the synthetic bracket
+        // owns profit-taking. The scalp-SL branch (gate 1 above) is
+        // unaffected — a price stop is always a safety bound.
+        if (!exitFired && !bracketActive && scalp.value && !isStopLoss) {
           action = 'scalp_exit';
           reason = scalp.reason;
           exitFired = true;
@@ -4990,7 +5033,7 @@ export class MonkeyKernel extends EventEmitter {
   }
 
   private async findOpenMonkeyTrade(symbol: string): Promise<
-    | { id: string; entry_price: string; quantity: string; leverage: number; order_id: string | null; side: 'long' | 'short'; lane: 'scalp' | 'swing' | 'trend' }
+    | { id: string; entry_price: string; quantity: string; leverage: number; order_id: string | null; side: 'long' | 'short'; lane: 'scalp' | 'swing' | 'trend'; take_profit: number | null; stop_loss: number | null }
     | null
   > {
     // Aggregate over ALL open lanes (back-compat: callers that don't
@@ -5000,7 +5043,8 @@ export class MonkeyKernel extends EventEmitter {
     try {
       const reasonPattern = `monkey|kernel=${this.instanceId}|%`;
       const result = await pool.query(
-        `SELECT id, entry_price, quantity, leverage, order_id, side, lane
+        `SELECT id, entry_price, quantity, leverage, order_id, side, lane,
+                take_profit, stop_loss
            FROM autonomous_trades
           WHERE reason LIKE $2 AND status = 'open' AND symbol = $1
           ORDER BY entry_time ASC`,
@@ -5009,14 +5053,27 @@ export class MonkeyKernel extends EventEmitter {
       const rows = result.rows as Array<{
         id: string; entry_price: string; quantity: string; leverage: number;
         order_id: string | null; side: string; lane: string;
+        take_profit: string | null; stop_loss: string | null;
       }>;
       const normSide = (s: string): 'long' | 'short' =>
         s === 'buy' || s === 'long' ? 'long' : 'short';
       const normLane = (l: string | null | undefined): 'scalp' | 'swing' | 'trend' =>
         (l === 'scalp' || l === 'trend') ? l : 'swing';
+      // numeric(20,8) columns come back as strings — normalise to
+      // number|null. The synthetic-bracket gate (shouldBracketExit)
+      // reads these; the OLDEST row's bracket represents the position's
+      // founding thesis (DCA adds extend it; Phase C revises it).
+      const numOrNull = (v: string | null): number | null =>
+        v === null || v === undefined ? null : Number(v);
       if (rows.length === 0) return null;
       if (rows.length === 1) {
-        return { ...rows[0], side: normSide(rows[0].side), lane: normLane(rows[0].lane) };
+        return {
+          ...rows[0],
+          side: normSide(rows[0].side),
+          lane: normLane(rows[0].lane),
+          take_profit: numOrNull(rows[0].take_profit),
+          stop_loss: numOrNull(rows[0].stop_loss),
+        };
       }
       // Multi-row: aggregate by quantity-weighted entry price across
       // ALL rows for legacy callers. The lane-aware path operates per
@@ -5035,6 +5092,8 @@ export class MonkeyKernel extends EventEmitter {
         order_id: rows[0].order_id,
         side: normSide(rows[0].side),
         lane: normLane(rows[0].lane),
+        take_profit: numOrNull(rows[0].take_profit),
+        stop_loss: numOrNull(rows[0].stop_loss),
       };
     } catch (err) {
       logger.debug('[Monkey] findOpenMonkeyTrade failed', {

--- a/apps/api/src/tests/shouldBracketExit.test.ts
+++ b/apps/api/src/tests/shouldBracketExit.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for shouldBracketExit — the Phase B2 mechanical synthetic-bracket
+ * exit gate. Given a committed TP/SL bracket and the live mark price,
+ * the gate fires when price has crossed a level. No discretion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldBracketExit } from '../services/monkey/executive.js';
+
+describe('shouldBracketExit — no bracket', () => {
+  it('both levels null → no_bracket, value false', () => {
+    const r = shouldBracketExit(100, 'long', null, null);
+    expect(r.value).toBe(false);
+    expect(r.reason).toBe('no_bracket');
+  });
+});
+
+describe('shouldBracketExit — LONG (TP above, SL below)', () => {
+  // entry ~100, TP 110, SL 95
+  it('fires bracket_tp when mark ≥ TP', () => {
+    const r = shouldBracketExit(110, 'long', 110, 95);
+    expect(r.value).toBe(true);
+    expect(r.reason).toContain('bracket_tp');
+    expect(r.derivation.exitTypeBit).toBe(11);
+  });
+
+  it('fires bracket_tp when mark above TP', () => {
+    expect(shouldBracketExit(112, 'long', 110, 95).value).toBe(true);
+  });
+
+  it('fires bracket_sl when mark ≤ SL', () => {
+    const r = shouldBracketExit(95, 'long', 110, 95);
+    expect(r.value).toBe(true);
+    expect(r.reason).toContain('bracket_sl');
+    expect(r.derivation.exitTypeBit).toBe(12);
+  });
+
+  it('does NOT fire while mark is inside the bracket', () => {
+    const r = shouldBracketExit(102, 'long', 110, 95);
+    expect(r.value).toBe(false);
+    expect(r.reason).toBe('within_bracket');
+  });
+});
+
+describe('shouldBracketExit — SHORT (TP below, SL above)', () => {
+  // entry ~100, TP 90, SL 105
+  it('fires bracket_tp when mark ≤ TP', () => {
+    const r = shouldBracketExit(90, 'short', 90, 105);
+    expect(r.value).toBe(true);
+    expect(r.reason).toContain('bracket_tp');
+    expect(r.derivation.exitTypeBit).toBe(11);
+  });
+
+  it('fires bracket_sl when mark ≥ SL', () => {
+    const r = shouldBracketExit(105, 'short', 90, 105);
+    expect(r.value).toBe(true);
+    expect(r.reason).toContain('bracket_sl');
+    expect(r.derivation.exitTypeBit).toBe(12);
+  });
+
+  it('does NOT fire while mark is inside the bracket', () => {
+    const r = shouldBracketExit(98, 'short', 90, 105);
+    expect(r.value).toBe(false);
+    expect(r.reason).toBe('within_bracket');
+  });
+});
+
+describe('shouldBracketExit — partial bracket (one level null)', () => {
+  it('TP-only LONG: fires on TP, ignores missing SL', () => {
+    expect(shouldBracketExit(110, 'long', 110, null).value).toBe(true);
+    expect(shouldBracketExit(50, 'long', 110, null).value).toBe(false);
+  });
+
+  it('SL-only LONG: fires on SL, ignores missing TP', () => {
+    expect(shouldBracketExit(95, 'long', null, 95).value).toBe(true);
+    expect(shouldBracketExit(200, 'long', null, 95).value).toBe(false);
+  });
+
+  it('SL-only SHORT: fires on SL', () => {
+    expect(shouldBracketExit(105, 'short', null, 105).value).toBe(true);
+  });
+});
+
+describe('shouldBracketExit — TP takes precedence when both crossed', () => {
+  it('LONG: degenerate bracket where mark satisfies both → TP wins', () => {
+    // TP 100, SL 100, mark 100 — TP checked first.
+    const r = shouldBracketExit(100, 'long', 100, 100);
+    expect(r.value).toBe(true);
+    expect(r.reason).toContain('bracket_tp');
+  });
+});


### PR DESCRIPTION
## Phase B2 of 5 — completes the synthetic TP/SL bracket

B1 committed the geometry-derived bracket to the trade row at entry;
**B2 adds the mechanical gate that enforces it.** Ships **dark** —
`MONKEY_BRACKET_EXIT_LIVE` defaults `false`, production behaviour
unchanged until the flag is flipped.

## Why synthetic

Poloniex v3 Futures has **no native TP/SL / trigger / conditional
order** (verified against the complete official API sitemap — only
MARKET/LIMIT/LIMIT_MAKER). The kernel watches the mark price and fires
the close itself; the *decision* was already made at entry. This
mirrors the canonical QIG indicator's `pos_tp`/`pos_sl` tracked vars.

## Changes

- **`executive.ts`** — `shouldBracketExit(markPrice, heldSide, tpPrice, slPrice)`,
  pure + mechanical. LONG: TP above / SL below; SHORT mirrored. Null
  level skipped; both null → `no_bracket`. exitTypeBit 11 = BRACKET_TP,
  12 = BRACKET_SL.
- **`loop.ts`**
  - `findOpenMonkeyTrade` SELECT returns `take_profit`/`stop_loss`; the
    OLDEST row's bracket = the position's founding thesis.
  - New **Gate 0** in the exit block, before every discretionary gate.
    When `MONKEY_BRACKET_EXIT_LIVE` and the row carries a bracket
    (`bracketActive`), `shouldBracketExit` owns the close.
  - When `bracketActive`, the discretionary **profit** gates are
    skipped: `shouldProfitHarvest`, `shouldAggregateHarvest`, scalp-TP.
    Loss-side safety gates (hard SL pre-check, fast-adverse, slow-bleed,
    aggregate-bleed) + Loop-2 `shouldExit` still run.

## Rollback / safety

- Flag default **OFF** → zero behaviour change on deploy.
- Per-row: rows without a bracket (pre-B1, ATR-warmup NULLs) fall
  through to legacy gates even with the flag on.
- Bracket SL does **not** replace the hard SL pre-check — both run,
  first to trigger closes. Safety bounds are never demoted.

## Test plan

- [x] **12 tests** — no-bracket, LONG/SHORT TP+SL hits + within-bracket,
  partial (one-level-null) brackets, TP-precedence on degenerate bracket
- [x] Build clean
- [x] Ships dark — flag-gated, behaviour-neutral until flipped

## Operator note

After this merges + deploys, flipping `MONKEY_BRACKET_EXIT_LIVE=true`
activates the commit-and-revise model. Recommend observing a few
bracketed entries in telemetry (`derivation.bracketExit`) before the
flip. Phase C then adds bracket *revision* on new intel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)