### PR TITLE
fix(monkey): start the proposal-bus subscriber at kernel boot

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1080,6 +1080,19 @@ export class MonkeyKernel extends EventEmitter {
     // seed is in place when tick 1 reads `state.phiLeaky`.
     await this.seedLeakyPhiFromHistory();
 
+    // Consensus proposal bus — start the Redis subscriber so peer
+    // proposals land in the in-process peer map. `publishProposal` and
+    // `getRecentPeerProposal` were already wired, but nothing ever
+    // called `initProposalBus()` — so the subscriber never connected and
+    // `getRecentPeerProposal()` always returned null, pinning every
+    // arbiter verdict to `single-kernel` even with a live peer fanout.
+    // Idempotent; no-ops when CONSENSUS_PROPOSAL_BUS_LIVE is off;
+    // fail-soft (connect errors are swallowed inside initProposalBus).
+    try {
+      const { initProposalBus } = await import('./proposal_bus.js');
+      await initProposalBus();
+    } catch { /* fail-soft — arbiter falls back to single-kernel */ }
+
     // 2026-05-13 MTF Phase 2 — bootstrap per-timeframe basin
     // histories from historical OHLCV so the 4h classifier doesn't
     // need 80 days of live ticks to warm up. Async + fail-soft;


### PR DESCRIPTION
## The bug

`initProposalBus()` (connects the Redis subscriber for `monkey:consensus:proposal`) had **zero callers**. `publishProposal` and `getRecentPeerProposal` were wired, but the subscriber was never started — so `_peerProposals` was never populated and `getRecentPeerProposal()` always returned `null`.

Every consensus arbiter verdict was therefore pinned to `single-kernel`. Confirmed in production after #886 activated the Python peer fanout: ml-worker received the fanout (`POST /monkey/tick/run 200` repeatedly) and ran ticks, but the TS arbiter never saw a peer — `[Consensus]` stayed `verdict:single-kernel, peer_wr:0`.

## The fix

Call `initProposalBus()` once in `MonkeyKernel.start()`. Idempotent, no-ops when `CONSENSUS_PROPOSAL_BUS_LIVE` is off, fail-soft on Redis connect error (the kernel falls back to single-kernel rather than crashing).

This is the last wire of the consensus de-shadow (#884 plan → #886 implementation). With the subscriber running, the arbiter receives the live TS+Py peer pair and verdicts move off `single-kernel`.

## Verification

- `tsc --noEmit` apps/api — clean
- `consensusArbiter.test.ts` — 17/17

Boot-wiring (a single idempotent call in `start()`) — real verification is the production `[Consensus]` logs flipping to non-single-kernel verdicts, which I monitor post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the consensus proposal bus subscriber is initialized at kernel boot so getRecentPeerProposal returns live peer proposals instead of always null.