### PR TITLE
fix(monkey): FAT master kill-switch — disable FAT engine by default

### DIFF
--- a/apps/api/src/services/fullyAutonomousTrader.ts
+++ b/apps/api/src/services/fullyAutonomousTrader.ts
@@ -88,6 +88,20 @@ const MAX_POSITION_FRACTION = 0.1;      // Max 10% of capital per position
 const VOLATILITY_HIGH = 0.03;           // >3% = high volatility
 const VOLATILITY_MEDIUM = 0.01;         // >1% = medium volatility
 
+/**
+ * Master kill-switch for the FAT trading loop.
+ *
+ * Disabled by default after 2026-05-20: the operator found FAT (and
+ * LiveSignal) detrimental relative to the Monkey kernel and asked for
+ * both to be switched off. LiveSignal/Persistent/AgentScheduler are
+ * already env-gated in index.ts — but FAT's loop auto-restores on
+ * module construction via loadActiveConfigs(), so AGENT_SCHEDULER_ENABLE
+ * never reached it. This gate is the single chokepoint: every path to
+ * the trading loop funnels through startTrading(). Re-enable with
+ * FAT_ENABLE=true.
+ */
+const fatEngineEnabled = (): boolean => process.env.FAT_ENABLE === 'true';
+
 interface TradingConfig {
   userId: string;
   initialCapital: number;
@@ -386,6 +400,16 @@ class FullyAutonomousTrader extends EventEmitter {
   private async startTrading(userId: string): Promise<void> {
     const config = this.configs.get(userId);
     if (!config || !config.enabled) {
+      return;
+    }
+
+    // Master kill-switch — FAT is disabled by default (2026-05-20 operator
+    // directive). The config stays in memory so getStatus() reports it
+    // honestly, but no trading interval is armed. See fatEngineEnabled().
+    if (!fatEngineEnabled()) {
+      logger.info(
+        `[FAT] startTrading skipped for user ${userId} — FAT engine disabled (set FAT_ENABLE=true to re-enable)`,
+      );
       return;
     }
 

--- a/apps/api/src/tests/fullyAutonomousTraderEnableGate.test.ts
+++ b/apps/api/src/tests/fullyAutonomousTraderEnableGate.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the FAT master kill-switch (FAT_ENABLE).
+ *
+ * FAT was disabled by default on 2026-05-20 (operator directive: FAT and
+ * LiveSignal found detrimental relative to the Monkey kernel). FAT's loop
+ * auto-restores on module construction via loadActiveConfigs(), so the
+ * env gate must sit on startTrading() — the single chokepoint every path
+ * to the trading interval funnels through. These tests lock that gate.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mock heavy dependencies so the class constructor doesn't touch the DB ──
+vi.mock('../db/connection.js', () => ({
+  pool: {
+    query: vi.fn().mockResolvedValue({ rows: [] })
+  }
+}));
+
+vi.mock('../services/poloniexFuturesService.js', () => ({ default: {} }));
+vi.mock('../services/riskService.js', () => ({ default: {} }));
+vi.mock('../services/mlPredictionService.js', () => ({ default: {} }));
+vi.mock('../services/apiCredentialsService.js', () => ({ apiCredentialsService: {} }));
+vi.mock('../utils/marketDataValidator.js', () => ({ validateMarketData: vi.fn() }));
+vi.mock('../services/marketCatalog.js', () => ({ getPrecisions: vi.fn() }));
+
+import { FullyAutonomousTrader } from '../services/fullyAutonomousTrader.js';
+
+/** Convenience alias to call private methods without TypeScript errors. */
+function priv(trader: FullyAutonomousTrader) {
+  return trader as any;
+}
+
+const USER = 'test-user-fat-gate';
+
+/** Minimal config that satisfies the `!config || !config.enabled` guard. */
+function seedConfig(trader: FullyAutonomousTrader): void {
+  priv(trader).configs.set(USER, {
+    userId: USER,
+    initialCapital: 1000,
+    maxRiskPerTrade: 2,
+    maxDrawdown: 10,
+    targetDailyReturn: 1,
+    symbols: ['BTC_USDT_PERP'],
+    enabled: true,
+    paperTrading: true,
+    stopLossPercent: 2,
+    takeProfitPercent: 4,
+    leverage: 3,
+    maxConcurrentPositions: 3,
+    tradingCycleSeconds: 60,
+    confidenceThreshold: 65,
+    signalScoreThreshold: 30,
+  });
+}
+
+describe('FullyAutonomousTrader – FAT_ENABLE kill-switch', () => {
+  let trader: FullyAutonomousTrader;
+  const savedEnv = process.env.FAT_ENABLE;
+
+  beforeEach(() => {
+    trader = new FullyAutonomousTrader();
+    seedConfig(trader);
+    // Stub the heavy fire-and-forget calls startTrading() makes when enabled.
+    vi.spyOn(priv(trader), 'tradingCycle').mockResolvedValue(undefined);
+    vi.spyOn(priv(trader), 'bootstrapMlModels').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    // Tear down any interval the enabled-path test armed.
+    const interval = priv(trader).runningIntervals.get(USER);
+    if (interval) clearInterval(interval);
+    if (savedEnv === undefined) delete process.env.FAT_ENABLE;
+    else process.env.FAT_ENABLE = savedEnv;
+  });
+
+  it('does NOT arm a trading interval when FAT_ENABLE is unset', async () => {
+    delete process.env.FAT_ENABLE;
+    await priv(trader).startTrading(USER);
+    expect(priv(trader).runningIntervals.has(USER)).toBe(false);
+  });
+
+  it('does NOT arm a trading interval when FAT_ENABLE is "false"', async () => {
+    process.env.FAT_ENABLE = 'false';
+    await priv(trader).startTrading(USER);
+    expect(priv(trader).runningIntervals.has(USER)).toBe(false);
+  });
+
+  it('arms the trading interval when FAT_ENABLE is "true"', async () => {
+    process.env.FAT_ENABLE = 'true';
+    await priv(trader).startTrading(USER);
+    expect(priv(trader).runningIntervals.has(USER)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

The operator reported that turning on FAT (and LiveSignal) was **detrimental** relative to the Monkey kernel and asked for both to be switched off ("analyse kernel success and switch off the worst ones — K is most reliable, then ML").

LiveSignal / Persistent / AgentScheduler are all env-gated in `index.ts`. **FAT was not.** FAT's trading loop auto-restores on module construction:

```
constructor() → loadActiveConfigs() → startTrading() → setInterval(...)
```

for every `autonomous_trading_configs` row with `enabled = true`. `AGENT_SCHEDULER_ENABLE=false` only stopped the per-user session *restorer* — it never reached FAT's own loop. Production deploy `72a93f83` confirmed this: `[FAT]` lines kept appearing after the scheduler was disabled.

## What

- New `FAT_ENABLE` env gate (`fatEngineEnabled()`), **default OFF**.
- Gate placed on `startTrading()` — the single chokepoint every path to the trading interval funnels through (`loadActiveConfigs`, the `/api/autonomous/enable` route, and `agentScheduler`).
- The config still loads into memory so `getStatus()` reports `enabled` honestly; no interval is armed.
- Re-enable with `FAT_ENABLE=true`.

Matches the existing env-gate pattern for the other engines.

## Tests

`fullyAutonomousTraderEnableGate.test.ts` — 3 cases: no interval armed when `FAT_ENABLE` is unset / `"false"`; interval armed when `"true"`. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an environment-gated master kill-switch to disable the FullyAutonomousTrader (FAT) trading loop by default while preserving configuration loading.

Bug Fixes:
- Prevent the FAT trading loop from auto-starting by default by requiring FAT_ENABLE=true before arming trading intervals.

Tests:
- Add unit tests to verify that trading intervals are only armed when FAT_ENABLE is explicitly set to true and remain disabled when unset or false.