### PR TITLE
feat(monkey): Phase E — wider market-data intel ingestion (final phase)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -61,6 +61,7 @@ import {
 import { callAutonomicTick } from './autonomic_client.js';
 import { aggregatePeakTracker } from './aggregate_peak.js';
 import { wsPositionCache } from './ws_position_cache.js';
+import { marketIntelCache } from './market_intel.js';
 import futuresWebSocket from '../../websocket/futuresWebSocket.js';
 import { BasinSync } from './basin_sync.js';
 import { BusEventType, getKernelBus, type KernelBus } from './kernel_bus.js';
@@ -2161,6 +2162,18 @@ export class MonkeyKernel extends EventEmitter {
       }
     }
 
+    // Phase E — wider market-data intel. When MONKEY_MARKET_INTEL_LIVE,
+    // keep the per-symbol Open Interest / index / premium / funding
+    // cache fresh (fire-and-forget, 60s throttle inside refreshIfStale —
+    // never blocks the tick). Fail-soft via the cache's own try/catch.
+    // Telemetry is written into `derivation` further down, once it is
+    // declared. Additive + shadow-only: no decision path consumes the
+    // signals yet; folding them into the perception basin is a
+    // deliberate follow-on.
+    if (process.env.MONKEY_MARKET_INTEL_LIVE === 'true') {
+      void marketIntelCache.refreshIfStale(symbol, 60_000);
+    }
+
     // REGIME-1 Phase 3 — compositional cell executive (3×3 (phase, direction)
     // matrix). Always evaluated for telemetry (shadow); only ENFORCED on size
     // and lane bias when REGIME_COMPOSITIONAL_LIVE=true. When either axis
@@ -2547,6 +2560,24 @@ export class MonkeyKernel extends EventEmitter {
             live: cellLive,
           },
     };
+
+    // Phase E — market-intel telemetry. The cache is kept fresh by the
+    // fire-and-forget refreshIfStale call above; surface the derived
+    // signals (premium basis, OI direction, funding) so retrospective
+    // analysis can correlate them with outcomes before a later PR folds
+    // them into the perception basin.
+    if (process.env.MONKEY_MARKET_INTEL_LIVE === 'true') {
+      const mi = marketIntelCache.get(symbol);
+      if (mi) {
+        derivation.marketIntel = {
+          premiumBasisPct: mi.premiumBasisPct,
+          oiDelta: mi.oiDelta,
+          oiDirection: mi.oiDirection,
+          fundingRate: mi.fundingRate,
+          ageMs: Date.now() - mi.observedAt,
+        };
+      }
+    }
 
     // v0.6.3: Monkey's "held side" is scoped to HER OWN open rows only.
     // If only liveSignal holds a position on this symbol, Monkey treats

