### PR TITLE
feat(monkey): enforce exit brackets + make adopted positions visible to K

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ redis_data/
 .playwright-mcp/
 agent-dashboard-*.png
 .claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/apps/api/src/services/monkey/__tests__/claimAdoptedPositions.test.ts
+++ b/apps/api/src/services/monkey/__tests__/claimAdoptedPositions.test.ts
@@ -1,0 +1,95 @@
+/**
+ * claimAdoptedPositions.test.ts — adoption pickup routing + bracket commit.
+ *
+ * The reconciler inserts operator-opened positions with reason
+ * `kernel_adopted|…`, invisible to findOpenMonkeyTrade (which keys on the
+ * `monkey|kernel=<instance>|` prefix). claimAdoptedPositions rewrites the
+ * prefix so exactly one instance — monkey-position — owns and manages
+ * them, and commits a geometry-derived bracket so the synthetic exit gate
+ * has a limit to enforce.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mirror the env mock used by the other loop.ts-importing tests so the
+// module load chain doesn't blow up on missing DATABASE_URL / JWT_SECRET.
+vi.mock('../../../config/env.js', () => ({
+  env: {
+    NODE_ENV: 'test',
+    PORT: 8765,
+    DATABASE_URL: 'postgresql://test:5432/test',
+    JWT_SECRET: 'test-jwt-secret-32-characters-xxxxxxxxxx',
+  },
+}));
+
+const queryMock = vi.fn();
+vi.mock('../../../db/connection.js', () => ({
+  pool: { query: queryMock },
+}));
+
+async function makeKernel(instanceId: string) {
+  const { MonkeyKernel } = await import('../loop.js');
+  return new MonkeyKernel({ instanceId, timeframe: '15m', tickMs: 30_000 });
+}
+
+describe('claimAdoptedPositions', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    queryMock.mockResolvedValue({ rowCount: 0, rows: [] });
+  });
+
+  it('does nothing on the non-position instance (single deterministic owner)', async () => {
+    const swing = await makeKernel('monkey-swing');
+    queryMock.mockClear();
+    await (swing as any).claimAdoptedPositions('BTC_USDT_PERP', {
+      tpDistance: 100, slDistance: 50,
+    });
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('rewrites the kernel_adopted| prefix on the position instance', async () => {
+    const pos = await makeKernel('monkey-position');
+    queryMock.mockClear();
+    await (pos as any).claimAdoptedPositions('BTC_USDT_PERP', null);
+    // frBracket is null → claim UPDATE only, no bracket commit.
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(sql).toContain('replace(reason');
+    expect(sql).toContain("'kernel_adopted|'");
+    expect(sql).toContain("'monkey|kernel=monkey-position|adopted|'");
+    expect(sql).toContain("reason LIKE 'kernel_adopted|%'");
+    expect(params).toEqual(['BTC_USDT_PERP']);
+  });
+
+  it('commits a side-aware bracket when geometry is derivable', async () => {
+    const pos = await makeKernel('monkey-position');
+    queryMock.mockClear();
+    await (pos as any).claimAdoptedPositions('ETH_USDT_PERP', {
+      tpDistance: 80, slDistance: 40,
+    });
+    // claim UPDATE + bracket-commit UPDATE.
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    const [sql, params] = queryMock.mock.calls[1];
+    expect(sql).toContain('take_profit = entry_price');
+    expect(sql).toContain('stop_loss');
+    expect(sql).toContain('take_profit IS NULL AND stop_loss IS NULL');
+    expect(params).toEqual(['ETH_USDT_PERP', 80, 40]);
+  });
+
+  it('skips the bracket commit when geometry is not derivable (0 distances)', async () => {
+    const pos = await makeKernel('monkey-position');
+    queryMock.mockClear();
+    await (pos as any).claimAdoptedPositions('SOL_USDT_PERP', {
+      tpDistance: 0, slDistance: 0,
+    });
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails soft on a DB error — never throws into the tick', async () => {
+    const pos = await makeKernel('monkey-position');
+    queryMock.mockClear();
+    queryMock.mockRejectedValueOnce(new Error('db down'));
+    await expect(
+      (pos as any).claimAdoptedPositions('BTC_USDT_PERP', null),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2594,6 +2594,13 @@ export class MonkeyKernel extends EventEmitter {
       }
     }
 
+    // Adoption pickup — the reconciler inserts operator-opened positions
+    // with reason `kernel_adopted|…`, which findOpenMonkeyTrade (keyed on
+    // the `monkey|kernel=<instance>|` prefix) would never see. Claim them
+    // onto the monkey-position instance and commit a bracket. Runs BEFORE
+    // findOpenMonkeyTrade so a row claimed this tick is managed this tick.
+    await this.claimAdoptedPositions(symbol, state.lastFrBracket);
+
     // v0.6.3: Monkey's "held side" is scoped to HER OWN open rows only.
     // If only liveSignal holds a position on this symbol, Monkey treats
     // herself as flat and her entry logic can still fire (risk kernel's
@@ -2681,9 +2688,11 @@ export class MonkeyKernel extends EventEmitter {
         // active, the discretionary PROFIT gates below (profit-harvest,
         // aggregate-harvest, scalp-TP) are skipped via `bracketActive`.
         // The loss-side safety gates (hard SL, fast-adverse, slow-bleed)
-        // still run — a price stop is not a time/tape stop. Default OFF;
-        // ships dark, flipped after observation.
-        const bracketExitLive = process.env.MONKEY_BRACKET_EXIT_LIVE === 'true';
+        // still run — a price stop is not a time/tape stop. Default ON
+        // (2026-05-20 operator directive: "close trades at its predicted
+        // or adjusted limit"); set MONKEY_BRACKET_EXIT_LIVE=false to
+        // disable as a kill-switch.
+        const bracketExitLive = process.env.MONKEY_BRACKET_EXIT_LIVE !== 'false';
         const hasBracket = (openRow.take_profit ?? null) !== null
           || (openRow.stop_loss ?? null) !== null;
         const bracketActive = bracketExitLive && hasBracket;
@@ -3303,9 +3312,12 @@ export class MonkeyKernel extends EventEmitter {
         // and trail the SL toward profit. Both edits are strictly
         // monotonic in the position's favour (shouldExtendBracket
         // enforces it), so revising every tick can only improve the
-        // bracket. Flag MONKEY_BRACKET_EXTEND_LIVE (default off).
+        // bracket. Default ON (2026-05-20 operator directive: "close
+        // trades at its predicted or adjusted limit" — the revision is
+        // the "adjusted" half); set MONKEY_BRACKET_EXTEND_LIVE=false to
+        // disable as a kill-switch.
         const bracketExtendLive =
-          process.env.MONKEY_BRACKET_EXTEND_LIVE === 'true';
+          process.env.MONKEY_BRACKET_EXTEND_LIVE !== 'false';
         if (
           !exitFired && bracketActive && bracketExtendLive
           && state.lastFrBracket !== null
@@ -5100,6 +5112,74 @@ export class MonkeyKernel extends EventEmitter {
     lane?: LaneType,
   ): Promise<{ winRate: number; avgWin: number; avgLoss: number } | null> {
     return getKellyRollingStats(agent, lane);
+  }
+
+  /**
+   * Claim operator-opened positions adopted by the reconciler.
+   *
+   * The reconciler (stateReconciliationService) inserts operator-opened
+   * positions with `agent='K'` but `reason='kernel_adopted|…'`. Every
+   * kernel lookup (findOpenMonkeyTrade / findOpenMonkeyTradesByLane / the
+   * bracket-revision UPDATE) keys on the `monkey|kernel=<instanceId>|`
+   * reason prefix, so an adopted row is invisible to every exit path —
+   * the "kernel adopts and manages it" contract was silently broken.
+   *
+   * Fix: exactly ONE instance — monkey-position, the patient 15m kernel —
+   * rewrites the `kernel_adopted|` prefix to
+   * `monkey|kernel=monkey-position|adopted|`. After the rewrite the row
+   * matches the canonical owned-row pattern and every existing query and
+   * UPDATE picks it up unchanged. A single deterministic owner avoids a
+   * dual-instance management race. The reconciler's orphan dedup keys on
+   * symbol+side (not `reason`), so the rewrite cannot trigger a duplicate
+   * insert.
+   *
+   * Adopted rows are inserted with NULL take_profit/stop_loss, so once
+   * claimed we commit a geometry-derived bracket (this tick's φ/ATR
+   * around the operator's recorded entry price) — the synthetic
+   * bracket-exit gate needs a limit to enforce. Also backfills any
+   * kernel-opened row whose Phase-B1 commit was skipped on a 0-ATR tick.
+   * Skipped entirely when geometry is not yet derivable.
+   */
+  private async claimAdoptedPositions(
+    symbol: string,
+    frBracket: { tpDistance: number; slDistance: number } | null,
+  ): Promise<void> {
+    // Single deterministic owner — only the position instance claims.
+    if (this.instanceId !== 'monkey-position') return;
+    try {
+      const claimed = await pool.query(
+        `UPDATE autonomous_trades
+            SET reason = replace(reason,
+                  'kernel_adopted|', 'monkey|kernel=monkey-position|adopted|')
+          WHERE reason LIKE 'kernel_adopted|%'
+            AND status = 'open' AND symbol = $1`,
+        [symbol],
+      );
+      if ((claimed.rowCount ?? 0) > 0) {
+        logger.info('[Monkey] adopted position(s) claimed', {
+          symbol, count: claimed.rowCount, instance: this.instanceId,
+        });
+      }
+      // Commit a geometry-derived bracket on any owned row that lacks
+      // one — side-aware TP/SL around the row's recorded entry price.
+      if (frBracket && frBracket.tpDistance > 0 && frBracket.slDistance > 0) {
+        await pool.query(
+          `UPDATE autonomous_trades
+              SET take_profit = entry_price + (CASE
+                    WHEN side IN ('long', 'buy') THEN $2 ELSE -$2 END),
+                  stop_loss   = entry_price + (CASE
+                    WHEN side IN ('long', 'buy') THEN -$3 ELSE $3 END)
+            WHERE reason LIKE 'monkey|kernel=monkey-position|%'
+              AND status = 'open' AND symbol = $1
+              AND take_profit IS NULL AND stop_loss IS NULL`,
+          [symbol, frBracket.tpDistance, frBracket.slDistance],
+        );
+      }
+    } catch (err) {
+      logger.warn('[Monkey] claimAdoptedPositions failed', {
+        symbol, err: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   private async findOpenMonkeyTrade(symbol: string): Promise<


### PR DESCRIPTION
## Why

Two findings from auditing the kernel against the operator directive *"close trades at its predicted or adjusted limit"*:

1. **The bracket was committed but never enforced.** Phase B1 computes a geometry-derived TP/SL and writes it to `autonomous_trades.take_profit/stop_loss` at entry. But Phase B2 (the synthetic exit gate that *reads* it) is gated on `MONKEY_BRACKET_EXIT_LIVE` — default OFF — and Phase C revision on `MONKEY_BRACKET_EXTEND_LIVE` — also OFF. Monkey wrote a bracket at entry and never looked at it again.

2. **Adopted positions were invisible to the kernel.** The reconciler inserts operator-opened positions with `agent='K'` but `reason='kernel_adopted|…'`. Every kernel lookup (`findOpenMonkeyTrade`, `findOpenMonkeyTradesByLane`, the bracket-revision UPDATE) keys on the `monkey|kernel=<instanceId>|` reason prefix — so adopted rows matched **nothing** and ran through **zero** exit paths. The "kernel adopts and manages it" contract was silently broken.

## What

- `MONKEY_BRACKET_EXIT_LIVE` + `MONKEY_BRACKET_EXTEND_LIVE` → **default ON** (`=== 'true'` → `!== 'false'`); flags remain as kill-switches.
- New `claimAdoptedPositions()`: the `monkey-position` instance (single deterministic owner — no dual-instance race) rewrites the `kernel_adopted|` reason prefix to `monkey|kernel=monkey-position|adopted|`. After the rewrite every existing query/UPDATE picks the row up unchanged.
- The reconciler's orphan dedup keys on **symbol+side**, not `reason`, so the rewrite cannot cause a duplicate insert (verified in `stateReconciliationService.ts`).
- Adopted rows have NULL `take_profit`/`stop_loss`; once claimed, a geometry-derived bracket is committed (this tick's φ/ATR around the operator's recorded entry price) so the synthetic exit gate has a limit to enforce. Also backfills any kernel row whose Phase-B1 commit was skipped on a 0-ATR tick.
- Gitignores `.claude/worktrees/`.

## Tests

`claimAdoptedPositions.test.ts` — instance routing, prefix rewrite SQL, side-aware bracket commit, geometry-not-derivable skip, fail-soft on DB error. Full `apps/api` suite green (1633 passed), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce bracket-based exits by default and ensure reconciler-adopted positions are visible to and managed by the monkey-position kernel instance.

New Features:
- Add automatic claiming of reconciler-adopted positions to the monkey-position instance so they become kernel-managed trades with committed brackets.

Enhancements:
- Enable bracket exit and bracket extension logic by default while retaining environment flags as kill switches.
- Backfill missing take-profit and stop-loss brackets on open trades that lack them when geometry is derivable, ensuring synthetic exit gates have enforceable limits.

Tests:
- Introduce unit tests for claimAdoptedPositions covering instance routing, SQL prefix rewriting, bracket commitment behavior, geometry edge cases, and soft-failure on database errors.

Chores:
- Update gitignore to exclude Claude worktree metadata directories.