### PR TITLE
feat(monkey): per-symbol self-observation bias

### DIFF
--- a/apps/api/src/services/monkey/__tests__/selfObservationSymbolBias.test.ts
+++ b/apps/api/src/services/monkey/__tests__/selfObservationSymbolBias.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { computeSymbolSideBias, type SymbolSideStats } from '../self_observation.js';
+
+const emptyStat = (symbol: string, side: 'long' | 'short'): SymbolSideStats => ({
+  symbol,
+  side,
+  trades: 0,
+  wins: 0,
+  losses: 0,
+  winRate: 0,
+  totalPnl: 0,
+  avgPnl: 0,
+});
+
+describe('computeSymbolSideBias', () => {
+  it('returns neutral (1.0) when no symbols have evidence', () => {
+    const bias = computeSymbolSideBias({});
+    expect(bias).toEqual({});
+  });
+
+  it('stays neutral when sample is too small for Wilson CI to exclude 0.5', () => {
+    // 2/3 wins on ETH long: classic small-sample case — CI ~[0.21, 0.94].
+    const ethLong: SymbolSideStats = {
+      ...emptyStat('ETH_USDT_PERP', 'long'),
+      trades: 3,
+      wins: 2,
+      losses: 1,
+      winRate: 2 / 3,
+    };
+    const bias = computeSymbolSideBias({
+      ETH_USDT_PERP: { long: ethLong, short: emptyStat('ETH_USDT_PERP', 'short') },
+    });
+    expect(bias.ETH_USDT_PERP.long).toBe(1.0);
+    expect(bias.ETH_USDT_PERP.short).toBe(1.0);
+  });
+
+  it('deflects bias upward (harder entry) for losing symbol-side with firm evidence', () => {
+    // ETH long: 30/100 (30% WR), CI ~[0.22, 0.40] — entirely below 0.5.
+    const ethLong: SymbolSideStats = {
+      ...emptyStat('ETH_USDT_PERP', 'long'),
+      trades: 100,
+      wins: 30,
+      losses: 70,
+      winRate: 0.30,
+    };
+    const bias = computeSymbolSideBias({
+      ETH_USDT_PERP: { long: ethLong, short: emptyStat('ETH_USDT_PERP', 'short') },
+    });
+    // winRateToBias(0.30) = 1 - (0.30-0.5)*2*0.30 = 1.12
+    expect(bias.ETH_USDT_PERP.long).toBeGreaterThan(1.0);
+    expect(bias.ETH_USDT_PERP.long).toBeCloseTo(1.12, 2);
+    // Short bucket stays neutral (no data).
+    expect(bias.ETH_USDT_PERP.short).toBe(1.0);
+  });
+
+  it('deflects bias downward (easier entry) for winning symbol-side with firm evidence', () => {
+    // BTC long: 70/100 (70% WR), CI ~[0.60, 0.78] — entirely above 0.5.
+    const btcLong: SymbolSideStats = {
+      ...emptyStat('BTC_USDT_PERP', 'long'),
+      trades: 100,
+      wins: 70,
+      losses: 30,
+      winRate: 0.70,
+    };
+    const bias = computeSymbolSideBias({
+      BTC_USDT_PERP: { long: btcLong, short: emptyStat('BTC_USDT_PERP', 'short') },
+    });
+    // winRateToBias(0.70) = 1 - (0.70-0.5)*2*0.30 = 0.88
+    expect(bias.BTC_USDT_PERP.long).toBeLessThan(1.0);
+    expect(bias.BTC_USDT_PERP.long).toBeCloseTo(0.88, 2);
+  });
+
+  it('applies independent biases per symbol — ETH long penalty does NOT bleed into BTC long', () => {
+    const ethLong: SymbolSideStats = {
+      ...emptyStat('ETH_USDT_PERP', 'long'),
+      trades: 100,
+      wins: 30,
+      losses: 70,
+      winRate: 0.30,
+    };
+    const btcLong: SymbolSideStats = {
+      ...emptyStat('BTC_USDT_PERP', 'long'),
+      trades: 100,
+      wins: 70,
+      losses: 30,
+      winRate: 0.70,
+    };
+    const bias = computeSymbolSideBias({
+      ETH_USDT_PERP: { long: ethLong, short: emptyStat('ETH_USDT_PERP', 'short') },
+      BTC_USDT_PERP: { long: btcLong, short: emptyStat('BTC_USDT_PERP', 'short') },
+    });
+    expect(bias.ETH_USDT_PERP.long).toBeGreaterThan(1.0);
+    expect(bias.BTC_USDT_PERP.long).toBeLessThan(1.0);
+  });
+
+  it('respects the MAX_BIAS_SWING bound (≤0.30) — extreme WR caps at [0.70, 1.30]', () => {
+    // 99/100 win-rate is firmer than firm; raw bias would be 1 - 0.49*2*0.30 = 0.706
+    const ethShort: SymbolSideStats = {
+      ...emptyStat('ETH_USDT_PERP', 'short'),
+      trades: 100,
+      wins: 99,
+      losses: 1,
+      winRate: 0.99,
+    };
+    const bias = computeSymbolSideBias({
+      ETH_USDT_PERP: { long: emptyStat('ETH_USDT_PERP', 'long'), short: ethShort },
+    });
+    expect(bias.ETH_USDT_PERP.short).toBeGreaterThanOrEqual(0.70);
+    expect(bias.ETH_USDT_PERP.short).toBeLessThanOrEqual(1.30);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2486,7 +2486,16 @@ export class MonkeyKernel extends EventEmitter {
     // operator directive.
     //
     // Cold start (history length < 2 → stddev undefined → identity 1).
-    const selfObsWinRateBias = this.selfObs?.entryBias[mode]?.[sideCandidate] ?? 1.0;
+    // Compose per-(mode, side) bias with per-(symbol, side) bias. The
+    // symbol axis is orthogonal to mode — closes the 2026-05-25 gap
+    // where ETH long losses pooled with BTC long wins in the
+    // (CREATOR_TREND_UP, long) bucket and never accumulated symbol-
+    // specific evidence. Both biases are Wilson-CI gated and bounded
+    // to [0.7, 1.3], so the composed multiplier is bounded to
+    // [0.49, 1.69] and stays neutral when either lacks evidence.
+    const selfObsModeBias = this.selfObs?.entryBias[mode]?.[sideCandidate] ?? 1.0;
+    const selfObsSymbolBias = this.selfObs?.symbolSideBias[symbol]?.[sideCandidate] ?? 1.0;
+    const selfObsWinRateBias = selfObsModeBias * selfObsSymbolBias;
     let selfObsPressure: number;
     if (state.surpriseHistory.length >= 2) {
       const n = state.surpriseHistory.length;

--- a/apps/api/src/services/monkey/self_observation.ts
+++ b/apps/api/src/services/monkey/self_observation.ts
@@ -36,6 +36,17 @@ export interface ModeStats {
   totalPnl: number;
 }
 
+export interface SymbolSideStats {
+  symbol: string;
+  side: Side;
+  trades: number;
+  wins: number;
+  losses: number;
+  winRate: number;
+  totalPnl: number;
+  avgPnl: number;
+}
+
 export interface SelfObservation {
   lookbackHours: number;
   /** Per-(mode, side) stats. */
@@ -44,6 +55,17 @@ export interface SelfObservation {
    *  < 1.0 = easier entry (good track record here).
    *  > 1.0 = harder entry (losing track record here). */
   entryBias: Record<MonkeyMode, Record<Side, number>>;
+  /** Per-(symbol, side) stats — orthogonal to mode. Lets ETH long
+   *  accumulate its own bias separately from BTC long, which the
+   *  mode-pooled selfObs cannot do. 2026-05-25 audit found ETH long
+   *  losses pool with BTC long wins in the (CREATOR_TREND_UP, long)
+   *  bucket, so the symbol-specific bias never accumulates. */
+  bySymbolSide: Record<string, Record<Side, SymbolSideStats>>;
+  /** Per-(symbol, side) entry-threshold multiplier. Wilson-CI gated
+   *  exactly like entryBias; multiplies with entryBias at the call
+   *  site so a symbol that's losing on a given side gets a harder
+   *  entry even when the mode-pooled bias is neutral. */
+  symbolSideBias: Record<string, Record<Side, number>>;
 }
 
 /**
@@ -105,6 +127,34 @@ function hasBiasEvidence(wins: number, trades: number): boolean {
 
 function emptyStats(mode: MonkeyMode, side: Side): ModeStats {
   return { mode, side, trades: 0, wins: 0, losses: 0, winRate: 0, avgPnl: 0, totalPnl: 0 };
+}
+
+function emptySymbolStats(symbol: string, side: Side): SymbolSideStats {
+  return { symbol, side, trades: 0, wins: 0, losses: 0, winRate: 0, avgPnl: 0, totalPnl: 0 };
+}
+
+/**
+ * Pure-function bias derivation per (symbol, side). Same Wilson-95% CI
+ * evidence gate as computeEntryBias — neutral 1.0 until the CI clearly
+ * excludes 0.5. Exported so the unit tests can pin the behaviour
+ * without a database round-trip.
+ *
+ * Empty input → empty output (caller falls back to 1.0 via ?.).
+ */
+export function computeSymbolSideBias(
+  bySymbolSide: Record<string, Record<Side, SymbolSideStats>>,
+): Record<string, Record<Side, number>> {
+  const out: Record<string, Record<Side, number>> = {};
+  for (const [symbol, sides] of Object.entries(bySymbolSide)) {
+    out[symbol] = { long: 1.0, short: 1.0 };
+    for (const side of SIDES) {
+      const s = sides[side];
+      if (hasBiasEvidence(s.wins, s.trades)) {
+        out[symbol][side] = winRateToBias(s.winRate);
+      }
+    }
+  }
+  return out;
 }
 
 /**
@@ -234,6 +284,7 @@ export async function computeSelfObservation(
   instanceId?: string,
 ): Promise<SelfObservation> {
   const byModeSide = buildEmptyByModeSide();
+  const bySymbolSide: Record<string, Record<Side, SymbolSideStats>> = {};
 
   try {
     // Scope to a specific kernel instance when provided (v0.6b multi-
@@ -246,6 +297,7 @@ export async function computeSelfObservation(
     const result = await pool.query(
       `SELECT at.pnl::float AS pnl,
               at.side        AS side,
+              at.symbol      AS symbol,
               at.exit_reason,
               md.derivation->'mode'->>'value' AS mode
          FROM autonomous_trades at
@@ -266,15 +318,36 @@ export async function computeSelfObservation(
       const sideRaw = String(row.side ?? '').toLowerCase();
       const side: Side = sideRaw === 'sell' || sideRaw === 'short' ? 'short' : 'long';
       const pnl = Number(row.pnl ?? 0);
+      const symbol = String(row.symbol ?? '');
       const stats = byModeSide[mode][side];
       stats.trades += 1;
       stats.totalPnl += pnl;
       if (pnl > 0) stats.wins += 1;
       else if (pnl < 0) stats.losses += 1;
+      if (symbol.length > 0) {
+        if (!bySymbolSide[symbol]) {
+          bySymbolSide[symbol] = {
+            long: emptySymbolStats(symbol, 'long'),
+            short: emptySymbolStats(symbol, 'short'),
+          };
+        }
+        const sStats = bySymbolSide[symbol][side];
+        sStats.trades += 1;
+        sStats.totalPnl += pnl;
+        if (pnl > 0) sStats.wins += 1;
+        else if (pnl < 0) sStats.losses += 1;
+      }
     }
     for (const mode of ALL_MODES) {
       for (const side of SIDES) {
         const s = byModeSide[mode][side];
+        s.winRate = s.trades > 0 ? s.wins / s.trades : 0;
+        s.avgPnl = s.trades > 0 ? s.totalPnl / s.trades : 0;
+      }
+    }
+    for (const symbol of Object.keys(bySymbolSide)) {
+      for (const side of SIDES) {
+        const s = bySymbolSide[symbol][side];
         s.winRate = s.trades > 0 ? s.wins / s.trades : 0;
         s.avgPnl = s.trades > 0 ? s.totalPnl / s.trades : 0;
       }
@@ -313,5 +386,6 @@ export async function computeSelfObservation(
   globalAll.winRate = globalAll.trades > 0 ? globalAll.wins / globalAll.trades : 0;
 
   const entryBias = computeEntryBias(byModeSide, modePooled, globalPooled, globalAll);
-  return { lookbackHours, byModeSide, entryBias };
+  const symbolSideBias = computeSymbolSideBias(bySymbolSide);
+  return { lookbackHours, byModeSide, entryBias, bySymbolSide, symbolSideBias };
 }


### PR DESCRIPTION
## Summary

The audit ([[polytrade_autonomy_loop_audit]]) identified that the
existing SelfObservation pools all symbols into the (mode, side) bucket,
so ETH long losses average with BTC long wins in CREATOR_TREND_UP and
symbol-specific evidence never accumulates. Live confirmation 2026-05-25:
ETH 25–33% WR across all windows while basinDir held positive every tick
and selfObsBias stayed neutral.

### Change
- `bySymbolSide[symbol][side]: ModeStats` — orthogonal axis to mode
- `symbolSideBias[symbol][side]: number` — Wilson-CI gated multiplier
- `selfObsWinRateBias = modeBias × symbolBias` in loop.ts:~2489

Bounds preserved: both biases stay at 1.0 until Wilson 95% CI excludes
0.5, and each is clamped to [0.7, 1.3]. Composed worst-case [0.49, 1.69].

### Why this and not direction-level feedback
Direction stays geometric (`geometricDirection(basinDir, tapeTrend)`).
This PR adds outcome feedback to the **entry-threshold** layer, which
is the existing canonical channel for self-observed learning. A more
aggressive change — flipping direction on per-symbol regret — would
introduce contrarian trades and needs separate validation; this PR
just raises the bar to enter on a symbol-side combination she's losing.

### Doctrine
Per the autonomy doctrine ([[polytrade_autonomy_doctrine]]) and P1:
this is observer-derived, not operator-tuned. The threshold value
comes from the Wilson CI of her own closed trades — no hardcoded knob.

## Test plan

- [x] `yarn tsc --noEmit` — clean
- [x] `yarn vitest run` — 1707 passed / 12 skipped / 0 failed (+6 new tests)
- [ ] CI green on the PR
- [ ] Post-deploy: tail polytrade-be logs for selfObsBias deflection on ETH-PERP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce per-symbol, per-side self-observation biases to refine trade entry thresholds based on symbol-specific performance rather than only mode-level stats.

New Features:
- Track self-observation statistics per (symbol, side) alongside existing per-(mode, side) stats.
- Apply a per-(symbol, side) entry-threshold multiplier that composes with the existing mode-level bias when deciding trade entries.

Enhancements:
- Refine self-observation bias computation into a reusable pure function for symbol-side biases with Wilson-CI-based evidence gating and bounded impact.

Tests:
- Add unit tests covering symbol-side bias computation, including evidence thresholds, bias direction, symbol isolation, and clamping bounds.