--- a/apps/api/src/services/monkey/market_intel.ts
+++ b/apps/api/src/services/monkey/market_intel.ts
@@ -1,0 +1,178 @@
+/**
+ * market_intel.ts — wider market-data ingestion (Phase E).
+ *
+ * The kernel's perception basin is built almost entirely from the
+ * symbol's own OHLCV. Poloniex v3 exposes several market-data endpoints
+ * the kernel never touched — Open Interest, Index Price, Mark Price,
+ * Funding Rate — that carry information OHLCV cannot: positioning
+ * (is new money entering or is the move an unwind?) and crowding (are
+ * longs paying a premium over spot?). Feeding these in is what lets the
+ * kernel "learn and continuously adapt" beyond pure price action.
+ *
+ * This module fetches those endpoints, derives a small set of signals,
+ * and caches them per symbol. The endpoints are public — no credentials.
+ *
+ * Phase E scope is ADDITIVE + shadow-only — the cache is populated and
+ * surfaced as telemetry; no decision path consumes it yet. Folding the
+ * signals into the perception basin's dimensions is the behavioural
+ * payoff and a deliberate follow-on (it changes regime classification,
+ * so it earns its own observation window).
+ *
+ * Derived signals:
+ *   premiumBasisPct — (mark − index)/index × 100. Positive = mark above
+ *     spot = perps trading rich = longs crowded / over-leveraged (a
+ *     mean-reversion headwind for longs). Negative = shorts crowded.
+ *   oiDelta / oiDirection — change in Open Interest vs the prior
+ *     observation. Rising OI = new money committing (trend
+ *     confirmation); falling OI = positions unwinding (exhaustion).
+ *
+ * Singleton, mirroring aggregate_peak.ts / ws_position_cache.ts.
+ */
+
+import { logger } from '../../utils/logger.js';
+import poloniexFuturesService from '../poloniexFuturesService.js';
+
+export interface MarketSignals {
+  /** (mark − index)/index × 100. */
+  premiumBasisPct: number;
+  /** Open-interest change vs the previous observation (contracts). */
+  oiDelta: number;
+  /** Sign of oiDelta: +1 building, −1 unwinding, 0 flat/first-obs. */
+  oiDirection: -1 | 0 | 1;
+}
+
+export interface MarketIntelSnapshot extends MarketSignals {
+  symbol: string;
+  openInterest: number;
+  indexPrice: number;
+  markPrice: number;
+  fundingRate: number;
+  observedAt: number;
+}
+
+/**
+ * Derive the market signals from raw readings. Pure — no I/O, no clock.
+ * `prevOpenInterest` is null on the first observation for a symbol, in
+ * which case oiDelta is 0 and oiDirection is 0 (no baseline to compare).
+ */
+export function deriveMarketSignals(args: {
+  openInterest: number;
+  prevOpenInterest: number | null;
+  indexPrice: number;
+  markPrice: number;
+}): MarketSignals {
+  const { openInterest, prevOpenInterest, indexPrice, markPrice } = args;
+
+  const premiumBasisPct = indexPrice > 0
+    ? ((markPrice - indexPrice) / indexPrice) * 100
+    : 0;
+
+  const oiDelta = prevOpenInterest === null
+    ? 0
+    : openInterest - prevOpenInterest;
+  const oiDirection: -1 | 0 | 1 =
+    oiDelta > 0 ? 1 : oiDelta < 0 ? -1 : 0;
+
+  return { premiumBasisPct, oiDelta, oiDirection };
+}
+
+/** Coerce a possibly-nested API numeric field to a finite number. */
+function pickNum(obj: unknown, ...keys: string[]): number {
+  if (obj && typeof obj === 'object') {
+    const rec = obj as Record<string, unknown>;
+    // Poloniex wraps payloads as { data: {...} } or { data: [{...}] }.
+    const data = rec.data ?? rec;
+    const target = Array.isArray(data) ? data[0] : data;
+    if (target && typeof target === 'object') {
+      const t = target as Record<string, unknown>;
+      for (const k of keys) {
+        const n = Number(t[k]);
+        if (Number.isFinite(n) && n !== 0) return n;
+      }
+    }
+  }
+  return 0;
+}
+
+class MarketIntelCache {
+  private snapshots: Map<string, MarketIntelSnapshot> = new Map();
+  private refreshing: Set<string> = new Set();
+
+  /**
+   * Fetch + derive + cache market intel for a symbol. Public endpoints,
+   * no credentials. Fully fail-soft — a failed fetch leaves the prior
+   * snapshot intact and logs at debug. A concurrent refresh for the
+   * same symbol is skipped (the `refreshing` guard) so a slow fetch
+   * can't stack.
+   */
+  async refresh(symbol: string): Promise<void> {
+    if (this.refreshing.has(symbol)) return;
+    this.refreshing.add(symbol);
+    try {
+      const [oiRes, idxRes, markRes, fundRes] = await Promise.all([
+        poloniexFuturesService.getOpenInterest(symbol),
+        poloniexFuturesService.getIndexPrice(symbol),
+        poloniexFuturesService.getMarkPrice(symbol),
+        poloniexFuturesService.getFundingRate(symbol),
+      ]);
+
+      const openInterest = pickNum(oiRes, 'openInterest', 'oi', 'value');
+      const indexPrice = pickNum(idxRes, 'indexPrice', 'iPx', 'price');
+      const markPrice = pickNum(markRes, 'markPrice', 'mPx', 'price');
+      const fundingRate = pickNum(fundRes, 'fundingRate', 'fundingRate8h', 'rate');
+
+      const prev = this.snapshots.get(symbol);
+      const signals = deriveMarketSignals({
+        openInterest,
+        prevOpenInterest: prev ? prev.openInterest : null,
+        indexPrice,
+        markPrice,
+      });
+
+      this.snapshots.set(symbol, {
+        symbol,
+        openInterest, indexPrice, markPrice, fundingRate,
+        ...signals,
+        observedAt: Date.now(),
+      });
+    } catch (err) {
+      logger.debug('[MarketIntel] refresh failed — prior snapshot kept', {
+        symbol, err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.refreshing.delete(symbol);
+    }
+  }
+
+  /**
+   * Refresh only if the cached snapshot is older than `maxAgeMs` (or
+   * absent). OI / index move on a minutes timescale — calling this each
+   * tick with a 60s window keeps the cache fresh without hammering the
+   * public endpoints.
+   */
+  async refreshIfStale(symbol: string, maxAgeMs: number): Promise<void> {
+    const s = this.snapshots.get(symbol);
+    if (!s || Date.now() - s.observedAt > maxAgeMs) {
+      await this.refresh(symbol);
+    }
+  }
+
+  /** Latest snapshot for a symbol, or null if never refreshed. */
+  get(symbol: string): MarketIntelSnapshot | null {
+    return this.snapshots.get(symbol) ?? null;
+  }
+
+  /** Telemetry — all cached snapshots. */
+  snapshot(): MarketIntelSnapshot[] {
+    return Array.from(this.snapshots.values());
+  }
+
+  /** Test/reset helper. */
+  resetForTests(): void {
+    this.snapshots.clear();
+    this.refreshing.clear();
+  }
+}
+
+export const marketIntelCache = new MarketIntelCache();
+export type { MarketIntelCache };

--- a/apps/api/src/tests/marketIntel.test.ts
+++ b/apps/api/src/tests/marketIntel.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for market_intel.ts — the Phase E wider market-data ingestion.
+ * Covers the pure deriveMarketSignals function and the cache's
+ * snapshot/reset surface.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  deriveMarketSignals,
+  marketIntelCache,
+} from '../services/monkey/market_intel.js';
+
+describe('deriveMarketSignals — premium basis', () => {
+  it('positive basis when mark trades above index (longs crowded)', () => {
+    const s = deriveMarketSignals({
+      openInterest: 1000, prevOpenInterest: 1000,
+      indexPrice: 100, markPrice: 101,
+    });
+    expect(s.premiumBasisPct).toBeCloseTo(1.0, 6); // (101-100)/100×100
+  });
+
+  it('negative basis when mark trades below index (shorts crowded)', () => {
+    const s = deriveMarketSignals({
+      openInterest: 1000, prevOpenInterest: 1000,
+      indexPrice: 200, markPrice: 199,
+    });
+    expect(s.premiumBasisPct).toBeCloseTo(-0.5, 6);
+  });
+
+  it('zero basis when index price is 0 (malformed) — no divide-by-zero', () => {
+    const s = deriveMarketSignals({
+      openInterest: 1000, prevOpenInterest: 1000,
+      indexPrice: 0, markPrice: 100,
+    });
+    expect(s.premiumBasisPct).toBe(0);
+  });
+});
+
+describe('deriveMarketSignals — open interest direction', () => {
+  it('rising OI → oiDirection +1 (new money committing)', () => {
+    const s = deriveMarketSignals({
+      openInterest: 1200, prevOpenInterest: 1000,
+      indexPrice: 100, markPrice: 100,
+    });
+    expect(s.oiDelta).toBe(200);
+    expect(s.oiDirection).toBe(1);
+  });
+
+  it('falling OI → oiDirection −1 (positions unwinding)', () => {
+    const s = deriveMarketSignals({
+      openInterest: 800, prevOpenInterest: 1000,
+      indexPrice: 100, markPrice: 100,
+    });
+    expect(s.oiDelta).toBe(-200);
+    expect(s.oiDirection).toBe(-1);
+  });
+
+  it('flat OI → oiDirection 0', () => {
+    const s = deriveMarketSignals({
+      openInterest: 1000, prevOpenInterest: 1000,
+      indexPrice: 100, markPrice: 100,
+    });
+    expect(s.oiDelta).toBe(0);
+    expect(s.oiDirection).toBe(0);
+  });
+
+  it('first observation (prev null) → oiDelta 0, oiDirection 0', () => {
+    const s = deriveMarketSignals({
+      openInterest: 1000, prevOpenInterest: null,
+      indexPrice: 100, markPrice: 100,
+    });
+    expect(s.oiDelta).toBe(0);
+    expect(s.oiDirection).toBe(0);
+  });
+});
+
+describe('marketIntelCache', () => {
+  beforeEach(() => {
+    marketIntelCache.resetForTests();
+  });
+
+  it('get returns null before any refresh', () => {
+    expect(marketIntelCache.get('BTC_USDT_PERP')).toBeNull();
+  });
+
+  it('snapshot is empty before any refresh', () => {
+    expect(marketIntelCache.snapshot()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Phase E of 5 — final phase

The kernel's perception basin is built almost entirely from the
symbol's own OHLCV. Poloniex v3 exposes market-data endpoints the
kernel never touched — **Open Interest, Index Price, Mark Price,
Funding Rate** — carrying information OHLCV cannot: positioning (new
money entering vs unwind) and crowding (perps rich/cheap vs spot).

## `market_intel.ts`

Singleton cache (mirrors `aggregate_peak` / `ws_position_cache`).

- **`deriveMarketSignals`** (pure): `premiumBasisPct = (mark−index)/index×100`
  — crowding; `oiDelta` / `oiDirection` — OI building (+1) vs
  unwinding (−1).
- **`refresh` / `refreshIfStale`** (60s throttle) — public endpoints,
  no credentials, fully fail-soft, concurrent-refresh guarded.

## Wiring (`loop.ts`)

Under `MONKEY_MARKET_INTEL_LIVE` (default **off**): each tick fires
`refreshIfStale(symbol, 60s)` fire-and-forget (never blocks the tick)
and writes the signals into `derivation.marketIntel` telemetry.

## Scope — additive + shadow-only

Signals fetched / cached / surfaced as telemetry; no decision path
consumes them yet. Folding them into the perception basin changes
regime classification → deliberate follow-on with its own observation
window. (Liquidations already partly ingested via
`liquidation_cascade_observer.ts`.)

## Test plan

- [x] **9 tests** — premium basis (positive/negative/zero-guard), OI
  direction (rising/falling/flat/first-obs), cache empty-state
- [x] Build clean · ships dark

## Completes the 5-phase program

| Phase | PR | What |
|---|---|---|
| A | #858 | FR trade-parameter layer (Pine P25 port) |
| B1 | #859 | entry commits FR TP/SL bracket |
| B2 | #860 | synthetic bracket-exit gate |
| C | #861 | bracket revision on new intel |
| D | #862 | WebSocket private position feed |
| **E** | **this** | **market-data intel ingestion** |

All five ship dark behind flags — see PR descriptions for the
flag names and the recommended observation-then-flip sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)