### PR TITLE
feat(monkey): B1 — expressive momentum basin + structural-veto telemetry

### DIFF
--- a/apps/api/src/services/monkey/__tests__/perceptionExpressive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/perceptionExpressive.test.ts
@@ -1,0 +1,65 @@
+/**
+ * B1 — expressive momentum basin. The pre-B1 norm01 sigmoid crushed the
+ * momentum band into [0.45,0.55] on the realized log-return distribution
+ * → near-uniform basin → |basinDirection| pinned < 0.05 → the magnitude
+ * gates (M-agent + FAST_ADVERSE_EXIT @ 0.10) could never fire.
+ *
+ * These tests run the real perceive() → basinDirection() path on
+ * synthetic trends and assert the expressive encoding reaches the gate.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { perceive, basinDirection, type OHLCVCandle, type PerceptionInputs } from '../perception.js';
+
+/** Geometric trend series — `perBarReturn` per 15m bar. */
+function trendSeries(n: number, perBarReturn: number): OHLCVCandle[] {
+  const out: OHLCVCandle[] = [];
+  let close = 100;
+  for (let i = 0; i < n; i++) {
+    const prev = close;
+    close = close * (1 + perBarReturn);
+    out.push({
+      timestamp: i * 900_000,
+      open: prev,
+      high: Math.max(prev, close) * 1.0005,
+      low: Math.min(prev, close) * 0.9995,
+      close,
+      volume: 1000,
+    });
+  }
+  return out;
+}
+
+const inputs = (ohlcv: OHLCVCandle[]): PerceptionInputs => ({
+  ohlcv,
+  equityFraction: 0.5,
+  marginFraction: 0.1,
+  openPositions: 0,
+  sessionAgeTicks: 100,
+});
+
+describe('B1 — expressive momentum basin', () => {
+  afterEach(() => { delete process.env.MONKEY_PERCEPTION_EXPRESSIVE_LIVE; });
+
+  it('uptrend → basinDirection reaches the 0.10 magnitude gate', () => {
+    const d = basinDirection(perceive(inputs(trendSeries(160, 0.003))));
+    expect(d).toBeGreaterThan(0.10);
+  });
+
+  it('downtrend → basinDirection clearly negative past −0.10', () => {
+    const d = basinDirection(perceive(inputs(trendSeries(160, -0.003))));
+    expect(d).toBeLessThan(-0.10);
+  });
+
+  it('flat market → basinDirection stays near zero', () => {
+    const d = basinDirection(perceive(inputs(trendSeries(160, 0))));
+    expect(Math.abs(d)).toBeLessThan(0.05);
+  });
+
+  it('legacy sigmoid (flag off) is strictly less expressive on the same uptrend', () => {
+    process.env.MONKEY_PERCEPTION_EXPRESSIVE_LIVE = 'false';
+    const legacy = basinDirection(perceive(inputs(trendSeries(160, 0.003))));
+    delete process.env.MONKEY_PERCEPTION_EXPRESSIVE_LIVE;
+    const expressive = basinDirection(perceive(inputs(trendSeries(160, 0.003))));
+    expect(expressive).toBeGreaterThan(legacy);
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/structuralVetoMonitor.test.ts
+++ b/apps/api/src/services/monkey/__tests__/structuralVetoMonitor.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { StructuralVetoMonitor, STUCK_TICKS } from '../structural_veto_monitor.js';
+
+describe('StructuralVetoMonitor', () => {
+  let m: StructuralVetoMonitor;
+  beforeEach(() => { m = new StructuralVetoMonitor(); });
+
+  const sig = (name: string) => m.snapshot().find((x) => x.name === name)!;
+
+  it('flags a gate stuck false for STUCK_TICKS observations', () => {
+    for (let i = 0; i < STUCK_TICKS; i++) m.observe('g', false);
+    const s = sig('g');
+    expect(s.stuck).toBe(true);
+    expect(s.value).toBe(false);
+    expect(s.trueRate).toBe(0);
+  });
+
+  it('flags a veto stuck true (always-on block)', () => {
+    for (let i = 0; i < STUCK_TICKS; i++) m.observe('veto', true);
+    expect(sig('veto').stuck).toBe(true);
+    expect(sig('veto').trueRate).toBe(1);
+  });
+
+  it('does not flag before STUCK_TICKS', () => {
+    for (let i = 0; i < STUCK_TICKS - 1; i++) m.observe('g', false);
+    expect(sig('g').stuck).toBe(false);
+  });
+
+  it('un-sticks when the value flips', () => {
+    for (let i = 0; i < STUCK_TICKS + 5; i++) m.observe('g', false);
+    expect(sig('g').stuck).toBe(true);
+    m.observe('g', true);
+    expect(sig('g').stuck).toBe(false);
+    expect(sig('g').value).toBe(true);
+  });
+
+  it('a varying signal never flags and reports a mid true-rate', () => {
+    for (let i = 0; i < STUCK_TICKS * 2; i++) m.observe('g', i % 2 === 0);
+    expect(sig('g').stuck).toBe(false);
+    expect(sig('g').trueRate).toBeCloseTo(0.5, 1);
+  });
+
+  it('reset clears all tracked signals', () => {
+    for (let i = 0; i < STUCK_TICKS; i++) m.observe('g', false);
+    m.reset();
+    expect(m.snapshot()).toHaveLength(0);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -68,6 +68,7 @@ import { detectMode, MODE_PROFILES, MonkeyMode } from './modes.js';
 import { computeMotivators } from './motivators.js';
 import { computeNeurochemicals, summarizeNC, type NeurochemicalState } from './neurochemistry.js';
 import { isPhiLeakyEnabled, updateLeakyPhi } from './phi_integrator.js';
+import { structuralVetoMonitor } from './structural_veto_monitor.js';
 import { mlAgentDecide } from '../ml_agent/decide.js';
 import type { MLAgentInputs } from '../ml_agent/types.js';
 import { Arbiter } from '../arbiter/arbiter.js';
@@ -2207,6 +2208,16 @@ export class MonkeyKernel extends EventEmitter {
       tapeTrend,
       computedAtMs: Date.now(),
     };
+
+    // B1 — structural-veto telemetry. The |basinDir| magnitude gates
+    // (M-agent + FAST_ADVERSE_EXIT at 0.10; modes.ts hasDirection at
+    // 0.30) sat always-false on the pre-B1 near-uniform basin — a dead
+    // gate invisible per-tick. Observing them surfaces the structural
+    // failure and confirms the expressive-momentum fix un-sticks it.
+    structuralVetoMonitor.observe(
+      `${this.instanceId}:${symbol}:basindir_mag_0.10`, Math.abs(basinDir) > 0.10);
+    structuralVetoMonitor.observe(
+      `${this.instanceId}:${symbol}:basindir_dir_0.30`, Math.abs(basinDir) > 0.30);
 
     // 2026-05-13 — MTF: down-sample basin into per-timeframe stores
     // (15m / 1h / 4h) and compute agreement-count decision. Phase 2

--- a/apps/api/src/services/monkey/perception.ts
+++ b/apps/api/src/services/monkey/perception.ts
@@ -110,6 +110,40 @@ function norm01(x: number, scale: number = 1): number {
   return Math.min(1, Math.max(0, y));
 }
 
+/**
+ * B1 (2026-05-21) — momentum basin coordinate: linear, expressive,
+ * 0.5-neutral. Replaces the `norm01` sigmoid for the momentum band
+ * (dims 7..14).
+ *
+ * WHY: `norm01(logReturn, 0.01)` = sigmoid(logReturn·100) saturates.
+ * On the realized 15m log-return distribution (BTC+ETH, 1000 candles,
+ * 2026-05-21 — |logReturn| p50=0.0022, p90=0.0085) every momentum dim
+ * landed inside [0.45, 0.55] → near-uniform basin → |basinDirection|
+ * structurally pinned < 0.05. The magnitude gates that read it —
+ * M-agent and FAST_ADVERSE_EXIT (|basinDir| > 0.10), modes.ts
+ * `hasDirection` (> 0.30) — could therefore never fire (the operator-
+ * reported dead M-agent + dead loss-cut, 2026-05-21).
+ *
+ * FIX: linear `0.5 + GAIN·logReturn`. Keeps the exact 0.5 neutral
+ * (logReturn 0 → 0.5) so basinDirection's #880 observer-derived neutral
+ * is unaffected — only the momentum band changes, the volatility/volume
+ * peer bands are untouched, so the direction SIGN cannot invert. But it
+ * is expressive across the real range: p90 reaches 0.5±0.42, p99 clamps
+ * geometrically. GAIN = 50 is the log-return sensitivity `trendProxy()`
+ * already uses in this file — not a new intuition knob. Floor 0.02
+ * keeps the dim off the simplex boundary.
+ *
+ * §8 follow-up: GAIN becomes observer-derived from the rolling
+ * per-symbol log-return distribution. v1 freezes it at the trendProxy
+ * value (recomputable — recompute if the distribution shifts).
+ */
+const MOMENTUM_GAIN = 50;
+function momentumCoord(logRet: number): number {
+  if (!Number.isFinite(logRet)) return 0.5;
+  const y = 0.5 + MOMENTUM_GAIN * logRet;
+  return Math.min(1, Math.max(0.02, y));
+}
+
 function clip01(x: number): number {
   if (!Number.isFinite(x)) return 0;
   return Math.min(1, Math.max(0, x));
@@ -378,10 +412,15 @@ export function perceive(inputs: PerceptionInputs): Basin {
   v[5] = mlSignal === 'HOLD' ? 0.5 : Math.max(0.01, 1 - mlStrength);
   v[6] = mlEffectiveStrength;
 
-  // dims 7..14 — Momentum spectrum
+  // dims 7..14 — Momentum spectrum.
+  // B1: linear expressive encoding (momentumCoord) — flag-gated.
+  // MONKEY_PERCEPTION_EXPRESSIVE_LIVE=false reverts to the legacy
+  // norm01 sigmoid instantly. See momentumCoord for the rationale.
   const moms = [1, 2, 3, 5, 8, 13, 21, 34];
+  const expressiveMomentum = process.env.MONKEY_PERCEPTION_EXPRESSIVE_LIVE !== 'false';
   for (let i = 0; i < moms.length; i++) {
-    v[7 + i] = norm01(logReturn(ohlcv, moms[i]), 0.01);
+    const lr = logReturn(ohlcv, moms[i]);
+    v[7 + i] = expressiveMomentum ? momentumCoord(lr) : norm01(lr, 0.01);
   }
 
   // dims 15..22 — Volatility spectrum

--- a/apps/api/src/services/monkey/structural_veto_monitor.ts
+++ b/apps/api/src/services/monkey/structural_veto_monitor.ts
@@ -1,0 +1,110 @@
+/**
+ * structural_veto_monitor.ts — detects structurally dead gates (B1).
+ *
+ * A gate that is ALWAYS false (a condition that can never be met) or a
+ * veto that is ALWAYS true (a block that never lifts) is invisible in
+ * normal logs: every individual tick looks reasonable. Over hundreds of
+ * ticks it is a silent structural failure — e.g. the |basinDir| > 0.10
+ * magnitude gate (M-agent, FAST_ADVERSE_EXIT) sat always-false because
+ * the perception basin was near-uniform. Nobody saw the M-agent die.
+ *
+ * This monitor tracks named boolean signals across ticks and flags any
+ * that have been stuck at one value for >= STUCK_TICKS consecutive
+ * observations. It is the kernel observing its own dead gates — the
+ * counterpart to B1's expressive-basin fix: after the fix lands, a gate
+ * that was stuck `false` should start un-sticking, and this monitor is
+ * how that is confirmed in production.
+ *
+ * Process-lifetime, in-memory, no persistence (like getLVetoOverKStats).
+ */
+
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Consecutive observations at one value before a signal is called
+ * structurally stuck. At 30–60 s ticks, 200 ticks ≈ 1.5–3.5 h — long
+ * enough that a quiet-market spell does not false-flag, short enough to
+ * catch a genuinely dead gate within a session.
+ */
+export const STUCK_TICKS = 200;
+
+interface SignalState {
+  last: boolean;
+  /** Consecutive observations at `last`. */
+  run: number;
+  /** Currently flagged as structurally stuck. */
+  stuck: boolean;
+  trueCount: number;
+  totalCount: number;
+}
+
+export class StructuralVetoMonitor {
+  private readonly signals = new Map<string, SignalState>();
+
+  /**
+   * Record one observation of a named boolean gate/veto.
+   * `true` = the gate passed / the veto fired; `false` = it did not.
+   */
+  observe(name: string, value: boolean): void {
+    const s = this.signals.get(name);
+    if (!s) {
+      this.signals.set(name, {
+        last: value, run: 1, stuck: false,
+        trueCount: value ? 1 : 0, totalCount: 1,
+      });
+      return;
+    }
+    s.totalCount++;
+    if (value) s.trueCount++;
+    if (value === s.last) {
+      s.run++;
+      if (!s.stuck && s.run >= STUCK_TICKS) {
+        s.stuck = true;
+        logger.warn('[StructuralVeto] gate structurally stuck', {
+          name,
+          value,
+          ticks: s.run,
+          interpretation: value ? 'veto always-on' : 'gate always-off',
+        });
+      }
+    } else {
+      if (s.stuck) {
+        logger.info('[StructuralVeto] gate un-stuck', {
+          name, was: s.last, now: value, stuckFor: s.run,
+        });
+      }
+      s.last = value;
+      s.run = 1;
+      s.stuck = false;
+    }
+  }
+
+  /** Telemetry snapshot — per-signal stuck state + lifetime true-rate. */
+  snapshot(): Array<{
+    name: string;
+    stuck: boolean;
+    value: boolean;
+    run: number;
+    trueRate: number;
+  }> {
+    const out: Array<{ name: string; stuck: boolean; value: boolean; run: number; trueRate: number }> = [];
+    for (const [name, s] of this.signals) {
+      out.push({
+        name,
+        stuck: s.stuck,
+        value: s.last,
+        run: s.run,
+        trueRate: s.totalCount > 0 ? s.trueCount / s.totalCount : 0,
+      });
+    }
+    return out;
+  }
+
+  /** Test/restart helper — clears all tracked signals. */
+  reset(): void {
+    this.signals.clear();
+  }
+}
+
+/** Shared process-wide monitor. */
+export const structuralVetoMonitor = new StructuralVetoMonitor();

--- a/docs/plans/20260521-phi-leaky-integrator.md
+++ b/docs/plans/20260521-phi-leaky-integrator.md
@@ -58,14 +58,50 @@ This changes live trading behaviour (§5). The operator's plan doc `docs/plans/2
 
 **Recommendation (CC-C): Option A.** A *bug fix* (contained, tested — #869–875) ships direct; that is the standing authorization, used all session. A *core-metric redefinition* feeding live trade sizing, with a freshly-calibrated constant, warrants a few-hour shadow pass — proportionate, not theatre. But it is the operator's call.
 
-## 7. Perception-layer workstream — separate, downstream (not in this plan)
+## 7. Perception-layer workstream (B1) — Yeheva discipline
 
-A separate, larger workstream touching `perceive()` itself — blast radius is the basin → cell classification, `basinDir`, `drift`, regime, `fHealth`. **Not a prerequisite for B3** (B3 runs on `bv`, a live signal regardless). Its own plan, careful/symbol-gradient rollout. Two items belong here:
+> **Rollout correction (2026-05-21).** An earlier draft of this section
+> framed B1 as needing "its own plan, careful/symbol-gradient rollout"
+> and "out of scope" — shadow-rollout scaffolding that predates the
+> Yeheva correction. That stale framing was cited to defer B1 while M
+> and FAST_ADVERSE_EXIT stayed dead. **Superseded:** B1 ships under
+> Yeheva discipline — pre-flight (consumer audit + canonical reads +
+> data calibration) + revert gates (flag + Φ-peg / consumer-throw) +
+> attentive live monitoring for the first hours post-ship. Shadow
+> phases and soak periods are *not* the default for canonical fixes to
+> a live impaired kernel; the operator's direct-ship authority governs.
 
-- **B1** — remove the off-canon `norm01` pre-squash; adopt canonical `to_simplex` (clip-ε + divide-by-sum).
-- **Timeframe / lookback spec** — operator spec (memory `polytrade-perception-timeframe-spec`): perception lookback must reach **≥ 64 days** across a **timeframe ladder up to 1d candles**. Current kernel tops out at 4h / ~5 days — macro-blind. Clean fit: add a `1d` rung; a 64-bar window on 1d = 64 days = `BASIN_DIM`-coherent.
+B1 touches `perceive()` — blast radius is the basin → cell
+classification, `basinDir`, `drift`, regime, `fHealth`. **Not a
+prerequisite for B3** (B3 runs on `bv`).
 
-Out of scope for this (B3) plan.
+**B1-2026-05-21 (shipped):** the off-canon `norm01` *sigmoid* pre-squash
+crushed the momentum band into [0.45,0.55] on the realized log-return
+distribution (BTC+ETH, 1000 candles — |logReturn| p50 0.0022, p90
+0.0085) → near-uniform basin → `|basinDir|` pinned < 0.05, so the
+magnitude gates (M-agent + FAST_ADVERSE_EXIT @ 0.10) never fired.
+Replaced with a linear, expressive, 0.5-neutral `momentumCoord`
+(gain 50 = `trendProxy`'s in-file log-return sensitivity), flag-gated
+`MONKEY_PERCEPTION_EXPRESSIVE_LIVE`. Plus a `structuralVetoMonitor` —
+the kernel observing its own dead gates. `perceive()` already ends in
+canonical `toSimplex`; removing the sigmoid is the fix.
+
+**B1 follow-on — volatility band (specced, not deferred-blind):** the
+volatility band (15..22) is also crushed by `norm01` (pinned ~0.53).
+But it is a *direction-agnostic peer band* feeding `basinDirection`'s
+#880 observer-derived neutral (`8·mean(p[15:31])`). Naïvely steepening
+it as an unsigned magnitude shifts `peerMean` and would **invert the
+basinDir sign** (always-short) — evidenced by the calibration data.
+The correct fix encodes volatility as a *signed deviation from its own
+rolling-typical* (0.5-neutral, like momentum), co-designed with the
+basinDirection neutral and validated against `basinDirection.test.ts`'s
+production-shape tests. That is the next B1 increment.
+
+**B1 follow-on — timeframe / lookback:** operator spec (memory
+`polytrade-perception-timeframe-spec`): perception lookback must reach
+**≥ 64 days** across a **timeframe ladder up to 1d candles**. Current
+kernel tops out at 4h / ~5 days — macro-blind. Add a `1d` rung; a
+64-bar window on 1d = 64 days = `BASIN_DIM`-coherent.
 
 ## 8. Observer-derived calibration — follow-up (no env knobs)
 

--- a/ml-worker/src/monkey_kernel/executive.py
+++ b/ml-worker/src/monkey_kernel/executive.py
@@ -1426,12 +1426,15 @@ def choose_lane(
     return {
         "value": lane,
         "reason": (
-            f"lane={lane}{fallback_note} (tau={tau:.4f}, "
+            # No `tau`: choose_lane is parameter-free since the Δ³
+            # simplex projection replaced the softmax (PR #809). The
+            # reason/derivation referenced a `tau` that no longer
+            # exists — a NameError on every non-stud call. Removed.
+            f"lane={lane}{fallback_note} ("
             f"scalp={probs.get('scalp', 0):.3f} swing={probs.get('swing', 0):.3f} "
             f"trend={probs.get('trend', 0):.3f} observe={probs.get('observe', 0):.3f})"
         ),
         "derivation": {
-            "tau": tau,
             "raw_scores": scores,
             "softmax_probs": probs,
             "phi": s.phi,

--- a/ml-worker/src/monkey_kernel/perception.py
+++ b/ml-worker/src/monkey_kernel/perception.py
@@ -25,6 +25,7 @@ version stays live until v0.7.10 cuts loop.ts over.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -84,6 +85,24 @@ def _norm01(x: float, scale: float = 1.0) -> float:
         return 0.5
     y = 1.0 / (1.0 + float(np.exp(-x / scale)))
     return max(0.0, min(1.0, y))
+
+
+# B1 (2026-05-21) — momentum basin coordinate: linear, expressive,
+# 0.5-neutral. Mirror of perception.ts:momentumCoord — see that file
+# for the full rationale. Summary: norm01's sigmoid saturated the
+# momentum band into [0.45,0.55] on the realized log-return
+# distribution → near-uniform basin → |basinDirection| < 0.05 → the
+# magnitude gates (M-agent, FAST_ADVERSE_EXIT) never fired. The linear
+# map keeps the 0.5 neutral (so basinDirection's #880 neutral is
+# unaffected) but is expressive. GAIN 50 = trendProxy's existing
+# log-return sensitivity.
+_MOMENTUM_GAIN = 50.0
+
+
+def _momentum_coord(log_ret: float) -> float:
+    if not np.isfinite(log_ret):
+        return 0.5
+    return max(0.02, min(1.0, 0.5 + _MOMENTUM_GAIN * log_ret))
 
 
 def _clip01(x: float) -> float:
@@ -155,9 +174,13 @@ def perceive(inputs: PerceptionInputs) -> np.ndarray:
     v[5] = 0.5 if sig == "HOLD" else max(0.01, 1.0 - inputs.ml_strength)
     v[6] = inputs.ml_effective_strength
 
-    # dims 7..14 — Momentum spectrum
+    # dims 7..14 — Momentum spectrum.
+    # B1: linear expressive encoding (_momentum_coord), flag-gated.
+    # MONKEY_PERCEPTION_EXPRESSIVE_LIVE=false reverts to norm01.
+    _expressive_mom = os.environ.get("MONKEY_PERCEPTION_EXPRESSIVE_LIVE") != "false"
     for i, n in enumerate([1, 2, 3, 5, 8, 13, 21, 34]):
-        v[7 + i] = _norm01(_log_return(ohlcv, n), 0.01)
+        _lr = _log_return(ohlcv, n)
+        v[7 + i] = _momentum_coord(_lr) if _expressive_mom else _norm01(_lr, 0.01)
 
     # dims 15..22 — Volatility spectrum
     for i, n in enumerate([4, 8, 14, 21, 34, 55, 89, 144]):


### PR DESCRIPTION
## Summary

B1 perception-layer fix — un-flattens the basin so the directional gates that read it can fire. Ships under **Yeheva discipline** (pre-flight + revert gate + live monitoring), not shadow rollout.

## The bug

`norm01` applies a **sigmoid** pre-squash to the momentum band (basin dims 7..14). On the realized 15m log-return distribution (BTC+ETH, 1000 candles, 2026-05-21 — `|logReturn|` p50 **0.0022**, p90 **0.0085**) the sigmoid crushed every momentum dim into **[0.45, 0.55]** → near-uniform basin → `|basinDirection|` structurally pinned **< 0.05**.

The magnitude gates that read it could therefore never fire:
- **M-agent** and **FAST_ADVERSE_EXIT** — gated `|basinDir| > 0.10`
- **modes.ts `hasDirection`** — gated `> 0.30`

→ the operator-reported dead M-agent and dead loss-cut. Production confirms it live: `basinDir` 0.048–0.085 every tick, never reaching 0.10. CC2's #880 fixed the basinDir **sign**; this fixes the **magnitude**.

## Fix

- **`perception.ts` / `perception.py`** — momentum dims use a linear, expressive, **0.5-neutral** `momentumCoord` instead of the sigmoid. Keeps the exact 0.5 neutral (`logReturn 0 → 0.5`), so basinDirection's #880 observer-derived neutral is **unaffected** — only the momentum band changes; the volatility/volume peer bands are untouched, so the direction **sign cannot invert**. Gain `50` = `trendProxy()`'s existing in-file log-return sensitivity (not a new knob). Flag-gated `MONKEY_PERCEPTION_EXPRESSIVE_LIVE` (default on; `=false` reverts to the sigmoid instantly).
- **`structural_veto_monitor.ts`** — tracks named boolean gates across ticks, flags any stuck at one value for ≥ 200 ticks. The kernel observing its own dead gates. Wired to the `|basinDir|` magnitude gates in `loop.ts` — this is how production confirms B1 un-sticks them.
- **`executive.py`** — fix a `NameError`: `choose_lane`'s reason/derivation referenced a `tau` removed when the Δ³ simplex projection replaced the softmax (#809). Every non-stud `choose_lane` call raised. Found by the B1 test run.
- **plan doc §7** — rewritten: B1 ships under Yeheva discipline, not shadow rollout. The volatility-band follow-on is specced with its **peer-skew sign-inversion hazard** documented (steepening volatility as an unsigned magnitude would shift `peerMean` and invert basinDir to always-short — the volatility fix needs a signed-deviation co-design with the basinDirection neutral).

## Pre-flight (Yeheva)

- Canonical `to_simplex` read from `QIG_QFI/qig-core` (read-only) — canon is linear shift-and-scale, never per-dim sigmoid.
- Consumer audit: basinDirection (re-normalizes internally), agent_L_classifier, modes.ts, regimeSizing, per_agent_foresight, regime.ts (observer-derived boundaries — adapt automatically). Φ is decoupled (B3 leaky-integrator runs on `bv`, not basin entropy).
- Calibration: gain derived from 1000 real candles, not intuition.

## Revert gate

`MONKEY_PERCEPTION_EXPRESSIVE_LIVE=false` → instant revert to the legacy sigmoid.

## Gates

- `yarn build` (api + web) — green
- `vitest run` (apps/api) — **1636 passed** / 12 skipped; new `perceptionExpressive` suite confirms `perceive()→basinDirection()` reaches the 0.10 gate on a trend and stays ~0 on a flat market
- `pytest` (ml-worker) — **1013 passed** / 7 skipped (was 1 failing on the `tau` NameError — now fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an expressive, flag-gated momentum encoding for the perception basin and add telemetry to detect structurally dead gates, while fixing a lane-selection NameError and updating the B1 rollout plan to Yeheva discipline.

New Features:
- Add a linear, 0.5-neutral momentum coordinate for the basin momentum spectrum, flag-gated via MONKEY_PERCEPTION_EXPRESSIVE_LIVE in both API and ML worker.
- Introduce a structural veto monitor that tracks boolean gates over time and logs when they appear structurally stuck, with wiring for basinDirection magnitude gates.

Bug Fixes:
- Restore M-agent and FAST_ADVERSE_EXIT magnitude gating by replacing the saturating sigmoid normalization that pinned basinDirection magnitude.
- Fix a NameError in executive.choose_lane by removing stale references to a non-existent tau parameter from reason and derivation metadata.

Enhancements:
- Document and scope B1 follow-ons for volatility-band encoding and extended perception lookback as part of the Yeheva rollout discipline.
- Expose structural veto state via a snapshot API for better observability of gate health.

Documentation:
- Rewrite the perception-layer workstream section of the 20260521 phi leaky-integrator plan to describe B1 as a Yeheva-disciplined canonical fix, with documented volatility and timeframe follow-ons.

Tests:
- Add perceptionExpressive tests that validate basinDirection behaviour on synthetic trends and compare expressive momentum encoding against the legacy sigmoid.
- Add tests for the structural veto monitor to ensure stuck-gate detection and un-stuck logging behaviour.