### PR TITLE
feat(web): Risk Appetite applies live + risk config consolidated to one place

### DIFF
--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -12,14 +12,21 @@ import MLLiveRecommendations from './MLLiveRecommendations';
 import PerformanceAnalytics from './PerformanceAnalytics';
 import StateOfTheBotCard from './StateOfTheBotCard';
 import StrategyApprovalQueue from './StrategyApprovalQueue';
+import RiskSettings from '@/components/risk/RiskSettings';
 import { safeNum } from '@/utils/safeNum';
 
 const API_BASE_URL = getBackendUrl();
 
+// Risk-appetite presets. The first four fields feed the /api/agent/start
+// payload; takeProfit / dailyLossLimit / maxLeverage extend the preset so
+// it maps cleanly onto the risk_settings table (PUT /api/risk/settings),
+// letting a risk-appetite change apply LIVE without restarting the agent.
+// maxLeverage stays <= 15 — the audited profitable ceiling (the kernel
+// clamps there regardless); "aggressive" raises size/drawdown, not lev.
 const RISK_CONFIGS = {
-  conservative: { maxDrawdown: 8, positionSize: 1, stopLossPercentage: 3, maxConcurrentPositions: 2 },
-  balanced: { maxDrawdown: 15, positionSize: 2, stopLossPercentage: 5, maxConcurrentPositions: 3 },
-  aggressive: { maxDrawdown: 25, positionSize: 5, stopLossPercentage: 8, maxConcurrentPositions: 5 }
+  conservative: { maxDrawdown: 8, positionSize: 1, stopLossPercentage: 3, maxConcurrentPositions: 2, takeProfit: 6, dailyLossLimit: 3, maxLeverage: 8 },
+  balanced: { maxDrawdown: 15, positionSize: 2, stopLossPercentage: 5, maxConcurrentPositions: 3, takeProfit: 8, dailyLossLimit: 5, maxLeverage: 15 },
+  aggressive: { maxDrawdown: 25, positionSize: 5, stopLossPercentage: 8, maxConcurrentPositions: 5, takeProfit: 12, dailyLossLimit: 10, maxLeverage: 15 }
 } as const;
 
 const FALLBACK_HEALTH_STATUS = {
@@ -111,6 +118,8 @@ const AutonomousAgentDashboard: React.FC = () => {
     timestamp: string;
   } | null>(null);
   const [riskAppetite, setRiskAppetite] = usePersistedState<'conservative' | 'balanced' | 'aggressive'>('agent_risk_appetite', 'balanced');
+  // True while a risk-appetite change is being PUT to /api/risk/settings.
+  const [riskAppetiteUpdating, setRiskAppetiteUpdating] = useState(false);
   // Execution Mode is a SAFETY OVERRIDE enforced by the server-side risk
   // kernel. The UI fetches it on mount and pushes updates via PUT; the
   // cache in localStorage is just an optimistic UI value so the buttons
@@ -163,6 +172,43 @@ const AutonomousAgentDashboard: React.FC = () => {
       setExecutionModeUpdating(false);
     }
   }, [setExecutionModeRaw]);
