### PR TITLE
feat(monkey): free K's capital — operator arbiter roster + authoritative headroom

### DIFF
--- a/apps/api/src/services/__tests__/riskKernel.test.ts
+++ b/apps/api/src/services/__tests__/riskKernel.test.ts
@@ -18,6 +18,7 @@ import {
   checkSymbolMaxLeverage,
   checkUnrealizedDrawdown,
   evaluatePreTradeVetoes,
+  explicitMinMarginHeadroomPct,
   type KernelAccountState,
   type KernelContext,
   type KernelOrder,
@@ -352,5 +353,73 @@ describe('evaluatePreTradeVetoes — margin_headroom priority', () => {
     } finally {
       delete process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT;
     }
+  });
+});
+
+describe('explicitMinMarginHeadroomPct', () => {
+  it('returns null when the env var is unset', () => {
+    delete process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT;
+    expect(explicitMinMarginHeadroomPct()).toBeNull();
+  });
+
+  it('returns the parsed reserve when set to a valid value', () => {
+    process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT = '0.15';
+    try {
+      expect(explicitMinMarginHeadroomPct()).toBe(0.15);
+    } finally {
+      delete process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT;
+    }
+  });
+
+  it('returns null for an out-of-range value (≥ 1)', () => {
+    process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT = '1.5';
+    try {
+      expect(explicitMinMarginHeadroomPct()).toBeNull();
+    } finally {
+      delete process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT;
+    }
+  });
+
+  it('returns 0 (explicit disable) when set to "0"', () => {
+    process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT = '0';
+    try {
+      expect(explicitMinMarginHeadroomPct()).toBe(0);
+    } finally {
+      delete process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT;
+    }
+  });
+});
+
+describe('evaluatePreTradeVetoes — operator headroom overrides the mode table', () => {
+  // Regression fix (2026-05-20): before this, the mode-conditional table
+  // (investigation = 25%) ALWAYS overrode the operator's env var because
+  // monkeyMode is set on every live tick — a dead knob. The operator's
+  // explicit value must now win.
+  const investigationCtx: KernelContext = {
+    isLive: true, mode: 'auto', symbolMaxLeverage: BTC_MAX_LEV,
+    monkeyMode: 'investigation',
+  };
+
+  it('operator 15% reserve wins over investigation-mode 25%', () => {
+    // used=60, new_margin=20 → projected=80 → 20% free.
+    // 20% ≥ 15% (operator) → ALLOW. 20% < 25% (mode) would BLOCK.
+    const state: KernelAccountState = { ...emptyAccount, equityUsdt: 100, usedMarginUsdt: 60 };
+    const order: KernelOrder = { ...btcOrder, notional: 200, leverage: 10 };
+    process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT = '0.15';
+    try {
+      expect(evaluatePreTradeVetoes(order, state, investigationCtx).allowed).toBe(true);
+    } finally {
+      delete process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT;
+    }
+  });
+
+  it('falls back to the mode table when the operator var is unset', () => {
+    // Same 20%-free case; no env var → investigation 25% applies → block.
+    const state: KernelAccountState = { ...emptyAccount, equityUsdt: 100, usedMarginUsdt: 60 };
+    const order: KernelOrder = { ...btcOrder, notional: 200, leverage: 10 };
+    delete process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT;
+    const r = evaluatePreTradeVetoes(order, state, investigationCtx);
+    expect(r.allowed).toBe(false);
+    expect(r.code).toBe('margin_headroom');
   });
 });

