### PR TITLE
fix(monkey): set engine_type on kernel trades so the arbiter can score them

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -7439,12 +7439,16 @@ export class MonkeyKernel extends EventEmitter {
             `INSERT INTO autonomous_trades
                (user_id, symbol, side, entry_price, quantity, leverage,
                 confidence, reason, order_id, paper_trade, engine_version, agent, lane,
-                take_profit, stop_loss)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+                take_profit, stop_loss, engine_type)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
             [
               userId, symbol, exchangeSide, paper.fillPrice, formattedSize, leverage,
               req.phi, reasonEncoded, orderId, true, getEngineVersion(), agentTag, laneTag,
-              tpPrice, slPrice,
+              // engine_type — consensus WR-matrix key; must match
+              // consensus_arbiter `selfEngineType` ('monkey-k'). Without it
+              // the kernel's trades bucket under 'unknown' and the arbiter
+              // never reaches `self_min` → permanent no-trade-divergence.
+              tpPrice, slPrice, 'monkey-k',
             ],
           );
         } catch (err) {
@@ -7701,12 +7705,14 @@ export class MonkeyKernel extends EventEmitter {
         `INSERT INTO autonomous_trades
            (user_id, symbol, side, entry_price, quantity, leverage,
             confidence, reason, order_id, paper_trade, engine_version, agent, lane,
-            take_profit, stop_loss)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+            take_profit, stop_loss, engine_type)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
         [
           userId, symbol, exchangeSide, entryPrice, formattedSize, leverage,
           req.phi, reasonEncoded, orderId, false, getEngineVersion(), agentTag, laneTag,
-          tpPrice, slPrice,
+          // engine_type — consensus WR-matrix key; must match
+          // consensus_arbiter `selfEngineType` ('monkey-k').
+          tpPrice, slPrice, 'monkey-k',
         ],
       );
     } catch (err) {


### PR DESCRIPTION
## Why

After #886/#888 activated the Python consensus peer, the arbiter returns `no-trade-divergence` on **every** tick: TS and Py disagree on side and neither engine has win-rate samples, so the arbiter can't pick a dominant kernel.

Root cause: `consensus_arbiter` scores engines via `getWRMatrix()`, which buckets `autonomous_trades` by the `engine_type` column. The kernel's two entry INSERTs (`loop.ts` paper + live) **never set `engine_type`** — every kernel trade lands under `engine_type = NULL` → `'unknown'`. The arbiter queries `'monkey-k'`, finds nothing → `self_min` permanently false.

## Fix

Set `engine_type = 'monkey-k'` on both kernel entry INSERTs, matching `consensus_arbiter`'s `selfEngineType`. As trades close, `getWRMatrix()` accumulates real `monkey-k` regime cells; once a cell reaches the 5-sample floor the arbiter produces actionable `dominant-fires` / `lesser-observe` verdicts instead of skipping.

`engine_type` (migration 050) was never populated; paper/live is tracked by the `paper_trade` boolean — so this does not regress the already-empty `/api/agent/performance` engine_type filter.

## What this unblocks

This is the last *code* blocker for `CONSENSUS_ARBITER_LIVE`. After it ships, the arbiter-authoritative flip is gated purely on the WR warmup — `monkey-k` accumulating ≥5 closed trades per regime — a data condition, not a code task. Flipping it before warmup would force HOLD on every divergence tick (halting entries), which is why it stays `false` until the matrix is warm.

## Gates

- `tsc --noEmit` apps/api — clean
- `vitest` monkey suite — 856/856
- Both INSERTs verified: 16 columns / `$1..$16` / 16 params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)