### PR TITLE
fix(monkey): seed leaky-Φ from persisted trajectory across restarts (B3.1)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1029,6 +1029,11 @@ export class MonkeyKernel extends EventEmitter {
       this.turtleStates.set(sym, newTurtleState());
     }
 
+    // B3.1 — seed the leaky-Φ integrator from persisted trajectory so Φ
+    // survives process restarts. Awaited before the first tick so the
+    // seed is in place when tick 1 reads `state.phiLeaky`.
+    await this.seedLeakyPhiFromHistory();
+
     // 2026-05-13 MTF Phase 2 — bootstrap per-timeframe basin
     // histories from historical OHLCV so the 4h classifier doesn't
     // need 80 days of live ticks to warm up. Async + fail-soft;
@@ -1379,6 +1384,44 @@ export class MonkeyKernel extends EventEmitter {
   private scheduleMTFBootstrapRetry(symbol: string, delayMs: number): void {
     this.mtfBootstrapRetryAtMs.set(symbol, Date.now() + delayMs);
     this.mtfBootstrapLastDelayMs.set(symbol, delayMs);
+  }
+
+  /**
+   * B3.1 — seed each symbol's leaky-Φ integrator from the last persisted
+   * `monkey_trajectory.phi` so Φ survives process restarts.
+   *
+   * `state.phiLeaky` is in-memory only. Without this seed, every redeploy
+   * re-seeds Φ from the legacy entropy-Φ (~0.22) and Φ then spends its
+   * ~45-min CHAIN→GRAPH convergence ramp re-climbing (leak half-life
+   * ≈ 46 ticks). On a service that redeploys several times a day Φ never
+   * settles into its ~0.58 GRAPH steady state — confirmed in production
+   * telemetry 2026-05-21 (Φ reached 0.51 in a 1 h uninterrupted window,
+   * then reset to 0.22 on the next deploy). The leaky Φ is already
+   * persisted every tick by the monkey_trajectory INSERT — read the
+   * latest value back. Fail-soft: no row / query error → `phiLeaky`
+   * stays undefined and tick 1 falls through to the entropy-Φ seed.
+   */
+  private async seedLeakyPhiFromHistory(): Promise<void> {
+    for (const [symbol, state] of this.symbolStates) {
+      try {
+        const res = await pool.query(
+          `SELECT phi FROM monkey_trajectory
+            WHERE symbol = $1 ORDER BY at DESC LIMIT 1`,
+          [symbol],
+        );
+        const last = res.rows[0]?.phi;
+        if (typeof last === 'number' && Number.isFinite(last)) {
+          state.phiLeaky = last;
+          logger.info('[Monkey] Φ seeded from trajectory history', {
+            instanceId: this.instanceId, symbol, phiLeaky: last.toFixed(3),
+          });
+        }
+      } catch (err) {
+        logger.debug('[Monkey] Φ seed failed (fail-soft to entropy seed)', {
+          symbol, err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   private newSymbolState(): SymbolState {


### PR DESCRIPTION
## Summary

Follow-up to #876 (B3 canonical leaky-integrator Φ). This is the **B3 validation pass result** turned into a fix.

B3's leaky integrator works — but `state.phiLeaky` is **in-memory only**, so every process restart re-seeds Φ from the legacy entropy-Φ (~0.22). Φ then spends its ~45-min CHAIN→GRAPH convergence ramp re-climbing (leak half-life ≈ 46 ticks).

## Evidence — `monkey_trajectory.phi`, production, last 8h (UTC 2026-05-21)

| Window | Φ behaviour |
|---|---|
| 00:30–01:45 | legacy flatline — Φ **0.213–0.218**, dead flat (pre-B3) |
| 02:00–03:45 | B3 engaged — clean leaky climb 0.24 → 0.30 |
| 04:00 | redeploy → Φ reset to ~0.22 |
| **05:00–05:30** | **uninterrupted hour — Φ climbed 0.38 → 0.49, peak 0.514**, approaching GRAPH floor (0.55) |
| 05:45 | redeploy (#878/#879) → Φ reset to ~0.22 again |

The integrator is mathematically sound (`Φ_ss ≈ 0.58` for observed mean `bv`), but production redeploys ≈hourly — **Φ has never completed its convergence and never reached the GRAPH band.** No revert trigger fired (no Φ-peg, no consumer-throw, sizing sane 8–13 USDT) — B3 is safe, just unable to settle.

## Fix

`seedLeakyPhiFromHistory()` seeds each symbol's `phiLeaky` on startup from the last persisted `monkey_trajectory.phi` (the leaky Φ is already written every tick). Awaited before the first tick so the seed isn't overwritten; fail-soft — no row / query error falls through to the existing entropy-Φ seed. Φ now survives restarts and converges into GRAPH as B3 designed.

## Gates
- `yarn build:api` — green
- `vitest run` (apps/api) — 1619 passed / 12 skipped (no regressions; `phi_integrator` suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Restore leaky-Φ continuity across service restarts by initializing each symbol's phiLeaky from the latest persisted monkey_trajectory.phi value, falling back to the existing entropy-based seed on failures.