+
+  /**
+   * Apply a risk-appetite change LIVE. Writes the preset to the
+   * risk_settings table via PUT /api/risk/settings; the Monkey kernel
+   * reads that table every tick (60s cache), so the new ceilings take
+   * effect without stopping or restarting the agent. The risk-appetite
+   * preset still also feeds the /api/agent/start payload for fresh
+   * starts — this just removes the stop→edit→restart requirement.
+   */
+  const setRiskAppetiteLive = useCallback(async (v: 'conservative' | 'balanced' | 'aggressive') => {
+    // Optimistic local update so the button highlight is instant.
+    setRiskAppetite(v);
+    setRiskAppetiteUpdating(true);
+    try {
+      const token = getAccessToken();
+      const rc = RISK_CONFIGS[v];
+      await axios.put(
+        `${API_BASE_URL}/api/risk/settings`,
+        {
+          maxDrawdown: rc.maxDrawdown,
+          maxPositionSize: rc.positionSize,
+          maxConcurrentPositions: rc.maxConcurrentPositions,
+          stopLoss: rc.stopLossPercentage,
+          takeProfit: rc.takeProfit,
+          dailyLossLimit: rc.dailyLossLimit,
+          maxLeverage: rc.maxLeverage,
+          riskLevel: v,
+        },
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+    } catch (err) {
+      // The optimistic localStorage value stands; surface the failure.
+      console.error('Failed to apply risk appetite live', err);
+    } finally {
+      setRiskAppetiteUpdating(false);
+    }
+  }, [setRiskAppetite]);
 
   /** Pull server-authoritative mode on mount so UI matches reality. */
   useEffect(() => {
@@ -830,8 +876,8 @@ const AutonomousAgentDashboard: React.FC = () => {
                 { value: 'aggressive', label: 'Aggressive', desc: 'High risk, high reward', activeClass: 'border-orange-500 bg-orange-50' }
               ] as const).map(opt => (
                 <button key={opt.value}
-                  onClick={() => setRiskAppetite(opt.value)}
-                  disabled={agentStatus?.status === 'running'}
+                  onClick={() => setRiskAppetiteLive(opt.value)}
+                  disabled={riskAppetiteUpdating}
                   className={`p-3 rounded-lg border-2 text-left transition-all disabled:opacity-50 ${
                     riskAppetite === opt.value
                       ? opt.activeClass
@@ -874,6 +920,21 @@ const AutonomousAgentDashboard: React.FC = () => {
             )}
           </div>
         </div>
+      </div>
+
+      {/* Detailed Risk Limits — the granular operator ceilings, kept
+          visually together with Risk Appetite above. Both write the same
+          risk_settings table; the Monkey kernel reads it live (60s cache,
+          no restart). Single home for risk config — RiskSettings was
+          removed from the Settings page so it is not split across two
+          screens. */}
+      <div className="bg-white rounded-lg shadow-lg p-6">
+        <h3 className="text-lg font-bold text-gray-900 mb-1">Detailed Risk Limits</h3>
+        <p className="text-sm text-gray-500 mb-4">
+          Applied live by the kernel — no need to stop the agent. Risk
+          Appetite above sets these in one click; adjust individually here.
+        </p>
+        <RiskSettings />
       </div>
 
       {/* Emergency Stop — visible when live trading is active. "Auto" mode

--- a/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
+++ b/apps/web/src/components/agent/AutonomousAgentDashboard.tsx
@@ -970,7 +970,7 @@ const AutonomousAgentDashboard: React.FC = () => {
             <div className="text-left">
               <p className="font-semibold text-gray-900">Agent Configuration</p>
               <p className="text-sm text-gray-500">
-                Futures {config.defaultLeverage}x · {config.tradingStyle.replace('_', ' ')} · {config.preferredPairs.join(', ')} · Max DD {config.maxDrawdown}%
+                {config.tradingStyle.replace('_', ' ')} · {config.preferredPairs.join(', ')} · {config.marginMode} margin
               </p>
             </div>
           </div>
@@ -979,7 +979,7 @@ const AutonomousAgentDashboard: React.FC = () => {
         {showConfig && (
           <div className="border-t border-gray-200 p-6 space-y-4">
             {agentStatus?.status === 'running' && (
-              <p className="text-sm text-amber-600 bg-amber-50 rounded p-2">⚠ Stop the agent to change configuration.</p>
+              <p className="text-sm text-amber-600 bg-amber-50 rounded p-2">⚠ These define the agent&apos;s trading universe — stop the agent to change them. Risk limits (above) apply live.</p>
             )}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {/* Trading Style */}
@@ -996,72 +996,12 @@ const AutonomousAgentDashboard: React.FC = () => {
                   <option value="swing_trading">Swing Trading (multi-day, wider stops)</option>
                 </select>
               </div>
-              {/* Max Drawdown */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Max Drawdown: {config.maxDrawdown}%
-                </label>
-                <input
-                  type="range"
-                  min={5}
-                  max={30}
-                  step={1}
-                  value={config.maxDrawdown}
-                  onChange={e => setConfig(c => ({ ...c, maxDrawdown: parseInt(e.target.value) }))}
-                  disabled={agentStatus?.status === 'running'}
-                  className="w-full accent-cyan-600"
-                />
-                <div className="flex justify-between text-xs text-gray-400"><span>5% (safe)</span><span>30% (aggressive)</span></div>
-              </div>
-              {/* Position Size */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Position Size: {config.positionSize}% of capital
-                </label>
-                <input
-                  type="range"
-                  min={1}
-                  max={10}
-                  step={0.5}
-                  value={config.positionSize}
-                  onChange={e => setConfig(c => ({ ...c, positionSize: parseFloat(e.target.value) }))}
-                  disabled={agentStatus?.status === 'running'}
-                  className="w-full accent-cyan-600"
-                />
-                <div className="flex justify-between text-xs text-gray-400"><span>1% (conservative)</span><span>10% (aggressive)</span></div>
-              </div>
-              {/* Stop Loss */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Stop Loss: {config.stopLossPercentage}%
-                </label>
-                <input
-                  type="range"
-                  min={1}
-                  max={10}
-                  step={0.5}
-                  value={config.stopLossPercentage}
-                  onChange={e => setConfig(c => ({ ...c, stopLossPercentage: parseFloat(e.target.value) }))}
-                  disabled={agentStatus?.status === 'running'}
-                  className="w-full accent-cyan-600"
-                />
-              </div>
-              {/* Max Concurrent Positions */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Max Concurrent Positions: {config.maxConcurrentPositions}
-                </label>
-                <input
-                  type="range"
-                  min={1}
-                  max={10}
-                  step={1}
-                  value={config.maxConcurrentPositions}
-                  onChange={e => setConfig(c => ({ ...c, maxConcurrentPositions: parseInt(e.target.value) }))}
-                  disabled={agentStatus?.status === 'running'}
-                  className="w-full accent-cyan-600"
-                />
-              </div>
+              {/* Risk limits (max drawdown, position size, stop loss,
+                  max concurrent, leverage) live in the Risk Appetite card
+                  + Detailed Risk Limits panel above — single source, applied
+                  live. They were removed from here to end the duplication
+                  (and were already overridden by the risk-appetite preset
+                  in the /api/agent/start payload). */}
               {/* Automation Level */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Automation Level</label>
@@ -1075,30 +1015,6 @@ const AutonomousAgentDashboard: React.FC = () => {
                   <option value="semi_autonomous">Semi-Autonomous (approve before live)</option>
                   <option value="manual_override">Manual Override (approve all actions)</option>
                 </select>
-              </div>
-              {/* Futures Leverage */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Futures Leverage: {config.defaultLeverage}x
-                </label>
-                <input
-                  type="range"
-                  min={1}
-                  max={75}
-                  step={1}
-                  value={config.defaultLeverage}
-                  onChange={e => setConfig(c => ({ ...c, defaultLeverage: parseInt(e.target.value) }))}
-                  disabled={agentStatus?.status === 'running'}
-                  className="w-full accent-cyan-600"
-                />
-                <div className="flex justify-between text-xs text-gray-400">
-                  <span>1x (no leverage)</span>
-                  <span>75x (BTC/ETH max)</span>
-                </div>
-                <p className="text-xs text-gray-500 mt-1">
-                  Per-symbol exchange maximums may be lower than 75x. The kernel
-                  clamps to each symbol&apos;s actual cap at order placement.
-                </p>
               </div>
               {/* Margin Mode */}
               <div>

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -10,8 +10,6 @@ import {
   X,
   Shield
 } from 'lucide-react';
-import RiskSettings from '@/components/risk/RiskSettings';
-import RiskMeter from '@/components/risk/RiskMeter';
 import { useSettings } from '../hooks/useSettings';
 import { usePoloniexData } from '../hooks/usePoloniexData';
 import { useDateFormatter } from '../hooks/useDateFormatter'; 
@@ -428,14 +426,16 @@ const Settings: React.FC = () => {
                 <Shield className="h-6 w-6 text-blue-600" />
                 <h2 className="text-xl font-bold">Risk Management</h2>
               </div>
-              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-                <div className="lg:col-span-2">
-                  <RiskSettings />
-                </div>
-                <div>
-                  <RiskMeter />
-                </div>
-              </div>
+              <p className="text-sm text-neutral-600">
+                Risk configuration now lives with the trading agent — Risk
+                Appetite presets and the detailed risk limits are together on
+                the{' '}
+                <a href="/autonomous-agent" className="font-medium text-blue-600 hover:underline">
+                  Autonomous Agent
+                </a>{' '}
+                page, so every risk control is in one place and applies live
+                without restarting the agent.
+              </p>
             </div>
           </div>
         </form>


### PR DESCRIPTION
## Why

Two operator complaints:
1. *"Why do I have to pause or stop trading to set the Agent configuration?"* — the Agent Config card disabled every input while `status==='running'`, and Risk Appetite was `localStorage` read only into the `/api/agent/start` payload. So config was stop→edit→restart only.
2. Risk config was **split across two screens** — Risk Appetite on the Autonomous Agent page, a separate `RiskSettings` panel on the Settings page.

## What

- **Risk Appetite applies live** — `setRiskAppetiteLive` PUTs the preset to `/api/risk/settings` (the `risk_settings` table the Monkey kernel reads every tick, 60 s cache — #865). No restart. Buttons gate on the in-flight PUT, not on `status==='running'`.
- `RISK_CONFIGS` extended with `takeProfit`/`dailyLossLimit`/`maxLeverage` so a preset maps cleanly onto `risk_settings`. `maxLeverage` stays ≤ 15 — the audited profitable ceiling; the kernel clamps there regardless.
- **Visually together** — the detailed `RiskSettings` panel now renders on the Autonomous Agent page, directly under Risk Appetite. Both surfaces, one page, both → `risk_settings`.
- **One home** — removed `RiskSettings`/`RiskMeter` from the Settings page; the `#risk` section now points to the Autonomous Agent page (nav anchor still resolves — no dead link).

## Verification

`tsc --noEmit` clean · `eslint` 0 errors on both files.

⚠️ Deployed-UX live-test (Gate B) is pending — staging auth is currently broken (separate issue: staging `polytrade-fe` missing `VITE_BACKEND_URL`), so the change can't be exercised on staging yet. Needs a click-through once staging auth is fixed or on the prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)