### PR TITLE
fix(monkey): B1.1 — noise-floor-anchored exact neutral for basinDirection

### DIFF
--- a/apps/api/src/services/monkey/__tests__/basinDirection.test.ts
+++ b/apps/api/src/services/monkey/__tests__/basinDirection.test.ts
@@ -275,3 +275,89 @@ describe('basinDirection — production basin shape (only-longs regression)', ()
     expect(d).toBeGreaterThan(0);
   });
 });
+
+// --- Skewed peer bands (B1.1 noise-floor-anchor regression) --------------
+// makeProductionShapedBasin() above sets the volatility + volume peer bands
+// to a uniform 0.5, so #880's `8·peerMean` neutral is coincidentally exact.
+// The REAL perceive() volume band is NOT 0.5-centred: it encodes
+// norm01(log(volRatio)) and volRatio runs mostly < 1, so volume dims sit
+// ~0.40. That biased `8·peerMean` LOW → momMass cleared it even on a
+// downtrend → sign pinned +1 (the post-#882 "still only longs" finding).
+//
+// B1.1 anchors the neutral to the noise floor instead — dims 39..54 are a
+// known fixed raw NOISE_FLOOR_VALUE, so they pin the simplex scale and the
+// neutral momentum share is exact, with zero dependence on the peer bands.
+
+/** Production-shaped basin with an independently skewable volume band. */
+function makeSkewedProductionBasin(momValue: number, volumeValue: number): Basin {
+  const v = new Float64Array(BASIN_DIM);
+  for (let i = 0; i < 3; i++) v[i] = 1 / 3;
+  v[3] = 0.01; v[4] = 0.01; v[5] = 0.5; v[6] = 0.0;
+  for (let i = 7; i <= 14; i++) v[i] = momValue;        // momentum spectrum
+  for (let i = 15; i <= 22; i++) v[i] = 0.5;            // volatility peer band
+  for (let i = 23; i <= 30; i++) v[i] = volumeValue;    // volume peer band — skewed
+  for (let i = 31; i <= 38; i++) v[i] = 0.5;
+  for (let i = 39; i <= 54; i++) v[i] = 0.0055;         // noise floor — the anchor
+  v[55] = 0.3; v[56] = 0.2; v[57] = 0.1; v[58] = 0.1;
+  for (let i = 59; i < 64; i++) v[i] = 0.01;
+  return toSimplex(v);
+}
+
+describe('basinDirection — skewed volume band (B1.1 noise-floor anchor)', () => {
+  const FLAG = 'MONKEY_PERCEPTION_EXPRESSIVE_LIVE';
+
+  function withFlag(value: string | undefined, fn: () => void): void {
+    const orig = process.env[FLAG];
+    if (value === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = value;
+    try { fn(); }
+    finally {
+      if (orig === undefined) delete process.env[FLAG];
+      else process.env[FLAG] = orig;
+    }
+  }
+
+  it('the peer-derived fallback IS skewed by a low volume band (the bug)', () => {
+    // Flag off → basinDirection falls back to #880's 8·peerMean. A
+    // downtrend (mom 0.45) with a low volume band (0.35) misreads as
+    // positive — this is the production "only longs" sign-pin.
+    withFlag('false', () => {
+      const d = basinDirection(makeSkewedProductionBasin(0.45, 0.35));
+      expect(d).toBeGreaterThan(0);
+    });
+  });
+
+  it('the noise-floor anchor reads the same downtrend as negative (the fix)', () => {
+    // Flag on (default) → noise-floor-anchored neutral. Same skewed basin,
+    // correct sign.
+    withFlag(undefined, () => {
+      const d = basinDirection(makeSkewedProductionBasin(0.45, 0.35));
+      expect(d).toBeLessThan(0);
+    });
+  });
+
+  it('a flat market reads ~ 0 even when the volume band is skewed', () => {
+    withFlag(undefined, () => {
+      const d = basinDirection(makeSkewedProductionBasin(0.5, 0.35));
+      expect(Math.abs(d)).toBeLessThan(1e-6);
+    });
+  });
+
+  it('an uptrend reads positive even when the volume band is skewed', () => {
+    withFlag(undefined, () => {
+      const d = basinDirection(makeSkewedProductionBasin(0.60, 0.35));
+      expect(d).toBeGreaterThan(0);
+    });
+  });
+
+  it('the anchor is monotone in momentum, immune to the volume skew', () => {
+    withFlag(undefined, () => {
+      let prev = -2;
+      for (const mom of [0.2, 0.35, 0.45, 0.5, 0.55, 0.65, 0.8]) {
+        const d = basinDirection(makeSkewedProductionBasin(mom, 0.35));
+        expect(d).toBeGreaterThanOrEqual(prev - 1e-9);
+        prev = d;
+      }
+    });
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/perceptionExpressive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/perceptionExpressive.test.ts
@@ -1,11 +1,15 @@
 /**
- * B1 — expressive momentum basin. The pre-B1 norm01 sigmoid crushed the
- * momentum band into [0.45,0.55] on the realized log-return distribution
- * → near-uniform basin → |basinDirection| pinned < 0.05 → the magnitude
- * gates (M-agent + FAST_ADVERSE_EXIT @ 0.10) could never fire.
+ * B1 — expressive momentum basin + B1.1 noise-anchored neutral.
  *
- * These tests run the real perceive() → basinDirection() path on
- * synthetic trends and assert the expressive encoding reaches the gate.
+ * The pre-B1 norm01 sigmoid crushed the momentum band into [0.45,0.55]
+ * on the realized log-return distribution → near-uniform basin →
+ * |basinDirection| pinned < 0.05 → the magnitude gates (M-agent +
+ * FAST_ADVERSE_EXIT @ 0.10) could never fire. B1.1 then fixed the
+ * neutral skew (#880's `8·peerMean` biased the sign +).
+ *
+ * These run the real perceive() → basinDirection() production path:
+ * expressive momentum + the noise-floor-anchored neutral (which
+ * engages automatically on a genuine perceive() basin).
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { perceive, basinDirection, type OHLCVCandle, type PerceptionInputs } from '../perception.js';
@@ -41,18 +45,15 @@ describe('B1 — expressive momentum basin', () => {
   afterEach(() => { delete process.env.MONKEY_PERCEPTION_EXPRESSIVE_LIVE; });
 
   it('uptrend → basinDirection reaches the 0.10 magnitude gate', () => {
-    const d = basinDirection(perceive(inputs(trendSeries(160, 0.003))));
-    expect(d).toBeGreaterThan(0.10);
+    expect(basinDirection(perceive(inputs(trendSeries(160, 0.003))))).toBeGreaterThan(0.10);
   });
 
   it('downtrend → basinDirection clearly negative past −0.10', () => {
-    const d = basinDirection(perceive(inputs(trendSeries(160, -0.003))));
-    expect(d).toBeLessThan(-0.10);
+    expect(basinDirection(perceive(inputs(trendSeries(160, -0.003))))).toBeLessThan(-0.10);
   });
 
   it('flat market → basinDirection stays near zero', () => {
-    const d = basinDirection(perceive(inputs(trendSeries(160, 0))));
-    expect(Math.abs(d)).toBeLessThan(0.05);
+    expect(Math.abs(basinDirection(perceive(inputs(trendSeries(160, 0)))))).toBeLessThan(0.05);
   });
 
   it('legacy sigmoid (flag off) is strictly less expressive on the same uptrend', () => {
@@ -61,5 +62,17 @@ describe('B1 — expressive momentum basin', () => {
     delete process.env.MONKEY_PERCEPTION_EXPRESSIVE_LIVE;
     const expressive = basinDirection(perceive(inputs(trendSeries(160, 0.003))));
     expect(expressive).toBeGreaterThan(legacy);
+  });
+
+  // B1.1 — noise-floor-anchored neutral. The pre-B1.1 `8·peerMean`
+  // neutral skewed low (the volume/volatility peer bands are not
+  // 0.5-centred) → basinDir was sign-pinned positive even on flat /
+  // mildly-down markets. The noise anchor makes the neutral exact.
+  it('neutral is unbiased — flat market reads ≈ 0 (not sign-pinned +)', () => {
+    expect(Math.abs(basinDirection(perceive(inputs(trendSeries(160, 0)))))).toBeLessThan(0.02);
+  });
+
+  it('neutral is unbiased — a mild down-drift reads negative', () => {
+    expect(basinDirection(perceive(inputs(trendSeries(160, -0.0006))))).toBeLessThan(0);
   });
 });

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2201,7 +2201,18 @@ export class MonkeyKernel extends EventEmitter {
     // existing ml-strength threshold below — a geometry-only TS
     // entry would require the full emotion stack ported. This is
     // the documented "TS counterpart for parity" path.
-    const basinDir = computeBasinDirection(basin);
+    // B1.1 — basinDir reads market DIRECTION, which lives in the RAW
+    // perception. The refracted `basin` is 70% frozen identity + 30%
+    // market (Pillar 2) — reading direction off it damps the market
+    // signal to 30% and muddies the sign. rawBasin is a verified
+    // perceive() output, so basinDirection's noise-floor neutral anchor
+    // engages exactly on it. Flag-gated with the rest of B1;
+    // MONKEY_PERCEPTION_EXPRESSIVE_LIVE=false reverts to the refracted
+    // basin (and basinDirection's #880 peerMean neutral).
+    const basinDir =
+      process.env.MONKEY_PERCEPTION_EXPRESSIVE_LIVE !== 'false'
+        ? computeBasinDirection(rawBasin)
+        : computeBasinDirection(basin);
     const tapeTrend = computeTrendProxy(ohlcv);
     state.latestBasinSnapshot = {
       basinDir,

--- a/apps/api/src/services/monkey/perception.ts
+++ b/apps/api/src/services/monkey/perception.ts
@@ -287,20 +287,21 @@ export function basinDirection(basin: Basin): number {
   // → basinDir sign pinned +1 (confirmed in production telemetry post-B1,
   // 2026-05-21). The noise anchor removes that skew.
   //
-  // Gate: MONKEY_PERCEPTION_EXPRESSIVE_LIVE on (momentumCoord active —
-  // the 0.5-neutral guarantee holds) AND the noise band reads as a
-  // genuine sub-uniform floor. A real perceive() noise band is ~0.5% of
-  // the basin (16 × 0.0055 raw out of T ≈ 17); a noiseSum ceiling of
-  // 0.05 (5%) clears that with a ~10× margin and excludes hand-built
-  // uniform test basins, where the "noise" dims sit at ~25% of the
-  // basin. Else fall back to #880's peerMean, then the 8/64 fallback.
+  // The anchor is EXACT only on a genuine perceive() output (noise dims
+  // at raw NOISE_FLOOR_VALUE). It self-detects that: a real perceive()
+  // noise band is 16 × 0.0055 raw ≈ 0.4–0.9% of the basin (T ≈ 10–20).
+  // The `noiseSum < 0.02` guard (2%) sits ~3× above that and well below
+  // any hand-built uniform-ish basin (whose 16 "noise" dims carry ≥4%)
+  // — so synthetic test fixtures and non-perceive basins fall through
+  // to #880's peerMean, no regression. MONKEY_PERCEPTION_EXPRESSIVE_LIVE
+  // =false reverts the whole B1 path. Final fallback: the 8/64 constant.
   let neutralMomMass: number;
   let noiseSum = 0;
   for (let i = 39; i <= 54; i++) noiseSum += p[i]!;
   if (
     process.env.MONKEY_PERCEPTION_EXPRESSIVE_LIVE !== 'false'
     && noiseSum > EPS
-    && noiseSum < 0.05
+    && noiseSum < 0.02
   ) {
     const noiseMean = noiseSum / 16;
     neutralMomMass = (8 * 0.5 * noiseMean) / NOISE_FLOOR_VALUE;

--- a/apps/api/src/services/monkey/perception.ts
+++ b/apps/api/src/services/monkey/perception.ts
@@ -144,6 +144,16 @@ function momentumCoord(logRet: number): number {
   return Math.min(1, Math.max(0.02, y));
 }
 
+/**
+ * Noise-floor raw value — dims 39..54 of every `perceive()` basin are
+ * pinned to this constant (Pillar 1 fluctuation reservoir). Because it
+ * is a *known fixed raw value*, the noise band pins the simplex scale
+ * `T`: after `toSimplex`, `p[noise] = NOISE_FLOOR_VALUE / T`, so
+ * `T = NOISE_FLOOR_VALUE / mean(p[39..54])`. `basinDirection` uses this
+ * to recover an EXACT neutral-momentum reference (B1.1).
+ */
+export const NOISE_FLOOR_VALUE = 0.0055;
+
 function clip01(x: number): number {
   if (!Number.isFinite(x)) return 0;
   return Math.min(1, Math.max(0, x));
@@ -256,21 +266,50 @@ export function basinDirection(basin: Basin): number {
     p[i] = Math.max(0, basin[i] ?? 0) / total;
   }
 
-  // Step 1: momentum-band mass and observer-derived neutral.
+  // Step 1: momentum-band mass and neutral reference.
   let momMass = 0;
   for (let i = 7; i <= 14; i++) momMass += p[i]!;
-  // Observer-derived neutral (P1 — no hardcoded knob). The momentum
-  // band's mass when momentum is NEUTRAL equals 8× the per-dim mass of
-  // its direction-agnostic peer bands: volatility (15..22) and volume
-  // (23..30) carry magnitude, not sign. A hardcoded 8/64 holds only for
-  // a uniform basin; perceive()'s 16 noise-floor dims (39..54 @ 0.0055)
-  // sit below uniform and force every other dim's share above uniform,
-  // so momMass exceeds 8/64 even on a flat market. Deriving the neutral
-  // from the basin's own peer bands self-corrects for that.
-  let peerSum = 0;
-  for (let i = 15; i <= 30; i++) peerSum += p[i]!;
-  const peerMean = peerSum / 16;
-  const neutralMomMass = peerMean > EPS ? 8 * peerMean : MOM_NEUTRAL_FALLBACK;
+  // B1.1 — noise-floor-anchored neutral (EXACT; supersedes #880's
+  // `8·peerMean` estimate).
+  //
+  // The momentum band is built by `momentumCoord`, which is 0.5-neutral
+  // by construction (logReturn 0 → 0.5 raw). So a neutral momentum band
+  // weighs 8 × 0.5 = 4 in raw (pre-toSimplex) units. The noise band
+  // (dims 39..54) is a fixed raw NOISE_FLOOR_VALUE per dim — it pins the
+  // simplex scale `T = NOISE_FLOOR_VALUE / noiseMean`, so the neutral
+  // momentum p-share is exact: (8·0.5)/T = 4·noiseMean/NOISE_FLOOR_VALUE.
+  // The sign test then reduces exactly to `mean(momentum dim) ≥ 0.5`.
+  //
+  // #880's `8·peerMean` averaged the volatility+volume bands as a proxy
+  // for "neutral per-dim mass" — but those bands are NOT 0.5-centred
+  // (volume's log(volRatio) runs mostly negative → volume dims ~0.40),
+  // so the neutral skewed low → momMass > neutral even on a flat market
+  // → basinDir sign pinned +1 (confirmed in production telemetry post-B1,
+  // 2026-05-21). The noise anchor removes that skew.
+  //
+  // Gate: MONKEY_PERCEPTION_EXPRESSIVE_LIVE on (momentumCoord active —
+  // the 0.5-neutral guarantee holds) AND the noise band reads as a
+  // genuine sub-uniform floor. A real perceive() noise band is ~0.5% of
+  // the basin (16 × 0.0055 raw out of T ≈ 17); a noiseSum ceiling of
+  // 0.05 (5%) clears that with a ~10× margin and excludes hand-built
+  // uniform test basins, where the "noise" dims sit at ~25% of the
+  // basin. Else fall back to #880's peerMean, then the 8/64 fallback.
+  let neutralMomMass: number;
+  let noiseSum = 0;
+  for (let i = 39; i <= 54; i++) noiseSum += p[i]!;
+  if (
+    process.env.MONKEY_PERCEPTION_EXPRESSIVE_LIVE !== 'false'
+    && noiseSum > EPS
+    && noiseSum < 0.05
+  ) {
+    const noiseMean = noiseSum / 16;
+    neutralMomMass = (8 * 0.5 * noiseMean) / NOISE_FLOOR_VALUE;
+  } else {
+    let peerSum = 0;
+    for (let i = 15; i <= 30; i++) peerSum += p[i]!;
+    const peerMean = peerSum / 16;
+    neutralMomMass = peerMean > EPS ? 8 * peerMean : MOM_NEUTRAL_FALLBACK;
+  }
   const sign = momMass >= neutralMomMass ? 1 : -1;
 
   // Step 2: build the no-momentum antipode.
@@ -455,7 +494,7 @@ export function perceive(inputs: PerceptionInputs): Basin {
   // Python port. A non-zero floor is the Pillar 1 requirement; per-tick
   // variance was decorative. toSimplex normalises so uniform mass still
   // keeps the basin off the boundary.
-  for (let i = 39; i < 55; i++) v[i] = 0.0055;
+  for (let i = 39; i < 55; i++) v[i] = NOISE_FLOOR_VALUE;
 
   // dims 55..63 — Account/coupling (9 dims)
   v[55] = clip01(inputs.equityFraction);

--- a/ml-worker/src/monkey_kernel/perception_scalars.py
+++ b/ml-worker/src/monkey_kernel/perception_scalars.py
@@ -19,6 +19,7 @@ similarity, no Adam-style gradient steps.
 
 from __future__ import annotations
 
+import os
 from typing import Sequence
 
 import numpy as np
@@ -28,6 +29,11 @@ import numpy as np
 # the alternative is a top-level circular import via the kernel
 # barrel module.
 _FR_DIAMETER = float(np.pi / 2.0)  # max Fisher-Rao distance on Δⁿ
+
+# Noise-floor raw value — dims 39..54 of every perceive() basin are
+# pinned here (mirror of perception.ts:NOISE_FLOOR_VALUE). basin_direction
+# uses it as the exact simplex-scale anchor for the neutral reference.
+_NOISE_FLOOR_VALUE = 0.0055
 
 
 def basin_direction(basin: np.ndarray) -> float:
@@ -108,20 +114,39 @@ def basin_direction(basin: np.ndarray) -> float:
 
     mom_mass = float(np.sum(p[7:15]))
 
-    # Observer-derived neutral reference (P1 — no hardcoded knob, per
-    # the perception-workstream §8 directive). The momentum band's mass
-    # when momentum is NEUTRAL equals 8× the per-dim mass of its
-    # direction-agnostic peer bands: volatility (15..22) and volume
-    # (23..30) carry magnitude, not sign. A hardcoded 8/64 holds only
-    # for a uniform basin; perceive()'s 16 noise-floor dims (39..54,
-    # pinned 0.0055) sit below uniform and force every other dim's
-    # share above uniform — so mom_mass exceeds 8/64 even on a flat
-    # market. Deriving the neutral from the basin's own peer bands
-    # self-corrects for whatever the noise floor does.
-    peer_mean = float(np.mean(p[15:31]))  # 16 direction-agnostic dims
-    neutral_mom_mass = (
-        8.0 * peer_mean if peer_mean > EPS else MOM_NEUTRAL_FALLBACK
-    )
+    # B1.1 — noise-floor-anchored neutral (EXACT). Mirror of
+    # perception.ts:basinDirection — see that file for the full
+    # rationale. The momentum band is built 0.5-neutral (momentum_coord /
+    # _momentum_coord), so a neutral momentum band weighs 8×0.5=4 raw.
+    # The noise band (39..54) is a fixed raw _NOISE_FLOOR_VALUE per dim,
+    # which pins the simplex scale T = _NOISE_FLOOR_VALUE / noise_mean —
+    # making the neutral momentum p-share exact:
+    # (8·0.5)·noise_mean / _NOISE_FLOOR_VALUE.
+    #
+    # Supersedes #880's `8·peer_mean`: the volatility+volume peer bands
+    # are NOT 0.5-centred (volume's log(volRatio) runs mostly negative),
+    # so that estimate skewed low → sign pinned +1 even on a flat market
+    # (production telemetry post-B1, 2026-05-21).
+    #
+    # The anchor is EXACT only on a genuine perceive() output (noise
+    # dims at raw _NOISE_FLOOR_VALUE). It self-detects that: a real
+    # perceive() noise band is ~0.4–0.9% of the basin, so the
+    # `noise_sum < 0.02` guard (2%) engages on genuine basins and falls
+    # through to #880's peer_mean for synthetic / non-perceive basins
+    # (no regression). Gated MONKEY_PERCEPTION_EXPRESSIVE_LIVE. Final
+    # fallback: the 8/64 degenerate constant.
+    noise_sum = float(np.sum(p[39:55]))  # 16 noise-floor dims
+    if (
+        os.environ.get("MONKEY_PERCEPTION_EXPRESSIVE_LIVE") != "false"
+        and EPS < noise_sum < 0.02
+    ):
+        noise_mean = noise_sum / 16.0
+        neutral_mom_mass = (8.0 * 0.5 * noise_mean) / _NOISE_FLOOR_VALUE
+    else:
+        peer_mean = float(np.mean(p[15:31]))  # 16 direction-agnostic dims
+        neutral_mom_mass = (
+            8.0 * peer_mean if peer_mean > EPS else MOM_NEUTRAL_FALLBACK
+        )
     sign = 1.0 if mom_mass >= neutral_mom_mass else -1.0
 
     # Build the no-momentum antipode: rescale the momentum band so its


### PR DESCRIPTION
## Summary

Completes B1. #882 made the momentum band expressive; production telemetry then showed `basinDir` **still sign-pinned slightly positive** (~+0.02, `side=long` even when tape was negative). This fixes the residual: `basinDirection()`'s neutral reference.

## Root cause

#880's neutral — `8·peerMean` over the volatility+volume bands — is **skewed**. Those peer bands are not 0.5-centred (volume's `log(volRatio)` runs mostly negative → volume dims average ~0.40), so the neutral sat *below* true neutral → `momMass > neutral` even on a flat market → sign pinned `+1`.

## Fix — exact neutral from the noise floor

`momentumCoord` (B1) is **0.5-neutral by construction**, so a neutral momentum band weighs `8 × 0.5 = 4` in raw (pre-`toSimplex`) units. The noise band (dims 39..54) is a fixed raw `NOISE_FLOOR_VALUE` per dim — it **pins the simplex scale** `T = NOISE_FLOOR_VALUE / noiseMean`, making the neutral momentum share **exact**: `4·noiseMean/NOISE_FLOOR_VALUE`. The sign test then reduces exactly to `mean(momentum dim) ≥ 0.5` — no peer-band skew.

- **`perception.ts` / `perception_scalars.py`** — `basinDirection` derives the neutral from the noise floor. Engages only when the noise band reads as a genuine sub-uniform floor (`noiseSum < 0.02` — a real `perceive()` noise band is ~0.5% of the basin; synthetic/non-perceive basins carry ≥4% there and fall through to #880's `peerMean`, **no regression**). Flag-gated `MONKEY_PERCEPTION_EXPRESSIVE_LIVE`; final fallback is the `8/64` constant.
- **`loop.ts`** — `basinDir` is computed from the **raw** perception (`rawBasin`), not the 70%-identity-refracted basin: direction is a market read, and `rawBasin` satisfies the noise-anchor precondition exactly. Flag-gated; `=false` reverts to the refracted basin + `peerMean`.

Matches the test contract merged in `2e08278f` (skewed-volume B1.1 regression suite, `makeSkewedProductionBasin`).

## Revert gate

`MONKEY_PERCEPTION_EXPRESSIVE_LIVE=false` → full B1+B1.1 revert (sigmoid momentum + `peerMean` neutral + refracted-basin direction).

## Gates

- `yarn build` (api + web) — green
- `vitest run` (apps/api) — **1645 passed** / 12 skipped (basinDirection B1.1 suite, agent_L, perceptionExpressive all green)
- `pytest` (ml-worker) — **1013 passed** / 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)