### PR TITLE
feat(monkey): Phase C — bracket revision on fresh intel (commit-and-revise)

### DIFF
--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -1442,3 +1442,104 @@ export function kernelShouldEnter(args: { emotions: EmotionState }): boolean {
   const hesitation = args.emotions.anxiety + args.emotions.confusion;
   return conviction > hesitation;
 }
+
+/**
+ * shouldExtendBracket — revise a committed bracket on fresh intel (Phase C).
+ *
+ * The "revise" half of commit-and-revise. Once a position carries a
+ * synthetic bracket (Phase B), each tick re-reads the geometry. When the
+ * fresh Fisher-Rao state says the move has further to run, the kernel:
+ *   - EXTENDS the take-profit further out (never pulls it in), and
+ *   - TRAILS the stop-loss toward profit (never widens it).
+ *
+ * Both edits are strictly monotonic in the position's favour — a bracket
+ * can only ever improve. That invariant is what makes revision safe to
+ * run every tick: it cannot turn a winning thesis into a worse one.
+ *
+ * TP extension gates (all must hold):
+ *   - position is in profit (currentRoiFrac > 0) — never chase a TP out
+ *     on a losing position
+ *   - conviction ≥ MONKEY_BRACKET_EXTEND_CONV (default 0.5) — only a
+ *     well-integrated, confident basin earns a longer target
+ *   - the freshly-projected TP is strictly further than the current one
+ *
+ * SL trail gates:
+ *   - position is in profit — trailing a stop on a red position is just
+ *     a tighter loss; the loss-side safety gates own that
+ *   - the trailed SL is strictly better (higher for long, lower for
+ *     short) than the current SL
+ *
+ * Returns `newTp` / `newSl` as numbers when a revision is warranted,
+ * null when that side is unchanged. Pure — caller performs the DB write.
+ */
+export interface BracketRevision {
+  /** True iff at least one of newTp / newSl is non-null. */
+  changed: boolean;
+  /** Revised take-profit price, or null to leave it unchanged. */
+  newTp: number | null;
+  /** Revised stop-loss price, or null to leave it unchanged. */
+  newSl: number | null;
+  /** Human-readable summary for telemetry / the trade reason field. */
+  reason: string;
+}
+
+export function shouldExtendBracket(args: {
+  heldSide: 'long' | 'short';
+  entryPrice: number;
+  markPrice: number;
+  currentTp: number | null;
+  currentSl: number | null;
+  /** Fresh FR bracket distances this tick (frBracketDistances output). */
+  freshTpDistance: number;
+  freshSlDistance: number;
+  /** Fresh conviction = φ × rConf ∈ [0,1]. */
+  conviction: number;
+  /** Current unrealised ROI as a fraction (e.g. +0.02 = +2%). */
+  currentRoiFrac: number;
+}): BracketRevision {
+  const {
+    heldSide, entryPrice, markPrice, currentTp, currentSl,
+    freshTpDistance, freshSlDistance, conviction, currentRoiFrac,
+  } = args;
+
+  const convThreshold =
+    Number(process.env.MONKEY_BRACKET_EXTEND_CONV) || 0.5;
+  const inProfit = currentRoiFrac > 0;
+  const long = heldSide === 'long';
+
+  // ── TP extension ────────────────────────────────────────────────
+  let newTp: number | null = null;
+  if (inProfit && conviction >= convThreshold && currentTp !== null) {
+    const candidateTp = long
+      ? entryPrice + freshTpDistance
+      : entryPrice - freshTpDistance;
+    // "Further out" = away from entry in the profit direction.
+    const further = long ? candidateTp > currentTp : candidateTp < currentTp;
+    if (further) newTp = candidateTp;
+  }
+
+  // ── SL trail ────────────────────────────────────────────────────
+  // Trail the stop `freshSlDistance` behind the mark, ratcheting only
+  // in the favourable direction.
+  let newSl: number | null = null;
+  if (inProfit && currentSl !== null) {
+    const candidateSl = long
+      ? markPrice - freshSlDistance
+      : markPrice + freshSlDistance;
+    const better = long ? candidateSl > currentSl : candidateSl < currentSl;
+    if (better) newSl = candidateSl;
+  }
+
+  const changed = newTp !== null || newSl !== null;
+  return {
+    changed,
+    newTp,
+    newSl,
+    reason: changed
+      ? `extend_bracket: ${newTp !== null ? `TP->${newTp.toFixed(2)} ` : ''}`
+        + `${newSl !== null ? `SL->${newSl.toFixed(2)} ` : ''}`
+        + `(conv=${conviction.toFixed(2)}, roi=${(currentRoiFrac * 100).toFixed(2)}%)`
+      : `bracket_hold: no favourable revision (conv=${conviction.toFixed(2)}, `
+        + `inProfit=${inProfit})`,
+  };
+}

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -124,6 +124,7 @@ import {
   shouldAggregateBleedExit,
   shouldAggregateHarvest,
   shouldBracketExit,
+  shouldExtendBracket,
   shouldDCAAdd,
   shouldExit,
   shouldProfitHarvest,
@@ -3205,6 +3206,64 @@ export class MonkeyKernel extends EventEmitter {
           action = 'scalp_exit';
           reason = scalp.reason;
           exitFired = true;
+        }
+
+        // ── Phase C: bracket revision on fresh intel ─────────────────
+        // The "revise" half of commit-and-revise. When the position is
+        // held (no exit fired), the bracket is live, and this tick's FR
+        // read says the move has further to run, extend the TP outward
+        // and trail the SL toward profit. Both edits are strictly
+        // monotonic in the position's favour (shouldExtendBracket
+        // enforces it), so revising every tick can only improve the
+        // bracket. Flag MONKEY_BRACKET_EXTEND_LIVE (default off).
+        const bracketExtendLive =
+          process.env.MONKEY_BRACKET_EXTEND_LIVE === 'true';
+        if (
+          !exitFired && bracketActive && bracketExtendLive
+          && state.lastFrBracket !== null
+          && currentRoi !== undefined
+        ) {
+          const revision = shouldExtendBracket({
+            heldSide,
+            entryPrice: Number(openRow.entry_price),
+            markPrice: lastPrice,
+            currentTp: openRow.take_profit ?? null,
+            currentSl: openRow.stop_loss ?? null,
+            freshTpDistance: state.lastFrBracket.tpDistance,
+            freshSlDistance: state.lastFrBracket.slDistance,
+            conviction: phi * regimeReading.confidence,
+            currentRoiFrac: currentRoi,
+          });
+          derivation.bracketRevision = {
+            changed: revision.changed ? 1 : 0,
+            ...(revision.newTp !== null ? { newTp: revision.newTp } : {}),
+            ...(revision.newSl !== null ? { newSl: revision.newSl } : {}),
+          };
+          if (revision.changed) {
+            try {
+              // Revise every open row this kernel owns on the symbol so
+              // a DCA stack shares one coherent bracket. COALESCE keeps
+              // the unchanged side intact.
+              await pool.query(
+                `UPDATE autonomous_trades
+                    SET take_profit = COALESCE($1, take_profit),
+                        stop_loss   = COALESCE($2, stop_loss)
+                  WHERE reason LIKE $3 AND status = 'open' AND symbol = $4`,
+                [
+                  revision.newTp, revision.newSl,
+                  `monkey|kernel=${this.instanceId}|%`, symbol,
+                ],
+              );
+              logger.info('[Monkey] bracket revised', {
+                symbol, heldSide, reason: revision.reason,
+              });
+            } catch (revErr) {
+              logger.warn('[Monkey] bracket revision UPDATE failed', {
+                symbol,
+                err: revErr instanceof Error ? revErr.message : String(revErr),
+              });
+            }
+          }
         }
 
         // Decrement defer window each tick we did not exit.

--- a/apps/api/src/tests/shouldExtendBracket.test.ts
+++ b/apps/api/src/tests/shouldExtendBracket.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for shouldExtendBracket — the Phase C bracket-revision decision.
+ * Both edits must be strictly monotonic in the position's favour: TP
+ * only ever moves further out, SL only ever trails toward profit.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { shouldExtendBracket } from '../services/monkey/executive.js';
+
+const ORIGINAL_ENV = { ...process.env };
+beforeEach(() => { delete process.env.MONKEY_BRACKET_EXTEND_CONV; });
+afterEach(() => { process.env = { ...ORIGINAL_ENV }; });
+
+describe('shouldExtendBracket — TP extension (LONG)', () => {
+  // entry 100, currentTp 110, in profit, high conviction
+  it('extends TP outward when fresh distance projects further', () => {
+    const r = shouldExtendBracket({
+      heldSide: 'long', entryPrice: 100, markPrice: 108,
+      currentTp: 110, currentSl: 95,
+      freshTpDistance: 20, freshSlDistance: 5, // fresh TP → 120 > 110
+      conviction: 0.8, currentRoiFrac: 0.08,
+    });
+    expect(r.changed).toBe(true);
+    expect(r.newTp).toBeCloseTo(120, 6);
+  });
+
+  it('does NOT pull TP in when fresh distance is shorter', () => {
+    const r = shouldExtendBracket({
+      heldSide: 'long', entryPrice: 100, markPrice: 108,
+      currentTp: 110, currentSl: 95,
+      freshTpDistance: 5, freshSlDistance: 5, // fresh TP → 105 < 110
+      conviction: 0.8, currentRoiFrac: 0.08,
+    });
+    expect(r.newTp).toBeNull();
+  });
+
+  it('does NOT extend TP below the conviction threshold', () => {
+    const r = shouldExtendBracket({
+      heldSide: 'long', entryPrice: 100, markPrice: 108,
+      currentTp: 110, currentSl: 95,
+      freshTpDistance: 20, freshSlDistance: 5,
+      conviction: 0.3, currentRoiFrac: 0.08, // conv < 0.5 default
+    });
+    expect(r.newTp).toBeNull();
+  });
+
+  it('does NOT extend TP on a losing position', () => {
+    const r = shouldExtendBracket({
+      heldSide: 'long', entryPrice: 100, markPrice: 96,
+      currentTp: 110, currentSl: 95,
+      freshTpDistance: 20, freshSlDistance: 5,
+      conviction: 0.9, currentRoiFrac: -0.04, // red
+    });
+    expect(r.newTp).toBeNull();
+    expect(r.newSl).toBeNull();
+    expect(r.changed).toBe(false);
+  });
+});
+
+describe('shouldExtendBracket — SL trail (LONG)', () => {
+  it('trails SL up toward profit (ratchets favourable only)', () => {
+    // mark 108, freshSlDistance 5 → candidate 103 > currentSl 95
+    const r = shouldExtendBracket({
+      heldSide: 'long', entryPrice: 100, markPrice: 108,
+      currentTp: 110, currentSl: 95,
+      freshTpDistance: 5, freshSlDistance: 5,
+      conviction: 0.1, currentRoiFrac: 0.08, // low conv → only SL moves
+    });
+    expect(r.newSl).toBeCloseTo(103, 6);
+    expect(r.newTp).toBeNull(); // low conviction blocks TP
+  });
+
+  it('does NOT widen SL (candidate worse than current)', () => {
+    // mark 102, freshSlDistance 20 → candidate 82 < currentSl 95 → reject
+    const r = shouldExtendBracket({
+      heldSide: 'long', entryPrice: 100, markPrice: 102,
+      currentTp: 110, currentSl: 95,
+      freshTpDistance: 5, freshSlDistance: 20,
+      conviction: 0.1, currentRoiFrac: 0.02,
+    });
+    expect(r.newSl).toBeNull();
+  });
+});
+
+describe('shouldExtendBracket — SHORT mirror', () => {
+  it('extends TP downward (further from entry) for a short', () => {
+    // entry 100, currentTp 90, freshTpDistance 20 → 80 < 90 → extend
+    const r = shouldExtendBracket({
+      heldSide: 'short', entryPrice: 100, markPrice: 92,
+      currentTp: 90, currentSl: 105,
+      freshTpDistance: 20, freshSlDistance: 5,
+      conviction: 0.8, currentRoiFrac: 0.08,
+    });
+    expect(r.newTp).toBeCloseTo(80, 6);
+  });
+
+  it('trails SL down toward profit for a short', () => {
+    // mark 92, freshSlDistance 5 → candidate 97 < currentSl 105 → trail
+    const r = shouldExtendBracket({
+      heldSide: 'short', entryPrice: 100, markPrice: 92,
+      currentTp: 90, currentSl: 105,
+      freshTpDistance: 5, freshSlDistance: 5,
+      conviction: 0.1, currentRoiFrac: 0.08,
+    });
+    expect(r.newSl).toBeCloseTo(97, 6);
+  });
+});
+
+describe('shouldExtendBracket — env override + edge cases', () => {
+  it('honours MONKEY_BRACKET_EXTEND_CONV', () => {
+    process.env.MONKEY_BRACKET_EXTEND_CONV = '0.9';
+    const r = shouldExtendBracket({
+      heldSide: 'long', entryPrice: 100, markPrice: 108,
+      currentTp: 110, currentSl: 95,
+      freshTpDistance: 20, freshSlDistance: 5,
+      conviction: 0.8, currentRoiFrac: 0.08, // 0.8 < 0.9 → no TP
+    });
+    expect(r.newTp).toBeNull();
+  });
+
+  it('null currentTp → no TP extension attempted', () => {
+    const r = shouldExtendBracket({
+      heldSide: 'long', entryPrice: 100, markPrice: 108,
+      currentTp: null, currentSl: 95,
+      freshTpDistance: 20, freshSlDistance: 5,
+      conviction: 0.9, currentRoiFrac: 0.08,
+    });
+    expect(r.newTp).toBeNull();
+    expect(r.newSl).not.toBeNull(); // SL side still trails
+  });
+
+  it('no favourable revision → changed false, bracket_hold reason', () => {
+    const r = shouldExtendBracket({
+      heldSide: 'long', entryPrice: 100, markPrice: 96,
+      currentTp: 110, currentSl: 95,
+      freshTpDistance: 5, freshSlDistance: 5,
+      conviction: 0.9, currentRoiFrac: -0.04,
+    });
+    expect(r.changed).toBe(false);
+    expect(r.reason).toContain('bracket_hold');
+  });
+});


### PR DESCRIPTION
## Phase C of 5 — the "revise" half of commit-and-revise

Once a position carries a synthetic bracket (Phase B), each held tick
re-reads the Fisher-Rao geometry; when the fresh state says the move
has further to run, the kernel **extends the take-profit** and **trails
the stop-loss**. Ships **dark** — `MONKEY_BRACKET_EXTEND_LIVE` default
`false`.

## `shouldExtendBracket` (executive.ts)

Pure decision → `BracketRevision { changed, newTp, newSl }`. Both edits
are **strictly monotonic in the position's favour**:
- TP only ever moves further from entry (never pulls in)
- SL only ever trails toward profit (never widens)

That invariant makes per-tick revision safe — a bracket can only improve.

| Edit | Gates |
|---|---|
| TP extend | in profit · `conviction ≥ MONKEY_BRACKET_EXTEND_CONV` (0.5) · fresh TP strictly further |
| SL trail | in profit · trailed SL strictly better than current |

## Wiring (loop.ts)

After exit gates resolve with the position held, when `bracketActive` +
`MONKEY_BRACKET_EXTEND_LIVE` + a fresh FR bracket exists, the revision
is evaluated against the live mark. On a favourable revision the kernel
`UPDATE`s `take_profit`/`stop_loss` across every open row it owns on the
symbol (`COALESCE` keeps the unchanged side) so a DCA stack shares one
coherent bracket. Fail-soft.

## Scope note

- **Capital scale-in** already exists via `shouldDCAAdd` — unchanged.
- **Mid-position leverage** deliberately NOT here: it intersects the
  `FR_MAX_LEV=5` vs live-22× divergence flagged in Phase A, which is a
  standalone operator decision, not a silent fold-in.

## Test plan

- [x] **11 tests** — TP extension (extend / no-pull-in / conviction
  floor / losing position), SL trail (ratchet / no-widen), SHORT mirror,
  env override, null-TP edge, no-revision hold
- [x] Build clean · ships dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)