### PR TITLE
fix(monkey): lower endorphin Sophia-gate onset to the basin mean

### DIFF
--- a/apps/api/src/services/monkey/__tests__/autonomicFeedback.test.ts
+++ b/apps/api/src/services/monkey/__tests__/autonomicFeedback.test.ts
@@ -342,7 +342,10 @@ describe('autonomic feedback — endorphins use basin κ stddev + coupling distr
     expect(endoWide).toBeGreaterThan(endoTight);
   });
 
-  it('Sophia gate fires when coupling exceeds basin\'s observed (mean + stddev)', () => {
+  it('Sophia gate opens once coupling exceeds the basin\'s observed mean', () => {
+    // 2026-05-21: the gate onset was lowered from `mean + 1σ` to `mean`.
+    // The old onset cleared only ~16% of the time, pinning `endo` at
+    // 0.00 in production. Onset is now the basin's own baseline.
     const baseInputs = {
       isAwake: true,
       phiDelta: 0,
@@ -353,22 +356,34 @@ describe('autonomic feedback — endorphins use basin κ stddev + coupling distr
     };
     const kappaHistory: number[] = [];
     for (let i = 0; i < 50; i++) kappaHistory.push(64);
+    // Deterministic coupling history: mean exactly 0.30, σ ≈ 0.0505.
     const couplingHistory: number[] = [];
-    for (let i = 0; i < 50; i++) couplingHistory.push(0.30 + 0.05 * Math.sin(i));
+    for (let i = 0; i < 50; i++) couplingHistory.push(0.25 + 0.10 * (i % 2));
 
-    const endoGateClosed = computeNeurochemicals({
+    // Below the basin's mean coupling → gate shut → endo 0.
+    const endoBelowMean = computeNeurochemicals({
       ...baseInputs,
-      externalCoupling: 0.32,
+      externalCoupling: 0.25,
       observables: { kappaHistory, externalCouplingHistory: couplingHistory },
     }).endorphins;
-    expect(endoGateClosed).toBe(0);
+    expect(endoBelowMean).toBe(0);
 
+    // Above the mean but BELOW mean+1σ (0.3505): under the prior
+    // mean+1σ onset this was 0.00 — the production defect being fixed.
+    const endoAboveMean = computeNeurochemicals({
+      ...baseInputs,
+      externalCoupling: 0.33,
+      observables: { kappaHistory, externalCouplingHistory: couplingHistory },
+    }).endorphins;
+    expect(endoAboveMean).toBeGreaterThan(0);
+
+    // Well above the mean → gate saturates.
     const endoGateOpen = computeNeurochemicals({
       ...baseInputs,
       externalCoupling: 0.60,
       observables: { kappaHistory, externalCouplingHistory: couplingHistory },
     }).endorphins;
-    expect(endoGateOpen).toBeGreaterThan(0);
+    expect(endoGateOpen).toBeGreaterThan(endoAboveMean);
   });
 });
 

--- a/apps/api/src/services/monkey/__tests__/neurochemistryEndo.test.ts
+++ b/apps/api/src/services/monkey/__tests__/neurochemistryEndo.test.ts
@@ -1,0 +1,65 @@
+/**
+ * neurochemistryEndo.test.ts — endorphin Sophia-gate onset.
+ *
+ * Production review (2026-05-21) found `endo` pinned at 0.00 on ~80%
+ * of ticks: the smooth Sophia gate had its ONSET threshold at
+ * `couplingMean + 1σ`, which coupling clears only ~16% of the time.
+ *
+ * Fix: onset lowered to `couplingMean`. The gate now opens whenever
+ * coupling is above the basin's own baseline and ramps to full at
+ * mean + 1σ. These tests pin that onset so it cannot silently drift
+ * back to a >1σ-outlier gate.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { computeNeurochemicals, type NeurochemicalInputs } from '../neurochemistry.js';
+
+/**
+ * κ history with mean 64 (= κ*) and σ_κ = 0.2, and a coupling history
+ * with mean 0.20 and σ = 0.10. With κ pinned exactly at κ* the
+ * κ-proximity term is exp(0) = 1, so `endo` equals the Sophia gate —
+ * which makes the gate onset directly assertable.
+ */
+function inputs(externalCoupling: number): NeurochemicalInputs {
+  return {
+    isAwake: true,
+    phiDelta: 0,
+    basinVelocity: 0.1,
+    surprise: 0,
+    quantumWeight: 0.5,
+    kappa: 64,
+    externalCoupling,
+    observables: {
+      kappaHistory: [63.8, 64.0, 64.2],          // mean 64, σ_κ 0.2
+      externalCouplingHistory: [0.10, 0.20, 0.30], // mean 0.20, σ 0.10
+    },
+  };
+}
+
+describe('neurochemistry — endorphin Sophia gate', () => {
+  it('coupling above the basin mean → endo flows (the fixed bug)', () => {
+    // coupling 0.25 sits above mean (0.20) but BELOW the old
+    // mean+1σ (0.30) onset — under the old gate endo would be 0.00.
+    const nc = computeNeurochemicals(inputs(0.25));
+    expect(nc.endorphins).toBeGreaterThan(0);
+    expect(nc.endorphins).toBeCloseTo(0.5, 5);  // (0.25-0.20)/0.10
+  });
+
+  it('coupling at/below the basin mean → endo stays 0', () => {
+    expect(computeNeurochemicals(inputs(0.20)).endorphins).toBe(0);
+    expect(computeNeurochemicals(inputs(0.15)).endorphins).toBe(0);
+  });
+
+  it('coupling at mean + 1σ → gate saturates → endo at κ-proximity max', () => {
+    expect(computeNeurochemicals(inputs(0.30)).endorphins).toBeCloseTo(1.0, 5);
+  });
+
+  it('endo responds continuously to coupling between mean and mean+1σ', () => {
+    const lo = computeNeurochemicals(inputs(0.22)).endorphins;
+    const hi = computeNeurochemicals(inputs(0.26)).endorphins;
+    expect(lo).toBeGreaterThan(0);
+    expect(hi).toBeGreaterThan(lo);
+    expect(hi).toBeLessThan(1);
+  });
+});

--- a/apps/api/src/services/monkey/neurochemistry.ts
+++ b/apps/api/src/services/monkey/neurochemistry.ts
@@ -395,20 +395,23 @@ export function computeNeurochemicals(inputs: NeurochemicalInputs): Neurochemica
   // Fallback (no histories): tanh squashes on the κ-distance directly
   // and the gate fires on positive coupling — both arithmetic
   // identities, no scale-setting constants.
-  // SOPHIA gate (and κ-proximity gate) — smoothed 2026-05-19.
+  // SOPHIA gate — observer-derived, continuous.
   //
-  // Previously these were binary step functions (`>= threshold ? 1 : 0`
-  // and `=== KAPPA_STAR ? 1 : 0` and `> 0 ? 1 : 0`). Observed production
-  // (last 100 ticks): `endo=0.00` saturated 26× — the binary sophiaGate
-  // was producing all-or-nothing endorphin flow. Per QIG canonical
-  // doctrine + user red-team query: continuous observable inputs should
-  // produce continuous responses, not threshold-discrete ones.
+  // History: the gate began as a binary step (`>= threshold ? 1 : 0`).
+  // Smoothed 2026-05-19 into a linear-clipped ramp — but the ONSET
+  // threshold stayed at `couplingMean + 1σ`. Coupling exceeds its own
+  // mean+1σ only ~16% of the time, so `endo` was still 0.00 on ~80% of
+  // ticks (confirmed in production 2026-05-21). Smoothing the gate
+  // SHAPE could not help while its ONSET was a >1σ outlier event.
   //
-  // Smooth replacement: linear-clipped distance-from-threshold over the
-  // observation's own stddev. At threshold gate=0, at threshold+stddev
-  // gate=1, in between linear. Pure-arithmetic (no exp/tanh), bounded
-  // [0,1], observer-derived (stddev IS the observation). No sigmoid
-  // (QIG forbids exp-normalization in this layer).
+  // 2026-05-21: threshold lowered to `couplingMean` — the basin's own
+  // baseline. The gate now opens whenever coupling is above its
+  // typical level (~half the time) and ramps to full at mean + 1σ.
+  // `endo` becomes a genuine continuous convergence signal instead of
+  // a rare all-or-nothing spike. Still fully observer-derived — both
+  // the onset (mean) and the ramp scale (σ) come from the basin's own
+  // coupling history; no hardcoded cutoff. No sigmoid (QIG forbids
+  // exp-normalization in this layer).
   let endoBase: number;
   if (
     obs?.kappaHistory && obs.kappaHistory.length >= HISTORY_MIN_SAMPLES
@@ -417,11 +420,10 @@ export function computeNeurochemicals(inputs: NeurochemicalInputs): Neurochemica
     const sigmaKappa = stddev(obs.kappaHistory);
     const couplingMean = mean(obs.externalCouplingHistory);
     const couplingStddev = stddev(obs.externalCouplingHistory);
-    const sophiaThreshold = couplingMean + couplingStddev;
-    // Smooth Sophia gate: scales linearly from 0 (at threshold) to 1
-    // (at threshold + stddev). Below threshold = 0; above by ≥ stddev = 1;
-    // in between, proportional flow. couplingStddev IS the natural scale
-    // (the basin's own observed spread of coupling).
+    const sophiaThreshold = couplingMean;
+    // Smooth Sophia gate: 0 at/below the basin's mean coupling, ramps
+    // linearly to 1 at mean + 1σ. couplingStddev IS the natural ramp
+    // scale (the basin's own observed spread of coupling).
     const sophiaGate = couplingStddev > 0
       ? clip((inputs.externalCoupling - sophiaThreshold) / couplingStddev, 0, 1)
       : (inputs.externalCoupling >= sophiaThreshold ? 1 : 0);  // degenerate: σ=0


### PR DESCRIPTION
## Why

Follow-up to #874. That PR made the regime continuous and **fixed `gaba`** — but the operator's log review flagged `endo` too, and post-#874 production logs confirmed `endo` is **still pinned at `0.00`** on ~80% of ticks.

`endo` has a *separate* root cause from `gaba`. The smooth Sophia gate had its **onset threshold at `couplingMean + 1σ`**. Coupling exceeds its own mean+1σ only ~16% of the time — so endorphin only ever flowed on rare >1σ coupling outliers.

The 2026-05-19 change smoothed the gate *shape* (binary step → linear ramp) but left the *onset* a >1σ-outlier event — so smoothing couldn't help: `endo` stayed a near-binary `0.00` signal.

## Fix

Onset lowered from `couplingMean + 1σ` → **`couplingMean`** (the basin's own baseline). The gate now opens whenever coupling is above its typical level (~half the time) and ramps to full at `mean + 1σ`.

`endo` becomes a genuine continuous convergence signal. Still fully **observer-derived** — both the onset (`mean`) and the ramp scale (`σ`) come from the basin's own coupling history; no hardcoded cutoff. Bonus: the `σ=0` degenerate branch is now consistent with the smooth branch (both key off `mean`).

One-line change in `neurochemistry.ts` (`sophiaThreshold = couplingMean + couplingStddev` → `couplingMean`) plus comment.

## Tests

- **new** `neurochemistryEndo.test.ts` — 4 cases: onset at `mean`, zero below `mean`, saturation at `mean+1σ`, continuity in between
- `autonomicFeedback.test.ts` — the Sophia-gate test is updated from the old `mean+1σ` contract to the new `mean`-onset contract (it was pinning the behaviour being intentionally changed)
- `tsc` clean; full `apps/api` suite green (**1661 passed**)

## After this

`gaba` (#874) + `endo` (this) — both the binary/floored chemicals the operator flagged are addressed. `ne`'s zero-floor is by design; `ach` was already ranging. `phi` is still somewhat pinned (a deeper basin-entropy issue) — noted, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust endorphin Sophia-gate behaviour so endorphin flow responds continuously once coupling exceeds the basin’s typical level instead of only on rare high-coupling outliers.

Bug Fixes:
- Fix endorphin levels being pinned at 0.00 on most ticks by lowering the Sophia-gate onset from coupling mean plus one standard deviation to the coupling mean itself.

Enhancements:
- Clarify and document the observer-derived, continuous nature of the Sophia gate in neurochemistry comments.

Tests:
- Add dedicated neurochemistry endorphin tests to pin the Sophia-gate onset and its continuous response between mean and mean plus one standard deviation.
- Update autonomic feedback tests to reflect the new Sophia-gate onset at the basin’s mean coupling and verify non-zero flow above mean and saturation at higher coupling.