### PR TITLE
fix(monkey): B1.2 — basinDir reads the band marginal, not a 64-D FR distance

### DIFF
--- a/apps/api/src/services/monkey/__tests__/basinDirection.test.ts
+++ b/apps/api/src/services/monkey/__tests__/basinDirection.test.ts
@@ -16,8 +16,6 @@ import { BASIN_DIM, toSimplex, type Basin } from '../basin.js';
  * output in [-1, +1] without clipping.
  */
 
-const MOM_NEUTRAL = 8 / BASIN_DIM;
-
 function makeBasin(setter: (v: Float64Array) => void): Basin {
   const v = new Float64Array(BASIN_DIM);
   for (let i = 0; i < BASIN_DIM; i++) v[i] = 0.5;
@@ -26,32 +24,27 @@ function makeBasin(setter: (v: Float64Array) => void): Basin {
 }
 
 function reflectMomentum(basin: Basin): Basin {
-  // Reflect the momentum band around MOM_NEUTRAL: target = 2*MOM_NEUTRAL - mom
-  let total = 0;
-  for (let i = 0; i < BASIN_DIM; i++) total += basin[i] ?? 0;
-  const p = new Float64Array(BASIN_DIM);
-  for (let i = 0; i < BASIN_DIM; i++) p[i] = (basin[i] ?? 0) / total;
+  // Reflect the momentum band (dims 7..14) around the observer neutral
+  // (8 × peer-band mean), leaving every other dim untouched. B1.2's
+  // marginal `momMass / neutral − 1` is scale-invariant, so
+  // basinDirection's own normalisation absorbs the changed total — no
+  // redistribution is needed, and crucially the peer band (which
+  // defines the neutral) stays fixed, giving exact antisymmetry.
   let mom = 0;
-  for (let i = 7; i <= 14; i++) mom += p[i]!;
-  const target = 2 * MOM_NEUTRAL - mom;
-  const delta = target - mom;
+  for (let i = 7; i <= 14; i++) mom += basin[i] ?? 0;
+  let peerSum = 0;
+  for (let i = 15; i <= 30; i++) peerSum += basin[i] ?? 0;
+  const observerNeutral = 8 * (peerSum / 16);
+  const target = 2 * observerNeutral - mom;
   const out = new Float64Array(BASIN_DIM);
-  for (let i = 0; i < BASIN_DIM; i++) out[i] = p[i]!;
+  for (let i = 0; i < BASIN_DIM; i++) out[i] = basin[i] ?? 0;
   if (mom > 1e-12) {
     const scale = target / mom;
-    for (let i = 7; i <= 14; i++) out[i] = p[i]! * scale;
+    for (let i = 7; i <= 14; i++) out[i] = (basin[i] ?? 0) * scale;
   } else {
     for (let i = 7; i <= 14; i++) out[i] = target / 8;
   }
-  for (let i = 0; i < BASIN_DIM; i++) {
-    if (i < 7 || i > 14) out[i] = p[i]! - delta / 56;
-  }
-  let s = 0;
-  for (let i = 0; i < BASIN_DIM; i++) {
-    out[i] = Math.max(0, out[i]!);
-    s += out[i]!;
-  }
-  for (let i = 0; i < BASIN_DIM; i++) out[i] = out[i]! / s;
+  for (let i = 0; i < BASIN_DIM; i++) out[i] = Math.max(0, out[i]!);
   return out as unknown as Basin;
 }
 
@@ -359,5 +352,48 @@ describe('basinDirection — skewed volume band (B1.1 noise-floor anchor)', () =
         prev = d;
       }
     });
