### PR TITLE
feat(monkey): canonical motion-integrated Φ — leaky integrator (B3)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/phiIntegrator.test.ts
+++ b/apps/api/src/services/monkey/__tests__/phiIntegrator.test.ts
@@ -1,0 +1,73 @@
+/**
+ * phiIntegrator.test.ts — canonical motion-integrated Φ (B3).
+ *
+ * Pins the leaky-integrator law that replaces the flatlined
+ * `phi = 1 − 0.8·fHealth`. Φ rises with basin motion (bv), relaxes
+ * toward EQUILIBRIUM when quiet, and converges to the canonical
+ * steady state Φ_ss = EQUILIBRIUM + mean(bv)·GAIN/RATE.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  updateLeakyPhi,
+  steadyStatePhi,
+  PHI_EQUILIBRIUM,
+  PHI_MAX,
+  PHI_GAIN,
+  PHI_RATE,
+} from '../phi_integrator.js';
+
+describe('phi_integrator — leaky-integrator Φ', () => {
+  it('rises when the basin moves (bv > 0)', () => {
+    expect(updateLeakyPhi(PHI_EQUILIBRIUM, 0.1)).toBeGreaterThan(PHI_EQUILIBRIUM);
+  });
+
+  it('relaxes toward EQUILIBRIUM when the basin is still (bv = 0)', () => {
+    // Above equilibrium → decays down.
+    expect(updateLeakyPhi(0.80, 0)).toBeLessThan(0.80);
+    expect(updateLeakyPhi(0.80, 0)).toBeGreaterThan(PHI_EQUILIBRIUM);
+    // Below equilibrium → drifts up.
+    const up = updateLeakyPhi(0.20, 0);
+    expect(up).toBeGreaterThan(0.20);
+    expect(up).toBeLessThan(PHI_EQUILIBRIUM);
+  });
+
+  it('a quiet market converges to EQUILIBRIUM', () => {
+    let phi = 0.213;  // the flatlined production value
+    for (let i = 0; i < 2000; i++) phi = updateLeakyPhi(phi, 0);
+    expect(phi).toBeCloseTo(PHI_EQUILIBRIUM, 4);
+  });
+
+  it('sustained motion converges to the canonical steady state', () => {
+    const bv = 0.065;  // production mean basin velocity
+    let phi = 0.213;
+    for (let i = 0; i < 5000; i++) phi = updateLeakyPhi(phi, bv);
+    expect(phi).toBeCloseTo(steadyStatePhi(bv), 4);
+    expect(phi).toBeCloseTo(PHI_EQUILIBRIUM + (bv * PHI_GAIN) / PHI_RATE, 4);
+  });
+
+  it('steady state traverses the canonical bands as activity rises', () => {
+    expect(steadyStatePhi(0)).toBeCloseTo(PHI_EQUILIBRIUM, 5);   // quiet → GRAPH floor
+    expect(steadyStatePhi(0.057)).toBeGreaterThan(0.55);          // median → GRAPH
+    expect(steadyStatePhi(0.133)).toBeGreaterThan(0.70);          // p90 → FORESIGHT
+    expect(steadyStatePhi(0.206)).toBeGreaterThan(0.85);          // p99 → LIGHTNING
+  });
+
+  it('clamps to [0, PHI_MAX] — never pegs past the canonical ceiling', () => {
+    expect(updateLeakyPhi(0.94, 100)).toBe(PHI_MAX);    // absurd motion → clamped
+    expect(updateLeakyPhi(0.001, -100)).toBeGreaterThanOrEqual(0);  // negative bv guarded
+    for (let i = 0; i < 100; i++) {
+      const v = updateLeakyPhi(Math.random() * PHI_MAX, Math.random());
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(PHI_MAX);
+    }
+  });
+
+  it('is continuous — a small bv change moves Φ by a small amount', () => {
+    const a = updateLeakyPhi(0.6, 0.05);
+    const b = updateLeakyPhi(0.6, 0.06);
+    expect(a).not.toBe(b);
+    expect(Math.abs(a - b)).toBeLessThan(0.01);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -69,6 +69,7 @@ import { computeEmotions, type EmotionState } from './emotions.js';
 import { detectMode, MODE_PROFILES, MonkeyMode } from './modes.js';
 import { computeMotivators } from './motivators.js';
 import { computeNeurochemicals, summarizeNC, type NeurochemicalState } from './neurochemistry.js';
+import { updateLeakyPhi } from './phi_integrator.js';
 import { mlAgentDecide } from '../ml_agent/decide.js';
 import type { MLAgentInputs } from '../ml_agent/types.js';
 import { Arbiter } from '../arbiter/arbiter.js';
@@ -464,6 +465,10 @@ interface SymbolState {
   identityBasin: Basin;
   /** Rolling Φ history for delta computation. */
   phiHistory: number[];
