### PR TITLE
fix(monkey): strip operator-halt suppressors — kernel is autonomous

### DIFF
--- a/apps/api/src/services/monkey/__tests__/riskSettings.test.ts
+++ b/apps/api/src/services/monkey/__tests__/riskSettings.test.ts
@@ -1,72 +1,16 @@
 /**
- * riskSettings.test.ts — operator risk-profile parsing + the daily-loss
- * halt condition (the pure logic behind the risk_settings → kernel wiring).
+ * riskSettings.test.ts — operator risk-profile parsing.
+ *
+ * The kernel only acts on `maxLeverage` (the audited 15× safety cap).
+ * The daily-loss + max-concurrent halts were removed 2026-05-25 —
+ * the kernel self-regulates via neurochemistry, not operator gates.
  */
 
 import { describe, it, expect } from 'vitest';
 import {
   parseRiskSettingsRow,
-  dailyLossHalted,
   DEFAULT_RISK_SETTINGS,
-  getEntryRiskSettingsHalt,
 } from '../risk_settings.js';
-
-describe('getEntryRiskSettingsHalt', () => {
-  it('returns null when no operator profile is saved', () => {
-    expect(getEntryRiskSettingsHalt({
-      riskSettings: null,
-      todayRealizedPnl: -500,
-      equityUsdt: 1000,
-      openMonkeyPositions: 99,
-    })).toBeNull();
-  });
-
-  it('halts new entries on daily loss before checking concurrency', () => {
-    expect(getEntryRiskSettingsHalt({
-      riskSettings: {
-        ...DEFAULT_RISK_SETTINGS,
-        dailyLossLimit: 5,
-        maxConcurrentPositions: 3,
-      },
-      todayRealizedPnl: -50,
-      equityUsdt: 1000,
-      openMonkeyPositions: 3,
-    })).toEqual({
-      kind: 'daily_loss_limit',
-      todayRealizedPnl: -50,
-      limitPct: 5,
-      equityUsdt: 1000,
-    });
-  });
-
-  it('halts new entries once max concurrent positions is reached', () => {
-    expect(getEntryRiskSettingsHalt({
-      riskSettings: {
-        ...DEFAULT_RISK_SETTINGS,
-        maxConcurrentPositions: 5,
-      },
-      todayRealizedPnl: 25,
-      equityUsdt: 1000,
-      openMonkeyPositions: 5,
-    })).toEqual({
-      kind: 'max_concurrent_positions',
-      openMonkeyPositions: 5,
-      cap: 5,
-    });
-  });
-
-  it('allows entries while both ceilings are still clear', () => {
-    expect(getEntryRiskSettingsHalt({
-      riskSettings: {
-        ...DEFAULT_RISK_SETTINGS,
-        maxConcurrentPositions: 5,
-      },
-      todayRealizedPnl: -10,
-      equityUsdt: 1000,
-      openMonkeyPositions: 4,
-    })).toBeNull();
-  });
-});
 
 describe('parseRiskSettingsRow', () => {
   it('returns defaults for a null/undefined row', () => {
@@ -77,88 +21,77 @@ describe('parseRiskSettingsRow', () => {
   it('parses a well-formed row (the aggressive UI preset)', () => {
     const parsed = parseRiskSettingsRow({
       max_drawdown: 25,
-      max_position_size: 10,
+      max_position_size: 5,
       max_concurrent_positions: 5,
-      stop_loss: 3,
-      take_profit: 6,
+      stop_loss: 8,
+      take_profit: 12,
       daily_loss_limit: 10,
-      max_leverage: 20,
+      max_leverage: 15,
       risk_level: 'aggressive',
     });
     expect(parsed).toEqual({
       maxDrawdown: 25,
-      maxPositionSize: 10,
+      maxPositionSize: 5,
       maxConcurrentPositions: 5,
-      stopLoss: 3,
-      takeProfit: 6,
+      stopLoss: 8,
+      takeProfit: 12,
       dailyLossLimit: 10,
-      maxLeverage: 20,
+      maxLeverage: 15,
       riskLevel: 'aggressive',
     });
   });
 
   it('parses numeric strings (pg NUMERIC columns arrive as strings)', () => {
     const parsed = parseRiskSettingsRow({
-      max_leverage: '12',
-      daily_loss_limit: '7.5',
-      max_concurrent_positions: '4',
+      max_drawdown: '15',
+      max_position_size: '2',
+      max_concurrent_positions: '3',
+      stop_loss: '5',
+      take_profit: '8',
+      daily_loss_limit: '5',
+      max_leverage: '15',
+      risk_level: 'balanced',
     });
-    expect(parsed.maxLeverage).toBe(12);
-    expect(parsed.dailyLossLimit).toBe(7.5);
-    expect(parsed.maxConcurrentPositions).toBe(4);
+    expect(parsed.maxDrawdown).toBe(15);
+    expect(parsed.maxLeverage).toBe(15);
   });
 
   it('clamps out-of-range values so a corrupt row cannot break a gate', () => {
-    const high = parseRiskSettingsRow({ max_leverage: 999, max_concurrent_positions: 80 });
-    expect(high.maxLeverage).toBe(100);
-    expect(high.maxConcurrentPositions).toBe(50);
-
-    const low = parseRiskSettingsRow({ max_leverage: 0, max_concurrent_positions: 0 });
-    expect(low.maxLeverage).toBe(1);
-    expect(low.maxConcurrentPositions).toBe(1);
+    const parsed = parseRiskSettingsRow({
+      max_drawdown: 500,
+      max_position_size: -10,
+      max_concurrent_positions: 999,
+      stop_loss: 0.001,
+      take_profit: 1000,
+      daily_loss_limit: 200,
+      max_leverage: 250,
+      risk_level: 'aggressive',
+    });
+    expect(parsed.maxDrawdown).toBe(100);
+    expect(parsed.maxLeverage).toBe(100);
   });
 
   it('falls back per-field on non-numeric / wrong-typed values', () => {
     const parsed = parseRiskSettingsRow({
-      max_leverage: 'not-a-number',
-      daily_loss_limit: null,
+      max_drawdown: 'not-a-number',
+      max_position_size: null,
+      max_concurrent_positions: undefined,
+      stop_loss: '',
+      take_profit: false,
+      daily_loss_limit: {},
       risk_level: 42,
     });
-    expect(parsed.maxLeverage).toBe(DEFAULT_RISK_SETTINGS.maxLeverage);
-    expect(parsed.dailyLossLimit).toBe(DEFAULT_RISK_SETTINGS.dailyLossLimit);
+    expect(parsed.maxDrawdown).toBe(DEFAULT_RISK_SETTINGS.maxDrawdown);
+    expect(parsed.maxPositionSize).toBe(DEFAULT_RISK_SETTINGS.maxPositionSize);
     expect(parsed.riskLevel).toBe(DEFAULT_RISK_SETTINGS.riskLevel);
   });
 
   it('rounds max_concurrent_positions and max_leverage to integers', () => {
-    const parsed = parseRiskSettingsRow({ max_concurrent_positions: 3.7, max_leverage: 14.2 });
+    const parsed = parseRiskSettingsRow({
+      max_concurrent_positions: 3.7,
+      max_leverage: 14.4,
+    });
     expect(parsed.maxConcurrentPositions).toBe(4);
     expect(parsed.maxLeverage).toBe(14);
-  });
-});
-
-describe('dailyLossHalted', () => {
-  // cap = 5% of 1000 = 50 USDT
-  it('does not halt while losses are within the cap', () => {
-    expect(dailyLossHalted(-10, 5, 1000)).toBe(false);
-    expect(dailyLossHalted(-49.99, 5, 1000)).toBe(false);
-  });
-
-  it('halts once realised loss reaches the cap', () => {
-    expect(dailyLossHalted(-50, 5, 1000)).toBe(true);
-    expect(dailyLossHalted(-80, 5, 1000)).toBe(true);
-  });
-
-  it('never halts on a profitable day', () => {
-    expect(dailyLossHalted(120, 5, 1000)).toBe(false);
-    expect(dailyLossHalted(0, 5, 1000)).toBe(false);
-  });
-
-  it('does not halt when equity or limit is non-positive (no spurious halt)', () => {
-    expect(dailyLossHalted(-500, 5, 0)).toBe(false);
-    expect(dailyLossHalted(-500, 0, 1000)).toBe(false);
-  });
-
-  it('does not halt on a non-finite PnL reading', () => {
-    expect(dailyLossHalted(NaN, 5, 1000)).toBe(false);
   });
 });

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -154,14 +154,7 @@ import {
 } from './compositional_executive.js';
 import { agentLDecide, type AgentLDecision } from './agent_L_classifier.js';
 import { signalScorer, resolveEntryGate } from './signal_scorer.js';
-import {
-  getOperatorRiskSettings,
-  getTodayMonkeyRealizedPnl,
-  getOpenMonkeyPositionCount,
-  getEntryRiskSettingsHalt,
-  adjustTodayMonkeyRealizedPnlCache,
-  adjustOpenMonkeyPositionCountCache,
-} from './risk_settings.js';
+import { getOperatorRiskSettings } from './risk_settings.js';
 import { QIGRAMv2State, isQigramV2Enabled } from './agent_L_qigram_v2.js';
 import {
   newMTFState,
@@ -200,10 +193,6 @@ import {
 
 /** Default Monkey watchlist. */
 const DEFAULT_SYMBOLS = ['BTC_USDT_PERP', 'ETH_USDT_PERP'];
-
-interface TickRiskProjection {
-  openMonkeyPositions: number | null;
-}
 
 /**
  * Env-number coercion that respects 0 as a legitimate value.
@@ -1563,10 +1552,9 @@ export class MonkeyKernel extends EventEmitter {
       // LIMIT_MAKER_STALE_MS (2 min). Errors are non-fatal — the next
       // tick retries cancel.
       try { await this.cancelStaleLimitMakers(); } catch { /* non-fatal */ }
-      const tickRiskProjection: TickRiskProjection = { openMonkeyPositions: null };
       for (const sym of this.symbols) {
         try {
-          await this.processSymbol(sym, tickRiskProjection);
+          await this.processSymbol(sym);
         } catch (err) {
           logger.warn(`[Monkey] ${sym} tick failed`, {
             err: err instanceof Error ? err.message : String(err),
@@ -1752,7 +1740,7 @@ export class MonkeyKernel extends EventEmitter {
    *   5. DECIDE   — propose action (observe-only in v0.1)
    *   6. PERSIST  — write trajectory + decision to DB for audit
    */
-  private async processSymbol(symbol: string, tickRiskProjection: TickRiskProjection): Promise<void> {
+  private async processSymbol(symbol: string): Promise<void> {
     const state = this.symbolStates.get(symbol);
     if (!state) return;
 
@@ -1910,50 +1898,14 @@ export class MonkeyKernel extends EventEmitter {
       availableEquity,
     } = await this.fetchAccountContext(symbol);
 
-    // Operator risk profile (RiskSettings UI → risk_settings table,
-    // migration 055). Honest hard ceilings only — leverage clamp,
-    // max-concurrent-positions gate, daily-loss halt. Cached 60s.
-    // riskSettings is null when no operator profile is saved → the
-    // ceilings below are skipped entirely (opt-in; no behaviour change).
-    // The three reads are independent — fetch in parallel so a
-    // cache-miss tick costs one round-trip of latency, not three.
-    const [riskSettings, todayRealizedPnl, openMonkeyPositions] = await Promise.all([
-      getOperatorRiskSettings(),
-      getTodayMonkeyRealizedPnl(),
-      getOpenMonkeyPositionCount(),
-    ]);
-    if (tickRiskProjection.openMonkeyPositions === null) {
-      tickRiskProjection.openMonkeyPositions = openMonkeyPositions;
-    }
-    let projectedTodayRealizedPnl = todayRealizedPnl;
-    const noteProjectedEntry = (): void => {
-      tickRiskProjection.openMonkeyPositions = Math.max(
-        0,
-        (tickRiskProjection.openMonkeyPositions ?? openMonkeyPositions) + 1,
-      );
-      adjustOpenMonkeyPositionCountCache(1);
-    };
-    const noteProjectedClose = (pnl: number, rowsClosed = 1): void => {
-      const closedRows = Number.isFinite(rowsClosed)
-        ? Math.max(0, Math.trunc(rowsClosed))
-        : 1;
-      if (Number.isFinite(pnl)) {
-        projectedTodayRealizedPnl += pnl;
-        adjustTodayMonkeyRealizedPnlCache(pnl);
-      }
-      tickRiskProjection.openMonkeyPositions = Math.max(
-        0,
-        (tickRiskProjection.openMonkeyPositions ?? openMonkeyPositions) - closedRows,
-      );
-      adjustOpenMonkeyPositionCountCache(-closedRows);
-    };
-    const currentEntryRiskSettingsHalt = (): ReturnType<typeof getEntryRiskSettingsHalt> =>
-      getEntryRiskSettingsHalt({
-        riskSettings,
-        todayRealizedPnl: projectedTodayRealizedPnl,
-        equityUsdt: availableEquity,
-        openMonkeyPositions: tickRiskProjection.openMonkeyPositions ?? openMonkeyPositions,
-      });
+    // Operator risk profile — only `max_leverage` is enforced (audited
+    // 15× safety ceiling, applied as a clamp on `maxLevBoundary` below).
+    // 2026-05-25 doctrine: the kernel trades autonomously. The
+    // daily-loss-limit and max-concurrent-positions halts that used to
+    // suppress entries have been removed — losses feed back to
+    // neurochemistry (dopamine drop, frustration); the kernel adjusts
+    // itself. Cached 60s; null when no profile saved (no ceiling).
+    const riskSettings = await getOperatorRiskSettings();
 
     // 2. PERCEIVE — raw basin then refract through identity.
     // Post #ml-separation: ml fields omitted; perception defaults dims
@@ -4086,24 +4038,6 @@ export class MonkeyKernel extends EventEmitter {
             lSource: 'agentLDecide(state.basinHistory)',
           });
         } else {
-          const riskHalt = currentEntryRiskSettingsHalt();
-          if (riskHalt?.kind === 'daily_loss_limit') {
-            // risk_settings daily-loss halt — today's realised Monkey PnL
-            // is at/below -dailyLossLimit% of equity. New entries are
-            // suppressed; exits are unaffected so losers can still close.
-            reason += ` | risk_settings: daily loss limit — today ${riskHalt.todayRealizedPnl.toFixed(2)} USDT ≤ -${riskHalt.limitPct}% of ${riskHalt.equityUsdt.toFixed(2)} (entry suppressed; exits unaffected)`;
-            (derivation as Record<string, unknown>).riskSettingsHalt = riskHalt;
-            logger.warn(`[Monkey] ${symbol} entry suppressed — risk_settings daily loss limit`, {
-              todayRealizedPnl: riskHalt.todayRealizedPnl,
-              limitPct: riskHalt.limitPct,
-              equityUsdt: riskHalt.equityUsdt,
-            });
-          } else if (riskHalt?.kind === 'max_concurrent_positions') {
-            // risk_settings max-concurrent-positions ceiling — counts
-            // Monkey-owned open rows only (never the account-wide total).
-            reason += ` | risk_settings: max concurrent positions (${riskHalt.openMonkeyPositions}/${riskHalt.cap})`;
-            (derivation as Record<string, unknown>).riskSettingsHalt = riskHalt;
-          } else {
           const isDCA = Boolean(derivation.isDCAAdd);
         // Cap K's margin to its arbiter share. Without this, the existing
         // size formula could exceed K's allocation when M has been
@@ -4148,7 +4082,6 @@ export class MonkeyKernel extends EventEmitter {
           if (execResult.reason.startsWith('monkey_paper_mode:')) {
             reason += ` | ${execResult.reason}`;
           }
-          noteProjectedEntry();
           // v0.6.2 bookkeeping
           state.lastEntryAtMs = Date.now();
           if (isDCA) {
@@ -4177,7 +4110,6 @@ export class MonkeyKernel extends EventEmitter {
             state.entryTimeMsByLane[entryLane] = Date.now();
           }
         }
-          }
         }  // close v0.8.7 trading-paused else branch
       } else if (action === 'scalp_exit' && heldSide) {
         const scalpDeriv = derivation.scalp as Record<string, unknown> | undefined;
@@ -4208,7 +4140,6 @@ export class MonkeyKernel extends EventEmitter {
           executed = closeResult.executed;
           monkeyOrderId = closeResult.orderId;
           if (executed) {
-            noteProjectedClose(pnlAtDecision);
             // Clear lane-scoped trade-level state now the lane closed.
             // Other lanes' bookkeeping is preserved (proposal #10).
             state.peakPnlUsdtByLane[scalpLane] = null;
@@ -4263,7 +4194,6 @@ export class MonkeyKernel extends EventEmitter {
             lane: ownOpenRow?.lane ?? 'swing',
           });
           if (closeResult.executed) {
-            noteProjectedClose(pnlAtDecision);
             state.peakPnlUsdt = null;
             state.peakTrackedTradeId = null;
             state.dcaAddCount = 0;
@@ -4314,25 +4244,6 @@ export class MonkeyKernel extends EventEmitter {
                 leg: 'reverse_reopen',
               });
             } else {
-              const reverseReopenRiskHalt = currentEntryRiskSettingsHalt();
-              if (reverseReopenRiskHalt) {
-                reason += ` | closed@${lastPrice.toFixed(2)} pnl=${pnlAtDecision.toFixed(4)} | risk_settings: reverse reopen suppressed (${reverseReopenRiskHalt.kind})`;
-                (derivation as Record<string, unknown>).reverseReopenRiskSettingsHalt = reverseReopenRiskHalt;
-                logger.warn('[Monkey] reverse reopen suppressed — risk_settings halt', {
-                  symbol,
-                  kind: reverseReopenRiskHalt.kind,
-                  ...(reverseReopenRiskHalt.kind === 'daily_loss_limit'
-                    ? {
-                        todayRealizedPnl: reverseReopenRiskHalt.todayRealizedPnl,
-                        limitPct: reverseReopenRiskHalt.limitPct,
-                        equityUsdt: reverseReopenRiskHalt.equityUsdt,
-                      }
-                    : {
-                        openMonkeyPositions: reverseReopenRiskHalt.openMonkeyPositions,
-                        cap: reverseReopenRiskHalt.cap,
-                      }),
-                });
-              } else {
             // Settle delay — give the exchange ~500ms to flatten net.
             await new Promise((resolve) => setTimeout(resolve, 500));
             const execResult = await this.executeEntry({
@@ -4356,7 +4267,6 @@ export class MonkeyKernel extends EventEmitter {
             executed = execResult.executed;
             monkeyOrderId = execResult.orderId;
             if (executed) {
-              noteProjectedEntry();
               state.lastEntryAtMs = Date.now();
               // Re-snapshot rejustification anchors for the new direction.
               state.regimeAtOpenByLane[reversalLane] = mode;
@@ -4371,7 +4281,6 @@ export class MonkeyKernel extends EventEmitter {
             } else {
               reason += ` | flattened ok, new-entry failed: ${execResult.reason}`;
             }
-              }
             }  // close v0.8.7 trading-paused else branch
           } else {
             reason += ` | flatten failed: ${closeResult.reason}; reverse aborted`;
@@ -4542,23 +4451,6 @@ export class MonkeyKernel extends EventEmitter {
           });
           (derivation as Record<string, unknown>).agentMTradingPausedSkipped = true;
         } else {
-          const riskHalt = currentEntryRiskSettingsHalt();
-          if (riskHalt?.kind === 'daily_loss_limit') {
-            (derivation as Record<string, unknown>).agentMRiskSettingsHalt = riskHalt;
-            logger.warn('[AgentM] entry suppressed — risk_settings daily loss limit', {
-              symbol,
-              todayRealizedPnl: riskHalt.todayRealizedPnl,
-              limitPct: riskHalt.limitPct,
-              equityUsdt: riskHalt.equityUsdt,
-            });
-          } else if (riskHalt?.kind === 'max_concurrent_positions') {
-            (derivation as Record<string, unknown>).agentMRiskSettingsHalt = riskHalt;
-            logger.warn('[AgentM] entry suppressed — risk_settings max concurrent positions', {
-              symbol,
-              openMonkeyPositions: riskHalt.openMonkeyPositions,
-              cap: riskHalt.cap,
-            });
-          } else {
         const mResult = await this.executeEntry({
           symbol,
           side: mDecision.action === 'enter_long' ? 'long' : 'short',
@@ -4581,7 +4473,6 @@ export class MonkeyKernel extends EventEmitter {
             symbol, side: mDecision.action, reason: mResult.reason,
           });
         } else {
-          noteProjectedEntry();
           logger.info('[AgentM] entry placed', {
             symbol, side: mDecision.action, orderId: mResult.orderId,
             margin: clampedSize.toFixed(2), leverage: mDecision.leverage,
@@ -4590,7 +4481,6 @@ export class MonkeyKernel extends EventEmitter {
         }
           }
         }  // close v0.8.7 trading-paused else branch
-      }
       }  // close mHeadroom > 0 else branch
     }
 
@@ -4693,24 +4583,6 @@ export class MonkeyKernel extends EventEmitter {
         // when MONKEY_TRADING_PAUSED=true. Exits below are unaffected.
         && !isTradingPaused()
       ) {
-        const riskHalt = currentEntryRiskSettingsHalt();
-        if (riskHalt) {
-          (derivation as Record<string, unknown>).agentTRiskSettingsHalt = riskHalt;
-          logger.warn('[AgentT] entry suppressed — risk_settings halt', {
-            symbol,
-            kind: riskHalt.kind,
-            ...(riskHalt.kind === 'daily_loss_limit'
-              ? {
-                  todayRealizedPnl: riskHalt.todayRealizedPnl,
-                  limitPct: riskHalt.limitPct,
-                  equityUsdt: riskHalt.equityUsdt,
-                }
-              : {
-                  openMonkeyPositions: riskHalt.openMonkeyPositions,
-                  cap: riskHalt.cap,
-                }),
-          });
-        } else {
         const tSide: 'long' | 'short' =
           tDecision.action === 'enter_long' || tDecision.action === 'pyramid_long'
             ? 'long'
@@ -4740,7 +4612,6 @@ export class MonkeyKernel extends EventEmitter {
         });
         derivation.agentTExecuted = tResult.executed;
         if (tResult.executed) {
-          noteProjectedEntry();
           // Mirror the new unit into TurtleState. Stop, ATR, leverage,
           // margin all derive from the decision; entryPrice is the
           // exchange fill estimate (executeEntry doesn't currently
@@ -4768,7 +4639,6 @@ export class MonkeyKernel extends EventEmitter {
           logger.info('[AgentT] entry rejected', {
             symbol, side: tSide, reason: tResult.reason,
           });
-        }
         }
       } else if (
         (tDecision.action === 'exit_stop' || tDecision.action === 'exit_donchian')
@@ -4821,7 +4691,6 @@ export class MonkeyKernel extends EventEmitter {
               lane: 'trend',
             });
             if (closeResult.executed) {
-              noteProjectedClose(pnlAtDecision, tRows.length);
               this.turtleStates.set(
                 symbol,
                 turtleClearUnits(tState, tDecision.action, Date.now()),
@@ -5071,24 +4940,6 @@ export class MonkeyKernel extends EventEmitter {
           }
           if (lMargin > 0) {
             const lLeverage = leverage.value;
-            const riskHalt = currentEntryRiskSettingsHalt();
-            if (riskHalt) {
-              (derivation as Record<string, unknown>).agentLRiskSettingsHalt = riskHalt;
-              logger.warn('[AgentL] entry suppressed — risk_settings halt', {
-                symbol,
-                kind: riskHalt.kind,
-                ...(riskHalt.kind === 'daily_loss_limit'
-                  ? {
-                      todayRealizedPnl: riskHalt.todayRealizedPnl,
-                      limitPct: riskHalt.limitPct,
-                      equityUsdt: riskHalt.equityUsdt,
-                    }
-                  : {
-                      openMonkeyPositions: riskHalt.openMonkeyPositions,
-                      cap: riskHalt.cap,
-                    }),
-              });
-            } else {
             const lResult = await this.executeEntry({
               symbol,
               side: lDecision.action === 'enter_long' ? 'long' : 'short',
@@ -5108,7 +4959,6 @@ export class MonkeyKernel extends EventEmitter {
             });
             (derivation as Record<string, unknown>).agentLExecuted = lResult.executed;
             if (lResult.executed) {
-              noteProjectedEntry();
               const ld = lDecision.labelDistribution;
               logger.info('[AgentL] entry placed', {
                 symbol, side: lDecision.action, orderId: lResult.orderId,
@@ -5143,7 +4993,6 @@ export class MonkeyKernel extends EventEmitter {
               logger.info('[AgentL] entry rejected', {
                 symbol, side: lDecision.action, reason: lResult.reason,
               });
-            }
             }
           }
         }

--- a/apps/api/src/services/monkey/risk_settings.ts
+++ b/apps/api/src/services/monkey/risk_settings.ts
@@ -1,33 +1,25 @@
 /**
- * risk_settings.ts — bridges the operator's RiskSettings UI panel to the
- * Monkey kernel.
+ * risk_settings.ts — operator's leverage-cap MANDATE.
  *
- * The UI (apps/web/src/components/risk/RiskSettings.tsx) PUTs to
- * /api/risk/settings, which upserts the `risk_settings` table (created
- * in migration 055). Until now the Monkey kernel read none of it — the
- * panel was a dead control. This module turns three of those settings
- * into honest hard ceilings on the kernel:
+ * 2026-05-25 doctrine: the kernel trades autonomously. Operator gates that
+ * suppress entries (daily-loss halt, max-concurrent-positions halt) are
+ * REMOVED — they short-circuited the kernel's own learning. Losses feed
+ * back to the neurochemistry layer (dopamine drop, frustration); the
+ * kernel adjusts itself. Everything else is telemetry on the
+ * /autonomous-agent panel, not a gate.
  *
+ * What REMAINS here:
  *   - max_leverage             → clamps maxLevBoundary in loop.ts. The
- *                                audited 15× ceiling (MONKEY_MAX_LEVERAGE_CAP,
- *                                loop.ts:2349-2362) still binds — the UI
- *                                value can only clamp leverage DOWN.
- *   - max_concurrent_positions → vetoes new Monkey entries once that many
- *                                Monkey-owned positions are already open.
- *   - daily_loss_limit         → halts new entries once today's realised
- *                                Monkey PnL is at/below -limit% of equity.
+ *                                audited 15× ceiling (MONKEY_MAX_LEVERAGE_CAP)
+ *                                still binds — the UI value can only clamp
+ *                                leverage DOWN. This is the one operator
+ *                                MANDATE that survives: a safety ceiling,
+ *                                not a behavioural knob.
  *
- * Ceilings only — they restrict, never amplify. A UI "aggressive" preset
- * cannot push the kernel past its own observer-derived sizing or past
- * the leverage audit; that would be the P1 operator-knob anti-pattern.
- *
- * Strictly opt-in: when no operator profile has been saved (empty table,
- * or a DB error) getOperatorRiskSettings returns null and the kernel
- * applies NO ceilings — behaviour is identical to before this module.
- * The ceilings only ever engage once the operator saves a profile.
- *
- * Reads are cached 60 s and fail soft (null / 0) — a DB hiccup must
- * never block trading or fabricate a loss halt.
+ * Strictly opt-in: when no operator profile has been saved
+ * `getOperatorRiskSettings` returns null and the kernel applies NO ceiling.
+ * Reads are cached 60 s and fail soft (null) — a DB hiccup must never
+ * block trading.
  *
  * QIG purity: SQL + arithmetic only. No geometric ops.
  */
@@ -47,7 +39,9 @@ export interface OperatorRiskSettings {
   riskLevel: string;
 }
 
-/** Mirrors the GET /api/risk/settings route defaults. */
+/** Mirrors the GET /api/risk/settings route defaults. The non-leverage
+ *  fields are retained for compatibility with the RiskSettings table and
+ *  any telemetry consumers; the kernel only acts on `maxLeverage`. */
 export const DEFAULT_RISK_SETTINGS: OperatorRiskSettings = {
   maxDrawdown: 15,
   maxPositionSize: 5,
@@ -71,7 +65,7 @@ function clampNum(raw: unknown, fallback: number, lo: number, hi: number): numbe
 /**
  * Pure: coerce + clamp a `risk_settings` DB row into OperatorRiskSettings.
  * A null/undefined row yields the defaults. Out-of-range values are
- * clamped so a corrupt row can never produce a nonsensical gate.
+ * clamped so a corrupt row can never produce a nonsensical leverage cap.
  */
 export function parseRiskSettingsRow(
   row: Record<string, unknown> | null | undefined,
@@ -91,94 +85,13 @@ export function parseRiskSettingsRow(
   };
 }
 
-/**
- * Pure: is the daily-loss halt tripped? The cap is `limitPct`% of equity;
- * the halt trips once today's realised PnL has fallen to -cap or worse.
- * Returns false when equity or limit is non-positive (no spurious halt).
- */
-export function dailyLossHalted(
-  todayRealizedPnl: number,
-  dailyLossLimitPct: number,
-  equityUsdt: number,
-): boolean {
-  if (!Number.isFinite(todayRealizedPnl)) return false;
-  if (!(dailyLossLimitPct > 0) || !(equityUsdt > 0)) return false;
-  const capUsd = (dailyLossLimitPct / 100) * equityUsdt;
-  return todayRealizedPnl <= -capUsd;
-}
-
-export type EntryRiskSettingsHalt =
-  | {
-      kind: 'daily_loss_limit';
-      todayRealizedPnl: number;
-      limitPct: number;
-      equityUsdt: number;
-    }
-  | {
-      kind: 'max_concurrent_positions';
-      openMonkeyPositions: number;
-      cap: number;
-    };
-
-/**
- * Pure: resolve whether the operator risk profile blocks a NEW Monkey
- * entry right now. Exits remain unaffected.
- */
-export function getEntryRiskSettingsHalt(args: {
-  riskSettings: OperatorRiskSettings | null;
-  todayRealizedPnl: number;
-  equityUsdt: number;
-  openMonkeyPositions: number;
-}): EntryRiskSettingsHalt | null {
-  const {
-    riskSettings,
-    todayRealizedPnl,
-    equityUsdt,
-    openMonkeyPositions,
-  } = args;
-  if (!riskSettings) return null;
-  if (dailyLossHalted(todayRealizedPnl, riskSettings.dailyLossLimit, equityUsdt)) {
-    return {
-      kind: 'daily_loss_limit',
-      todayRealizedPnl,
-      limitPct: riskSettings.dailyLossLimit,
-      equityUsdt,
-    };
-  }
-  if (openMonkeyPositions >= riskSettings.maxConcurrentPositions) {
-    return {
-      kind: 'max_concurrent_positions',
-      openMonkeyPositions,
-      cap: riskSettings.maxConcurrentPositions,
-    };
-  }
-  return null;
-}
-
 const TTL_MS = 60_000;
 
 let settingsCache: { value: OperatorRiskSettings | null; atMs: number } | null = null;
-let pnlCache: { value: number; atMs: number } | null = null;
-let openCountCache: { value: number; atMs: number } | null = null;
 
-export function adjustTodayMonkeyRealizedPnlCache(delta: number): void {
-  if (!pnlCache || !Number.isFinite(delta) || delta === 0) return;
-  pnlCache = { value: pnlCache.value + delta, atMs: pnlCache.atMs };
-}
-
-export function adjustOpenMonkeyPositionCountCache(delta: number): void {
-  if (!openCountCache || !Number.isFinite(delta) || delta === 0) return;
-  openCountCache = {
-    value: Math.max(0, openCountCache.value + Math.trunc(delta)),
-    atMs: openCountCache.atMs,
-  };
-}
-
-/** Test seam — clears the module caches. */
+/** Test seam — clears the module cache. */
 export function resetRiskSettingsCache(): void {
   settingsCache = null;
-  pnlCache = null;
-  openCountCache = null;
 }
 
 /**
@@ -192,8 +105,8 @@ export function resetRiskSettingsCache(): void {
  * becomes multi-tenant this MUST be re-keyed by the operator's user_id.
  *
  * Returns `null` when no profile has been saved (empty table) OR on a
- * DB error. `null` means the kernel applies NO ceilings — behaviour is
- * identical to before this module. The risk panel is strictly opt-in:
+ * DB error. `null` means the kernel applies NO ceiling — behaviour is
+ * identical to before this module. The leverage cap is strictly opt-in:
  * an unset profile must never make the kernel more (or less) aggressive.
  */
 export async function getOperatorRiskSettings(): Promise<OperatorRiskSettings | null> {
@@ -212,188 +125,10 @@ export async function getOperatorRiskSettings(): Promise<OperatorRiskSettings | 
     settingsCache = { value, atMs: Date.now() };
     return value;
   } catch (err) {
-    logger.warn('[risk-settings] read failed — no ceilings applied this cycle', {
+    logger.warn('[risk-settings] read failed — no ceiling applied this cycle', {
       err: err instanceof Error ? err.message : String(err),
     });
     settingsCache = { value: null, atMs: Date.now() };
     return null;
-  }
-}
-
-/**
- * Today's realised PnL for Monkey-owned closed trades (UTC day boundary).
- * Cached 60 s; 0 on error — a DB hiccup must not fabricate a loss halt.
- * Engine filter mirrors kelly_rolling_stats.ts: `reason LIKE 'monkey|%'`.
- *
- * Diagnostic breakdown (2026-05-25): on every cache miss we ALSO run a
- * one-shot breakdown query and log row-counts / wins / losses / nulls /
- * by-agent / by-reason-prefix. CSV ground-truth showed the SUM was
- * inflated 27× vs Poloniex's actual close ledger — the breakdown lets
- * us see which slice (agent, reason-prefix, NULL-pnl rows, gross_loss
- * vs gross_win asymmetry, time range) is the inflation source without
- * needing DB-paste from the operator. Logged at WARN so it surfaces in
- * Railway log search; the cost is one extra small query per minute.
- */
-export async function getTodayMonkeyRealizedPnl(): Promise<number> {
-  if (pnlCache && Date.now() - pnlCache.atMs < TTL_MS) return pnlCache.value;
-  try {
-    const r = await pool.query(
-      // Explicit UTC day boundary — date_trunc on a bare NOW() would use
-      // the DB session timezone. Drop NOW() to UTC wall-clock, truncate
-      // to the day, then re-attach UTC so the comparison against
-      // exit_time (timestamptz) is unambiguous regardless of server tz.
-      `SELECT COALESCE(SUM(pnl), 0) AS pnl
-         FROM autonomous_trades
-        WHERE status = 'closed'
-          AND reason LIKE 'monkey|%'
-          AND exit_time >= date_trunc('day', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'`,
-    );
-    const pnl = Number((r.rows[0] as { pnl?: unknown } | undefined)?.pnl ?? 0);
-    const value = Number.isFinite(pnl) ? pnl : 0;
-    pnlCache = { value, atMs: Date.now() };
-    // Fire-and-forget breakdown — never block the cache fill on it.
-    logDailyPnlBreakdown(value).catch(() => { /* diagnostic only */ });
-    return value;
-  } catch (err) {
-    logger.warn('[risk-settings] daily-PnL read failed — assuming 0', {
-      err: err instanceof Error ? err.message : String(err),
-    });
-    pnlCache = { value: 0, atMs: Date.now() };
-    return 0;
-  }
-}
-
-/**
- * One-shot diagnostic breakdown for the today-PnL SUM. Runs alongside
- * the cached query on cache misses; logs a wide row that exposes the
- * shape of the rows the SUM is summing.
- *
- * Built to localise the 2026-05-25 inflation bug (DB SUM read −$61.65;
- * Poloniex ledger ground truth −$2.30). The breakdown distinguishes:
- *   - NULL-pnl rows  → reconciler closes that never wrote a real pnl
- *   - by-agent       → K/L/T/M split asymmetries
- *   - reason-prefix  → only `monkey|%` rows count; if wins live under
- *                      another prefix (e.g. `kernel_adopted|%`) the
- *                      SUM is loss-biased
- *   - gross_win / gross_loss → if gross_win ≈ 0 the wins are missing
- *   - PnL extremes   → a single inflated outlier (e.g. leverage-x'd
- *                      row) shows up as max/min far from the others
- *
- * Logs at WARN (always-on visibility) for the next several minutes;
- * delete this diagnostic once the bug class is found.
- */
-async function logDailyPnlBreakdown(observedSum: number): Promise<void> {
-  try {
-    const r = await pool.query<{
-      rows_n: string;
-      wins: string;
-      losses: string;
-      zeros: string;
-      null_pnls: string;
-      gross_wins: string;
-      gross_losses: string;
-      max_pnl: string;
-      min_pnl: string;
-      distinct_agents: string;
-      distinct_reason_prefixes: string;
-      first_exit: string | null;
-      last_exit: string | null;
-    }>(
-      `SELECT COUNT(*) AS rows_n,
-              COUNT(*) FILTER (WHERE pnl > 0) AS wins,
-              COUNT(*) FILTER (WHERE pnl < 0) AS losses,
-              COUNT(*) FILTER (WHERE pnl = 0) AS zeros,
-              COUNT(*) FILTER (WHERE pnl IS NULL) AS null_pnls,
-              COALESCE(SUM(pnl) FILTER (WHERE pnl > 0), 0) AS gross_wins,
-              COALESCE(SUM(pnl) FILTER (WHERE pnl < 0), 0) AS gross_losses,
-              COALESCE(MAX(pnl), 0) AS max_pnl,
-              COALESCE(MIN(pnl), 0) AS min_pnl,
-              COUNT(DISTINCT agent) AS distinct_agents,
-              COUNT(DISTINCT split_part(reason, '|', 1)) AS distinct_reason_prefixes,
-              MIN(exit_time)::text AS first_exit,
-              MAX(exit_time)::text AS last_exit
-         FROM autonomous_trades
-        WHERE status = 'closed'
-          AND reason LIKE 'monkey|%'
-          AND exit_time >= date_trunc('day', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'`,
-    );
-    const row = r.rows[0];
-    if (!row) return;
-    logger.warn('[risk-settings] daily-PnL breakdown (diagnostic)', {
-      observedSum: Number(observedSum.toFixed(4)),
-      rows: Number(row.rows_n),
-      wins: Number(row.wins),
-      losses: Number(row.losses),
-      zeros: Number(row.zeros),
-      null_pnls: Number(row.null_pnls),
-      gross_wins: Number(Number(row.gross_wins).toFixed(4)),
-      gross_losses: Number(Number(row.gross_losses).toFixed(4)),
-      max_pnl: Number(Number(row.max_pnl).toFixed(4)),
-      min_pnl: Number(Number(row.min_pnl).toFixed(4)),
-      distinct_agents: Number(row.distinct_agents),
-      distinct_reason_prefixes: Number(row.distinct_reason_prefixes),
-      first_exit: row.first_exit,
-      last_exit: row.last_exit,
-    });
-
-    // Per-agent slice — distinguishes K/L/T/M splits going asymmetric.
-    const agentRows = await pool.query<{
-      agent: string | null;
-      n: string;
-      net: string;
-      gross_win: string;
-      gross_loss: string;
-    }>(
-      `SELECT agent, COUNT(*) AS n,
-              COALESCE(SUM(pnl), 0) AS net,
-              COALESCE(SUM(pnl) FILTER (WHERE pnl > 0), 0) AS gross_win,
-              COALESCE(SUM(pnl) FILTER (WHERE pnl < 0), 0) AS gross_loss
-         FROM autonomous_trades
-        WHERE status = 'closed'
-          AND reason LIKE 'monkey|%'
-          AND exit_time >= date_trunc('day', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
-        GROUP BY agent
-        ORDER BY agent NULLS FIRST`,
-    );
-    for (const a of agentRows.rows) {
-      logger.warn('[risk-settings] daily-PnL by agent', {
-        agent: a.agent ?? '<null>',
-        n: Number(a.n),
-        net: Number(Number(a.net).toFixed(4)),
-        gross_win: Number(Number(a.gross_win).toFixed(4)),
-        gross_loss: Number(Number(a.gross_loss).toFixed(4)),
-      });
-    }
-  } catch {
-    /* diagnostic-only; never throw out of a cache-fill */
-  }
-}
-
-/**
- * Count of currently-open Monkey-owned positions. Cached 60 s; 0 on
- * error. Counts Monkey's own rows only (`reason LIKE 'monkey|%'`) — NOT
- * the account-wide open count, which also includes operator-opened
- * positions and must never gate Monkey (loop.ts fetchAccountContext
- * 2026-04-21 note).
- */
-export async function getOpenMonkeyPositionCount(): Promise<number> {
-  if (openCountCache && Date.now() - openCountCache.atMs < TTL_MS) return openCountCache.value;
-  try {
-    const r = await pool.query(
-      `SELECT COUNT(*)::int AS n
-         FROM autonomous_trades
-        WHERE status = 'open'
-          AND reason LIKE 'monkey|%'`,
-    );
-    const n = Number((r.rows[0] as { n?: unknown } | undefined)?.n ?? 0);
-    const value = Number.isFinite(n) && n >= 0 ? n : 0;
-    openCountCache = { value, atMs: Date.now() };
-    return value;
-  } catch (err) {
-    logger.warn('[risk-settings] open-position count read failed — assuming 0', {
-      err: err instanceof Error ? err.message : String(err),
-    });
-    openCountCache = { value: 0, atMs: Date.now() };
-    return 0;
   }
 }


### PR DESCRIPTION
## Doctrine shift

Operator directive 2026-05-25: *"the system doesn't need it and trades autonomously. everything is telemetry really. with goal of as much profit as possible however achieved. all telemetry fed back to kernels. and neurotransmitter rewards where appropriate for wins."*

## What's removed

Two halts that suppressed kernel entries:
- **daily_loss_limit halt** — today the query read −\$61.65 while the Poloniex ledger (ground truth) showed −\$2.30. Kernel got halt-locked with no way to verify the discrepancy short of DB-paste. Even if the query were correct, the halt is an operator-style circuit breaker the kernel doesn't need — losses already feed back through the neurochemistry layer (dopamine ↓, frustration in \`autonomic.push_reward\`).
- **max_concurrent_positions halt** — same shape, removed for the same reason.

Plus the supporting machinery (\`getTodayMonkeyRealizedPnl\`, \`getOpenMonkeyPositionCount\`, the projection bookkeeping, PR907's diagnostic helper which becomes moot once the query it instrumented is gone).

5 enforcement blocks in \`loop.ts\` removed (Monkey-K entry, reverse-reopen, Monkey-M entry, Monkey-T entry, Monkey-L entry). 8 \`noteProjectedEntry/Close\` call sites removed. \`TickRiskProjection\` interface removed.

## What stays

Operator MANDATEs only:
- **Audited 15× leverage ceiling** (clamp, not halt — \`loop.ts:~2621\` still reads \`riskSettings.maxLeverage\`).
- **Execution-mode kill switch** (UI control — \`/api/agent/execution-mode\`).

\`OperatorRiskSettings\` interface + \`parseRiskSettingsRow\` + \`getOperatorRiskSettings\` kept for the leverage clamp.

## Verification

- ✅ \`apps/api\` \`tsc --noEmit\` clean
- ✅ vitest **1701 passed / 12 skipped**
- ✅ Test for removed \`dailyLossHalted\` + \`getEntryRiskSettingsHalt\` deleted; \`parseRiskSettingsRow\` tests retained (6 tests, all green)

## Expected post-deploy behavior

The kernel was halt-locked at sov=1.0 with sized entries blocked. Removing the halt + the (now stale) cache:
- Entries resume on the next tick after deploy.
- Sizing reflects Option D's sov fix (margin ~\$20-50 / notional \$200-600 / leverage 11-13×).
- Losses + wins flow back to the neurochemistry stack as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove operator-driven entry halts so the Monkey kernel trades autonomously while retaining only the leverage safety cap.

Bug Fixes:
- Resolve incorrect daily PnL–driven halt-lock by removing the fragile daily-loss limit gate and its dependency on an inflated PnL query.

Enhancements:
- Simplify Monkey risk settings so the kernel only enforces an optional max-leverage ceiling and ignores other operator telemetry fields.
- Remove max-concurrent-positions gating and associated per-tick risk projections so entries are no longer suppressed by operator-configured position limits.
- Streamline Monkey loop processing by eliminating entry-halt plumbing and related logging from all agents and reverse-reopen flows.

Tests:
- Update risk settings tests to focus on parsing and clamping of leverage and related fields, and delete tests that covered the removed daily-loss halt logic.