### PR TITLE
fix(qigram): bounded LRU window restores meaningful sovereignty signal

### DIFF
--- a/apps/api/src/services/monkey/__tests__/qigramV2BoundedWindow.test.ts
+++ b/apps/api/src/services/monkey/__tests__/qigramV2BoundedWindow.test.ts
@@ -1,0 +1,141 @@
+/**
+ * qigramV2BoundedWindow.test.ts — bounded-window sovereignty (post-PR906 follow-up).
+ *
+ * The PR906 "consolidate every tick" fix replaced one degenerate-sov pathology
+ * with another. activeEntries() filters weight > MIN_ACTIVE_WEIGHT;
+ * consolidate() deletes weight ≤ MIN_ACTIVE_WEIGHT. After per-tick
+ * consolidate, the two views are bit-identical by construction and
+ * sovereignty = active / total = 1.0 deterministically. The downstream
+ * baseFrac = Φ × sov × maturity term collapses to baseFrac = Φ × maturity —
+ * the sov factor is silently deleted from sizing.
+ *
+ * The fix: bound _entries at HISTORY_MAX (LRU eviction by insertion order),
+ * stop per-tick consolidate. Then sovereignty = (active in last HISTORY_MAX)
+ * / HISTORY_MAX ranges meaningfully — responds to decay over time, to
+ * wrong-outcome zeroing (when recordOutcome wires), and to activity pauses.
+ *
+ * The follow-up architectural fix (separate sizing-sovereignty from
+ * storage-fraction) is a larger PR. This file pins the LRU-bounded-window
+ * contract.
+ */
+import { describe, test, expect } from 'vitest';
+import { QIGRAMv2State, QIGRAMV2_HISTORY_MAX, MIN_ACTIVE_WEIGHT } from '../agent_L_qigram_v2.js';
+import { uniformBasin } from '../basin.js';
+
+const B = uniformBasin();
+
+describe('QIGRAMv2State bounded window', () => {
+  test('_entries.size never exceeds HISTORY_MAX under continuous integration', () => {
+    const store = new QIGRAMv2State();
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX * 3; i++) {
+      store.integrate(`tick|${i}`, B, { weight: 1.0, correct: true });
+    }
+    expect(store.totalEntries).toBe(QIGRAMV2_HISTORY_MAX);
+  });
+
+  test('oldest entry is evicted (LRU by insertion order) when at capacity', () => {
+    const store = new QIGRAMv2State();
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX; i++) {
+      store.integrate(`tick|${i}`, B, { weight: 1.0, correct: true });
+    }
+    expect(store.totalEntries).toBe(QIGRAMV2_HISTORY_MAX);
+    // Insert one more — tick|0 should be evicted.
+    store.integrate(`tick|${QIGRAMV2_HISTORY_MAX}`, B, { weight: 1.0, correct: true });
+    expect(store.totalEntries).toBe(QIGRAMV2_HISTORY_MAX);
+    // The recall pool must NOT contain the evicted oldest id.
+    const ids = store.activeEntries().map((e) => e.id);
+    expect(ids).not.toContain('tick|0');
+    expect(ids).toContain(`tick|${QIGRAMV2_HISTORY_MAX}`);
+  });
+
+  test('re-integrating an existing id replaces in place — does NOT evict another', () => {
+    const store = new QIGRAMv2State();
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX; i++) {
+      store.integrate(`tick|${i}`, B, { weight: 1.0, correct: true });
+    }
+    // Updating an existing entry should not change the storage footprint.
+    store.integrate('tick|50', B, { weight: 1.0, correct: true });
+    expect(store.totalEntries).toBe(QIGRAMV2_HISTORY_MAX);
+    const ids = store.activeEntries().map((e) => e.id);
+    expect(ids).toContain('tick|0');  // tick|0 must still be present
+    expect(ids).toContain('tick|50');
+  });
+
+  test('sovereignty is NOT pinned at 1.0 in steady state — ranges meaningfully', () => {
+    // Simulate the loop.ts per-tick pattern: integrate + decayAll every
+    // tick, NO per-tick consolidate. Run long enough that decay drives
+    // the oldest entries below MIN_ACTIVE_WEIGHT while LRU keeps them
+    // stored. Active / total then reads "fraction of last N still hot."
+    const store = new QIGRAMv2State();
+    const TICKS = QIGRAMV2_HISTORY_MAX * 2;
+    for (let i = 0; i < TICKS; i++) {
+      store.integrate(`tick|${i}`, B, { weight: 1.0, correct: true });
+      store.decayAll();
+    }
+    const sov = store.sovereignty;
+    // Expectation: roughly the proportion of stored entries whose age in
+    // ticks puts them above 0.95^age > MIN_ACTIVE_WEIGHT (~0.01), i.e.
+    // age < 89.78. With HISTORY_MAX entries of ages 1..HISTORY_MAX, that
+    // is min(HISTORY_MAX, 89) / HISTORY_MAX ≈ 0.89 for HISTORY_MAX=100.
+    expect(sov).toBeGreaterThan(0.5);
+    expect(sov).toBeLessThan(1.0);
+    expect(store.totalEntries).toBe(QIGRAMV2_HISTORY_MAX);
+  });
+
+  test('sovereignty drops when integration pauses (decay-only window)', () => {
+    const store = new QIGRAMv2State();
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX; i++) {
+      store.integrate(`tick|${i}`, B, { weight: 1.0, correct: true });
+    }
+    const sovStart = store.sovereignty;
+    expect(sovStart).toBe(1.0);
+    // Pause integration; let decay run past the threshold (0.95^90 ≈ 0.0099).
+    for (let t = 0; t < 100; t++) store.decayAll();
+    // Storage stays at capacity (LRU never evicted these), but the active
+    // ratio drops because every entry has decayed below MIN_ACTIVE_WEIGHT.
+    expect(store.sovereignty).toBeCloseTo(0, 6);
+    expect(store.totalEntries).toBe(QIGRAMV2_HISTORY_MAX);
+  });
+
+  test('sovereignty drops when recordOutcome zeroes weights (wrong-outcome signal)', () => {
+    const store = new QIGRAMv2State();
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX; i++) {
+      store.integrate(`tick|${i}`, B, { weight: 1.0, correct: true });
+    }
+    expect(store.sovereignty).toBe(1.0);
+    // Zero half the buffer via recordOutcome(false).
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX / 2; i++) {
+      store.recordOutcome(`tick|${i}`, false);
+    }
+    // The wrong half drops below MIN_ACTIVE_WEIGHT (zero weight); the
+    // sov reading reflects the loss rate, not just storage uptime.
+    expect(store.sovereignty).toBeCloseTo(0.5, 6);
+    expect(store.totalEntries).toBe(QIGRAMV2_HISTORY_MAX);
+  });
+
+  test('consolidate still works for explicit cleanup, but is no longer required per-tick', () => {
+    // PR906 paired consolidate with decayAll every tick. With the LRU
+    // cap that pairing is unnecessary (storage cannot grow unboundedly),
+    // and per-tick consolidate makes sov pin at 1.0. The method itself
+    // stays valid for explicit "sweep dead entries" cleanups (e.g. before
+    // persistence, or in a teardown path).
+    const store = new QIGRAMv2State();
+    for (let i = 0; i < 50; i++) {
+      store.integrate(`tick|${i}`, B, { weight: 1.0, correct: true });
+    }
+    for (let t = 0; t < 95; t++) store.decayAll();  // all decay-dead
+    expect(store.totalEntries).toBe(50);
+    expect(store.activeEntries().length).toBe(0);
+    const pruned = store.consolidate();
+    expect(pruned).toBe(50);
+    expect(store.totalEntries).toBe(0);
+  });
+
+  test('HISTORY_MAX is exported and matches the kernel-wide convention (100)', () => {
+    // Same value as loop.ts HISTORY_MAX so this isn't a new tuning knob,
+    // it's a memory-shape bound consistent with phiHistory / basinHistory /
+    // surpriseHistory etc.
+    expect(QIGRAMV2_HISTORY_MAX).toBe(100);
+    expect(MIN_ACTIVE_WEIGHT).toBe(0.01);
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/qigramV2Consolidate.test.ts
+++ b/apps/api/src/services/monkey/__tests__/qigramV2Consolidate.test.ts
@@ -1,17 +1,25 @@
 /**
- * qigramV2Consolidate.test.ts — QIGRAMv2State.consolidate() (PR4).
+ * qigramV2Consolidate.test.ts — QIGRAMv2State.consolidate() invariants.
  *
- * The sovereignty/sizing bug: loop.ts integrates a fresh basin every tick
- * with a unique `${symbol}|tick=N` key and decays all weights, but nothing
- * ever REMOVES decayed-dead entries. So `_entries.size` (the sovereignty
- * denominator) grows unboundedly with session uptime — sovereignty decays
- * ~90/tickCount toward 0, and `baseFrac = Φ × sovereignty × maturity`
- * collapses position size ~17× too small.
+ * Historical context (PR906): consolidate() was originally introduced
+ * to bound _entries growth when the loop integrates a fresh basin per
+ * tick. PR906 paired it with decayAll() per-tick to fix the
+ * "sov decays toward zero with session uptime" pathology — but that
+ * created a different degeneracy: post-prune the active set equals
+ * the storage set by construction, so sovereignty pinned at 1.0
+ * deterministically and silently zeroed the sov factor in
+ * baseFrac = Φ × sov × maturity.
  *
- * consolidate() is the canonical fix — the sleep-cycle's CONSOLIDATING-phase
- * memory pass (mirrors qig-core 2.8.0 SleepCycleManager.consolidate(), which
- * prunes low-mass entries). It is SEPARATE from decayAll(): decay reduces
- * weight every tick; consolidate removes entries decay has already killed.
+ * The current contract bounds _entries via LRU eviction at integrate
+ * time (QIGRAMV2_HISTORY_MAX), so per-tick consolidate is no longer
+ * needed. consolidate() remains valid for explicit sweeps — e.g.
+ * pre-persistence cleanup, or removing accumulated wrong-outcome
+ * tombstones via recordOutcome(false). These tests pin THOSE
+ * invariants: it never touches a live entry, and it always agrees
+ * with activeEntries() about which entries are dead.
+ *
+ * See qigramV2BoundedWindow.test.ts for the bounded-window /
+ * meaningful-sovereignty contract.
  */
 import { describe, test, expect } from 'vitest';
 import { QIGRAMv2State, MIN_ACTIVE_WEIGHT } from '../agent_L_qigram_v2.js';
@@ -46,22 +54,30 @@ describe('QIGRAMv2State.consolidate', () => {
     expect(store.activeEntries().length).toBe(3);
   });
 
-  test('sovereignty recovers from a decayed ratio to ~1.0 after consolidate', () => {
+  test('explicit consolidate after recordOutcome(false) removes wrong-outcome tombstones', () => {
+    // Models the eventual recordOutcome flow: integrate basins on entry,
+    // attribute wrong outcomes on close (weight→0), call consolidate()
+    // periodically to sweep tombstones. Bounded-window LRU still works
+    // for live entries; consolidate is the explicit cleanup for the
+    // zero-weight ones that recordOutcome leaves behind.
     const store = new QIGRAMv2State();
     for (let i = 0; i < 5; i++) {
       store.integrate(`old|${i}`, B, { weight: 1.0, correct: true });
     }
-    decayToDeath(store);
-    for (let i = 0; i < 3; i++) {
-      store.integrate(`fresh|${i}`, B, { weight: 1.0, correct: true });
-    }
-    // The bug: 3 active / 8 total = 0.375 — depressed by dead tombstones.
-    expect(store.sovereignty).toBeCloseTo(3 / 8, 6);
+    // Three of the five later attribute as wrong → weight=0.
+    store.recordOutcome('old|0', false);
+    store.recordOutcome('old|1', false);
+    store.recordOutcome('old|2', false);
+    // 2 active / 5 total = 0.4 — sov reads the loss rate.
+    expect(store.sovereignty).toBeCloseTo(2 / 5, 6);
 
-    store.consolidate();
+    const pruned = store.consolidate();
 
-    // After consolidation the denominator is the active set — sovereignty
-    // reflects kernel health, not session uptime.
+    expect(pruned).toBe(3);
+    expect(store.totalEntries).toBe(2);
+    // Post-prune sov is degenerate (active == total) — exactly the
+    // PR906 pathology if consolidate runs per-tick. That's why
+    // consolidate is now an explicit-cleanup op, not a per-tick call.
     expect(store.sovereignty).toBe(1.0);
   });
 
@@ -85,12 +101,12 @@ describe('QIGRAMv2State.consolidate', () => {
     expect(store.totalEntries).toBe(0);
   });
 
-  // ─── Tombstone-reaper invariants — Option D safety net ──────────────
-  // These tests pin the property that lets loop.ts call consolidate()
-  // every tick without behavioural risk: consolidate cannot remove a
-  // live (above-threshold) entry, only entries that decayAll() has
-  // already driven dead. If a future change makes consolidate
-  // destructive, both tests below break loudly.
+  // ─── Tombstone-reaper invariants ────────────────────────────────────
+  // These tests pin the property that consolidate can be called safely
+  // as an explicit cleanup op: it never removes a live (above-threshold)
+  // entry, only entries that decay or recordOutcome(false) have already
+  // driven dead. If a future change makes consolidate destructive, both
+  // tests below break loudly.
 
   test('consolidate on an empty store is a safe no-op', () => {
     const store = new QIGRAMv2State();
@@ -98,19 +114,19 @@ describe('QIGRAMv2State.consolidate', () => {
     expect(store.totalEntries).toBe(0);
   });
 
-  test('200 fresh entries × 100 decay ticks → consolidate reaps all 200', () => {
-    // 0.95^90 ≈ 0.0099 < MIN_ACTIVE_WEIGHT, so 100 ticks of decay drives
-    // every weight=1.0 entry below threshold. consolidate must then
-    // reap the lot — proving _entries.size cannot grow unboundedly when
-    // consolidate is paired with decayAll().
+  test('LRU-capped buffer × 100 decay ticks → consolidate reaps all stored', () => {
+    // After 200 fresh integrations the LRU cap holds storage at
+    // QIGRAMV2_HISTORY_MAX (100); after 100 ticks of decay every
+    // weight=1.0 entry has dropped below MIN_ACTIVE_WEIGHT
+    // (0.95^90 ≈ 0.0099). consolidate must reap the lot.
     const store = new QIGRAMv2State();
     for (let i = 0; i < 200; i++) {
       store.integrate(`bulk|${i}`, B, { weight: 1.0, correct: true });
     }
-    expect(store.totalEntries).toBe(200);
+    expect(store.totalEntries).toBe(100);
     for (let t = 0; t < 100; t++) store.decayAll();
     expect(store.activeEntries().length).toBe(0);
-    expect(store.consolidate()).toBe(200);
+    expect(store.consolidate()).toBe(100);
     expect(store.totalEntries).toBe(0);
   });
 });

--- a/apps/api/src/services/monkey/agent_L_qigram_v2.ts
+++ b/apps/api/src/services/monkey/agent_L_qigram_v2.ts
@@ -63,6 +63,16 @@ export const KAPPA_DRIFT = 0.1;
  *  Matches canonical `if correct and dominance > 0.7`. */
 export const KAPPA_CONFIDENCE_THRESHOLD = 0.7;
 
+/** LRU cap on `_entries`. Matches loop.ts HISTORY_MAX = 100 so this is
+ *  a kernel-wide memory-shape bound (same as phiHistory / basinHistory /
+ *  surpriseHistory), not a new tuning knob. With this cap the
+ *  sovereignty getter ranges meaningfully: active / HISTORY_MAX
+ *  responds to decay over time, to wrong-outcome zeroing via
+ *  `recordOutcome`, and to integration pauses. Without it,
+ *  per-tick consolidate produces sov === 1.0 deterministically
+ *  (active and total are the same set by construction). */
+export const QIGRAMV2_HISTORY_MAX = 100;
+
 /** κ delta on a correct + high-confidence outcome. */
 export const KAPPA_UP_STEP = 2.0;
 
@@ -225,6 +235,7 @@ export class QIGRAMv2State {
       category: opts.category ?? existing?.category ?? '',
       trajectory: opts.trajectory ?? existing?.trajectory ?? {},
     });
+    this.evictOldestIfFull();
   }
 
   /** Store a basin without an outcome (default weight=1.0, correct=null).
@@ -243,6 +254,20 @@ export class QIGRAMv2State {
       category: opts.category ?? existing?.category ?? '',
       trajectory: opts.trajectory ?? existing?.trajectory ?? {},
     });
+    this.evictOldestIfFull();
+  }
+
+  /** LRU eviction by insertion order. Map iteration order is insertion
+   *  order, and Map.set on an existing key preserves that position —
+   *  so re-integrating an existing id does NOT count as a fresh insert
+   *  and does not displace another. Only true new-id inserts that push
+   *  size above QIGRAMV2_HISTORY_MAX trigger eviction of the oldest. */
+  private evictOldestIfFull(): void {
+    while (this._entries.size > QIGRAMV2_HISTORY_MAX) {
+      const oldestKey = this._entries.keys().next().value;
+      if (oldestKey === undefined) return;
+      this._entries.delete(oldestKey);
+    }
   }
 
   /** Attribute an outcome to a previously-stored basin entry.

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2117,17 +2117,18 @@ export class MonkeyKernel extends EventEmitter {
     // MIN_ACTIVE_WEIGHT (canonical 0.01). decayAll() only DECAYS weight —
     // it never removes entries, so without consolidate() below `_entries`
     // grows unboundedly and the sovereignty denominator (and thus
-    // position size) decays toward zero with session uptime.
-    //
-    // consolidate() is a tombstone reaper: it can only remove entries
-    // that decayAll() has already driven below MIN_ACTIVE_WEIGHT — it
-    // cannot touch a live entry. So it is safe to pair with decayAll()
-    // every tick. The earlier `phi < SLEEP_PHI_THRESHOLD` phase gate
-    // inherited rationale from qig-core 2.8.0's richer SleepCycleManager
-    // (which had destructive ops); the TS port reduced consolidate() to
-    // just the eviction subset, leaving the gate guarding nothing — and
-    // the hardcoded 0.45 sat below this kernel's actual Φ band (0.57+),
-    // so consolidate never fired and sovereignty pinned at ~0.05.
+    // position size) decays toward zero with session uptime. PR906 paired
+    // consolidate() with decayAll() per-tick, but consolidate deletes the
+    // same set activeEntries() filters out, so post-prune the two views
+    // are bit-identical and sovereignty pins at 1.0 deterministically —
+    // a different degenerate reading that silently zeroes the sov factor
+    // in baseFrac = Φ × sov × maturity. The current fix bounds _entries
+    // at QIGRAMV2_HISTORY_MAX via LRU eviction inside integrate(), so
+    // storage cannot grow unboundedly without needing per-tick prune,
+    // and sov = active / _entries.size ranges meaningfully — responds to
+    // decay, to recordOutcome(false) zeroing (when that wires), and to
+    // integration pauses. consolidate() remains valid for explicit
+    // sweeps (e.g. pre-persistence).
     let sovereignty: number;
     if (isQigramV2Enabled()) {
       this.qigramV2TickCount += 1;
@@ -2140,7 +2141,6 @@ export class MonkeyKernel extends EventEmitter {
         { weight: 1.0, correct: true },
       );
       this.qigramV2Store.decayAll();
-      this.qigramV2Store.consolidate(); // tombstone reaper — safe per-tick
       sovereignty = this.qigramV2Store.sovereignty;
     } else {
       sovereignty = await resonanceBank.sovereignty();


### PR DESCRIPTION
## Summary

**PR906 didn't fix the sov bug; it replaced one degenerate reading with another.**

`activeEntries()` filters `weight > MIN_ACTIVE_WEIGHT`.
`consolidate()` deletes `weight ≤ MIN_ACTIVE_WEIGHT`.
The two views draw the same line, so per-tick consolidate makes them
bit-identical and `sov = active / total = 1.0` deterministically.

Downstream silent damage:
- `baseFrac = Φ × sov × maturity` → effectively `Φ × maturity`
  (sov factor deleted from sizing)
- DCA gate `sov > 0.1` is permanently open

This is worse than the pre-PR906 sov=0.053 pathology because 1.000
reads as "max confidence" while actually being noise. Live confirmation:
post-PR906 production logs show `sov:1.000` on every tick across BTC and
ETH symbols.

## Fix

Bound `_entries` at `QIGRAMV2_HISTORY_MAX = 100` (matches the kernel-wide
`HISTORY_MAX` convention used for `phiHistory` / `basinHistory` /
`surpriseHistory` etc — a memory-shape bound, not a tuning knob). LRU
eviction by insertion order happens inside `integrate()` / `store()`,
so storage cannot grow unboundedly without needing per-tick prune.
Per-tick `consolidate()` is removed from `loop.ts`.

Sovereignty now ranges meaningfully:
- Continuous integration + decay → ~0.89 steady state
  (10 oldest of 100 have decayed below MIN_ACTIVE_WEIGHT)
- Integration pause → drops as remaining entries decay
- `recordOutcome(false)` zeroing → drops with loss rate (when the
  recordOutcome→close-path mapping wires; see the audit memory)

`consolidate()` remains valid for explicit sweeps (pre-persistence,
wrong-outcome tombstone cleanup). It is no longer required per-tick.

## Scope: the LRU step now

The doctrinally cleanest fix (separate sizing-sovereignty from
storage-fraction — derive a `kernelConfidence` from `phiHistory`
stability) is a larger architectural PR. This PR just stops the
degenerate signal flowing into sizing; the conceptual rework is
deferred.

## Tests

- 8 new `qigramV2BoundedWindow.test.ts` cases pin the contract:
  storage cap, LRU eviction, re-integration preserves order,
  sov-not-pinned-at-1.0 in steady state, sov-drops-on-pause,
  sov-drops-on-wrong-outcome, consolidate-still-works.
- PR906 test docblock updated to flag historical context.
- `yarn tsc --noEmit` clean
- `yarn vitest run` — 1715 passed / 12 skipped / 0 failed (+8 new)

## Post-deploy watch

Tail polytrade-be `[Monkey]` logs; `sov:` should appear near `~0.89`
on continuous-integration symbols and drop on activity pauses, NOT
pin at `1.000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)