### PR TITLE
fix(monkey): cast bracket-commit params to numeric ("operator is not unique")

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -5199,12 +5199,16 @@ export class MonkeyKernel extends EventEmitter {
       // Commit a geometry-derived bracket on any owned row that lacks
       // one — side-aware TP/SL around the row's recorded entry price.
       if (frBracket && frBracket.tpDistance > 0 && frBracket.slDistance > 0) {
+        // Positional params arrive as Postgres type `unknown`; unary
+        // minus on `unknown` is ambiguous ("operator is not unique:
+        // - unknown"). Explicit ::numeric casts resolve it — entry_price
+        // is DECIMAL(30,18) = NUMERIC, so the arithmetic types match.
         await pool.query(
           `UPDATE autonomous_trades
               SET take_profit = entry_price + (CASE
-                    WHEN side IN ('long', 'buy') THEN $2 ELSE -$2 END),
+                    WHEN side IN ('long', 'buy') THEN $2::numeric ELSE -($2::numeric) END),
                   stop_loss   = entry_price + (CASE
-                    WHEN side IN ('long', 'buy') THEN -$3 ELSE $3 END)
+                    WHEN side IN ('long', 'buy') THEN -($3::numeric) ELSE $3::numeric END)
             WHERE reason LIKE 'monkey|kernel=monkey-position|%'
               AND status = 'open' AND symbol = $1
               AND take_profit IS NULL AND stop_loss IS NULL`,


### PR DESCRIPTION
## Bug

Production logs (00:00–00:04Z 2026-05-21) showed a Postgres error firing every ~30s:

```
ERROR: operator is not unique: - unknown at character 140
HINT: Could not choose a best candidate operator. You might need to add explicit type casts.
[Monkey] claimAdoptedPositions failed {err: "operator is not unique: - unknown"}
```

The bracket-commit `UPDATE` in `claimAdoptedPositions` had `entry_price + (CASE ... -$2 ... END)`. Postgres parses positional parameters as type `unknown`; unary `-` on `unknown` is ambiguous — operator overload resolution can't pick a candidate.

**Impact:** soft-fails correctly (per `claimAdoptedPositions.test.ts` — no tick crash), but **silently leaves operator-adopted positions without TP/SL brackets**. The synthetic exit gate (PR #870) then has no bracket to enforce on adopted positions — the exact orphan-recovery path #870 was built to fix.

## Fix

Explicit `::numeric` casts on `$2`/`$3`. `entry_price` is `DECIMAL(30,18)` (= `NUMERIC`) per `migrations/000_base_schema.sql`, so the arithmetic types match. Parens around `-($2::numeric)` make precedence explicit.

## Tests

`tsc` clean. `claimAdoptedPositions.test.ts` (5 tests) + full monkey suite (794 tests) green — the test contract (`take_profit = entry_price`, param shape `['ETH_USDT_PERP', 80, 40]`) is unchanged by the cast.

## Post-deploy verification

`claimAdoptedPositions failed` / `operator is not unique` should drop to zero in Railway logs; adopted open rows should get non-NULL `take_profit`/`stop_loss` within one tick of discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix Postgres ambiguity in claimAdoptedPositions bracket UPDATE by casting distance parameters to numeric, preventing failures that left adopted positions without take-profit/stop-loss brackets.