### PR TITLE
feat(monkey): surface kernel directional lean in [Consensus] log

### DIFF
--- a/apps/api/src/services/monkey/__tests__/consensusArbiter.test.ts
+++ b/apps/api/src/services/monkey/__tests__/consensusArbiter.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { computeConsensus, type ConsensusInputs } from '../consensus_arbiter.js';
+import { logger } from '../../../utils/logger.js';
+import {
+  computeAndLogConsensus,
+  computeConsensus,
+  type ConsensusInputs,
+} from '../consensus_arbiter.js';
 import type { ProposalEvent } from '../proposal_bus.js';
 import type { RegimeMatrix } from '../wr_matrix.js';
 
@@ -213,5 +218,42 @@ describe('computeConsensus — rethink trigger', () => {
     expect(d.verdict).toBe('single-kernel');
     expect(d.size_usdt).toBe(15);  // 30 × 0.5
     expect(d.telemetry.rethink_active).toBe(true);
+  });
+});
+
+describe('computeAndLogConsensus — [Consensus] log telemetry', () => {
+  it('logs the kernel directional lean even when the executed side is null (hold)', () => {
+    const spy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    try {
+      const inputs = baseInputs({
+        peerProposal: null,
+        ownProposal: makeProposal({ proposed_action: 'hold', side: null }),
+        ownLean: 'long',
+      });
+      const decision = computeAndLogConsensus(inputs);
+      // Execution side stays null — a hold opens no trade. Correct by design.
+      expect(decision.side).toBeNull();
+      // The log line still surfaces the geometric lean so a hold is not an
+      // observability black hole when debugging directional bias.
+      const lastCall = spy.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe('[Consensus]');
+      expect(lastCall?.[1]).toMatchObject({ side: null, lean: 'long' });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('lean falls back to flat when no directional read is supplied', () => {
+    const spy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+    try {
+      const inputs = baseInputs({
+        peerProposal: null,
+        ownProposal: makeProposal({ proposed_action: 'hold', side: null }),
+      });
+      computeAndLogConsensus(inputs);
+      expect(spy.mock.calls.at(-1)?.[1]).toMatchObject({ lean: 'flat' });
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/apps/api/src/services/monkey/consensus_arbiter.ts
+++ b/apps/api/src/services/monkey/consensus_arbiter.ts
@@ -70,6 +70,13 @@ export interface ConsensusInputs {
   /** Per-engine loss bookkeeping for RETHINK trigger. */
   consecutiveLosses: { self: number; peer: number };
   cumulativeLoss: { self: number; peer: number };
+  /**
+   * Self kernel's geometric directional read for this tick (basinDir +
+   * tape). Telemetry-only — distinct from the executable `side`, which is
+   * null on a hold. Logging the lean keeps a hold from being an
+   * observability black hole when debugging directional bias.
+   */
+  ownLean?: 'long' | 'short' | 'flat';
 }
 
 export type ConsensusVerdict =
@@ -316,7 +323,11 @@ export function computeAndLogConsensus(inputs: ConsensusInputs): ConsensusDecisi
     symbol: inputs.ownProposal.symbol,
     verdict: decision.verdict,
     action: decision.action,
+    // `side` is the executable trade side — null on a hold, by design.
+    // `lean` is the kernel's geometric directional read, surfaced even on
+    // holds so the [Consensus] line matches the [Monkey] tick telemetry.
     side: decision.side,
+    lean: inputs.ownLean ?? 'flat',
     size_usdt: decision.size_usdt,
     leverage: decision.leverage,
     self_wr: decision.telemetry.self_wr,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -3893,6 +3893,7 @@ export class MonkeyKernel extends EventEmitter {
           bankSize: bankSize ?? 0,
           consecutiveLosses: { self: 0, peer: 0 },  // wired via CB state in follow-up
           cumulativeLoss: { self: 0, peer: 0 },     // wired via CB state in follow-up
+          ownLean: direction,  // geometric lean — surfaced on holds too
         });
 
         consensusOverride = {


### PR DESCRIPTION
## What

The `[Consensus]` log line showed `"side":null` on every **hold** tick. Investigating the `side:null` flagged during the "only longs" directional-bias work confirmed it is **correct by design** — `consensus_arbiter.ts` returns `side: own.side`, and the K proposal sets `side` only for entry actions. A hold opens no trade, so there is no executable side.

But the bare `null` left the log uninformative *precisely* when an operator is debugging directional bias: the `[Monkey]` tick log already carries the kernel's geometric directional read, while `[Consensus]` did not — the two lines disagreed for the same tick.

## Change

- `ConsensusInputs` gains an optional `ownLean?: 'long' | 'short' | 'flat'`.
- `computeAndLogConsensus` logs it as `lean` (falls back to `'flat'`).
- `loop.ts` threads the existing `direction` (basinDir + tape → `kernelDirection`) through.

`side` (the executable trade side) is **untouched** — still `null` on holds, so execution semantics do not change. `lean` is telemetry-only.

A hold now reads `side:null, lean:"long"` — the kernel's directional lean is visible even when it does not act, consistent with the `[Monkey]` tick telemetry.

## Test

TDD: two new tests in `consensusArbiter.test.ts` (RED → GREEN) assert the `[Consensus]` payload carries `lean` on a hold and falls back to `flat` when no read is supplied.

- `vitest run` consensus suite: 13/13 ✅
- Full main-tree monkey suite: 836/836 ✅
- `tsc --noEmit` apps/api: clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface the kernel’s directional lean in the [Consensus] log without changing execution behavior, improving observability of holds and directional bias.

New Features:
- Add optional ownLean directional field to consensus inputs and log it as lean alongside side in [Consensus] telemetry.

Enhancements:
- Thread the existing kernel direction through the monkey loop into consensus evaluation so holds expose the kernel’s geometric lean in logs.

Tests:
- Add tests verifying [Consensus] logging preserves side:null on holds while emitting the kernel lean, and falls back to flat when no lean is provided.