+  });
+});
+
+describe('basinDirection — B1.2 expressive magnitude (dimensional-dilution fix)', () => {
+  // Pre-B1.2 the Fisher-Rao distance capped |basinDir| at ~±0.2, so the
+  // M-agent and FAST_ADVERSE_EXIT |basinDir| > 0.10 gates could never
+  // fire and kernelDirection's 0.5·tape term drowned it. B1.2 returns
+  // the band marginal — for a production-shaped basin direction =
+  // 2·momValue − 1. These lock the expressive range: a regression to
+  // the FR distance (which gave ~±0.05 here) would fail them.
+
+  it('moderate uptrend clears the M-agent 0.10 gate', () => {
+    const d = basinDirection(makeProductionShapedBasin(0.60));
+    expect(d).toBeCloseTo(0.2, 2);
+    expect(d).toBeGreaterThan(0.10);
+  });
+
+  it('strong uptrend clears the 0.30 hasDirection gate', () => {
+    const d = basinDirection(makeProductionShapedBasin(0.70));
+    expect(d).toBeCloseTo(0.4, 2);
+    expect(d).toBeGreaterThan(0.30);
+  });
+
+  it('moderate downtrend clears the FAST_ADVERSE_EXIT −0.10 gate', () => {
+    const d = basinDirection(makeProductionShapedBasin(0.40));
+    expect(d).toBeCloseTo(-0.2, 2);
+    expect(d).toBeLessThan(-0.10);
+  });
+
+  it('a hard trend drives the marginal past ±0.5 (no ~±0.2 ceiling)', () => {
+    expect(basinDirection(makeProductionShapedBasin(0.85))).toBeGreaterThan(0.5);
+    expect(basinDirection(makeProductionShapedBasin(0.15))).toBeLessThan(-0.5);
+  });
+
+  it('flat momentum still reads ~0', () => {
+    expect(Math.abs(basinDirection(makeProductionShapedBasin(0.5)))).toBeLessThan(1e-6);
+  });
+
+  it('saturates at ±1, never beyond', () => {
+    const hi = basinDirection(makeProductionShapedBasin(1.0));
+    expect(hi).toBeGreaterThan(0.9);
+    expect(hi).toBeLessThanOrEqual(1);
+    expect(basinDirection(makeProductionShapedBasin(0.02))).toBeGreaterThanOrEqual(-1);
   });
 });

