### PR TITLE
fix(monkey): honest telemetry — real phi/sov on AgentT orders, 'none' in [Consensus]

### DIFF
--- a/apps/api/src/services/monkey/__tests__/consensusArbiter.test.ts
+++ b/apps/api/src/services/monkey/__tests__/consensusArbiter.test.ts
@@ -236,13 +236,16 @@ describe('computeAndLogConsensus — [Consensus] log telemetry', () => {
         ownLean: 'long',
       });
       const decision = computeAndLogConsensus(inputs);
-      // Execution side stays null — a hold opens no trade. Correct by design.
+      // The decision's executable side stays null — a hold opens no
+      // trade. Correct by design.
       expect(decision.side).toBeNull();
-      // The log line still surfaces the geometric lean so a hold is not an
-      // observability black hole when debugging directional bias.
+      // The log line renders that as the string 'none' (not a bare
+      // null, so the line does not read as missing data) and still
+      // surfaces the geometric lean so a hold is not an observability
+      // black hole when debugging directional bias.
       const lastCall = spy.mock.calls.at(-1);
       expect(lastCall?.[0]).toBe('[Consensus]');
-      expect(lastCall?.[1]).toMatchObject({ side: null, lean: 'long' });
+      expect(lastCall?.[1]).toMatchObject({ side: 'none', lean: 'long' });
     } finally {
       spy.mockRestore();
     }

--- a/apps/api/src/services/monkey/consensus_arbiter.ts
+++ b/apps/api/src/services/monkey/consensus_arbiter.ts
@@ -323,10 +323,12 @@ export function computeAndLogConsensus(inputs: ConsensusInputs): ConsensusDecisi
     symbol: inputs.ownProposal.symbol,
     verdict: decision.verdict,
     action: decision.action,
-    // `side` is the executable trade side — null on a hold, by design.
-    // `lean` is the kernel's geometric directional read, surfaced even on
-    // holds so the [Consensus] line matches the [Monkey] tick telemetry.
-    side: decision.side,
+    // `side` is the executable trade side — 'none' on a hold, by design
+    // (logged as the string 'none', not a bare null, so the line does
+    // not read as missing data). `lean` is the kernel's geometric
+    // directional read, surfaced even on holds so the [Consensus] line
+    // matches the [Monkey] tick telemetry.
+    side: decision.side ?? 'none',
     lean: inputs.ownLean ?? 'flat',
     size_usdt: decision.size_usdt,
     leverage: decision.leverage,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -4590,13 +4590,15 @@ export class MonkeyKernel extends EventEmitter {
           leverage: tDecision.leverage,
           entryPrice: lastPrice,
           minNotional,
-          // T does not consume kernel state. Pass zeros for the
-          // K-only fields the executor uses for its reason-encoding;
-          // these are diagnostic, not used by the executor's risk
-          // logic. The agent='T' tag is what matters downstream.
-          phi: 0,
-          kappa: 0,
-          sovereignty: 0,
+          // T does not consume kernel state for its DECISION, but the
+          // executor stamps phi/kappa/sovereignty onto the ORDER PLACED
+          // log and the autonomous_trades `reason` string as "kernel
+          // state at order time". Pass the real tick values, not zeros,
+          // so an AgentT trade row does not read as a dead-kernel
+          // phi=0.000 / sov=0.000 (misleading telemetry — 2026-05-21).
+          phi,
+          kappa: state.kappa,
+          sovereignty,
           trajectoryId: null,
           isDCAAdd: false,
           dcaAddIndex: 0,


### PR DESCRIPTION
## Summary

Two misleading null/zero values surfaced in production logs (operator standing concern: a `null` / `0.00` in a log line should mean a bug, not be ambient noise).

### 1. `[Monkey] ORDER PLACED … "phi":"0.000","sov":"0.000"`

AgentT (turtle) entries called `executeEntry` with hardcoded `phi: 0, kappa: 0, sovereignty: 0`. AgentT doesn't consume kernel state for its *decision* — but the executor **stamps those fields onto the ORDER PLACED log and the `autonomous_trades.reason` string** as "kernel state at order time". So every AgentT trade row read as a dead-kernel `phi=0.000 / sov=0.000` even while the kernel's real Φ was ~0.6 and sovereignty 1.0.

Fix: pass the real tick values. No risk-logic change — those fields were always diagnostic-only for T; this just makes the telemetry honest.

### 2. `[Consensus] … "side":null`

`side` is genuinely null on a `hold` (a hold opens no trade — correct by design), but a bare `null` in the log line reads as missing data. Now rendered as the string `'none'`. The `ConsensusDecision.side` object field is **unchanged** (still `null`) — only the log render changes. Test updated.

## Gates

- `yarn build` (api + web) — green
- `vitest run` (apps/api) — **1658 passed** / 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)