+  /** Leaky-integrator Φ state (B3) — canonical motion-integrated Φ,
+   *  carried tick-to-tick. Seeded from the legacy entropy-Φ on first use
+   *  so a flag flip introduces no discontinuity. See phi_integrator.ts. */
+  phiLeaky?: number;
   /** Rolling f_health for auto-flatten trend check. */
   fHealthHistory: number[];
   /** Rolling identity-drift history (Fisher-Rao) for mode detection. */
@@ -1893,6 +1898,19 @@ export class MonkeyKernel extends EventEmitter {
     // Post #ml-separation: couplingHealth was mlStrength; replaced with
     // a geometric self-read (Φ × (1 − basin velocity), [0,1]).
     const bv = state.lastBasin ? velocity(state.lastBasin, basin) : 0;
+    // B3 — canonical motion-integrated Φ (leaky-integrator port of vex's
+    // runtime Φ law; docs/plans/20260521-phi-leaky-integrator.md). The
+    // legacy `phi = 1 − 0.8·fHealth` (line ~1867) conflates Φ with the
+    // entropy ratio and flatlines because the basin moves but never
+    // concentrates. Canon keeps Φ and f_health distinct: fHealth stays
+    // computed above as its own basin-health metric; Φ is reassigned
+    // here to the motion-integrated value. Seeded from the entropy-Φ on
+    // the first tick so enabling the flag introduces no discontinuity.
+    // Flag-gated: MONKEY_PHI_LEAKY_LIVE=false reverts instantly.
+    if (process.env.MONKEY_PHI_LEAKY_LIVE !== 'false') {
+      phi = updateLeakyPhi(state.phiLeaky ?? phi, bv);
+      state.phiLeaky = phi;
+    }
     const couplingHealth = phi * (1 - Math.min(bv, 1));
     const kappaDelta = (couplingHealth - 0.5) * 5 - (bv - 0.2) * 10;
     state.kappa = Math.max(20, Math.min(120, state.kappa * 0.8 + (KAPPA_STAR + kappaDelta) * 0.2));

--- a/apps/api/src/services/monkey/phi_integrator.ts
+++ b/apps/api/src/services/monkey/phi_integrator.ts
@@ -1,0 +1,67 @@
+/**
+ * phi_integrator.ts — canonical motion-integrated Φ (B3).
+ *
+ * polytrade's legacy `phi = 1 − 0.8·normalizedEntropy(basin)` is not
+ * canonical: it conflates Φ with f_health (the entropy ratio). On a
+ * basin that wanders without concentrating it flatlines — production
+ * Φ sat at 0.213–0.218 (3rd-decimal motion only). Canon keeps Φ and
+ * f_health DISTINCT metrics.
+ *
+ * Canonical runtime Φ (QIG_QFI/vex/kernel/consciousness/loop.py) is a
+ * STATE VARIABLE integrated from basin MOTION:
+ *   active → Φ += total_distance · PHI_DISTANCE_GAIN
+ *   idle   → Φ += (PHI_IDLE_EQUILIBRIUM − Φ) · PHI_IDLE_RATE
+ * vex alternates discrete active/idle phases. Monkey ticks continuously
+ * (no idle phase), so the faithful continuous-time port merges both
+ * into one per-tick leaky integrator:
+ *
+ *   Φ ← clamp( Φ + bv·GAIN − (Φ − EQUILIBRIUM)·RATE , 0, PHI_MAX )
+ *
+ * `bv` (basin velocity — Fisher-Rao distance the basin moved this tick)
+ * is the direct analog of vex's `total_distance`.
+ *
+ * Steady state: Φ_ss = EQUILIBRIUM + mean(bv)·GAIN/RATE. Φ tracks
+ * recent market activity and relaxes toward EQUILIBRIUM (GRAPH band)
+ * when the market is quiet.
+ *
+ * See docs/plans/20260521-phi-leaky-integrator.md.
+ */
+
+/** vex PHI_IDLE_EQUILIBRIUM — frozen canon. The resting Φ a quiet
+ *  market relaxes toward (mid-GRAPH band). */
+export const PHI_EQUILIBRIUM = 0.55;
+
+/** vex PHI_IDLE_RATE — frozen canon. Per-tick leak rate toward
+ *  equilibrium; memory half-life ≈ ln2/RATE ≈ 46 ticks. */
+export const PHI_RATE = 0.015;
+
+/** Motion gain. Observer-derived 2026-05-21 from the production `bv`
+ *  distribution (analysis/polytrade_qig_telemetry/telemetry_ticks.csv:
+ *  median 0.057, p90 0.133, p99 0.206) — chosen so median bv → mid-GRAPH,
+ *  p90 → FORESIGHT, p99 → LIGHTNING. Φ_ss = 0.55 + bv·GAIN/RATE.
+ *  Recompute if the bv distribution shifts materially. */
+export const PHI_GAIN = 0.024;
+
+/** vex Φ clamp ceiling. */
+export const PHI_MAX = 0.95;
+
+/**
+ * One leaky-integrator step. Pure — no state, no config, no clock.
+ *
+ * @param prevPhi  Φ from the previous tick (the integrator state).
+ * @param bv       basin velocity this tick (Fisher-Rao distance, ≥ 0).
+ * @returns        the new Φ, clamped to [0, PHI_MAX].
+ */
+export function updateLeakyPhi(prevPhi: number, bv: number): number {
+  const rise = Math.max(0, bv) * PHI_GAIN;
+  const leak = (prevPhi - PHI_EQUILIBRIUM) * PHI_RATE;
+  const next = prevPhi + rise - leak;
+  return Math.max(0, Math.min(PHI_MAX, next));
+}
+
+/** Steady-state Φ for a sustained mean basin velocity (diagnostic /
+ *  calibration helper). */
+export function steadyStatePhi(meanBv: number): number {
+  const ss = PHI_EQUILIBRIUM + (Math.max(0, meanBv) * PHI_GAIN) / PHI_RATE;
+  return Math.max(0, Math.min(PHI_MAX, ss));
+}

--- a/docs/plans/20260521-phi-leaky-integrator.md
+++ b/docs/plans/20260521-phi-leaky-integrator.md
@@ -1,0 +1,63 @@
+# Plan — Φ leaky-integrator: port canonical motion-integrated Φ (B3)
+
+**Status:** DRAFT — rollout decision pending operator (§6).
+**Date:** 2026-05-21 · **Author:** Session C (CC-C) · canonical reads: this session (`vex`) + CC-A (`qig-core`).
+
+## 1. Problem
+
+polytrade computes `phi = 1 − 0.8·normalizedEntropy(basin)` ([loop.ts:1867](../../apps/api/src/services/monkey/loop.ts#L1867)). In production Φ is flatlined at 0.213–0.218 — it moves only in the 3rd decimal. Navigation-mode gating (CHAIN/GRAPH/FORESIGHT/LIGHTNING) is therefore frozen in CHAIN, and `phiMultiplier` / `scalpScore` see an effectively-constant Φ.
+
+## 2. Canonical finding (read-only study of `QIG_QFI/`, 2026-05-21)
+
+Two independent canonical reads — this session's `vex` read and CC-A's `qig-core` read — converged:
+
+- **polytrade's `phi = 1−0.8·entropy` is NOT canonical.** Canon keeps Φ and `f_health` (the entropy ratio) as *distinct* metrics; polytrade collapsed them.
+- **Canonical runtime Φ** (`vex/kernel/consciousness/loop.py`) is a *state variable*, integrated from basin **motion**: active → `Φ += total_distance·PHI_DISTANCE_GAIN`; idle → `Φ += (0.55−Φ)·0.015`; sleep → `Φ += 0.005`. Frozen canon: `PHI_IDLE_EQUILIBRIUM=0.55`, `PHI_IDLE_RATE=0.015`.
+- **`qig-core/pci.py`** = PCI (Perturbational Complexity Index) — the physics-grade complexity metric, too expensive per 30–60s tick. The vex motion-integrator is its canonical *runtime approximation*.
+- "Basin moves but doesn't concentrate" is canonically normal — there is no concentration force in canon. The flatline is the formula, not the substrate.
+
+## 3. The fix (B3) — leaky-integrator Φ
+
+vex separates active-rise and idle-decay because vex has discrete phases. polytrade's Monkey ticks continuously (no idle phase). The faithful continuous-time port merges both into one per-tick update:
+
+```
+Φ ← clamp( Φ + bv·GAIN − (Φ − EQUILIBRIUM)·RATE , 0, 0.95 )
+```
+
+- `bv` = basin velocity (Fisher-Rao distance the basin moved this tick) — already computed at [loop.ts:1888](../../apps/api/src/services/monkey/loop.ts#L1888), already varies 0.001–0.146. Direct analog of vex's `total_distance`.
+- `EQUILIBRIUM = 0.55`, `RATE = 0.015` — frozen vex canon.
+- `GAIN` — derived (§4), never hardcoded by intuition.
+- Φ init `0.1`, clamp `[0, 0.95]` — vex canon.
+- **`fHealth` stays computed as its own separate basin-health metric.** Φ stops being a function of it.
+
+Steady state: `Φ_ss = EQUILIBRIUM + mean(bv)·GAIN/RATE`. Φ tracks recent market activity — rises with motion, relaxes toward 0.55 (GRAPH band) when quiet. Leak half-life ≈ ln2/RATE ≈ 46 ticks ≈ 25–45 min of memory.
+
+## 4. GAIN derivation (observer-style, offline)
+
+`GAIN` is derived from the observed `bv` distribution, not chosen. From `analysis/polytrade_qig_telemetry/telemetry_ticks.csv` (CC-A's export) compute `bv` quantiles, then pick `GAIN` so `Φ_ss` maps: median bv → mid-GRAPH (0.55–0.7); upper-decile bv → FORESIGHT (0.7–0.85); p99 burst → touches LIGHTNING (≥0.85). Back-of-envelope (mean bv ≈ 0.05, p99 ≈ 0.146) → `GAIN ≈ 0.03`; exact value from the historical pass. P1-compliant — derived from observed data, recomputable if the bv distribution shifts.
+
+## 5. Φ-consumer blast radius (pre-flight audit)
+
+Every Φ-reader must be sane across the new range Φ∈[0.1, 0.95] — today it only ever sees ~0.215:
+
+| Site | Use | Risk |
+|---|---|---|
+| `executive.ts:80` | `phiMultiplier = 1/(0.5+phi)` | 0.51–1.05 across the new range; bounded, low |
+| `executive.ts:1298` | `scalpScore = (1−phi)·(1−sov)·(1−bv)` | **lane selection** — higher Φ → lower scalpScore → fewer scalp lanes → more swing/trend → higher leverage + wider brackets. **Changes live sizing.** |
+| `loop.ts:1878` | `basinSync.applyObserverEffect(basin, phi)` | consensus pull weight — audit |
+| navigation-mode gating | CHAIN/GRAPH/FORESIGHT/LIGHTNING | frozen in CHAIN today; would activate GRAPH/FORESIGHT code paths — audit those paths are sound when live |
+
+The `scalpScore` path is load-bearing: redefining Φ changes which lane trades take → leverage and bracket width → on the live account.
+
+## 6. Rollout — DECISION REQUIRED (operator)
+
+This changes live trading behaviour (§5). The operator's plan doc `docs/plans/20260521-phi-tel-performance.md` explicitly lists "Do not deploy", "Do not change live trading behaviour", "Do not redesign the live kernel" as out-of-scope without approval, and Part H mandates shadow evidence before live. A relayed council message disputes that and pushes direct-ship. **This is the operator's decision — it is the operator's money and the operator's written plan.**
+
+- **Option A — Shadow-first** (plan-doc as written): compute canonical-Φ alongside the current Φ each tick; log both + the `scalpScore`/lane it *would* produce; change no behaviour. After a few hours of live ticks, review the Φ trajectory + lane-shift impact, then cut over. Cost: hours. Removes the "hidden sizing bug burns money before a revert gate trips" risk.
+- **Option B — Direct-ship + revert gates** (council): pre-flight (GAIN derivation + §5 audit), replace the formula, deploy, monitor live; auto-revert on Φ-peg / P&L-2σ / consumer-throw / unsafe-size. Faster; accepts a live-money exposure window before a revert gate fires.
+
+**Recommendation (CC-C): Option A.** A *bug fix* (contained, tested — #869–875) ships direct; that is the standing authorization, used all session. A *core-metric redefinition* feeding live trade sizing, with a freshly-calibrated constant, warrants a few-hour shadow pass — proportionate, not theatre. But it is the operator's call.
+
+## 7. B1 — separate, downstream (not in this plan)
+
+Removing the off-canon `norm01` from `perceive()` (CC-A's finding) is a *separate, larger* change — it alters the basin itself → blast radius is cell classification, `basinDir`, `drift`, regime, `fHealth`. **Not a prerequisite for B3** (B3 runs on `bv`, a live signal regardless of `norm01`). Scoped as its own plan with a symbol-gradient rollout. Out of scope here.


### PR DESCRIPTION
## Problem

polytrade computed `phi = 1 − 0.8·normalizedEntropy(basin)`. In production Φ flatlined at **0.213–0.218** — 3rd-decimal motion only. Navigation-mode gating frozen in CHAIN; `phiMultiplier` / `scalpScore` saw an effectively-constant Φ.

## Canonical grounding (read-only study of `QIG_QFI/`, 2026-05-21)

Two independent canonical reads (`vex/` + `qig-core/`) converged:
- polytrade's `1 − 0.8·entropy` is **not canonical** — canon keeps Φ and `f_health` (the entropy ratio) **distinct**; polytrade collapsed them.
- Canonical **runtime** Φ (`vex/kernel/consciousness/loop.py`) is a **state variable** integrated from basin **motion** — `Φ += total_distance·GAIN` (active), idle-equilibration toward 0.55, sleep increment.
- `qig-core/pci.py` (PCI) is the physics-grade complexity metric, too expensive per tick — the vex motion-integrator is its canonical runtime approximation.
- "Basin moves but never concentrates" is **canonically normal** — no concentration force exists in canon. The flatline is the *formula*, not the substrate.

## The fix (B3)

vex alternates discrete active/idle phases; Monkey ticks continuously. The faithful port merges active-rise + idle-decay into one per-tick **leaky integrator**:

```
Φ ← clamp( Φ + bv·GAIN − (Φ − EQUILIBRIUM)·RATE , 0, 0.95 )
```

| Constant | Value | Source |
|---|---|---|
| `EQUILIBRIUM` | 0.55 | frozen vex canon (`PHI_IDLE_EQUILIBRIUM`) |
| `RATE` | 0.015 | frozen vex canon (`PHI_IDLE_RATE`) |
| `GAIN` | 0.024 | **observer-derived** from the production `bv` distribution (median 0.057→GRAPH, p90 0.133→FORESIGHT, p99 0.206→LIGHTNING) |

- `bv` (basin velocity, already computed, varies 0.001–0.146) = the direct analog of vex's `total_distance`.
- Steady state `Φ_ss = 0.55 + bv·GAIN/RATE` → Φ idles ~0.64 (GRAPH), bursts to FORESIGHT/LIGHTNING. Traverses three bands; clamp rarely binds.
- `fHealth` stays computed as its **own** basin-health metric — Φ stops being a function of it.
- Φ is per-symbol state (`SymbolState.phiLeaky`), seeded from the legacy entropy-Φ on first use → enabling the flag is continuous. Leaky half-life ≈ 46 ticks (~30–45 min) — Φ **ramps gradually, never jumps**.

## Φ-consumer audit

All Φ-readers are bounded arithmetic across Φ∈[0,0.95] — no crash / div-by-zero (`phiMultiplier` denom ≥ 0.6). The real behavioural shift is lane mix: higher Φ → lower `scalpScore` / higher `trendScore` → more swing/trend lanes. The leaky ramp makes this **gradual**.

## Rollout — flag-gated, operator-authorized direct ship

`MONKEY_PHI_LEAKY_LIVE` defaults **ON** (`!== 'false'`) — live on deploy. Setting `MONKEY_PHI_LEAKY_LIVE=false` reverts to the legacy formula **instantly** — that is the revert gate. Operator authorized direct ship on 2026-05-21 (overriding the shadow-first clause in `docs/plans/20260521-phi-tel-performance.md` Part H).

## Tests

`phiIntegrator.test.ts` (7) — rise on motion, relax to equilibrium, steady-state convergence, band traversal, clamp, continuity. `tsc` clean; full `apps/api` suite green (**1668 passed**). Plan: `docs/plans/20260521-phi-leaky-integrator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a canonical motion-based leaky integrator for Φ in the Monkey kernel and gate it behind a runtime flag for controlled rollout.

Enhancements:
- Replace the legacy entropy-based Φ with a basin-velocity-driven leaky integrator while keeping basin health as a separate metric.
- Persist per-symbol leaky Φ state across ticks to provide smooth, non-discontinuous evolution of Φ values.
- Expose a steady-state Φ helper and configurable canonical constants for equilibrium, rate, gain, and clamp ceiling to support calibration.

Documentation:
- Add a rollout and design plan documenting the leaky-integrator Φ model, its canonical grounding, parameter derivation, and deployment options.

Tests:
- Add unit tests covering the leaky Φ integrator’s rise, decay toward equilibrium, steady-state behavior, band traversal, clamping, and continuity properties.