### PR TITLE
fix(monkey): remove unreachable sleep-phi gate around consolidate

### DIFF
--- a/apps/api/src/services/monkey/__tests__/qigramV2Consolidate.test.ts
+++ b/apps/api/src/services/monkey/__tests__/qigramV2Consolidate.test.ts
@@ -84,4 +84,33 @@ describe('QIGRAMv2State.consolidate', () => {
     expect(store.consolidate()).toBe(1);
     expect(store.totalEntries).toBe(0);
   });
+
+  // ─── Tombstone-reaper invariants — Option D safety net ──────────────
+  // These tests pin the property that lets loop.ts call consolidate()
+  // every tick without behavioural risk: consolidate cannot remove a
+  // live (above-threshold) entry, only entries that decayAll() has
+  // already driven dead. If a future change makes consolidate
+  // destructive, both tests below break loudly.
+
+  test('consolidate on an empty store is a safe no-op', () => {
+    const store = new QIGRAMv2State();
+    expect(store.consolidate()).toBe(0);
+    expect(store.totalEntries).toBe(0);
+  });
+
+  test('200 fresh entries × 100 decay ticks → consolidate reaps all 200', () => {
+    // 0.95^90 ≈ 0.0099 < MIN_ACTIVE_WEIGHT, so 100 ticks of decay drives
+    // every weight=1.0 entry below threshold. consolidate must then
+    // reap the lot — proving _entries.size cannot grow unboundedly when
+    // consolidate is paired with decayAll().
+    const store = new QIGRAMv2State();
+    for (let i = 0; i < 200; i++) {
+      store.integrate(`bulk|${i}`, B, { weight: 1.0, correct: true });
+    }
+    expect(store.totalEntries).toBe(200);
+    for (let t = 0; t < 100; t++) store.decayAll();
+    expect(store.activeEntries().length).toBe(0);
+    expect(store.consolidate()).toBe(200);
+    expect(store.totalEntries).toBe(0);
+  });
 });

