### PR TITLE
fix(web): derive backend host on Railway split FE/BE deploys — fixes staging auth

### DIFF
--- a/apps/web/src/utils/environment.ts
+++ b/apps/web/src/utils/environment.ts
@@ -143,6 +143,19 @@ export const getBackendUrl = (): string => {
       return `${protocol}//${hostname}:8765`;
     }
 
+    // Railway split FE/BE deploys (staging, PR previews) name the
+    // frontend host `polytrade-fe-<suffix>` and the backend
+    // `polytrade-be-<suffix>` (e.g. polytrade-fe-staging ↔
+    // polytrade-be-staging). Derive the backend host so these
+    // environments work WITHOUT a per-env VITE_BACKEND_URL build var —
+    // without this the same-origin fallback below POSTs the API to the
+    // static frontend host and gets index.html back (breaks auth).
+    // Production sets VITE_BACKEND_URL explicitly (priority 1) and never
+    // reaches this branch; its host name does not contain `polytrade-fe`.
+    if (hostname.includes('polytrade-fe')) {
+      return `${protocol}//${hostname.replace('polytrade-fe', 'polytrade-be')}`;
+    }
+
     // Fall back to same origin for other cases
     return window.location.origin;
   }


### PR DESCRIPTION
## Problem

Register/login broken on **staging**.

## Diagnosis (probed live)

| Check | Result |
|---|---|
| Staging DB schema | ✅ 76 tables; `users`, `user_api_credentials`, `risk_settings` all present |
| Staging backend health | ✅ `200` |
| `POST /api/auth/login` (backend) | ✅ correct `401` for bad creds — route works |
| CORS preflight (staging FE origin) | ✅ `204`, `access-control-allow-origin` echoes the staging FE |
| `POST /api/auth/login` to the **frontend** host | ❌ `200 text/html` — returns `index.html` |

So the backend, DB and CORS are all fine. The break is `getBackendUrl()`: the staging frontend has **no `VITE_BACKEND_URL`** baked in — `.env.staging` is gitignored so Railway's build never sees it — so it falls through to the **same-origin fallback**. The browser then POSTs `/api/auth/*` to the *static frontend host*, gets `index.html` back, and `axios` fails. Both register and login die there.

## Fix

Before the same-origin fallback, derive the backend from the frontend host on Railway split deploys: `polytrade-fe-<suffix>` → `polytrade-be-<suffix>` (staging **and** PR-preview environments). No per-env `VITE_BACKEND_URL` build var needed.

Production is unaffected — it sets `VITE_BACKEND_URL` explicitly (priority 1) and its host name (`poloniex-trading-platform-production`) doesn't contain `polytrade-fe`, so it never reaches this branch either way.

## Verification

`tsc` + `eslint` clean. Staging `polytrade-fe` must redeploy to pick up the rebuilt bundle; then register/login resolve to `polytrade-be-staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)