### PR TITLE
fix(monkey): observer-derived basinDir neutral — un-pin the long-only bias

### DIFF
--- a/apps/api/src/services/monkey/__tests__/basinDirection.test.ts
+++ b/apps/api/src/services/monkey/__tests__/basinDirection.test.ts
@@ -233,3 +233,45 @@ describe('basinDirection — TS / Python parity', () => {
     expect(d).toBeLessThanOrEqual(1.0);
   });
 });
+
+// --- Production basin shape (only-longs regression, CC2 2026-05-21) ------
+// Every test above uses makeBasin() — uniform-0.5 basins, where 8/64 is
+// coincidentally the correct neutral. The REAL perceive() basin has 16
+// noise-floor dims (39..54) at 0.0055 — sub-uniform — which forces momMass
+// above 8/64 even on a flat market. Comparing to a hardcoded 8/64 then
+// reads "uptrend" on a flat market and can never go negative: the live
+// "only longs" bug. Mirrors test_basin_direction.py:TestBasinDirectionProductionShape.
+
+function makeProductionShapedBasin(momValue: number): Basin {
+  const v = new Float64Array(BASIN_DIM);
+  for (let i = 0; i < 3; i++) v[i] = 1 / 3;          // regime — uniform prior
+  v[3] = 0.01; v[4] = 0.01; v[5] = 0.5; v[6] = 0.0;  // ml posture (K ml-free)
+  for (let i = 7; i <= 14; i++) v[i] = momValue;     // momentum spectrum
+  for (let i = 15; i <= 22; i++) v[i] = 0.5;         // volatility — peer band
+  for (let i = 23; i <= 30; i++) v[i] = 0.5;         // volume — peer band
+  for (let i = 31; i <= 38; i++) v[i] = 0.5;         // price-structure
+  for (let i = 39; i <= 54; i++) v[i] = 0.0055;      // noise floor — the culprit
+  v[55] = 0.3; v[56] = 0.2; v[57] = 0.1; v[58] = 0.1; // account / coupling
+  for (let i = 59; i < 64; i++) v[i] = 0.01;         // reserved
+  return toSimplex(v);
+}
+
+describe('basinDirection — production basin shape (only-longs regression)', () => {
+  it('flat market reads ~ 0 despite the noise floor', () => {
+    // Momentum band at the same 0.5 level as its direction-agnostic peer
+    // bands (volatility, volume) = a flat market → must read ~0.
+    const d = basinDirection(makeProductionShapedBasin(0.5));
+    expect(Math.abs(d)).toBeLessThan(1e-6);
+  });
+
+  it('downtrend reads negative despite the noise floor', () => {
+    // Momentum band below its peer bands = downtrend. Pre-fix: read positive.
+    const d = basinDirection(makeProductionShapedBasin(0.40));
+    expect(d).toBeLessThan(0);
+  });
+
+  it('uptrend still reads positive on the production shape', () => {
+    const d = basinDirection(makeProductionShapedBasin(0.60));
+    expect(d).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/services/monkey/perception.ts
+++ b/apps/api/src/services/monkey/perception.ts
@@ -180,11 +180,12 @@ export function atr14(
  *
  * The new formulation:
  *   1. Build a "no-momentum antipode" basin: rescale dims 7..14 to
- *      total mass = MOM_NEUTRAL (= 8/64), redistribute the surplus
- *      / deficit uniformly across the 56 non-momentum dims.
+ *      total mass = neutralMomMass (observer-derived — see below),
+ *      redistribute the surplus / deficit uniformly across the 56
+ *      non-momentum dims.
  *   2. Compute the Fisher-Rao geodesic distance between basin and
  *      antipode: ``d = arccos(Σ √(p·q))`` on Δ⁶³.
- *   3. Sign by ``mom_mass - MOM_NEUTRAL``.
+ *   3. Sign by ``mom_mass - neutralMomMass``.
  *   4. Normalise by π/2 (the simplex diameter) so output ∈ [-1, +1]
  *      WITHOUT clipping. Saturation is geometric, not artificial.
  *
@@ -196,9 +197,19 @@ export function atr14(
  * this commit had basinDir computed under the saturating formula.
  * Migration 041 flags those rows so the kernel can avoid re-using
  * stale-coordinate-system bubbles (UCP §11.8).
+ *
+ * BUG FIX (2026-05-21): the neutral was a hardcoded MOM_NEUTRAL = 8/64
+ * — correct only for a uniform basin. perceive()'s sub-uniform noise
+ * floor (dims 39..54 @ 0.0055) made mom_mass exceed 8/64 even on a
+ * flat market → sign pinned +1 → basinDir never went negative (the
+ * live "only longs" bug). Fixed: neutral is derived from the basin's
+ * own direction-agnostic peer bands (volatility 15..22 + volume
+ * 23..30). Observer-derived, no hardcoded knob (P1).
  */
 export function basinDirection(basin: Basin): number {
-  const MOM_NEUTRAL = 8 / BASIN_DIM;  // 0.125
+  // Degenerate-basin fallback ONLY. The live neutral is observer-derived
+  // below (neutralMomMass) — 8/64 is correct only for a uniform basin.
+  const MOM_NEUTRAL_FALLBACK = 8 / BASIN_DIM;  // 0.125
   const FR_DIAMETER = Math.PI / 2;
   const EPS = 1e-12;
 
@@ -211,21 +222,33 @@ export function basinDirection(basin: Basin): number {
     p[i] = Math.max(0, basin[i] ?? 0) / total;
   }
 
-  // Step 1: momentum-band mass and sign.
+  // Step 1: momentum-band mass and observer-derived neutral.
   let momMass = 0;
   for (let i = 7; i <= 14; i++) momMass += p[i]!;
-  const sign = momMass >= MOM_NEUTRAL ? 1 : -1;
+  // Observer-derived neutral (P1 — no hardcoded knob). The momentum
+  // band's mass when momentum is NEUTRAL equals 8× the per-dim mass of
+  // its direction-agnostic peer bands: volatility (15..22) and volume
+  // (23..30) carry magnitude, not sign. A hardcoded 8/64 holds only for
+  // a uniform basin; perceive()'s 16 noise-floor dims (39..54 @ 0.0055)
+  // sit below uniform and force every other dim's share above uniform,
+  // so momMass exceeds 8/64 even on a flat market. Deriving the neutral
+  // from the basin's own peer bands self-corrects for that.
+  let peerSum = 0;
+  for (let i = 15; i <= 30; i++) peerSum += p[i]!;
+  const peerMean = peerSum / 16;
+  const neutralMomMass = peerMean > EPS ? 8 * peerMean : MOM_NEUTRAL_FALLBACK;
+  const sign = momMass >= neutralMomMass ? 1 : -1;
 
   // Step 2: build the no-momentum antipode.
   const antipode: number[] = p.slice();
   const bandN = 8;
   const nonbandN = BASIN_DIM - bandN; // 56
-  const excess = momMass - MOM_NEUTRAL;
+  const excess = momMass - neutralMomMass;
   if (momMass > EPS) {
-    const scale = MOM_NEUTRAL / momMass;
+    const scale = neutralMomMass / momMass;
     for (let i = 7; i <= 14; i++) antipode[i] = p[i]! * scale;
   } else {
-    for (let i = 7; i <= 14; i++) antipode[i] = MOM_NEUTRAL / bandN;
+    for (let i = 7; i <= 14; i++) antipode[i] = neutralMomMass / bandN;
   }
   if (nonbandN > 0) {
     const add = excess / nonbandN;

--- a/ml-worker/src/monkey_kernel/perception_scalars.py
+++ b/ml-worker/src/monkey_kernel/perception_scalars.py
@@ -44,9 +44,9 @@ def basin_direction(basin: np.ndarray) -> float:
     and structurally suppresses short conviction. The new
     formulation computes a SIGNED, NORMALISED Fisher-Rao distance:
 
-      sign = sign(mom_mass - MOM_NEUTRAL)
-      antipode = a copy of ``basin`` with the momentum band flattened
-                 to its uniform expectation (no-momentum reference)
+      sign = sign(mom_mass - neutral_mom_mass)
+      antipode = a copy of ``basin`` with the momentum band rescaled
+                 to ``neutral_mom_mass`` (the no-momentum reference)
       d_FR = arccos(Σ √(basin · antipode))
       return sign * d_FR / (π/2)
 
@@ -71,10 +71,26 @@ def basin_direction(basin: np.ndarray) -> float:
     produced basinDir ≈ −1.0 on every tick. The 2026-04-24 fix
     introduced ``mom_mass - MOM_NEUTRAL`` then tanh-saturated; this
     proposal replaces that with the Fisher-Rao reprojection above.
+
+    BUG FIX (2026-05-21): the neutral reference was a hardcoded
+    ``MOM_NEUTRAL = 8/64`` — the momentum-band mass of a *uniform*
+    basin. perceive()'s real basin is not uniform: dims 39..54 are a
+    noise floor pinned at 0.0055 (sub-uniform), which forces every
+    other dim's mass share above uniform. So ``mom_mass`` exceeded
+    8/64 even on a flat market → ``sign`` pinned +1 → basinDir never
+    went negative → the live "only longs" bug (operator report,
+    2026-05-21). Fixed by deriving the neutral from the basin's own
+    direction-agnostic peer bands (volatility 15..22 + volume 23..30):
+    ``neutral_mom_mass = 8 × mean(p[15:31])``. Observer-derived, no
+    hardcoded knob (P1 / perception-workstream §8).
     """
     BASIN_DIM = 64
-    MOM_NEUTRAL = 8.0 / BASIN_DIM  # 0.125 — uniform mass on 8 momentum dims
     EPS = 1e-12
+    # Degenerate-basin fallback ONLY. The live neutral reference is
+    # observer-derived below (``neutral_mom_mass``). A hardcoded 8/64 is
+    # correct only for a uniform basin; perceive()'s sub-uniform noise
+    # floor breaks that — see the 2026-05-21 BUG FIX note above.
+    MOM_NEUTRAL_FALLBACK = 8.0 / BASIN_DIM
 
     arr = np.asarray(basin, dtype=np.float64)
     if arr.shape[0] != BASIN_DIM:
@@ -91,26 +107,40 @@ def basin_direction(basin: np.ndarray) -> float:
     p = arr / mass  # simplex-normalised basin
 
     mom_mass = float(np.sum(p[7:15]))
-    sign = 1.0 if mom_mass >= MOM_NEUTRAL else -1.0
 
-    # Build the no-momentum antipode: rescale the momentum band so
-    # its total mass equals MOM_NEUTRAL (the uniform-on-band
-    # expectation), and redistribute the surplus/deficit uniformly
-    # across the 56 non-momentum dims. The antipode stays on Δ⁶³
-    # (sum = 1). Critically, when the basin's momentum band carries
-    # ABOVE-uniform mass — even if the band is internally flat — the
-    # antipode differs from the basin, so the Fisher-Rao distance
-    # captures the directional deviation.
+    # Observer-derived neutral reference (P1 — no hardcoded knob, per
+    # the perception-workstream §8 directive). The momentum band's mass
+    # when momentum is NEUTRAL equals 8× the per-dim mass of its
+    # direction-agnostic peer bands: volatility (15..22) and volume
+    # (23..30) carry magnitude, not sign. A hardcoded 8/64 holds only
+    # for a uniform basin; perceive()'s 16 noise-floor dims (39..54,
+    # pinned 0.0055) sit below uniform and force every other dim's
+    # share above uniform — so mom_mass exceeds 8/64 even on a flat
+    # market. Deriving the neutral from the basin's own peer bands
+    # self-corrects for whatever the noise floor does.
+    peer_mean = float(np.mean(p[15:31]))  # 16 direction-agnostic dims
+    neutral_mom_mass = (
+        8.0 * peer_mean if peer_mean > EPS else MOM_NEUTRAL_FALLBACK
+    )
+    sign = 1.0 if mom_mass >= neutral_mom_mass else -1.0
+
+    # Build the no-momentum antipode: rescale the momentum band so its
+    # total mass equals ``neutral_mom_mass`` (the observer-derived
+    # no-momentum reference), and redistribute the surplus/deficit
+    # uniformly across the 56 non-momentum dims. The antipode stays on
+    # Δ⁶³ (sum = 1). When the momentum band carries above-neutral mass
+    # — even if internally flat — the antipode differs from the basin,
+    # so the Fisher-Rao distance captures the directional deviation.
     antipode = p.copy()
     band_n = 8
     nonband_n = BASIN_DIM - band_n  # 56
-    excess = mom_mass - MOM_NEUTRAL
+    excess = mom_mass - neutral_mom_mass
     if mom_mass > EPS:
-        # Scale momentum band down to MOM_NEUTRAL total.
-        antipode[7:15] = p[7:15] * (MOM_NEUTRAL / mom_mass)
+        # Scale momentum band to the observer-derived neutral total.
+        antipode[7:15] = p[7:15] * (neutral_mom_mass / mom_mass)
     else:
         # Degenerate basin (zero mass on momentum band) — flatten band.
-        antipode[7:15] = MOM_NEUTRAL / band_n
+        antipode[7:15] = neutral_mom_mass / band_n
     # Redistribute the excess across the non-momentum dims.
     if nonband_n > 0:
         non_mask = np.ones(BASIN_DIM, dtype=bool)

--- a/ml-worker/tests/monkey_kernel/test_basin_direction.py
+++ b/ml-worker/tests/monkey_kernel/test_basin_direction.py
@@ -356,3 +356,77 @@ class TestBasinDirectionParametrized:
         d = basin_direction(v)
         assert -1.0 <= d <= 1.0
         assert np.isfinite(d)
+
+
+# --- Production-basin-shape regression (CC2, 2026-05-21) ---------------
+# Every test above builds basins with _make_simplex_basin / np.full —
+# i.e. all 64 dims at one uniform level. On a uniform basin MOM_NEUTRAL =
+# 8/64 is coincidentally the correct neutral, so the bug never showed.
+#
+# The REAL perceive() basin is NOT uniform: dims 39..54 are a noise
+# floor pinned at 0.0055 — far below uniform (1/64 ≈ 0.0156). That
+# sub-uniform mass forces every other dim's share ABOVE uniform, so
+# mom_mass is structurally > 8/64 even when the momentum band sits at
+# the SAME level as its direction-agnostic peer bands. Comparing
+# mom_mass to a hardcoded 8/64 therefore reads "uptrend" on a flat
+# market and can never read negative — the live "only longs" bug
+# (operator report, 2026-05-21).
+
+def _make_production_shaped_basin(mom_value: float) -> np.ndarray:
+    """A 64-dim basin matching perceive()'s real layout.
+
+    The momentum band (7..14) is set to ``mom_value``; its
+    direction-agnostic peer bands — volatility (15..22) and volume
+    (23..30) — sit at the neutral 0.5. So ``mom_value == 0.5`` is a
+    genuinely flat market and must read ~0. dims 39..54 carry the
+    real 0.0055 noise floor. Returned as a simplex point.
+    """
+    v = np.zeros(BASIN_DIM, dtype=np.float64)
+    v[0:3] = 1.0 / 3.0                  # regime — uniform prior
+    v[3:7] = [0.01, 0.01, 0.5, 0.0]     # ml posture (K runs ml-free)
+    v[7:15] = mom_value                 # momentum spectrum
+    v[15:23] = 0.5                      # volatility — direction-agnostic peer
+    v[23:31] = 0.5                      # volume shape — direction-agnostic peer
+    v[31:39] = 0.5                      # price-structure
+    v[39:55] = 0.0055                   # noise floor — sub-uniform, the culprit
+    v[55:59] = [0.3, 0.2, 0.1, 0.1]     # account / coupling
+    v[59:64] = 0.01                     # reserved
+    return v / v.sum()
+
+
+class TestBasinDirectionProductionShape:
+    """basin_direction on the REAL perceive() basin shape (sub-uniform
+    noise floor present). Guards the 2026-05-21 'only longs' bug."""
+
+    def test_flat_market_reads_near_zero_with_noise_floor(self):
+        """Momentum band at the same 0.5 level as its direction-agnostic
+        peer bands (volatility, volume) = a flat market. basin_direction
+        MUST read ~0. The pre-fix code compares mom_mass to a hardcoded
+        8/64 — wrong once the noise floor drags the uniform reference
+        below the momentum band — and reads positive."""
+        flat = _make_production_shaped_basin(0.5)
+        d = basin_direction(flat)
+        assert abs(d) < 1e-6, f"flat market read {d:+.4f}, expected ~0"
+
+    def test_downtrend_reads_negative_with_noise_floor(self):
+        """Momentum band BELOW its peer bands = a downtrend. Must read
+        negative even though the noise floor inflates mom_mass past
+        8/64."""
+        bear = _make_production_shaped_basin(0.40)
+        d = basin_direction(bear)
+        assert d < 0.0, f"downtrend read {d:+.4f}, expected negative"
+
+    def test_uptrend_reads_positive_with_noise_floor(self):
+        """Companion guard: momentum band ABOVE its peers reads positive
+        on the production shape (must survive the fix)."""
+        bull = _make_production_shaped_basin(0.60)
+        d = basin_direction(bull)
+        assert d > 0.0, f"uptrend read {d:+.4f}, expected positive"
+
+    def test_production_shape_sign_is_symmetric_about_peer_level(self):
+        """Reflecting the momentum band around its peer level (0.5)
+        flips the sign — the neutral reference is the peer bands, not a
+        hardcoded constant."""
+        d_bear = basin_direction(_make_production_shaped_basin(0.40))
+        d_bull = basin_direction(_make_production_shaped_basin(0.60))
+        assert d_bear < 0.0 < d_bull


### PR DESCRIPTION
## Problem

Operator reported **"only longs are opening"** (2026-05-21, live-money kernel).

`basin_direction` (and its TS mirror `basinDirection`) set the sign of the kernel's geometric direction read by comparing the momentum band's mass to a hardcoded `MOM_NEUTRAL = 8/64` — the band mass of a **uniform** basin.

`perceive()`'s real basin is **not** uniform: dims 39..54 are a noise floor pinned at `0.0055` (sub-uniform). That sub-uniform mass forces every other dim's share **above** uniform, so `mom_mass` exceeds `8/64` even on a flat market → `sign` pinned `+1` → `basinDir` structurally positive.

Fresh production logs confirm it: **105/105 ticks, `basinDir ∈ [+0.031, +0.044]`, never negative.** That biased Agent K's entry side long → only longs.

## Fix

Derive the neutral reference from the basin's **own direction-agnostic peer bands** — volatility (15..22) + volume (23..30) carry magnitude, not direction:

```
neutral_mom_mass = 8 × mean(p[15:31])
```

Observer-derived, no hardcoded knob (P1 / perception-workstream §8 directive). On a uniform basin this equals `8/64`, so existing tests are unaffected — it only corrects the real production shape. `8/64` is retained solely as a degenerate-basin fallback.

## Scope — what this does NOT fix

This fixes **K's directional long-tilt** — the reported "only longs."

It does **not** restore the M agent or `FAST_ADVERSE_EXIT`: both gate on `|basinDir| > 0.10`, a **magnitude** requirement unreachable on a near-uniform basin regardless of sign. That needs the **B1** expressive-basin work (`norm01` removal) tracked in `docs/plans/20260521-phi-leaky-integrator.md §7` — out of scope here, orthogonal to this change.

## Tests (TDD)

- New regression tests on the **real production basin shape** (with the sub-uniform noise floor) in both mirrors. RED verified (pre-fix, a downtrend reads `+0.076`); GREEN verified.
- `test_basin_direction.py`: 64 pass (60 existing unaffected + 4 new).
- TS monkey suite: 820 pass (54 files); `tsc --noEmit` clean.

## Rollout

**Do not auto-merge / deploy from this PR without operator sign-off.** This changes live trading direction. Per `docs/plans/20260521-phi-tel-performance.md` Part H and the standing live-money caution discipline, CI gates run first and the live cutover is the operator's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust basin direction neutral reference to remove structural long bias and add regression coverage for the real production basin shape.

Bug Fixes:
- Derive the momentum-band neutral mass from volatility and volume peer bands instead of a hardcoded uniform constant to allow basin direction to go negative on flat or down markets and eliminate the structural long-only bias.

Enhancements:
- Keep a uniform-basin neutral mass as a fallback for degenerate cases while basing Fisher-Rao antipode construction on the observer-derived neutral momentum mass.

Tests:
- Add Python and TypeScript regression tests that construct the real production-shaped basin, verifying near-zero reading for flat markets and correct sign for uptrend and downtrend scenarios.