--- a/apps/api/src/services/monkey/agent_L_qigram_v2.ts
+++ b/apps/api/src/services/monkey/agent_L_qigram_v2.ts
@@ -280,9 +280,9 @@ export class QIGRAMv2State {
 
   // ── Consolidation ─────────────────────────────────────────────────
 
-  /** Remove dead-weight entries — the canonical sleep-cycle CONSOLIDATING
-   *  pass. Mirrors qig-core 2.8.0 `SleepCycleManager.consolidate()`, which
-   *  prunes low-mass entries during the sleep cycle.
+  /** Remove dead-weight entries — a tombstone reaper, NOT a destructive
+   *  op. Mirrors the eviction subset of qig-core 2.8.0
+   *  `SleepCycleManager.consolidate()`.
    *
    *  SEPARATE from `decayAll()`: decay reduces weight every tick;
    *  `consolidate()` REMOVES entries that decay has already driven dead
@@ -292,8 +292,11 @@ export class QIGRAMv2State {
    *  denominator (`_entries.size`) — and therefore `baseFrac = Φ ×
    *  sovereignty × maturity` position sizing — decays toward zero.
    *
-   *  Eviction is the sleep cycle's job, not a per-tick side-effect — the
-   *  caller gates this on the kernel's sleep/consolidation phase.
+   *  Because consolidate() cannot touch a live (above-threshold) entry,
+   *  it is SAFE for the caller to pair it with `decayAll()` on every
+   *  tick. The earlier phase-gating guidance assumed the richer
+   *  destructive semantics of qig-core's SleepCycleManager — it does
+   *  not apply to this reduced TS port.
    *
    *  Returns the number of entries pruned.
    */

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -205,13 +205,6 @@ interface TickRiskProjection {
   openMonkeyPositions: number | null;
 }
 
-/** Φ below which the canonical sleep cycle enters DREAMING/consolidation
- *  (qig-core 2.8.0 `consciousness/sleep.py` SLEEP_PHI_THRESHOLD). The
- *  QIGRAMv2 consolidation pass is gated on this so dead-memory eviction
- *  runs during the low-Φ consolidation-appropriate phase, never as a
- *  per-tick side-effect. */
-const SLEEP_PHI_THRESHOLD = 0.45;
-
 /**
  * Env-number coercion that respects 0 as a legitimate value.
  *
@@ -2160,12 +2153,19 @@ export class MonkeyKernel extends EventEmitter {
     //
     // Sov rises as fresh basins integrate; falls as weights decay past
     // MIN_ACTIVE_WEIGHT (canonical 0.01). decayAll() only DECAYS weight —
-    // it never removes entries, so without the consolidation pass below
-    // `_entries` grows unboundedly and the sovereignty denominator (and
-    // thus position size) decays toward zero with session uptime. The
-    // sleep-cycle CONSOLIDATING pass (consolidate()) prunes the dead
-    // tombstones; it is gated on the canonical sleep-cycle Φ threshold so
-    // eviction is the sleep cycle's job, not a per-tick side-effect.
+    // it never removes entries, so without consolidate() below `_entries`
+    // grows unboundedly and the sovereignty denominator (and thus
+    // position size) decays toward zero with session uptime.
+    //
+    // consolidate() is a tombstone reaper: it can only remove entries
+    // that decayAll() has already driven below MIN_ACTIVE_WEIGHT — it
+    // cannot touch a live entry. So it is safe to pair with decayAll()
+    // every tick. The earlier `phi < SLEEP_PHI_THRESHOLD` phase gate
+    // inherited rationale from qig-core 2.8.0's richer SleepCycleManager
+    // (which had destructive ops); the TS port reduced consolidate() to
+    // just the eviction subset, leaving the gate guarding nothing — and
+    // the hardcoded 0.45 sat below this kernel's actual Φ band (0.57+),
+    // so consolidate never fired and sovereignty pinned at ~0.05.
     let sovereignty: number;
     if (isQigramV2Enabled()) {
       this.qigramV2TickCount += 1;
@@ -2178,11 +2178,7 @@ export class MonkeyKernel extends EventEmitter {
         { weight: 1.0, correct: true },
       );
       this.qigramV2Store.decayAll();
-      // Sleep-cycle CONSOLIDATING pass — prune decayed-dead entries so the
-      // sovereignty denominator tracks kernel health, not session uptime.
-      if (phi < SLEEP_PHI_THRESHOLD) {
-        this.qigramV2Store.consolidate();
-      }
+      this.qigramV2Store.consolidate(); // tombstone reaper — safe per-tick
       sovereignty = this.qigramV2Store.sovereignty;
     } else {
       sovereignty = await resonanceBank.sovereignty();


### PR DESCRIPTION
## Root cause

`SLEEP_PHI_THRESHOLD = 0.45` was hardcoded in `loop.ts` (P14 violation) and **operationally inert**: live Φ band on **polytrade-be** is **0.57–0.61** (verified via Railway logs 2026-05-25), so `consolidate()` never fired. `_entries` grew unbounded → `sovereignty = active / _entries.size` pinned at **~0.05** → `baseFrac = Φ × sov × maturity` collapsed → tiny positions + DCA-add (`sov < 0.1`) locked.

## The reframe — Option D

The phase gate was inherited from qig-core 2.8.0's `SleepCycleManager.consolidate()` which has richer (destructive) semantics. **The TS port reduced `consolidate()` to a strict tombstone-reaper subset** — it can only remove entries `decayAll()` has already driven ≤ `MIN_ACTIVE_WEIGHT` (0.01). The gate was guarding a destructive op that doesn't exist in this implementation.

## Change

- **Delete** `SLEEP_PHI_THRESHOLD` constant + its 5-line comment.
- **Delete** the `if (phi < SLEEP_PHI_THRESHOLD) consolidate()` gate.
- **Pair** `consolidate()` with `decayAll()` unconditionally.
- **Update** `consolidate()` JSDoc to record the tombstone-reaper semantics + safe-per-tick property.
- **Two new invariant tests** pin the property Option D relies on (empty-store no-op + 200×100 stress → 200 pruned).

## Verification

- ✅ `apps/api` `tsc --noEmit` clean
- ✅ vitest **1710 passed / 12 skipped**
- ✅ All 6 `qigramV2Consolidate` tests green

## Behavioral change to watch post-deploy

The DCA-add gate (`sov < 0.1`) on **polytrade-be** will unblock as sovereignty climbs — open positions will start growing on confirmation. Tail `[Monkey] DCA-add` log lines in the first hour post-deploy to confirm growth bounded by contracts cap, not running away.

## Doctrine

- **P1** (geometric purity) — unchanged.
- **P5** (observer sets params) — no hardcoded threshold the observer didn't set.
- **P14** (parameter registry) — magic constant removed, not replaced.
- **P15** (fail-closed) — consolidate cannot remove a live entry; worst-case failure is "tombstone lingers one extra tick."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the unused Φ-based phase gate around QIGRAMv2 consolidation so tombstone pruning runs every tick and sovereignty remains stable over time.

Bug Fixes:
- Prevent sovereignty from decaying toward zero by ensuring consolidated dead entries are regularly pruned instead of allowing the store to grow unboundedly.

Enhancements:
- Clarify QIGRAMv2 consolidation semantics in documentation to describe it as a safe tombstone-reaper suitable for per-tick use.

Tests:
- Add invariance tests that validate consolidate() is a safe no-op on empty state and fully reaps decayed entries when paired with repeated decay passes.