### PR TITLE
feat(monkey): close TS→Py reward bridge at 3 close sites

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -55,7 +55,7 @@ import {
   velocity,
   type Basin,
 } from './basin.js';
-import { callAutonomicTick } from './autonomic_client.js';
+import { callAutonomicTick, callAutonomicReward } from './autonomic_client.js';
 import { aggregatePeakTracker } from './aggregate_peak.js';
 import { wsPositionCache } from './ws_position_cache.js';
 import { marketIntelCache } from './market_intel.js';
@@ -1186,6 +1186,16 @@ export class MonkeyKernel extends EventEmitter {
             agent,
           });
         } catch { /* non-fatal */ }
+        // Mirror the same reward into the Python autonomic kernel so
+        // both neurochemistries see the same outcome stream. Fire-and-
+        // forget — callAutonomicReward already swallows transport errors.
+        void callAutonomicReward({
+          instanceId: this.instanceId,
+          source: `reconciler_recovered:${String(payload.ghostReason ?? 'unknown')}`,
+          symbol: event.symbol,
+          realizedPnlUsdt: pnl,
+          marginUsdt: 5,
+        });
         const ghostReason = String(payload.ghostReason ?? 'unknown');
         logger.info(
           `[Monkey] Agent ${agent} emotion stack updated from recovered ghost close: pnl=${pnl.toFixed(4)} side=${side} reason=${ghostReason}`,
@@ -7758,6 +7768,16 @@ export class MonkeyKernel extends EventEmitter {
           kappaAtExit: symState?.kappa,
           agent: agentKey,
         });
+        // Mirror the close into Python autonomic so both kernels'
+        // neurochemistries share the same outcome stream.
+        void callAutonomicReward({
+          instanceId: this.instanceId,
+          source: `own_close:${agentKey}`,
+          symbol,
+          realizedPnlUsdt: t.pnl,
+          marginUsdt: margin,
+          kappaAtExit: symState?.kappa,
+        });
       }
     } catch { /* non-fatal */ }
   }
@@ -8071,6 +8091,13 @@ export class MonkeyKernel extends EventEmitter {
           realizedPnlUsdt: realizedPnl * 0.5,  // half-weight (witnessed, not her own)
           marginUsdt: 5,
           agent: 'K',
+        });
+        void callAutonomicReward({
+          instanceId: this.instanceId,
+          source: 'witnessed_liveSignal',
+          symbol,
+          realizedPnlUsdt: realizedPnl * 0.5,
+          marginUsdt: 5,
         });
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Wire `callAutonomicReward` at every `pushReward` site in `loop.ts` so the
Python autonomic kernel's `_pending_rewards` queue receives the same
outcome stream the TS-side `pendingRewards` queue already sees.

Identified by the loop audit ([[polytrade_autonomy_loop_audit]]):
`callAutonomicReward` was defined in `autonomic_client.ts` but never
called from production. Python neurochemistry has been running on
Φ-gradient only since the v0.7 migration. With this PR both kernels'
chemistries see closes, so consensus-arbiter behaviour (when
`CONSENSUS_ARBITER_LIVE` is flipped) reflects real trade outcomes on
the Py side too.

### Sites wired
- `loop.ts:~1181` — reconciler-recovered ghost close
- `loop.ts:~7753` — `own_close` (per-agent close totals)
- `loop.ts:~8068` — `witnessed_liveSignal` (half-weight reinforcement)

### What this does NOT do
This is the *mechanical* loop closure — outcome stream now flows to Py
neurochemistry. It does **not** add per-symbol bias to direction
selection. That architectural gap (ETH chronic long-bias) is the
follow-up PR.

## Test plan

- [x] `yarn tsc --noEmit` — clean
- [x] `yarn vitest run` (apps/api) — 1701 passed / 12 skipped / 0 failed
- [ ] CI green on the PR
- [ ] Post-deploy: tail polytrade-be logs for `autonomic/reward` POSTs on next close; tail ml-worker logs for `push_reward` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire trade close rewards from the TypeScript monkey loop into the Python autonomic kernel so both sides receive the same outcome stream.

Enhancements:
- Route reconciler-recovered ghost close rewards to the Python autonomic reward endpoint.
- Route own_close rewards for per-agent closes to the Python autonomic reward endpoint.
- Route witnessed_liveSignal half-weight rewards to the Python autonomic reward endpoint.