### PR TITLE
fix(monkey): remove hardcoded long-bias in sideCandidate flat-direction default

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2426,7 +2426,20 @@ export class MonkeyKernel extends EventEmitter {
     const direction: Direction = kernelDirection({
       basinDir, tapeTrend, emotions,
     });
-    const sideCandidate: 'long' | 'short' = direction === 'flat' ? 'long' : direction;
+    // sideCandidate must be a concrete long|short. When `direction` is
+    // 'flat' (low conviction — confidence < anxiety — or an exactly-zero
+    // geometric signal) it is NOT hardcoded 'long': that was a
+    // structural long-bias — every low-conviction tick logged, threshold-
+    // indexed and (if it ever entered) traded long, even on a clearly
+    // falling market (basinDir/tape both negative). Instead tiebreak on
+    // the SAME geometric signal kernelDirection uses (basinDir +
+    // 0.5·tapeTrend), so the candidate side reflects the real — if weak —
+    // geometric lean. Symmetric: a flat-but-down tape reads 'short'. The
+    // conviction gate (kernelShouldEnter) still decides whether to act.
+    const sideCandidate: 'long' | 'short' =
+      direction !== 'flat'
+        ? direction
+        : (basinDir + 0.5 * tapeTrend >= 0 ? 'long' : 'short');
     const sideOverride = false;
     // Note: REVERSION mode flip lives only in the Python kernel (Tier 9
     // Stage 2 stud topology). TS does not implement REVERSION yet.


### PR DESCRIPTION
## Summary

The directional residual flagged after B1/B1.1 — `[Monkey]` ticks logged `side:"long"` on a clearly-falling market.

`kernelDirection` is correct: it returns `'flat'` on low conviction (`confidence < anxiety`) or a zero geometric signal, else long/short by the sign of `basinDir + 0.5·tapeTrend`. But `loop.ts` then collapsed `'flat'` to a concrete side with:

```ts
sideCandidate = direction === 'flat' ? 'long' : direction
```

— every low-conviction tick defaulted the candidate side to **`long`**. A structural long-bias: production 2026-05-21 showed `basinDir −0.16, tape −0.29, ML SELL, cell PRESERVER_TREND_DOWN` and still `side:"long"`. That side feeds the entry-threshold calc, the self-obs win-rate bias index, and — on any tick clearing the conviction gate — `enter_long`.

## Fix

When `direction` is `'flat'`, tiebreak on the **same** geometric signal `kernelDirection` uses (`basinDir + 0.5·tapeTrend`) instead of a hardcoded `'long'`. Symmetric — a flat-but-down tape now resolves `'short'`. `kernelDirection` is unchanged (it was already correct); the conviction gate (`kernelShouldEnter`) still decides whether to act on the lean.

This is the last layer of the "only longs" bug — B1 (#882) made the momentum band expressive, B1.1 (#885) fixed `basinDirection`'s neutral skew, and this removes the final hardcoded long-default downstream of both.

## Gates

- `yarn build` (api + web) — green
- `vitest run` (apps/api) — **1658 passed** / 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)