### PR TITLE
feat(monkey): soft regime scores — continuous basin dims, unpin neurochemistry

### DIFF
--- a/apps/api/src/services/monkey/__tests__/perceptionCanonicalDims.test.ts
+++ b/apps/api/src/services/monkey/__tests__/perceptionCanonicalDims.test.ts
@@ -80,3 +80,67 @@ describe('perception canonical dims', () => {
     expect(basin[1]).toBeCloseTo(basin[2]!, 4);
   });
 });
+
+describe('perception canonical dims — continuous soft scores', () => {
+  const base = {
+    ohlcv: syntheticOhlcv(100),
+    equityFraction: 1, marginFraction: 0, openPositions: 0, sessionAgeTicks: 0,
+  };
+
+  it('soft scores encode dims 0/1/2 in proportion (creator-heavy)', () => {
+    const basin = perceive({
+      ...base,
+      canonicalRegime: 'creator',
+      canonicalRegimeScores: { creator: 0.5, preserver: 0.3, dissolver: 0.2 },
+    });
+    expect(basin[0]).toBeGreaterThan(basin[1]!);
+    expect(basin[1]).toBeGreaterThan(basin[2]!);
+  });
+
+  it('soft scores are continuous — a near-even triple is NOT pinned to a one-hot', () => {
+    // The defect being fixed: one-hot snapped the loser dims to ~ε.
+    // With continuous scores, every dim carries real weight.
+    const basin = perceive({
+      ...base,
+      canonicalRegime: 'creator',
+      canonicalRegimeScores: { creator: 0.4, preserver: 0.35, dissolver: 0.25 },
+    });
+    // Smallest dim is a substantial fraction of the largest — not ~ε.
+    expect(basin[2]! / basin[0]!).toBeGreaterThan(0.3);
+    // And distinct from the one-hot encoding of the same label.
+    const oneHot = perceive({ ...base, canonicalRegime: 'creator' });
+    expect(basin[2]! / basin[0]!).toBeGreaterThan(oneHot[2]! / oneHot[0]! * 10);
+  });
+
+  it('soft scores take precedence over the hard canonicalRegime label', () => {
+    // Label says creator, but scores say dissolver-dominant → dim 2 wins.
+    const basin = perceive({
+      ...base,
+      canonicalRegime: 'creator',
+      canonicalRegimeScores: { creator: 0.2, preserver: 0.2, dissolver: 0.6 },
+    });
+    expect(basin[2]).toBeGreaterThan(basin[0]!);
+    expect(basin[2]).toBeGreaterThan(basin[1]!);
+  });
+
+  it('null soft scores → falls back to one-hot of the hard label', () => {
+    const basin = perceive({
+      ...base,
+      canonicalRegime: 'preserver',
+      canonicalRegimeScores: null,
+    });
+    expect(basin[1]).toBeGreaterThan(basin[0]!);
+    expect(basin[1]).toBeGreaterThan(basin[2]!);
+    expect(basin[0]).toBeCloseTo(basin[2]!, 4);
+  });
+
+  it('degenerate zero-sum soft scores → one-hot fallback (no divide-by-zero)', () => {
+    const basin = perceive({
+      ...base,
+      canonicalRegime: 'dissolver',
+      canonicalRegimeScores: { creator: 0, preserver: 0, dissolver: 0 },
+    });
+    expect(Number.isFinite(basin[0]!)).toBe(true);
+    expect(basin[2]).toBeGreaterThan(basin[0]!);  // fell back to dissolver one-hot
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/regimeClassifierScores.test.ts
+++ b/apps/api/src/services/monkey/__tests__/regimeClassifierScores.test.ts
@@ -1,0 +1,48 @@
+/**
+ * regimeClassifierScores.test.ts — parseRegimeScores contract.
+ *
+ * The ml-worker's /regime/classify_prices now returns an optional
+ * `regime_scores` triple (the CAL-3 soft observer). parseRegimeScores
+ * is the validation gate: a partial / NaN / negative / all-zero
+ * payload must yield null so perception falls back to the hard
+ * one-hot label rather than encoding a poisoned continuous basin.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseRegimeScores } from '../regime_classifier_client.js';
+
+describe('parseRegimeScores', () => {
+  it('accepts a complete finite non-negative triple', () => {
+    expect(parseRegimeScores({ creator: 0.5, preserver: 0.3, dissolver: 0.2 }))
+      .toEqual({ creator: 0.5, preserver: 0.3, dissolver: 0.2 });
+  });
+
+  it('accepts a triple with a zero component (sum still > 0)', () => {
+    expect(parseRegimeScores({ creator: 0, preserver: 1, dissolver: 0 }))
+      .toEqual({ creator: 0, preserver: 1, dissolver: 0 });
+  });
+
+  it('rejects null / non-object (warmup → ml-worker sends null)', () => {
+    expect(parseRegimeScores(null)).toBeNull();
+    expect(parseRegimeScores(undefined)).toBeNull();
+    expect(parseRegimeScores(42)).toBeNull();
+  });
+
+  it('rejects a partial triple (missing a component)', () => {
+    expect(parseRegimeScores({ creator: 0.5, preserver: 0.5 })).toBeNull();
+  });
+
+  it('rejects NaN / non-finite components', () => {
+    expect(parseRegimeScores({ creator: NaN, preserver: 0.5, dissolver: 0.5 })).toBeNull();
+    expect(parseRegimeScores({ creator: Infinity, preserver: 0.5, dissolver: 0.5 })).toBeNull();
+  });
+
+  it('rejects negative components', () => {
+    expect(parseRegimeScores({ creator: -0.1, preserver: 0.6, dissolver: 0.5 })).toBeNull();
+  });
+
+  it('rejects an all-zero triple (zero sum → divide-by-zero downstream)', () => {
+    expect(parseRegimeScores({ creator: 0, preserver: 0, dissolver: 0 })).toBeNull();
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1826,12 +1826,18 @@ export class MonkeyKernel extends EventEmitter {
     // 0/1/2. Classifier unreachable → null → perception emits a
     // uniform 1/3 prior on dims 0/1/2.
     let canonicalRegime: 'creator' | 'preserver' | 'dissolver' | null = null;
+    let canonicalRegimeScores:
+      | { creator: number; preserver: number; dissolver: number }
+      | null = null;
     try {
       const { classifyPrices } = await import('./regime_classifier_client.js');
       const closes = ohlcv.map((c) => c.close);
       const cls = await classifyPrices(symbol, closes);
       if (cls) {
         canonicalRegime = cls.regime;
+        // Soft 3-way membership (null during observer warmup) — lets
+        // perception encode dims 0-2 continuously instead of one-hot.
+        canonicalRegimeScores = cls.scores;
       }
     } catch (err) {
       logger.debug('[perception] regime classifier fetch failed', {
@@ -1846,6 +1852,7 @@ export class MonkeyKernel extends EventEmitter {
       openPositions,
       sessionAgeTicks: state.sessionTicks,
       canonicalRegime,
+      canonicalRegimeScores,
     });
 
     // §3.3 Pillar 2 surface absorption — external input at 30% max

--- a/apps/api/src/services/monkey/perception.ts
+++ b/apps/api/src/services/monkey/perception.ts
@@ -89,6 +89,15 @@ export interface PerceptionInputs {
    * (cached client; <15s staleness). null = legacy path.
    */
   canonicalRegime?: 'creator' | 'preserver' | 'dissolver' | null;
+  /**
+   * PERCEPTION-1 (soft): continuous 3-way regime membership from the
+   * CAL-3 soft observer. When present, dims 0/1/2 encode this
+   * continuous distribution instead of a one-hot of `canonicalRegime`
+   * — which keeps downstream signals (quantumWeight → gaba, basin
+   * entropy → Φ) continuous instead of quantised. null/absent →
+   * one-hot fallback. Sums to ~1; need not be exactly normalised.
+   */
+  canonicalRegimeScores?: { creator: number; preserver: number; dissolver: number } | null;
 }
 
 /**
@@ -296,26 +305,39 @@ export function perceive(inputs: PerceptionInputs): Basin {
   const mlStrength = inputs.mlStrength ?? 0;
   const mlEffectiveStrength = inputs.mlEffectiveStrength ?? 0;
 
-  // dims 0..2 — Three regimes (canonical one-hot from observer-driven
-  // classifier; CAL-3 + PERCEPTION-1). Indices match canonical
-  // Python ordering:
+  // dims 0..2 — Three regimes (canonical, observer-driven classifier;
+  // CAL-3 + PERCEPTION-1). Indices match canonical Python ordering:
   //   0 = CREATOR    1 = PRESERVER    2 = DISSOLVER
   //
   // Caller (loop.ts) fetches the classification from ml-worker's
-  // POST /regime/classify_prices (cached per symbol) and passes the
-  // label here. ε=1e-3 padding keeps the simplex non-degenerate for
-  // the downstream toSimplex normaliser.
+  // POST /regime/classify_prices (cached per symbol). ε=1e-3 padding
+  // keeps the simplex non-degenerate for the downstream toSimplex
+  // normaliser.
   //
-  // When the classifier is unreachable, canonicalRegime is null and
-  // we emit a uniform 1/3-each prior — the safest interim until the
-  // next /regime/classify_prices succeeds.
+  // PREFERRED — continuous: when the soft observer supplies a 3-way
+  // membership (`canonicalRegimeScores`), encode it CONTINUOUSLY. A
+  // one-hot label snaps dims 0-2 to a fixed (winner, loser, loser)
+  // triple every tick, which quantises everything derived from them
+  // (quantumWeight → gaba went binary; basin entropy → Φ pinned).
+  // The soft scores move tick-to-tick, so dims 0-2 carry live signal.
   //
-  // The prior ATR/trend×ml/residual encoding had three known bugs
-  // (mlEffectiveStrength always 0, label collision with canonical,
-  // hardcoded *10 magnification) and was retired in full. No
-  // flag-gated dual-path soak: canonical is the only path.
+  // FALLBACK — one-hot: during the observer's warmup, or when the
+  // ml-worker omits scores, encode a one-hot of the hard `regime`
+  // label. Classifier unreachable entirely → uniform 1/3 prior.
   const epsilon = 1e-3;
-  if (inputs.canonicalRegime === 'creator') {
+  const scores = inputs.canonicalRegimeScores;
+  const scoreSum = scores
+    ? Math.max(0, scores.creator) + Math.max(0, scores.preserver) + Math.max(0, scores.dissolver)
+    : 0;
+  if (scores && scoreSum > 0) {
+    // Normalise to a simplex with an ε floor on each dim so no regime
+    // is exactly 0 (keeps toSimplex non-degenerate) while preserving
+    // the relative continuous weighting.
+    const span = 1 - 3 * epsilon;
+    v[0] = epsilon + span * (Math.max(0, scores.creator) / scoreSum);
+    v[1] = epsilon + span * (Math.max(0, scores.preserver) / scoreSum);
+    v[2] = epsilon + span * (Math.max(0, scores.dissolver) / scoreSum);
+  } else if (inputs.canonicalRegime === 'creator') {
     v[0] = 1 - 2 * epsilon; v[1] = epsilon; v[2] = epsilon;
   } else if (inputs.canonicalRegime === 'preserver') {
     v[0] = epsilon; v[1] = 1 - 2 * epsilon; v[2] = epsilon;

--- a/apps/api/src/services/monkey/regime_classifier_client.ts
+++ b/apps/api/src/services/monkey/regime_classifier_client.ts
@@ -24,6 +24,15 @@ export type CanonicalRegime = 'creator' | 'preserver' | 'dissolver';
 
 export interface RegimeClassification {
   regime: CanonicalRegime;
+  /**
+   * Continuous 3-way regime membership from the soft observer (CAL-3).
+   * Sums to ~1. `null` during the observer's warmup or when the
+   * ml-worker omits it — perception then falls back to a one-hot of
+   * the hard `regime` label. Encoding this continuously on basin dims
+   * 0-2 is what keeps downstream neurochemistry off the rails (e.g.
+   * `gaba = 1 - quantumWeight` was binary while the regime was one-hot).
+   */
+  scores: { creator: number; preserver: number; dissolver: number } | null;
   h: number;
   j: number;
   observer: {
@@ -46,6 +55,27 @@ const _cache = new Map<string, CacheEntry>();
 /** Test/cleanup helper. */
 export function _resetClassifierCache(): void {
   _cache.clear();
+}
+
+/**
+ * Parse + validate the optional soft 3-way regime membership from an
+ * ml-worker response. Returns null unless all three components are
+ * finite, non-negative, and sum to > 0 — a partial / NaN / all-zero
+ * payload must not poison the continuous encoding (perception then
+ * falls back to the hard one-hot label). Exported for unit testing.
+ */
+export function parseRegimeScores(
+  rs: unknown,
+): { creator: number; preserver: number; dissolver: number } | null {
+  if (!rs || typeof rs !== 'object') return null;
+  const o = rs as Record<string, unknown>;
+  const c = Number(o.creator);
+  const p = Number(o.preserver);
+  const d = Number(o.dissolver);
+  if ([c, p, d].every((x) => Number.isFinite(x) && x >= 0) && c + p + d > 0) {
+    return { creator: c, preserver: p, dissolver: d };
+  }
+  return null;
 }
 
 /**
@@ -87,6 +117,7 @@ export async function classifyPrices(
     }
     const body = await res.json() as {
       regime?: string;
+      regime_scores?: { creator?: number; preserver?: number; dissolver?: number } | null;
       h?: number;
       j?: number;
       observer_state?: { n?: number; warm?: boolean; lower?: number | null; upper?: number | null };
@@ -98,6 +129,7 @@ export async function classifyPrices(
     }
     const classification: RegimeClassification = {
       regime,
+      scores: parseRegimeScores(body.regime_scores),
       h: Number(body.h ?? 0),
       j: Number(body.j ?? 0),
       observer: {

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -680,7 +680,7 @@ async def regime_classify_prices(request: RegimeClassifyRequest):
         import numpy as _np  # noqa: PLC0415
         from proprietary_core.lattice_inputs import market_to_lattice_inputs  # noqa: PLC0415
         from proprietary_core.regime_observer import (  # noqa: PLC0415
-            classify_via_observer, observer_snapshot,
+            classify_via_observer, observer_snapshot, observer_soft_scores,
         )
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(
@@ -692,6 +692,7 @@ async def regime_classify_prices(request: RegimeClassifyRequest):
     if len(prices) < 2:
         return {
             "regime": "dissolver",
+            "regime_scores": None,
             "h": 0.0,
             "j": 0.0,
             "observer_state": {"n": 0, "warm": False, "lower": None, "upper": None},
@@ -704,6 +705,7 @@ async def regime_classify_prices(request: RegimeClassifyRequest):
     if len(p_arr) < 2:
         return {
             "regime": "dissolver",
+            "regime_scores": None,
             "h": 0.0,
             "j": 0.0,
             "observer_state": {"n": 0, "warm": False, "lower": None, "upper": None},
@@ -728,8 +730,15 @@ async def regime_classify_prices(request: RegimeClassifyRequest):
         "lower": float(bounds.lower) if bounds is not None else None,
         "upper": float(bounds.upper) if bounds is not None else None,
     }
+    # Continuous 3-way regime membership. None during warmup — the TS
+    # client / perception then falls back to the hard one-hot label.
+    # Lets perception encode a continuous distribution on basin dims
+    # 0-2 instead of a quantised one-hot (which pinned downstream
+    # neurochemistry — e.g. gaba = 1 - quantum_weight went binary).
+    regime_scores = observer_soft_scores(float(h_value), float(j_value))
     return {
         "regime": regime.value,
+        "regime_scores": regime_scores,
         "h": float(h_value),
         "j": float(j_value),
         "observer_state": state,

--- a/ml-worker/src/proprietary_core/regime_observer.py
+++ b/ml-worker/src/proprietary_core/regime_observer.py
@@ -221,6 +221,49 @@ class RegimeObserver:
         bounds = self._discover_bounds(snap)
         return n, bounds
 
+    def soft_scores(self, ratio: float) -> Optional[dict[str, float]]:
+        """Continuous 3-way regime membership for ``ratio``.
+
+        The hard ``_navigate`` buckets a tick's h/J ratio into exactly
+        one tercile. Downstream consumers (TS perception → basin dims
+        0-2 → neurochemistry) then only ever see three discrete states,
+        which pins derived signals like ``gaba = 1 - quantum_weight``.
+
+        Soft variant: place the ratio's percentile rank ``p`` in the
+        observed window onto a triangular partition-of-unity over the
+        three regimes:
+
+            p → 0    ordered    (PRESERVER)
+            p → 0.5  critical   (CREATOR)
+            p → 1    disordered (DISSOLVER)
+
+        Pure arithmetic, sums to 1 by construction, no exp-normalization
+        (the neurochemistry layer that ultimately consumes this forbids
+        exp-softmax — keep the whole regime path consistent).
+
+        Returns None during warmup or when the ratio is degenerate
+        (non-finite) — the caller falls back to the hard one-hot label.
+        """
+        if not np.isfinite(ratio):
+            return None
+        with self._lock:
+            window = [r for r in self._ratios if np.isfinite(r)]
+        if len(window) < self.warmup:
+            return None
+        arr = np.asarray(window, dtype=np.float64)
+        # Percentile rank of this tick's ratio within the observed
+        # window — bounded [0, 1] regardless of the raw h/J scale.
+        p = float(np.count_nonzero(arr <= ratio)) / float(len(arr))
+        # Triangular partition of unity on p ∈ [0, 1].
+        m_preserver = max(0.0, 1.0 - 2.0 * p)
+        m_creator = 1.0 - abs(2.0 * p - 1.0)
+        m_dissolver = max(0.0, 2.0 * p - 1.0)
+        return {
+            "creator": m_creator,
+            "preserver": m_preserver,
+            "dissolver": m_dissolver,
+        }
+
     def reset(self) -> None:
         """Test helper — clear the rolling buffer."""
         with self._lock:
@@ -243,6 +286,23 @@ def classify_via_observer(
 def observer_snapshot() -> tuple[int, Optional[RegimeBoundaries]]:
     """Diagnostic accessor for /governance/status surfacing."""
     return _observer.snapshot()
+
+
+def observer_soft_scores(
+    h_value: float, j_value: float,
+) -> Optional[dict[str, float]]:
+    """Continuous regime membership for the current (h, J).
+
+    Read-only: does NOT append to the observation window.
+    ``classify_via_observer`` already observed this tick — calling this
+    afterwards scores the same ratio against the (post-append) window.
+    Returns None during warmup / degenerate coupling.
+    """
+    if j_value > 1e-12:
+        ratio = h_value / j_value
+    else:
+        ratio = float("inf")
+    return _observer.soft_scores(ratio)
 
 
 def _reset_observer() -> None:

--- a/ml-worker/src/proprietary_core/tests/test_regime_observer.py
+++ b/ml-worker/src/proprietary_core/tests/test_regime_observer.py
@@ -156,6 +156,79 @@ class TestZeroCouplingHandling:
         assert bounds.upper == float("inf")
 
 
+class TestSoftScores:
+    """Continuous 3-way regime membership. The hard ``_navigate`` buckets
+    a ratio into one tercile; ``soft_scores`` places its percentile rank
+    on a triangular partition-of-unity so downstream consumers see a
+    continuous distribution, not three discrete states."""
+
+    def _warm_observer(self) -> RegimeObserver:
+        """A RegimeObserver seeded with a uniform 0..100 ratio window."""
+        observer = RegimeObserver(window=_WARMUP_TICKS + 100, warmup=_WARMUP_TICKS)
+        fake = _fake_qig_warp("ordered")
+        with mock.patch.dict(sys.modules, {"qig_warp": fake}):
+            for r in np.linspace(0.0, 100.0, _WARMUP_TICKS + 100):
+                observer.observe_and_classify(h_value=r, j_value=1.0)
+        return observer
+
+    def test_warmup_returns_none(self) -> None:
+        """Before warmup there is no window to derive a percentile from."""
+        observer = RegimeObserver(window=_WARMUP_TICKS + 100, warmup=_WARMUP_TICKS)
+        assert observer.soft_scores(3.5) is None
+
+    def test_non_finite_ratio_returns_none(self) -> None:
+        """Zero-coupling (inf ratio) has no soft derivation — caller
+        falls back to the hard DISSOLVER label."""
+        observer = self._warm_observer()
+        assert observer.soft_scores(float("inf")) is None
+
+    def test_scores_are_a_partition_of_unity(self) -> None:
+        """creator + preserver + dissolver == 1 for any ratio."""
+        observer = self._warm_observer()
+        for ratio in (1.0, 10.0, 33.0, 50.0, 67.0, 90.0, 200.0):
+            scores = observer.soft_scores(ratio)
+            assert scores is not None
+            assert set(scores) == {"creator", "preserver", "dissolver"}
+            assert all(v >= 0.0 for v in scores.values())
+            assert sum(scores.values()) == pytest.approx(1.0, abs=1e-9)
+
+    def test_low_ratio_favours_preserver(self) -> None:
+        """Bottom of the window → ordered → PRESERVER dominant."""
+        observer = self._warm_observer()
+        scores = observer.soft_scores(5.0)
+        assert scores is not None
+        assert scores["preserver"] > scores["creator"]
+        assert scores["preserver"] > scores["dissolver"]
+
+    def test_median_ratio_favours_creator(self) -> None:
+        """Middle of the window → critical → CREATOR dominant."""
+        observer = self._warm_observer()
+        scores = observer.soft_scores(50.0)
+        assert scores is not None
+        assert scores["creator"] > scores["preserver"]
+        assert scores["creator"] > scores["dissolver"]
+
+    def test_high_ratio_favours_dissolver(self) -> None:
+        """Top of the window → disordered → DISSOLVER dominant."""
+        observer = self._warm_observer()
+        scores = observer.soft_scores(95.0)
+        assert scores is not None
+        assert scores["dissolver"] > scores["creator"]
+        assert scores["dissolver"] > scores["preserver"]
+
+    def test_scores_are_continuous_across_ratios(self) -> None:
+        """The defect being fixed: a small ratio change must move the
+        scores continuously, not snap between discrete states."""
+        observer = self._warm_observer()
+        a = observer.soft_scores(48.0)
+        b = observer.soft_scores(52.0)
+        assert a is not None and b is not None
+        # Distinct (not snapped to the same triple) yet close (continuous).
+        assert a != b
+        for key in ("creator", "preserver", "dissolver"):
+            assert abs(a[key] - b[key]) < 0.25
+
+
 class TestObserverSnapshotDiagnostic:
     def test_snapshot_returns_n_and_bounds(self) -> None:
         """Used by /governance/status to surface the observer state."""


### PR DESCRIPTION
## The bug (operator log review)

Production neurotransmitter telemetry showed saturation across 42 sampled ticks:

| Chem | Behaviour | |
|---|---|---|
| `gaba` | *only ever* `0.40` or `0.80` | 🔴 binary |
| `endo` | `0.00` in ~33/42; max ever `0.26` | 🔴 floored |
| `phi`  | `0.214–0.218` every line | 🔴 pinned |
| `ach`  | clips to `1.00` constantly | 🟠 degraded |

## Root cause (traced end-to-end)

`neurochemistry.ts` is **not** the bug — it faithfully derives chemicals from a basin that lost its signal:

1. The regime classifier returns a **hard categorical label** (`regime_classifier_client.ts` kept only `'creator'|'preserver'|'dissolver'`).
2. `perception.ts` **one-hots** that label onto basin dims 0–2.
3. `refract()` softens the one-hot toward identity by a fixed 30% → a fixed **`(0.6, 0.2, 0.2)`** triple every tick.

→ `quantumWeight = basin[0]/total ∈ {0.2, 0.6}` → `gaba = 1 − quantumWeight ∈ {0.4, 0.8}` (binary). Basin entropy barely moves → `phi` pinned → `couplingHealth` pinned → `endo` Sophia-gate never opens. `ach`'s self-similarity input is flat → ratio clips to 1.

## The fix — make the regime soft (one upstream change, cascades)

- **ml-worker `regime_observer.py`** — new `soft_scores()`: places a tick's `h/J` **percentile rank** in the observed window onto a triangular **partition-of-unity** over the three regimes. Pure arithmetic, sums to 1, no exp-normalization (the neurochemistry layer forbids exp-softmax — kept consistent). `observer_soft_scores()` module fn, read-only.
- **ml-worker `main.py`** — `/regime/classify_prices` returns `regime_scores` (null during the observer warmup).
- **`regime_classifier_client.ts`** — `parseRegimeScores()` validates the triple (finite, non-negative, positive sum); null on any partial/NaN payload.
- **`perception.ts`** — dims 0–2 encode the continuous distribution when scores are present; one-hot fallback during warmup / classifier-down. ε-floored simplex preserves relative weighting.
- **`loop.ts`** — threads `canonicalRegimeScores` into `perceive()`.

Continuous regime weights move tick-to-tick → `quantumWeight` continuous → **`gaba` continuous**; dims 0–2 carry live signal → `fHealth`/`phi`/`endo`/`ach` gain variance. **Additive + backward-compatible** — the hard `regime` label is unchanged and every consumer falls back cleanly when scores are absent.

## Tests

- `test_regime_observer.py` +7 (partition-of-unity, monotonicity, warmup→None, continuity) — **14/14 pass**
- `perceptionCanonicalDims.test.ts` +5 (continuous encoding, precedence, fallbacks) — **10/10**
- `regimeClassifierScores.test.ts` — **new**, 7 cases pinning the `parseRegimeScores` validation contract
- `tsc` clean; full `apps/api` suite green (**1657 passed**)
- Pre-existing unrelated ml-worker failures (`test_training.py` Adam, `test_strategy_loop.py`) confirmed present on pristine `main` — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce continuous soft regime scores from the ml-worker observer and thread them through the classifier client into perception so basin regime dimensions carry a live distribution instead of a one-hot label.

New Features:
- Expose soft 3-way regime membership from the regime observer as percentile-based scores over creator, preserver, and dissolver.
- Return regime soft scores from the /regime/classify_prices endpoint and surface them via the TS regime classifier client into the monkey loop and perception pipeline.
- Encode basin dimensions 0–2 using continuous regime scores when available, with safe fallbacks to one-hot labels or uniform priors when scores are missing or invalid.

Bug Fixes:
- Prevent downstream neurochemistry signals (e.g. quantum weight, gaba, phi) from becoming quantised or pinned by replacing hard one-hot regime inputs with continuous scores where possible.
- Guard against malformed or degenerate regime score payloads so perception cleanly falls back to discrete regime labels instead of emitting invalid basin values.

Enhancements:
- Add a soft scoring method in the regime observer that computes a triangular partition-of-unity over regimes based on the current ratio percentile, preserving consistency with non-softmax neurochemistry.
- Extend the monkey loop to carry both the hard canonical regime label and soft scores so existing consumers remain backward compatible while benefitting from the continuous signal when present.

Tests:
- Add Python tests for the regime observer soft scoring behaviour, including warmup handling, partition-of-unity, dominance ordering, and continuity across ratios.
- Add TypeScript tests for perception’s continuous encoding of soft scores, precedence over hard labels, and fallbacks for null or zero-sum scores.
- Add unit tests for parsing and validating regime scores in the classifier client to pin the expected contract for optional soft scores.