### PR TITLE
fix(qigram): per-symbol partition — close the sov pathology under multi-symbol kernels

### DIFF
--- a/apps/api/src/services/monkey/__tests__/qigramV2PerSymbolPartition.test.ts
+++ b/apps/api/src/services/monkey/__tests__/qigramV2PerSymbolPartition.test.ts
@@ -1,0 +1,115 @@
+/**
+ * qigramV2PerSymbolPartition.test.ts — per-symbol sovereignty signal.
+ *
+ * Topology audit (post-#912): each MonkeyKernel handles DEFAULT_SYMBOLS
+ * = ['BTC_USDT_PERP', 'ETH_USDT_PERP'] through ONE shared QIGRAMv2State.
+ * With LRU-at-HISTORY_MAX (100) and 2 inserts per tick, the oldest entry
+ * in a shared store has been decayed at most ~49 times (0.95^49 ≈ 0.081)
+ * — never below MIN_ACTIVE_WEIGHT (0.01). So sov pins at 1.0 in steady
+ * state, identical pathology to PR906's per-tick consolidate via a
+ * different mechanism.
+ *
+ * Fix: partition the store by symbol. Each symbol gets its own
+ * QIGRAMv2State; LRU and decay then cover ~100 ticks per symbol
+ * (≥ the 90-tick decay-to-threshold). Per-symbol sov is also more
+ * informative than the conflated aggregate, mirroring the per-symbol
+ * SelfObservation asymmetry surfaced by PR #911.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  QIGRAMv2Partition,
+  QIGRAMV2_HISTORY_MAX,
+} from '../agent_L_qigram_v2.js';
+import { uniformBasin } from '../basin.js';
+
+const B = uniformBasin();
+const BTC = 'BTC_USDT_PERP';
+const ETH = 'ETH_USDT_PERP';
+
+describe('QIGRAMv2Partition (per-symbol store)', () => {
+  test('integrate routes by symbol — BTC inserts do not displace ETH entries', () => {
+    const part = new QIGRAMv2Partition();
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX; i++) {
+      part.integrate(ETH, `eth|${i}`, B, { weight: 1.0, correct: true });
+    }
+    // Now flood BTC — ETH partition must be untouched.
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX * 3; i++) {
+      part.integrate(BTC, `btc|${i}`, B, { weight: 1.0, correct: true });
+    }
+    expect(part.totalEntries(ETH)).toBe(QIGRAMV2_HISTORY_MAX);
+    expect(part.totalEntries(BTC)).toBe(QIGRAMV2_HISTORY_MAX);
+    // Each partition LRU-evicted only within its own bucket.
+    const ethIds = part.activeEntries(ETH).map((e) => e.id);
+    expect(ethIds).toContain('eth|0');  // ETH's oldest survived the BTC flood
+  });
+
+  test('decayAll(symbol) decays only that symbol — sovereignties diverge', () => {
+    const part = new QIGRAMv2Partition();
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX; i++) {
+      part.integrate(BTC, `tick|${i}`, B, { weight: 1.0, correct: true });
+      part.integrate(ETH, `tick|${i}`, B, { weight: 1.0, correct: true });
+    }
+    // Decay only ETH past the threshold.
+    for (let t = 0; t < 100; t++) part.decayAll(ETH);
+    expect(part.sovereignty(BTC)).toBe(1.0);
+    expect(part.sovereignty(ETH)).toBeCloseTo(0, 6);
+  });
+
+  test('sovereignty(symbol) is not pinned at 1.0 in steady state — ranges meaningfully per partition', () => {
+    // Per-symbol partition restores the bounded-window guarantee even
+    // with 2 symbols ticking. Each store covers HISTORY_MAX ticks ≥
+    // decay-to-threshold (90), so the oldest live entry can age below
+    // MIN_ACTIVE_WEIGHT before LRU evicts it.
+    const part = new QIGRAMv2Partition();
+    const TICKS = QIGRAMV2_HISTORY_MAX * 2;
+    for (let i = 0; i < TICKS; i++) {
+      part.integrate(BTC, `tick|${i}`, B, { weight: 1.0, correct: true });
+      part.integrate(ETH, `tick|${i}`, B, { weight: 1.0, correct: true });
+      part.decayAll(BTC);
+      part.decayAll(ETH);
+    }
+    const sovBtc = part.sovereignty(BTC);
+    const sovEth = part.sovereignty(ETH);
+    expect(sovBtc).toBeGreaterThan(0.5);
+    expect(sovBtc).toBeLessThan(1.0);
+    expect(sovEth).toBeGreaterThan(0.5);
+    expect(sovEth).toBeLessThan(1.0);
+    expect(part.totalEntries(BTC)).toBe(QIGRAMV2_HISTORY_MAX);
+    expect(part.totalEntries(ETH)).toBe(QIGRAMV2_HISTORY_MAX);
+  });
+
+  test('sovereignty(symbol) is 1.0 (or 0 with no entries) when partition is empty', () => {
+    const part = new QIGRAMv2Partition();
+    // Empty partition: no information — caller treats as "no signal yet".
+    expect(part.totalEntries('UNKNOWN_PERP')).toBe(0);
+    expect(part.activeEntries('UNKNOWN_PERP')).toEqual([]);
+    expect(part.sovereignty('UNKNOWN_PERP')).toBe(1.0);
+  });
+
+  test('recall and recallByCategory are partition-scoped', () => {
+    const part = new QIGRAMv2Partition();
+    part.integrate(BTC, 'btc|a', B, { weight: 1.0, correct: true, category: 'CREATOR_TREND_UP' });
+    part.integrate(ETH, 'eth|a', B, { weight: 1.0, correct: true, category: 'DISSOLVER_CHOP' });
+    // BTC partition recall hits BTC ids only.
+    const btcHit = part.recallByCategory(BTC, 'CREATOR_TREND_UP');
+    expect(btcHit?.source).toBe('btc|a');
+    const btcMiss = part.recallByCategory(BTC, 'DISSOLVER_CHOP');
+    expect(btcMiss).toBeNull();
+    // ETH partition is independent.
+    const ethHit = part.recallByCategory(ETH, 'DISSOLVER_CHOP');
+    expect(ethHit?.source).toBe('eth|a');
+  });
+
+  test('recordOutcome routes by symbol — wrong outcome on BTC does not affect ETH sov', () => {
+    const part = new QIGRAMv2Partition();
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX; i++) {
+      part.integrate(BTC, `tick|${i}`, B, { weight: 1.0, correct: true });
+      part.integrate(ETH, `tick|${i}`, B, { weight: 1.0, correct: true });
+    }
+    for (let i = 0; i < QIGRAMV2_HISTORY_MAX / 2; i++) {
+      part.recordOutcome(BTC, `tick|${i}`, false);
+    }
+    expect(part.sovereignty(BTC)).toBeCloseTo(0.5, 6);
+    expect(part.sovereignty(ETH)).toBe(1.0);
+  });
+});

--- a/apps/api/src/services/monkey/agent_L_qigram_v2.ts
+++ b/apps/api/src/services/monkey/agent_L_qigram_v2.ts
@@ -437,6 +437,126 @@ export class QIGRAMv2State {
   }
 }
 
+// ─── Per-symbol partition ────────────────────────────────────────────
+
+/** Per-symbol partition over QIGRAMv2State. Each MonkeyKernel handles
+ *  DEFAULT_SYMBOLS (currently 2) and integrates one basin per symbol
+ *  per tick. With a single shared QIGRAMv2State, the LRU cap at
+ *  QIGRAMV2_HISTORY_MAX (100) only covers ~100/N_SYMBOLS ticks of
+ *  age before eviction — for N_SYMBOLS = 2 that is ~49 ticks, far
+ *  below the ~90 ticks needed for 0.95^k decay to cross
+ *  MIN_ACTIVE_WEIGHT, so sov pins at 1.0 in steady state.
+ *
+ *  Per-symbol partition isolates each symbol's LRU buffer so
+ *  HISTORY_MAX = 100 covers ≥ 90-tick decay-to-threshold on every
+ *  symbol independently. Bonus: per-symbol sov is a more informative
+ *  signal than the conflated aggregate (mirrors the per-symbol
+ *  SelfObservation asymmetry surfaced by PR #911).
+ *
+ *  Empty partitions return sov=1.0 ("no information yet"); the kernel
+ *  treats that the same as a freshly-warmed legitimate 1.0. */
+export class QIGRAMv2Partition {
+  private readonly stores: Map<string, QIGRAMv2State> = new Map();
+  private readonly totalProblemsPerSymbol: number | null;
+
+  constructor(totalProblemsPerSymbol: number | null = null) {
+    this.totalProblemsPerSymbol = totalProblemsPerSymbol;
+  }
+
+  private storeFor(symbol: string): QIGRAMv2State {
+    let s = this.stores.get(symbol);
+    if (!s) {
+      s = new QIGRAMv2State(this.totalProblemsPerSymbol);
+      this.stores.set(symbol, s);
+    }
+    return s;
+  }
+
+  integrate(
+    symbol: string,
+    id: string,
+    basin: Basin,
+    opts: {
+      weight: number;
+      correct: boolean;
+      category?: string;
+      trajectory?: Record<string, unknown>;
+    },
+  ): void {
+    this.storeFor(symbol).integrate(id, basin, opts);
+  }
+
+  store(
+    symbol: string,
+    id: string,
+    basin: Basin,
+    opts: { category?: string; trajectory?: Record<string, unknown> } = {},
+  ): void {
+    this.storeFor(symbol).store(id, basin, opts);
+  }
+
+  decayAll(symbol: string): void {
+    const s = this.stores.get(symbol);
+    if (s) s.decayAll();
+  }
+
+  /** Explicit cleanup of a symbol's dead-weight entries. Not required
+   *  per-tick under LRU; useful before persistence or after a wrong-
+   *  outcome attribution burst. */
+  consolidate(symbol: string): number {
+    const s = this.stores.get(symbol);
+    return s ? s.consolidate() : 0;
+  }
+
+  recordOutcome(symbol: string, id: string, correct: boolean): boolean {
+    const s = this.stores.get(symbol);
+    return s ? s.recordOutcome(id, correct) : false;
+  }
+
+  recall(symbol: string, query: Basin): RecallResultV2 | null {
+    const s = this.stores.get(symbol);
+    return s ? s.recall(query) : null;
+  }
+
+  recallByCategory(symbol: string, category: string): CategoryRecallResultV2 | null {
+    const s = this.stores.get(symbol);
+    return s ? s.recallByCategory(category) : null;
+  }
+
+  tack(symbol: string, confidence: number, correct: boolean): void {
+    this.storeFor(symbol).tack(confidence, correct);
+  }
+
+  kappa(symbol: string): number {
+    const s = this.stores.get(symbol);
+    return s ? s.kappa : KAPPA_FIXED_POINT;
+  }
+
+  activeEntries(symbol: string): BasinEntryV2[] {
+    const s = this.stores.get(symbol);
+    return s ? s.activeEntries() : [];
+  }
+
+  totalEntries(symbol: string): number {
+    const s = this.stores.get(symbol);
+    return s ? s.totalEntries : 0;
+  }
+
+  /** Sovereignty for a single symbol. Empty partition returns 1.0
+   *  ("no information") so a cold-start symbol does not inject a
+   *  spurious 0 into baseFrac = Φ × sov × maturity. */
+  sovereignty(symbol: string): number {
+    const s = this.stores.get(symbol);
+    if (!s || s.totalEntries === 0) return 1.0;
+    return s.sovereignty;
+  }
+
+  /** All symbols currently tracked. Useful for telemetry. */
+  symbols(): string[] {
+    return Array.from(this.stores.keys());
+  }
+}
+
 // ─── Env-flag helper ─────────────────────────────────────────────────
 
 /** Returns true when the operator has explicitly enabled the v2 layer.

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -155,7 +155,7 @@ import {
 import { agentLDecide, type AgentLDecision } from './agent_L_classifier.js';
 import { signalScorer, resolveEntryGate } from './signal_scorer.js';
 import { getOperatorRiskSettings } from './risk_settings.js';
-import { QIGRAMv2State, isQigramV2Enabled } from './agent_L_qigram_v2.js';
+import { QIGRAMv2Partition, isQigramV2Enabled } from './agent_L_qigram_v2.js';
 import {
   newMTFState,
   onTickAppend as mtfOnTickAppend,
@@ -1035,10 +1035,13 @@ export class MonkeyKernel extends EventEmitter {
    * fresh basins are integrated. Only consumed when
    * `L_QIGRAM_V2_ENABLED === 'true'`; otherwise the legacy
    * resonance-bank sovereignty path is preserved (default behavior). */
