### PR TITLE
fix(monkey): consensus override governs entries only — never suppress exits

### DIFF
--- a/apps/api/src/services/monkey/__tests__/consensusArbiter.test.ts
+++ b/apps/api/src/services/monkey/__tests__/consensusArbiter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { logger } from '../../../utils/logger.js';
 import {
+  applyConsensusOverride,
   computeAndLogConsensus,
   computeConsensus,
   type ConsensusInputs,
@@ -490,5 +491,56 @@ describe('py-live peer path — non-single-kernel verdict regression guard', () 
 
     // Stale peer → arbiter falls back to single-kernel (correct safe default)
     expect(d.verdict).toBe('single-kernel');
+  });
+});
+
+describe('applyConsensusOverride — arbiter governs ENTRIES only, exits sacrosanct', () => {
+  // Regression 2026-05-21: after the Python peer was activated, the arbiter
+  // returned `no-trade-divergence` (action 'hold'). loop.ts applied that
+  // 'hold' to whatever the kernel had decided — including stop-loss and
+  // bracket exits — so losing positions could not be closed. The override
+  // must touch ENTRY decisions only; risk-management exits always execute.
+
+  it('does NOT suppress a stop-loss exit on a hold verdict (the regression)', () => {
+    const own = { action: 'exit', size_usdt: 0, leverage: 11 };
+    const out = applyConsensusOverride(own, { action: 'hold', size_usdt: 0, leverage: 1 });
+    expect(out.action).toBe('exit');
+  });
+
+  it('does NOT suppress scalp_exit / flatten on a hold verdict', () => {
+    for (const exitAction of ['scalp_exit', 'flatten']) {
+      const own = { action: exitAction, size_usdt: 0, leverage: 8 };
+      const out = applyConsensusOverride(own, { action: 'hold', size_usdt: 0, leverage: 1 });
+      expect(out.action).toBe(exitAction);
+    }
+  });
+
+  it('vetoes a proposed ENTRY on a hold verdict', () => {
+    const own = { action: 'enter_long', size_usdt: 30, leverage: 5 };
+    const out = applyConsensusOverride(own, { action: 'hold', size_usdt: 0, leverage: 1 });
+    expect(out).toEqual({ action: 'hold', size_usdt: 0, leverage: 5 });
+  });
+
+  it('vetoes a pyramid add on a hold verdict (pyramids are entries)', () => {
+    const own = { action: 'pyramid_long', size_usdt: 20, leverage: 5 };
+    const out = applyConsensusOverride(own, { action: 'hold', size_usdt: 0, leverage: 1 });
+    expect(out.action).toBe('hold');
+  });
+
+  it('resizes/resides an ENTRY when the verdict is an entry', () => {
+    const own = { action: 'enter_long', size_usdt: 30, leverage: 5 };
+    const out = applyConsensusOverride(own, { action: 'enter_short', size_usdt: 18, leverage: 3 });
+    expect(out).toEqual({ action: 'enter_short', size_usdt: 18, leverage: 3 });
+  });
+
+  it('leaves a plain hold untouched', () => {
+    const own = { action: 'hold', size_usdt: 0, leverage: 1 };
+    const out = applyConsensusOverride(own, { action: 'hold', size_usdt: 0, leverage: 1 });
+    expect(out.action).toBe('hold');
+  });
+
+  it('null override is a no-op', () => {
+    const own = { action: 'exit', size_usdt: 0, leverage: 8 };
+    expect(applyConsensusOverride(own, null)).toEqual(own);
   });
 });

--- a/apps/api/src/services/monkey/consensus_arbiter.ts
+++ b/apps/api/src/services/monkey/consensus_arbiter.ts
@@ -341,3 +341,49 @@ export function computeAndLogConsensus(inputs: ConsensusInputs): ConsensusDecisi
   });
   return decision;
 }
