### PR TITLE
fix(riskKernel): strip per-symbol exposure cap + auto-drawdown kill switch

### DIFF
--- a/apps/api/src/services/__tests__/riskKernel.test.ts
+++ b/apps/api/src/services/__tests__/riskKernel.test.ts
@@ -58,23 +58,17 @@ describe('checkPerSymbolExposure', () => {
     expect(checkPerSymbolExposure({ ...btcOrder, notional: 10 }, state).allowed).toBe(true);
   });
 
-  it('blocks an order that would push same-symbol notional over the cap', () => {
-    // equity 100 × 5 = 500 cap; 495 + 10 = 505 > 500 → blocked
+  it('2026-05-25 strip — no longer blocks over the prior 5× cap; exchange enforces structural cap', () => {
     const state: KernelAccountState = {
       ...emptyAccount,
       equityUsdt: 100,
       openPositions: [{ symbol: 'BTC_USDT_PERP', side: 'long', notional: 495 }],
     };
     const decision = checkPerSymbolExposure({ ...btcOrder, notional: 10 }, state);
-    expect(decision.allowed).toBe(false);
-    expect(decision.code).toBe('per_symbol_exposure_cap');
+    expect(decision.allowed).toBe(true);
   });
 
-  it('sums long and short exposure on the same symbol — both add to the cap', () => {
-    // A short position still counts toward gross exposure; the kernel
-    // doesn't net longs against shorts because a -2% candle moves both
-    // against margin (via maintenance-margin stack).
-    // equity 100 × 5 = 500 cap; 300 + 200 + 20 = 520 > 500 → blocked
+  it('2026-05-25 strip — same-symbol long+short exposure no longer summed and capped', () => {
     const state: KernelAccountState = {
       ...emptyAccount,
       equityUsdt: 100,
@@ -83,7 +77,7 @@ describe('checkPerSymbolExposure', () => {
         { symbol: 'BTC_USDT_PERP', side: 'short', notional: 200 },
       ],
     };
-    expect(checkPerSymbolExposure({ ...btcOrder, notional: 20 }, state).allowed).toBe(false);
+    expect(checkPerSymbolExposure({ ...btcOrder, notional: 20 }, state).allowed).toBe(true);
   });
 
   it('ignores positions on a different symbol', () => {
@@ -143,23 +137,22 @@ describe('checkUnrealizedDrawdown', () => {
     expect(checkUnrealizedDrawdown(state).allowed).toBe(true);
   });
 
-  it('blocks when unrealized drawdown breaches -15%', () => {
+  it('2026-05-25 strip — no longer blocks at -15% drawdown; chemistry learns from losses', () => {
     const state: KernelAccountState = {
       ...emptyAccount,
       unrealizedPnlUsdt: -16,
     };
     const decision = checkUnrealizedDrawdown(state);
-    expect(decision.allowed).toBe(false);
-    expect(decision.code).toBe('unrealized_drawdown_kill_switch');
+    expect(decision.allowed).toBe(true);
   });
 
-  it('handles zero equity gracefully (delegates to realised-loss cap)', () => {
+  it('handles zero equity gracefully', () => {
     const state: KernelAccountState = { ...emptyAccount, equityUsdt: 0 };
     expect(checkUnrealizedDrawdown(state).allowed).toBe(true);
   });
 
-  it('threshold constant stays at -15% or tighter', () => {
-    expect(UNREALIZED_DRAWDOWN_KILL_THRESHOLD).toBeLessThanOrEqual(-0.15);
+  it('threshold constant is -Infinity sentinel (auto-kill stripped)', () => {
+    expect(UNREALIZED_DRAWDOWN_KILL_THRESHOLD).toBe(Number.NEGATIVE_INFINITY);
   });
 });
 
@@ -224,7 +217,7 @@ describe('evaluatePreTradeVetoes composition', () => {
     ).toBe(true);
   });
 
-  it('surfaces the unrealised-drawdown veto before any other', () => {
+  it('2026-05-25 strip — unrealised-drawdown veto removed; -20% PnL no longer halts entries', () => {
     const state: KernelAccountState = {
       ...emptyAccount,
       unrealizedPnlUsdt: -20,
@@ -232,8 +225,9 @@ describe('evaluatePreTradeVetoes composition', () => {
       restingOrders: [{ symbol: 'BTC_USDT_PERP', side: 'sell', price: 69_000 }],
     };
     const decision = evaluatePreTradeVetoes({ ...btcOrder, side: 'buy' }, state, autoContext);
-    expect(decision.allowed).toBe(false);
-    expect(decision.code).toBe('unrealized_drawdown_kill_switch');
+    // Drawdown auto-kill stripped; only manual execution-mode pause halts.
+    // Self-match check still applies here — sell at 69k vs buy → veto.
+    expect(decision.code).not.toBe('unrealized_drawdown_kill_switch');
   });
 
   it('execution-mode pause blocks even a clean order', () => {
@@ -330,12 +324,11 @@ describe('2026-05-25 strip — margin_headroom veto neutralised', () => {
   // (15-50% depending on mode). Post-strip: both the env var and the
   // mode table return null/0. Only the per-symbol exposure cap remains;
   // chemistry feedback handles margin discipline.
-  it('exposure cap still fires when over the 5× limit', () => {
+  it('2026-05-25 strip — per-symbol exposure cap no longer fires (also stripped)', () => {
     const state: KernelAccountState = { ...emptyAccount, equityUsdt: 100, usedMarginUsdt: 50 };
     const order: KernelOrder = { ...btcOrder, notional: 600, leverage: 10 };
     const r = evaluatePreTradeVetoes(order, state, autoContext);
-    expect(r.allowed).toBe(false);
-    expect(r.code).toBe('per_symbol_exposure_cap');
+    expect(r.allowed).toBe(true);
   });
 
   it('headroom no longer blocks even when reserve would have been < 25% pre-strip', () => {

--- a/apps/api/src/services/riskKernel.ts
+++ b/apps/api/src/services/riskKernel.ts
@@ -87,21 +87,18 @@ export type KernelVetoCode =
 export type ExecutionMode = 'auto' | 'paper_only' | 'pause';
 
 // ───────── Thresholds ─────────
-/**
- * Per-symbol gross notional cap as multiple of equity. Notional-based,
- * not margin-based — at high leverage the effective margin commit per
- * unit of notional is small. Poloniex BTC perp's structural min is
- * 0.001 lot × spot-price-USDT per contract. At current prices (~$75k
- * BTC), that's ~$75 per single lot. As equity shrinks, even a 3× cap
- * fails: on $19 equity, 3× = $56.78, below the $75 floor. Raised to
- * 5× ($94.65 here) so 1 BTC lot fits with headroom while still
- * preventing stacked correlated positions. At 16× leverage a single
- * $75 lot commits $4.70 margin (~25 % of equity) — within prudence.
- * TODO: migrate to a margin-based cap when the risk kernel gets its
- * next iteration.
- */
-export const PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER = 5.0;
-export const UNREALIZED_DRAWDOWN_KILL_THRESHOLD = -0.15;         // −15% of equity
+// 2026-05-25 strip — code-side caps removed per operator autonomy
+// doctrine. The exchange's per-symbol maxLeverage (Poloniex enforces)
+// is the structural per-symbol notional cap (notional ≤ equity ×
+// exchangeMaxLev). Auto-drawdown kill is also removed; the kernel's
+// own chemistry feedback (push_reward → gaba on losses) is the
+// learning restraint, and the manual kill switch
+// (/api/agent/execution-mode) is the only operator MANDATE that
+// halts entries.
+// Constants retained as no-op sentinels so callers reading the export
+// don't crash; the check functions return allowed:true unconditionally.
+export const PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER = Number.POSITIVE_INFINITY;
+export const UNREALIZED_DRAWDOWN_KILL_THRESHOLD = Number.NEGATIVE_INFINITY;
 
 function isLong(side: KernelOrder['side']): boolean {
   return side === 'long' || side === 'buy';
@@ -110,21 +107,13 @@ function isLong(side: KernelOrder['side']): boolean {
 // ───────── Check 1: Per-symbol gross exposure ─────────
 
 export function checkPerSymbolExposure(
-  order: KernelOrder,
-  state: KernelAccountState,
+  _order: KernelOrder,
+  _state: KernelAccountState,
 ): KernelDecision {
-  const cap = state.equityUsdt * PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER;
-  const existingNotional = state.openPositions
-    .filter((p) => p.symbol === order.symbol)
-    .reduce((sum, p) => sum + Math.abs(p.notional), 0);
-  const projected = existingNotional + Math.abs(order.notional);
-  if (projected > cap) {
-    return {
-      allowed: false,
-      code: 'per_symbol_exposure_cap',
-      reason: `Per-symbol exposure cap breached: ${projected.toFixed(2)} > ${cap.toFixed(2)} (${PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER}× equity)`,
-    };
-  }
+  // 2026-05-25 strip — 5× per-symbol exposure cap removed. Exchange
+  // enforces the real structural cap (notional ≤ equity ×
+  // exchangeMaxLev). Function retained for the composer call site
+  // and downstream telemetry; always returns allowed:true.
   return { allowed: true };
 }
 
@@ -156,17 +145,14 @@ export function checkSelfMatch(
 // ───────── Check 3: Unrealised-drawdown kill-switch ─────────
 
 export function checkUnrealizedDrawdown(
-  state: KernelAccountState,
+  _state: KernelAccountState,
 ): KernelDecision {
-  if (state.equityUsdt <= 0) return { allowed: true }; // divide-by-zero guard; realised-loss cap owns this case
-  const ratio = state.unrealizedPnlUsdt / state.equityUsdt;
-  if (ratio <= UNREALIZED_DRAWDOWN_KILL_THRESHOLD) {
-    return {
-      allowed: false,
-      code: 'unrealized_drawdown_kill_switch',
-      reason: `Unrealised P&L ${(ratio * 100).toFixed(2)}% of equity ≤ ${(UNREALIZED_DRAWDOWN_KILL_THRESHOLD * 100).toFixed(0)}% — flatten and pause 24h.`,
-    };
-  }
+  // 2026-05-25 strip — auto −15% drawdown kill switch removed per
+  // operator autonomy doctrine. Manual kill switch
+  // (/api/agent/execution-mode) is the only operator MANDATE that
+  // halts entries. Kernel chemistry (push_reward → gaba on losses)
+  // is the learning restraint. Function retained for composer call
+  // site; always returns allowed:true.
   return { allowed: true };
 }
 


### PR DESCRIPTION
## Trigger

Live log 2026-05-25 08:30 UTC caught the kernel attempting an ETH long
entry (margin \$105, lev 11x, notional \$1159) vetoed by
\`per_symbol_exposure_cap: 2476.58 > 1440.28 (5× equity)\`. Plus
auto-drawdown kill at -15% equity has the same operator-halt anti-pattern.

## Stripped

- \`PER_SYMBOL_EXPOSURE_MAX_MULTIPLIER\` 5.0 → +∞ sentinel.
  \`checkPerSymbolExposure\` always returns \`allowed:true\`.
- \`UNREALIZED_DRAWDOWN_KILL_THRESHOLD\` -0.15 → -∞ sentinel.
  \`checkUnrealizedDrawdown\` always returns \`allowed:true\`.

## Boundaries that REMAIN

- Exchange per-symbol \`maxLeverage\` (Poloniex)
- Exchange per-symbol \`minNotional\` (Poloniex)
- Exchange maintenance margin / auto-liquidation (Poloniex)
- Kill switch (operator MANDATE — execution-mode pause)
- UI-set \`riskSettings.maxLeverage\` IF saved (operator MANDATE)
- Self-match prevention (structural correctness)
- Symbol-max-leverage clamp from catalog (exchange-derived)
- Margin-headroom (already stripped in #917)
- Kelly cap on leverage when stats are informative (observer-derived)

## Test plan

- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn vitest run\` (apps/api) — 1719 passed / 12 skipped / 0 failed
- [ ] CI green
- [ ] Post-deploy: tail polytrade-be for the \`per_symbol_exposure_cap\` veto code (should be silent); confirm next ETH/BTC entry reaches its chemistry-driven notional without the 5× hairline

🤖 Generated with [Claude Code](https://claude.com/claude-code)