--- a/apps/api/src/services/monkey/__tests__/arbiterRoster.test.ts
+++ b/apps/api/src/services/monkey/__tests__/arbiterRoster.test.ts
@@ -1,0 +1,63 @@
+/**
+ * arbiterRoster.test.ts — operator-controlled arbiter agent roster.
+ *
+ * MONKEY_ARBITER_AGENTS lets the operator choose which agents compete
+ * for capital. Concentrating the roster hands the excluded agents'
+ * shares to those that remain — so when only K is meant to trade, K is
+ * not capped by stranded M/T/L reservations.
+ */
+import { describe, expect, it, afterEach, vi } from 'vitest';
+
+// Mirror the env mock used by the other loop.ts-importing tests.
+vi.mock('../../../config/env.js', () => ({
+  env: {
+    NODE_ENV: 'test',
+    PORT: 8765,
+    DATABASE_URL: 'postgresql://test:5432/test',
+    JWT_SECRET: 'test-jwt-secret-32-characters-xxxxxxxxxx',
+  },
+}));
+
+vi.mock('../../../db/connection.js', () => ({
+  pool: { query: vi.fn() },
+}));
+
+describe('arbiterRoster', () => {
+  afterEach(() => {
+    delete process.env.MONKEY_ARBITER_AGENTS;
+  });
+
+  async function roster(): Promise<Set<string>> {
+    const { arbiterRoster } = await import('../loop.js');
+    return arbiterRoster();
+  }
+
+  it('defaults to all four agents when MONKEY_ARBITER_AGENTS is unset', async () => {
+    expect(await roster()).toEqual(new Set(['K', 'M', 'T', 'L']));
+  });
+
+  it('honours a concentrated roster', async () => {
+    process.env.MONKEY_ARBITER_AGENTS = 'K,M';
+    expect(await roster()).toEqual(new Set(['K', 'M']));
+  });
+
+  it('supports a K-only roster (K gets the whole pool)', async () => {
+    process.env.MONKEY_ARBITER_AGENTS = 'K';
+    expect(await roster()).toEqual(new Set(['K']));
+  });
+
+  it('always includes K even when omitted', async () => {
+    process.env.MONKEY_ARBITER_AGENTS = 'M,T';
+    expect(await roster()).toEqual(new Set(['M', 'T', 'K']));
+  });
+
+  it('ignores unknown tokens and is case/whitespace insensitive', async () => {
+    process.env.MONKEY_ARBITER_AGENTS = ' k , m , x , FOO ';
+    expect(await roster()).toEqual(new Set(['K', 'M']));
+  });
+
+  it('falls back to the full roster on a blank value', async () => {
+    process.env.MONKEY_ARBITER_AGENTS = '   ';
+    expect(await roster()).toEqual(new Set(['K', 'M', 'T', 'L']));
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -705,6 +705,33 @@ const BUS_RING_CAP = 32;
 // the QIGRAMv2 canonical class attribute, NOT a parameter introduced
 // by this PR — pre-existing, declared at the module boundary).
 
+/** Valid arbiter agent labels. */
+const ARBITER_AGENT_LABELS = ['K', 'M', 'T', 'L'] as const;
+
+/**
+ * Parse MONKEY_ARBITER_AGENTS into the set of agent labels allowed in
+ * the capital-allocation pool. Default 'K,M,T,L' — all four, unchanged
+ * behaviour. Concentrating the roster (e.g. 'K,M' or 'K') hands the
+ * excluded agents' shares to those that remain, so the operator can
+ * direct capital to the agents they trust without the arbiter stranding
+ * a reservation on a benched agent.
+ *
+ * 'K' is always included — it is the kernel executive. Unknown tokens
+ * are ignored; a blank/unset var falls back to the full default roster.
+ *
+ * Exported for tests.
+ */
+export function arbiterRoster(): Set<string> {
+  const valid = new Set<string>(ARBITER_AGENT_LABELS);
+  const raw = (process.env.MONKEY_ARBITER_AGENTS ?? '').trim();
+  if (raw === '') return new Set(valid);
+  const parsed = raw.split(',')
+    .map((s) => s.trim().toUpperCase())
+    .filter((s) => valid.has(s));
+  parsed.push('K'); // K is mandatory — the kernel executive.
+  return new Set(parsed);
+}
+
 /**
  * MonkeyKernel — the top-level kernel that ticks Monkey.
  *
@@ -3526,10 +3553,19 @@ export class MonkeyKernel extends EventEmitter {
     // Agent L (Fisher-Rao KNN classifier) eligibility: needs basin history
     // to build a multi-scale tuple. < 60 ticks = warmup, no L allocation.
     const lEligible = state.basinHistory.length >= 60;
-    const baseLabels = ['K', 'M'];
-    if (tEligible) baseLabels.push('T');
-    if (lEligible) baseLabels.push('L');
-    const arbiterAgentLabels: string[] = baseLabels;
+    // Operator-controlled arbiter roster — MONKEY_ARBITER_AGENTS (default
+    // 'K,M,T,L', no behaviour change). Concentrating the roster (e.g.
+    // 'K,M' or 'K') hands the excluded agents' capital shares to those
+    // that remain — the fix for "when only K is trading it should access
+    // all the capital within headroom" (2026-05-20 operator directive).
+    // K is always retained — the kernel executive. M/T/L gate on roster
+    // membership; T/L additionally gate on their own eligibility
+    // (equity floor / basin-history warmup) exactly as before.
+    const roster = arbiterRoster();
+    const arbiterAgentLabels: string[] = ['K'];
+    if (roster.has('M')) arbiterAgentLabels.push('M');
+    if (roster.has('T') && tEligible) arbiterAgentLabels.push('T');
+    if (roster.has('L') && lEligible) arbiterAgentLabels.push('L');
     const arbiterAllocationMany = this.arbiter.allocateMany(
       availableEquity,
       arbiterAgentLabels,

--- a/apps/api/src/services/riskKernel.ts
+++ b/apps/api/src/services/riskKernel.ts
@@ -249,6 +249,27 @@ function getMinMarginHeadroomPct(): number {
   return raw;
 }
 
+/**
+ * Operator-explicit headroom override. Returns the parsed reserve when
+ * MONKEY_MIN_MARGIN_HEADROOM_PCT is set to a valid value in [0, 1); null
+ * when unset / blank / out-of-range (caller falls back to the
+ * mode-conditional default).
+ *
+ * Distinct from getMinMarginHeadroomPct(), which collapses "unset" into
+ * the 0.0 disabled default and so cannot be used to tell "operator chose
+ * 0" apart from "operator chose nothing". evaluatePreTradeVetoes needs
+ * that distinction: an explicit operator value must win over the
+ * mode-conditional table (before 2026-05-20 the mode table silently
+ * overrode the env var on every live tick — a dead knob).
+ */
+export function explicitMinMarginHeadroomPct(): number | null {
+  const raw = process.env.MONKEY_MIN_MARGIN_HEADROOM_PCT;
+  if (raw === undefined || raw === null || raw === '') return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed >= 1) return null;
+  return parsed;
+}
+
 /** 2026-05-13 — mode-conditional headroom reserves.
  *
  * EXPLORATION (flat / fast scalp): need MORE headroom because each
@@ -329,10 +350,19 @@ export function evaluatePreTradeVetoes(
   state: KernelAccountState,
   context: KernelContext,
 ): KernelDecision {
-  // 2026-05-13 — mode-conditional headroom override. When the kernel
-  // supplies monkeyMode (cognitive mode), use that to pick the reserve
-  // pct. Otherwise fall through to env default.
-  const headroomPct = modeMarginHeadroomPct(context.monkeyMode) ?? undefined;
+  // Headroom reserve precedence (2026-05-20):
+  //   1. operator-explicit MONKEY_MIN_MARGIN_HEADROOM_PCT (wins always)
+  //   2. mode-conditional default (exploration 35% … drift 50%)
+  //   3. env default (0.0 = disabled)
+  // Before 2026-05-20 the mode table (step 2) always overrode the env
+  // var, because monkeyMode is set on every live tick — so the operator
+  // could set MONKEY_MIN_MARGIN_HEADROOM_PCT and it did nothing. The
+  // operator's explicit reserve is now authoritative; the mode table is
+  // the default used only when the operator has not set the var.
+  const explicitHeadroom = explicitMinMarginHeadroomPct();
+  const headroomPct = explicitHeadroom
+    ?? modeMarginHeadroomPct(context.monkeyMode)
+    ?? undefined;
   const checks: KernelDecision[] = [
     checkUnrealizedDrawdown(state),
     checkExecutionMode(context.isLive, context.mode),


### PR DESCRIPTION
## Why

Operator directive: *"when only K is trading it should access all the capital within the headroom."* The audit found two reasons K is structurally capital-starved.

1. **Stranded arbiter shares.** The arbiter splits `availableEquity` across every eligible agent (K/M/T/L) and floors each at a min-share. An agent that is benched or simply not trading still holds a capital reservation K cannot claim — with all four eligible, K is capped near 25%.

2. **A dead headroom knob.** `MONKEY_MIN_MARGIN_HEADROOM_PCT` (set to `0.15` in prod) never applied. `evaluatePreTradeVetoes` always used the mode-conditional table (investigation 25% … drift 50%) because `monkeyMode` is set on every live tick — so the veto reserved 25%, not the operator's 15%.

## What

**1. Operator-controlled arbiter roster — `MONKEY_ARBITER_AGENTS`**
- Default `K,M,T,L` — **no behaviour change**.
- Concentrating it (`K,M`, or `K`) hands the excluded agents' shares to those that remain. `K` is always retained (kernel executive). `T`/`L` still gate on their own eligibility (equity floor / basin warmup).
- Setting it `K,M` post-merge gives K+M the whole pool — K's warmup share goes 25% → 50%, and post-warmup K's performance share is no longer capped by T/L floors.

**2. Authoritative margin-headroom reserve**
- New precedence: explicit `MONKEY_MIN_MARGIN_HEADROOM_PCT` → mode table → `0.0` (disabled).
- `explicitMinMarginHeadroomPct()` returns the operator value or `null`, distinguishing "unset" from "explicitly chose 0".
- The mode-conditional table remains the default when the operator hasn't set the var.

## Tests

`arbiterRoster.test.ts` (6) — default, concentrate, K-only, K-always-included, unknown-token, blank. `riskKernel.test.ts` +6 — explicit-pct parsing + the **env-wins-over-mode-table** regression. Full `apps/api` suite green (1645 passed), `tsc --noEmit` clean.

## Follow-up env (post-merge)

Per "K most reliable, followed by ML": set `MONKEY_ARBITER_AGENTS=K,M` on `polytrade-be` so K+M hold the full pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce operator-configurable capital allocation roster and make explicit margin headroom reserve authoritative over mode-based defaults.

New Features:
- Add MONKEY_ARBITER_AGENTS configuration to control which agents participate in the arbiter capital-allocation pool, with K always included.

Bug Fixes:
- Ensure the MONKEY_MIN_MARGIN_HEADROOM_PCT environment setting, including explicit zero, takes precedence over mode-based headroom defaults when evaluating pre-trade vetoes, fixing the previously ineffective knob.

Tests:
- Add unit tests for arbiter roster parsing and eligibility handling, and for explicit margin headroom parsing and precedence over mode-based rules in pre-trade veto evaluation.