+
+/** Input/output shape for {@link applyConsensusOverride}. */
+export interface ConsensusOverrideInput {
+  action: string;
+  size_usdt: number;
+  leverage: number;
+}
+
+/** The only actions the consensus arbiter is allowed to override. */
+const CONSENSUS_ENTRY_ACTIONS: ReadonlySet<string> = new Set([
+  'enter_long', 'enter_short', 'pyramid_long', 'pyramid_short',
+]);
+
+/**
+ * Apply a consensus verdict to the kernel's own decision.
+ *
+ * The arbiter governs ENTRY decisions only. Exit and risk-management
+ * actions — stop-loss, take-profit, bracket, `scalp_exit`, `flatten` —
+ * MUST execute untouched: a `hold` verdict means "do not open a new
+ * trade", never "do not close a losing one".
+ *
+ * Regression 2026-05-21: with the Python peer live the arbiter returned
+ * `no-trade-divergence` (action `hold`); the old call site applied that
+ * `hold` to whatever the kernel had decided, including exits, so
+ * stop-losses were suppressed for ~14h. This helper gates the override
+ * to entry actions only — every non-entry action passes through.
+ */
+export function applyConsensusOverride(
+  own: ConsensusOverrideInput,
+  override: ConsensusOverrideInput | null,
+): ConsensusOverrideInput {
+  if (override === null) return own;
+  // Exits / holds / flatten / scalp_exit are never touched by consensus.
+  if (!CONSENSUS_ENTRY_ACTIONS.has(own.action)) return own;
+  if (override.action === 'hold') {
+    return { action: 'hold', size_usdt: 0, leverage: own.leverage };
+  }
+  if (override.action === 'enter_long' || override.action === 'enter_short') {
+    return {
+      action: override.action,
+      size_usdt: override.size_usdt,
+      leverage: override.leverage,
+    };
+  }
+  return own;
+}

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -90,6 +90,7 @@ import {
   type OHLCVCandle,
 } from './perception.js';
 import { frBracketDistances } from './fr_trade_params.js';
+import { applyConsensusOverride } from './consensus_arbiter.js';
 import {
   CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT,
   CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT,
@@ -3983,16 +3984,19 @@ export class MonkeyKernel extends EventEmitter {
     // size remain available for logging via the override telemetry.
     if (consensusOverride !== null) {
       (derivation as Record<string, unknown>).consensus = consensusOverride;
-      // Replace action + size with consensus output. Note: side flips
-      // require flipping the action string too (enter_long ↔ enter_short).
-      if (consensusOverride.action === 'hold') {
-        action = 'hold';
-        size.value = 0;
-      } else if (consensusOverride.action === 'enter_long' || consensusOverride.action === 'enter_short') {
-        action = consensusOverride.action;
-        size.value = consensusOverride.size_usdt;
-        leverage.value = consensusOverride.leverage;
-      }
+      // The arbiter governs ENTRIES only. applyConsensusOverride leaves
+      // every non-entry action (hold, exit, scalp_exit, flatten, bracket
+      // exits) untouched — a 'hold' verdict must never suppress a
+      // stop-loss or take-profit. Regression 2026-05-21: the old inline
+      // `=== 'hold'` branch applied the verdict to exits too, suppressing
+      // stop-losses for ~14h once the Python peer went live.
+      const applied = applyConsensusOverride(
+        { action, size_usdt: size.value, leverage: leverage.value },
+        consensusOverride,
+      );
+      action = applied.action;
+      size.value = applied.size_usdt;
+      leverage.value = applied.leverage;
       reason += ` | consensus.${consensusOverride.verdict}`;
     }
 


### PR DESCRIPTION
## The regression (≈ −$61, ~14h)

After the Python consensus peer was activated, the arbiter returned `no-trade-divergence` / `lesser-observe` verdicts with action `hold`. `loop.ts` applied that `hold` to **whatever the kernel had decided — including stop-loss, take-profit and synthetic-bracket exits**. Poloniex has no native SL/TP, so a suppressed bracket = a position that never closes. Losing positions bled for ~14h; winners were never banked. CSV confirms ≈ −$61 realised, zero wins.

Pre-de-shadow the bug was dormant — the verdict was always `single-kernel` → `consensus.action = own.proposed_action` (`exit` for an exit), so the `=== 'hold'` branch never fired on an exit. Activating the peer exposed it.

Full analysis: `analysis/polytrade_qig_telemetry/loss-period-postmortem-20260522.md`.

## Fix

`applyConsensusOverride()` (consensus_arbiter.ts) — the arbiter governs **ENTRY actions only** (`enter_long/short`, `pyramid_long/short`). Every non-entry action — `hold`, `exit`, `scalp_exit`, `flatten`, bracket exits — passes through untouched. A `hold` verdict means "do not open a new trade", never "do not close a losing one". `loop.ts` routes the override through this helper.

## Tests

7 new TDD tests in `consensusArbiter.test.ts` (RED → GREEN) lock it: exit + hold-verdict → exit preserved; `scalp_exit`/`flatten` + hold-verdict → preserved; entry + hold-verdict → entry vetoed.

- `tsc --noEmit` apps/api — clean
- `vitest` monkey suite — 863/863

## Note

The consensus layer is currently **off** in production (operator-held env). This fix makes the override safe so the layer *can* be re-enabled — it does not itself change live behaviour while `CONSENSUS_EXECUTOR_LIVE` is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)