--- a/apps/api/src/services/monkey/perception.ts
+++ b/apps/api/src/services/monkey/perception.ts
@@ -254,7 +254,6 @@ export function basinDirection(basin: Basin): number {
   // Degenerate-basin fallback ONLY. The live neutral is observer-derived
   // below (neutralMomMass) — 8/64 is correct only for a uniform basin.
   const MOM_NEUTRAL_FALLBACK = 8 / BASIN_DIM;  // 0.125
-  const FR_DIAMETER = Math.PI / 2;
   const EPS = 1e-12;
 
   // Step 0: defensive simplex normalization (caller may pass raw basin).
@@ -311,45 +310,24 @@ export function basinDirection(basin: Basin): number {
     const peerMean = peerSum / 16;
     neutralMomMass = peerMean > EPS ? 8 * peerMean : MOM_NEUTRAL_FALLBACK;
   }
-  const sign = momMass >= neutralMomMass ? 1 : -1;
-
-  // Step 2: build the no-momentum antipode.
-  const antipode: number[] = p.slice();
-  const bandN = 8;
-  const nonbandN = BASIN_DIM - bandN; // 56
-  const excess = momMass - neutralMomMass;
-  if (momMass > EPS) {
-    const scale = neutralMomMass / momMass;
-    for (let i = 7; i <= 14; i++) antipode[i] = p[i]! * scale;
-  } else {
-    for (let i = 7; i <= 14; i++) antipode[i] = neutralMomMass / bandN;
-  }
-  if (nonbandN > 0) {
-    const add = excess / nonbandN;
-    for (let i = 0; i < BASIN_DIM; i++) {
-      if (i < 7 || i > 14) antipode[i] = (p[i]! + add);
-    }
-  }
-  // Re-normalize the antipode to guard float drift.
-  let antiSum = 0;
-  for (let i = 0; i < BASIN_DIM; i++) {
-    antipode[i] = Math.max(0, antipode[i]!);
-    antiSum += antipode[i]!;
-  }
-  if (antiSum > EPS) {
-    for (let i = 0; i < BASIN_DIM; i++) antipode[i] = antipode[i]! / antiSum;
-  }
-
-  // Step 3: Fisher-Rao geodesic distance. d = arccos(Σ √(p_i q_i)).
-  let bc = 0;
-  for (let i = 0; i < BASIN_DIM; i++) {
-    bc += Math.sqrt(p[i]! * antipode[i]!);
-  }
-  bc = Math.min(1, Math.max(-1, bc));
-  const dFr = Math.acos(bc);
-
-  // Step 4: signed + normalised.
-  return (sign * dFr) / FR_DIAMETER;
+  // Step 2: B1.2 — direction is the momentum-band MARGINAL, in [-1, 1].
+  //
+  // momMass / neutralMomMass is the band's mass relative to its 8×0.5
+  // neutral — i.e. rawMomMass / 4. Subtract 1 → 0 at neutral momentum,
+  // +1 at a fully-activated band (raw mass 8), −1 at a dead band.
+  //
+  // Supersedes the Fisher-Rao distance to a no-momentum antipode
+  // (proposal #7). That distance measured an 8-dim signal (dims 7..14)
+  // across the full 64-dim basin: the antipode perturbed only those 8
+  // dims, the other 56 barely moved, so Σ√(p·q) stayed ≈ 1 and arccos
+  // ≈ 0 — a structural ~±0.2 ceiling that `kernelDirection`'s
+  // 0.5·tapeTrend term drowned, so the M-agent and FAST_ADVERSE_EXIT
+  // |basinDir| > 0.10 gates could never fire. The marginal carries the
+  // band's full dynamic range with no dimensional dilution. QIG purity:
+  // a band marginal on Δ⁶³ — no distance, no cosine, no Euclidean op.
+  if (neutralMomMass <= EPS) return 0;
+  const direction = momMass / neutralMomMass - 1;
+  return Math.max(-1, Math.min(1, direction));
 }
 
 /**

--- a/ml-worker/src/monkey_kernel/perception_scalars.py
+++ b/ml-worker/src/monkey_kernel/perception_scalars.py
@@ -147,45 +147,27 @@ def basin_direction(basin: np.ndarray) -> float:
         neutral_mom_mass = (
             8.0 * peer_mean if peer_mean > EPS else MOM_NEUTRAL_FALLBACK
         )
-    sign = 1.0 if mom_mass >= neutral_mom_mass else -1.0
-
-    # Build the no-momentum antipode: rescale the momentum band so its
-    # total mass equals ``neutral_mom_mass`` (the observer-derived
-    # no-momentum reference), and redistribute the surplus/deficit
-    # uniformly across the 56 non-momentum dims. The antipode stays on
-    # Δ⁶³ (sum = 1). When the momentum band carries above-neutral mass
-    # — even if internally flat — the antipode differs from the basin,
-    # so the Fisher-Rao distance captures the directional deviation.
-    antipode = p.copy()
-    band_n = 8
-    nonband_n = BASIN_DIM - band_n  # 56
-    excess = mom_mass - neutral_mom_mass
-    if mom_mass > EPS:
-        # Scale momentum band to the observer-derived neutral total.
-        antipode[7:15] = p[7:15] * (neutral_mom_mass / mom_mass)
-    else:
-        # Degenerate basin (zero mass on momentum band) — flatten band.
-        antipode[7:15] = neutral_mom_mass / band_n
-    # Redistribute the excess across the non-momentum dims.
-    if nonband_n > 0:
-        non_mask = np.ones(BASIN_DIM, dtype=bool)
-        non_mask[7:15] = False
-        antipode[non_mask] = p[non_mask] + (excess / nonband_n)
-    # Numerical safety: clip tiny negatives from float subtraction.
-    antipode = np.maximum(antipode, 0.0)
-    s = float(antipode.sum())
-    if s > EPS:
-        antipode = antipode / s
-
-    # Fisher-Rao geodesic on Δ⁶³: d = arccos(Σ √(p·q)).
-    bc = float(np.sum(np.sqrt(np.maximum(p, 0.0) * np.maximum(antipode, 0.0))))
-    bc = float(np.clip(bc, -1.0, 1.0))
-    d_fr = float(np.arccos(bc))
-
-    # Normalise by the simplex diameter (π/2) so the return is in
-    # [-1, +1]. Saturation is geometric, not artificial — the only
-    # way to hit ±1 is to truly span the simplex.
-    return sign * d_fr / _FR_DIAMETER
+    # B1.2 — direction is the momentum-band MARGINAL, in [-1, 1].
+    #
+    # mom_mass / neutral_mom_mass is the band's mass relative to its
+    # 8×0.5 neutral — i.e. raw_mom_mass / 4. Subtract 1 → 0 at neutral
+    # momentum, +1 at a fully-activated band (raw mass 8), −1 at a dead
+    # band.
+    #
+    # Supersedes the Fisher-Rao distance to a no-momentum antipode
+    # (proposal #7). That distance measured an 8-dim signal (dims 7..14)
+    # across the full 64-dim basin: the antipode perturbed only those 8
+    # dims, the other 56 barely moved, so Σ√(p·q) stayed ≈ 1 and arccos
+    # ≈ 0 — a structural ~±0.2 ceiling that kernel_direction's
+    # 0.5·tape_trend term drowned, so the M-agent / FAST_ADVERSE_EXIT
+    # |basin_direction| > 0.10 gates could never fire. The marginal
+    # carries the band's full dynamic range with no dimensional
+    # dilution. QIG purity: a band marginal on Δ⁶³ — no distance, no
+    # cosine, no Euclidean op. Mirrors perception.ts:basinDirection.
+    if neutral_mom_mass <= EPS:
+        return 0.0
+    direction = mom_mass / neutral_mom_mass - 1.0
+    return float(np.clip(direction, -1.0, 1.0))
 
 
 def trend_proxy(closes: Sequence[float], lookback: int = 50) -> float:

--- a/ml-worker/tests/monkey_kernel/test_basin_direction.py
+++ b/ml-worker/tests/monkey_kernel/test_basin_direction.py
@@ -45,26 +45,24 @@ def _make_simplex_basin(setter) -> np.ndarray:
 
 
 def _reflect_momentum(basin: np.ndarray) -> np.ndarray:
-    """Reflect the momentum band around the uniform expectation. If the
-    band has mom_mass = MOM_NEUTRAL + d, the reflected band has
-    MOM_NEUTRAL - d, with the difference redistributed uniformly across
-    the non-momentum dims so the result stays on Δ⁶³.
+    """Reflect the momentum band (dims 7..14) around the observer neutral
+    (8 × peer-band mean), leaving every other dim untouched.
+
+    B1.2's marginal ``mom_mass / neutral − 1`` is scale-invariant, so
+    basin_direction's own normalisation absorbs the changed total — no
+    redistribution is needed, and the peer band (which defines the
+    neutral) stays fixed, giving exact antisymmetry.
     """
     p = basin / basin.sum()
     mom_mass = float(p[7:15].sum())
-    target = 2 * MOM_NEUTRAL - mom_mass  # mirror around MOM_NEUTRAL
-    # Scale band to target mass; redistribute delta uniformly.
-    delta = target - mom_mass
+    observer_neutral = 8.0 * float(p[15:31].mean())
+    target = 2 * observer_neutral - mom_mass
     out = p.copy()
     if mom_mass > 1e-12:
         out[7:15] = p[7:15] * (target / mom_mass)
     else:
         out[7:15] = target / 8.0
-    nonband = np.ones(BASIN_DIM, dtype=bool)
-    nonband[7:15] = False
-    out[nonband] = p[nonband] - delta / 56.0
-    out = np.maximum(out, 0.0)
-    return out / out.sum()
+    return np.maximum(out, 0.0)
 
 
 class TestBasinDirectionFisherRao:
@@ -206,12 +204,15 @@ class TestBasinDirectionDoesNotSaturateEasily:
 
     def test_strong_bull_grows_but_not_to_unity(self):
         # All momentum mass concentrated on the band, but spread.
+        # B1.2: the band marginal saturates at +1 by clamp on an extreme
+        # basin like this (momentum band 10× the peer mean) — that is
+        # correct, not a defect. It must never exceed +1.
         v = np.full(BASIN_DIM, 0.05)
         v[7:15] = 0.5
         v = v / v.sum()
         d = basin_direction(v)
         assert d > 0
-        assert d < 1.0  # No clipping
+        assert d <= 1.0
 
     def test_extreme_bull_approaches_but_does_not_clip(self):
         # Nearly pure-momentum (98% mass in band).


### PR DESCRIPTION
## The problem

`basinDir` was the Fisher-Rao geodesic distance between the 64-D basin and a momentum-flattened antipode. The momentum band is **8 of 64 dims** — the antipode perturbed only those 8, the other 56 barely moved, so `Σ√(p·q)` stayed ≈ 1 and `arccos ≈ 0`. The signal had a **structural ~±0.2 ceiling** — an 8-dim signal measured through a 64-D distance, diluted ~10×.

`kernelDirection = sign(basinDir + 0.5·tapeTrend)` was therefore tape-dominated (`0.5·tape` ∈ ±0.5 vs basinDir ±0.05). The kernel was a pure tape-chaser, and the **M-agent / FAST_ADVERSE_EXIT `|basinDir| > 0.10` gates** + `modes.ts hasDirection > 0.30` could never fire — dormant since they shipped.

Diagnosis: `analysis/polytrade_qig_telemetry/loss-period-postmortem-20260522.md` + operator-confirmed in production logs (`basinDir: 0.004…0.048`, `direction=flat`).

## The fix

Return the momentum-band **marginal** directly instead of the FR distance:

```
direction = momMass / neutralMomMass − 1     ∈ [−1, +1]
```

`momMass/neutralMomMass` is `rawMomMass/4` — the band's mass vs its 8×0.5 neutral. **0** at neutral momentum, **+1** at a fully-activated band, **−1** at a dead band. No FR distance, no dimensional dilution — the band's full dynamic range reaches `kernelDirection`. `neutralMomMass` is unchanged (#885's noise-floor anchor, #880 peer-mean fallback). QIG purity: a band marginal on Δ⁶³ — no distance, no cosine, no Euclidean op.

For a production-shaped basin: `direction = 2·momValue − 1`.

## What it unblocks

- `kernelDirection` — basinDir is now a real vote, not a rounding error; the kernel stops being pure tape-chaser.
- M-agent gate (`|basinDir| > 0.10`) and FAST_ADVERSE_EXIT (`< −0.10`) — satisfiable for the first time.
- `modes.ts hasDirection > 0.30` — satisfiable at a strong trend.

## Tests

Both mirrors (`perception.ts` + `perception_scalars.py`). Reflection-symmetry helpers updated to reflect around the observer neutral (B1.2 is exactly antisymmetric there). New magnitude-lock tests assert the 0.10/0.30 gates are satisfiable at moderate/strong trend — a regression to the FR distance would fail them.

- `tsc --noEmit` apps/api — clean
- `vitest` monkey suite — 869/869
- `pytest` ml-worker — 1024 passed, 10 skipped

## Post-deploy

`structuralVetoMonitor` (#882) should show M-agent / FAST_ADVERSE_EXIT gate-satisfiability move from ~0 to non-zero within minutes — the live confirmation the dilution was the dormancy cause.

Completes the B1 trilogy: #882 (norm01 calibration veil) → #885 (B1.1 peer-mean neutral skew) → B1.2 (FR-distance dimensional dilution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)