-  private readonly qigramV2Store: QIGRAMv2State = new QIGRAMv2State();
-  /** Tick counter for QIGRAMv2 store decay scheduling. Decays all
-   *  weights every SOV_DECAY_PERIOD_TICKS calls. */
-  private qigramV2TickCount = 0;
+  private readonly qigramV2Store: QIGRAMv2Partition = new QIGRAMv2Partition();
+  /** Per-symbol tick counter for QIGRAMv2 store id generation. Each
+   *  symbol's partition has its own LRU buffer, so the counter is
+   *  partitioned too — keeps ids unique within a symbol's store and
+   *  prevents BTC ticks from displacing ETH ids in any shared key
+   *  space. */
+  private readonly qigramV2TickCount: Map<string, number> = new Map();
 
   constructor(config?: Partial<MonkeyKernelConfig>) {
     super();
@@ -2117,31 +2120,30 @@ export class MonkeyKernel extends EventEmitter {
     // MIN_ACTIVE_WEIGHT (canonical 0.01). decayAll() only DECAYS weight —
     // it never removes entries, so without consolidate() below `_entries`
     // grows unboundedly and the sovereignty denominator (and thus
-    // position size) decays toward zero with session uptime. PR906 paired
-    // consolidate() with decayAll() per-tick, but consolidate deletes the
-    // same set activeEntries() filters out, so post-prune the two views
-    // are bit-identical and sovereignty pins at 1.0 deterministically —
-    // a different degenerate reading that silently zeroes the sov factor
-    // in baseFrac = Φ × sov × maturity. The current fix bounds _entries
-    // at QIGRAMV2_HISTORY_MAX via LRU eviction inside integrate(), so
-    // storage cannot grow unboundedly without needing per-tick prune,
-    // and sov = active / _entries.size ranges meaningfully — responds to
-    // decay, to recordOutcome(false) zeroing (when that wires), and to
-    // integration pauses. consolidate() remains valid for explicit
-    // sweeps (e.g. pre-persistence).
+    // position size) decays toward zero with session uptime. PR906
+    // paired consolidate() with decayAll() per-tick which made the
+    // active and storage sets bit-identical (sov pinned at 1.0). #912
+    // replaced that with an LRU bound on _entries inside the store.
+    // But a single shared store across DEFAULT_SYMBOLS (BTC + ETH) sees
+    // 2 inserts per tick, so HISTORY_MAX = 100 only covered ~49 ticks
+    // of age — still below the ~90 ticks needed for decay to cross
+    // MIN_ACTIVE_WEIGHT. Sov pinned at 1.0 again via a different
+    // mechanism. This fix partitions the store by symbol: each
+    // symbol's buffer covers ≥ 90-tick decay-to-threshold independently,
+    // and per-symbol sov is a more informative signal than the
+    // conflated aggregate.
     let sovereignty: number;
     if (isQigramV2Enabled()) {
-      this.qigramV2TickCount += 1;
-      // Per-symbol|per-tick key so different symbols' snapshots
-      // coexist; weight=1.0 at storage time (canonical initial), correct
-      // =true (basin counts toward active until decayed below threshold).
+      const nextTick = (this.qigramV2TickCount.get(symbol) ?? 0) + 1;
+      this.qigramV2TickCount.set(symbol, nextTick);
       this.qigramV2Store.integrate(
-        `${symbol}|tick=${this.qigramV2TickCount}`,
+        symbol,
+        `tick=${nextTick}`,
         basin,
         { weight: 1.0, correct: true },
       );
-      this.qigramV2Store.decayAll();
-      sovereignty = this.qigramV2Store.sovereignty;
+      this.qigramV2Store.decayAll(symbol);
+      sovereignty = this.qigramV2Store.sovereignty(symbol);
     } else {
       sovereignty = await resonanceBank.sovereignty();
     }


### PR DESCRIPTION
## Summary

Third turn of the same pathology arc. #912 capped `_entries` at
`QIGRAMV2_HISTORY_MAX = 100` with LRU eviction, but each `MonkeyKernel`
handles `DEFAULT_SYMBOLS = ['BTC_USDT_PERP', 'ETH_USDT_PERP']` through
ONE shared store. Two inserts per tick × LRU-at-100 = ~49 ticks of
max age, far below the ~90 ticks needed for `0.95^k` to cross
`MIN_ACTIVE_WEIGHT` (0.01). Sov pins at 1.0 in steady state — same
degenerate ratio via a different mechanism. CC2 caught it before the
50-min warmup window could confirm it.

## Fix

New `QIGRAMv2Partition` class keying `Map<symbol, QIGRAMv2State>`. Each
symbol's LRU buffer is independent, so HISTORY_MAX covers each
symbol's integration history with the 90-tick decay-to-threshold
horizon fitting inside.

- `qigramV2Store` is now a `QIGRAMv2Partition` (was `QIGRAMv2State`).
- `qigramV2TickCount` is now `Map<symbol, number>` so each symbol's
  stored ids are unique within its partition.
- `sovereignty(symbol)` is the new getter; the kernel reads it
  per-symbol where it previously read the conflated aggregate.

Bonus signal quality: per-symbol sov mirrors the per-symbol
`SelfObservation` asymmetry that #911 already surfaced.

## Scope — what this PR does NOT touch

Storage-fraction-sov and sizing-confidence-sov are conceptually
different. Even with per-symbol partition, storage fraction will
hover near a constant (~0.89) in steady-state-engaged markets. The
proper sizing-sov signal — outcome-weighted basin confidence —
belongs in the `recordOutcome` + `.tack` wiring PR where it can
compose with realized close attribution. This PR only stops the
degenerate-ratio signal from flowing into sizing.

## Tests

- 6 new `qigramV2PerSymbolPartition.test.ts` cases: routing isolation,
  decay isolation, steady-state ranging, empty-partition sentinel,
  partition-scoped recall, per-symbol `recordOutcome`.
- `yarn tsc --noEmit` clean
- `yarn vitest run` — 1721 passed / 12 skipped / 0 failed (+6 new)

## Post-deploy watch

Tail polytrade-be `[Monkey]` logs; `sov:` should now differ between
BTC and ETH rows, both settling ~0.89 once each symbol's buffer fills
(~50 ticks each ≈ 25 minutes wall-clock at 30s cycles). Not pinned
at 1.000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)