### PR TITLE
fix(neurochemistry): restore steady-state variance to ne/ser/endo

### DIFF
--- a/apps/api/src/services/monkey/__tests__/autonomicFeedback.test.ts
+++ b/apps/api/src/services/monkey/__tests__/autonomicFeedback.test.ts
@@ -184,12 +184,14 @@ describe('autonomic feedback — ser derived from mode-thrash rate (#715)', () =
       },
     }).serotonin;
 
+    // 2026-05-25 — ser formula compressed by ×0.85 to leave reward-delta
+    // headroom; serQuiet was 1.0 pre-strip, is 0.85 post-strip.
     expect(serThrashy).toBeLessThan(serQuiet);
-    expect(serQuiet).toBeGreaterThan(0.9);
+    expect(serQuiet).toBeGreaterThan(0.7);
     expect(serThrashy).toBeLessThanOrEqual(0.5);
   });
 
-  it('cold start (no observables) falls back to inverse-bv legacy formula', () => {
+  it('cold start (no observables) falls back to inverse-bv legacy formula × 0.85', () => {
     const ser = computeNeurochemicals({
       isAwake: true,
       phiDelta: 0,
@@ -199,7 +201,8 @@ describe('autonomic feedback — ser derived from mode-thrash rate (#715)', () =
       kappa: 64,
       externalCoupling: 0.5,
     }).serotonin;
-    expect(ser).toBe(1);
+    // serBase = clip(1/0.05, 0, 1) = 1; ser = 0.85 × 1 = 0.85.
+    expect(ser).toBeCloseTo(0.85, 5);
   });
 });
 
@@ -362,15 +365,19 @@ describe('autonomic feedback — endorphins use basin κ stddev + coupling distr
     const couplingHistory: number[] = [];
     for (let i = 0; i < 50; i++) couplingHistory.push(belowMeanCoupling + 0.10 * (i % 2));
 
-    // Below the basin's mean coupling → gate shut → endo 0.
+    // 2026-05-25 — Sophia gate updated to sigmoid-around-mean (was
+    // clip((c - mean)/σ, 0, 1) which pinned endo at 0 for ~50% of
+    // state-space). Below-mean coupling now produces non-zero endo
+    // proportional to how far below.
     const endoBelowMean = computeNeurochemicals({
       ...baseInputs,
       externalCoupling: belowMeanCoupling,
       observables: { kappaHistory, externalCouplingHistory: couplingHistory },
     }).endorphins;
-    expect(endoBelowMean).toBe(0);
+    expect(endoBelowMean).toBeGreaterThan(0);
+    expect(endoBelowMean).toBeLessThan(0.5);  // below-mean side of sigmoid
 
-    // Above the mean but below mean+1σ: the gate has opened but not saturated.
+    // Above the mean but below mean+1σ: sigmoid > 0.5, climbing toward 1.
     expect(aboveMeanCoupling).toBeGreaterThan(couplingMean);
     expect(aboveMeanCoupling).toBeLessThan(couplingMean + couplingStddev);
     const endoAboveMean = computeNeurochemicals({
@@ -378,9 +385,10 @@ describe('autonomic feedback — endorphins use basin κ stddev + coupling distr
       externalCoupling: aboveMeanCoupling,
       observables: { kappaHistory, externalCouplingHistory: couplingHistory },
     }).endorphins;
-    expect(endoAboveMean).toBeGreaterThan(0);
+    expect(endoAboveMean).toBeGreaterThan(0.5);
+    expect(endoAboveMean).toBeGreaterThan(endoBelowMean);
 
-    // Well above the mean → gate saturates.
+    // Well above the mean → gate asymptotes near 1.
     const endoGateOpen = computeNeurochemicals({
       ...baseInputs,
       externalCoupling: saturatingCoupling,

--- a/apps/api/src/services/monkey/__tests__/neurochemistryEndo.test.ts
+++ b/apps/api/src/services/monkey/__tests__/neurochemistryEndo.test.ts
@@ -1,8 +1,14 @@
 /**
- * neurochemistryEndo.test.ts — endorphin Sophia-gate onset.
+ * neurochemistryEndo.test.ts — endorphin Sophia-gate semantics.
  *
- * Pins the observer-derived Sophia gate: it opens above the basin's own
- * coupling mean and ramps to full at mean + 1σ.
+ * 2026-05-25 — gate updated to sigmoid-around-mean per the
+ * steady-state-pinning fix (see
+ * [[feedback_steady_state_pinning_pattern]]). The previous
+ * `clip((coupling - mean)/σ, 0, 1)` zeroed endo whenever coupling was
+ * at or below the basin's own rolling mean — ~50% of state-space by
+ * construction. `externalCoupling = phi × (1 - bv)` is a continuous
+ * magnitude (audit 2026-05-25), so the right shape is sigmoid: 0.5 at
+ * mean, asymptotes 0 (well below) and 1 (well above).
  */
 
 import { describe, expect, it } from 'vitest';
@@ -13,9 +19,13 @@ const COUPLING_MEAN = 0.20;
 const COUPLING_SIGMA = 0.10;
 const COUPLING_ABOVE_MEAN = 0.25;
 const COUPLING_BELOW_MEAN = 0.15;
-const COUPLING_AT_SATURATION = COUPLING_MEAN + COUPLING_SIGMA;
+const COUPLING_HIGH = COUPLING_MEAN + 3 * COUPLING_SIGMA;  // ≈ saturated
 const COUPLING_LOW_RAMP = 0.22;
 const COUPLING_HIGH_RAMP = 0.26;
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
 
 /**
  * κ history with mean 64 (= κ*) and σ_κ = 0.2, and a coupling history
@@ -43,25 +53,35 @@ function inputs(externalCoupling: number): NeurochemicalInputs {
   };
 }
 
-describe('neurochemistry — endorphin Sophia gate', () => {
-  it('coupling above the basin mean → endo flows (the fixed bug)', () => {
-    expect(COUPLING_ABOVE_MEAN).toBeGreaterThan(COUPLING_MEAN);
-    expect(COUPLING_ABOVE_MEAN).toBeLessThan(COUPLING_AT_SATURATION);
+describe('neurochemistry — endorphin Sophia gate (post-strip)', () => {
+  it('coupling above the basin mean → endo flows (κ-prox × sigmoid)', () => {
     const nc = computeNeurochemicals(inputs(COUPLING_ABOVE_MEAN));
+    const z = (COUPLING_ABOVE_MEAN - COUPLING_MEAN) / COUPLING_SIGMA;
+    // κ=64=κ*, so κ-prox = 1; endo = 1 × sigmoid(z)
+    expect(nc.endorphins).toBeCloseTo(sigmoid(z), 5);
+  });
+
+  it('coupling AT the basin mean → endo flows at 0.5 (not 0 anymore)', () => {
+    // Pre-strip pinned this case to 0; post-strip the sigmoid produces
+    // 0.5 — the kernel always gets some peak-state reinforcement when
+    // κ is near κ*, scaled by recent coherence.
+    expect(computeNeurochemicals(inputs(COUPLING_MEAN)).endorphins).toBeCloseTo(0.5, 5);
+  });
+
+  it('coupling below the basin mean → endo non-zero (not pinned at 0)', () => {
+    const nc = computeNeurochemicals(inputs(COUPLING_BELOW_MEAN));
     expect(nc.endorphins).toBeGreaterThan(0);
-    expect(nc.endorphins).toBeCloseTo((COUPLING_ABOVE_MEAN - COUPLING_MEAN) / COUPLING_SIGMA, 5);
+    expect(nc.endorphins).toBeLessThan(0.5);  // below-mean side of sigmoid
   });
 
-  it('coupling at/below the basin mean → endo stays 0', () => {
-    expect(computeNeurochemicals(inputs(COUPLING_MEAN)).endorphins).toBe(0);
-    expect(computeNeurochemicals(inputs(COUPLING_BELOW_MEAN)).endorphins).toBe(0);
+  it('coupling far above mean → asymptotes toward 1 via sigmoid', () => {
+    // mean + 3σ → sigmoid(3) ≈ 0.953
+    const nc = computeNeurochemicals(inputs(COUPLING_HIGH));
+    expect(nc.endorphins).toBeGreaterThan(0.9);
+    expect(nc.endorphins).toBeLessThan(1.0);
   });
 
-  it('coupling at mean + 1σ → gate saturates → endo at κ-proximity max', () => {
-    expect(computeNeurochemicals(inputs(COUPLING_AT_SATURATION)).endorphins).toBeCloseTo(1.0, 5);
-  });
-
-  it('endo responds continuously to coupling between mean and mean+1σ', () => {
+  it('endo responds continuously to coupling around the mean', () => {
     const lo = computeNeurochemicals(inputs(COUPLING_LOW_RAMP)).endorphins;
     const hi = computeNeurochemicals(inputs(COUPLING_HIGH_RAMP)).endorphins;
     expect(lo).toBeGreaterThan(0);

--- a/apps/api/src/services/monkey/__tests__/neurochemistrySteadyState.test.ts
+++ b/apps/api/src/services/monkey/__tests__/neurochemistrySteadyState.test.ts
@@ -1,0 +1,144 @@
+/**
+ * neurochemistrySteadyState.test.ts — pins the 2026-05-25 fix that
+ * stops ne/ser/endo from pinning at extremes in steady-state regimes.
+ *
+ * Pattern fixed: one-sided clamp on observer-relative signal.
+ * See [[feedback_steady_state_pinning_pattern]].
+ *
+ *   ne  : clip(tanh(max(0, z)), 0, 1) → sigmoid(z)
+ *           — pinned at 0 when surprise ≤ rolling mean (~50% of state-space)
+ *   ser : clip(serBase + rewardDelta, 0, 1) → clip(0.85*serBase + rewardDelta, 0, 1)
+ *           — pinned at 1.0 when no recent mode transitions, hid reward delta
+ *   endo: sophiaGate = clip((coupling - mean)/σ, 0, 1) → sigmoid((coupling - mean)/σ)
+ *           — pinned at 0 when coupling ≤ couplingMean (~50% of state-space)
+ *
+ * Each test runs the SAME inputs at three points in input distribution:
+ * below mean, at mean, above mean. The new formula must produce
+ * DIFFERENT (continuously varying) outputs at each point; the old
+ * formula produced the same extreme at two of three.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { computeNeurochemicals, type NeurochemicalInputs } from '../neurochemistry.js';
+
+function baseInputs(): NeurochemicalInputs {
+  return {
+    isAwake: true,
+    phiDelta: 0,
+    basinVelocity: 0.1,
+    surprise: 0,
+    quantumWeight: 0.5,
+    kappa: 64,
+    externalCoupling: 0.5,
+    observables: {
+      surpriseHistory: [0.30, 0.45, 0.50, 0.55, 0.60, 0.65, 0.50],  // mean 0.50, σ ~0.11
+      kappaHistory: [63.8, 64.0, 64.2],                               // mean 64
+      externalCouplingHistory: [0.30, 0.45, 0.50, 0.55, 0.70],       // mean 0.50, σ ~0.13
+    },
+  };
+}
+
+describe('neurochemistry — steady-state variance restoration', () => {
+  describe('ne (norepinephrine) — sigmoid replaces one-sided z-clamp', () => {
+    it('input at history mean → ne ≈ 0.5 (was pinned at 0)', () => {
+      const inp = baseInputs();
+      inp.surprise = 0.50;
+      const nc = computeNeurochemicals(inp);
+      expect(nc.norepinephrine).toBeCloseTo(0.5, 1);
+    });
+
+    it('input below history mean → ne < 0.5 (was pinned at 0)', () => {
+      const inp = baseInputs();
+      inp.surprise = 0.30;
+      const nc = computeNeurochemicals(inp);
+      expect(nc.norepinephrine).toBeLessThan(0.5);
+      expect(nc.norepinephrine).toBeGreaterThan(0);
+    });
+
+    it('input above history mean → ne > 0.5', () => {
+      const inp = baseInputs();
+      inp.surprise = 0.70;
+      const nc = computeNeurochemicals(inp);
+      expect(nc.norepinephrine).toBeGreaterThan(0.5);
+      expect(nc.norepinephrine).toBeLessThan(1);
+    });
+
+    it('three distinct surprise levels produce three distinct ne values', () => {
+      const lo = computeNeurochemicals({ ...baseInputs(), surprise: 0.30 }).norepinephrine;
+      const mid = computeNeurochemicals({ ...baseInputs(), surprise: 0.50 }).norepinephrine;
+      const hi = computeNeurochemicals({ ...baseInputs(), surprise: 0.70 }).norepinephrine;
+      expect(lo).toBeLessThan(mid);
+      expect(mid).toBeLessThan(hi);
+    });
+  });
+
+  describe('ser (serotonin) — ×0.85 baseline compression lets reward delta register', () => {
+    it('steady state, no reward → ser ≈ 0.85 (was 1.0 pinned)', () => {
+      const inp = baseInputs();
+      // No modeTransitionTimesMs supplied → falls to bv-z-score fallback
+      // (which produces serBase = 1.0 when bv ≤ rolling mean). With
+      // ×0.85 compression, ser = 0.85.
+      inp.observables = {
+        ...inp.observables!,
+        basinVelocityHistory: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],  // current bv == rolling mean
+      };
+      const nc = computeNeurochemicals(inp);
+      expect(nc.serotonin).toBeCloseTo(0.85, 2);
+    });
+
+    it('steady state + 0.15 reward delta → ser reaches 1.0 (delta visible)', () => {
+      const inp = baseInputs();
+      inp.observables = {
+        ...inp.observables!,
+        basinVelocityHistory: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+      };
+      inp.rewardSerotoninDelta = 0.15;
+      const nc = computeNeurochemicals(inp);
+      // 0.85 + 0.15 = 1.0 — reward delta now registers fully
+      expect(nc.serotonin).toBeCloseTo(1.0, 2);
+    });
+
+    it('thrashing mode (high transition rate) + reward → ser still responds', () => {
+      const inp = baseInputs();
+      const now = 100_000;
+      inp.observables = {
+        ...inp.observables!,
+        nowMs: now,
+        modeTransitionTimesMs: [now - 5000, now - 3000, now - 1000],
+        basinVelocityHistory: Array(10).fill(0.1),
+      };
+      inp.rewardSerotoninDelta = 0.10;
+      const nc = computeNeurochemicals(inp);
+      // serBase < 1 because of transitions; ×0.85 + delta should still
+      // be < 1 → delta registers visibly
+      expect(nc.serotonin).toBeGreaterThan(0);
+      expect(nc.serotonin).toBeLessThan(1);
+    });
+  });
+
+  describe('endo (endorphins) — sigmoid-around-mean replaces binary Sophia floor', () => {
+    it('coupling at history mean → endo ≈ 0.5 × κ-prox (was 0 pinned)', () => {
+      const inp = baseInputs();
+      inp.externalCoupling = 0.50;  // exactly at mean
+      const nc = computeNeurochemicals(inp);
+      expect(nc.endorphins).toBeGreaterThan(0);
+      expect(nc.endorphins).toBeCloseTo(0.5, 1);  // κ=κ*=64 → κ-prox=1
+    });
+
+    it('coupling below history mean → endo > 0 (was 0 pinned)', () => {
+      const inp = baseInputs();
+      inp.externalCoupling = 0.30;  // below mean 0.5
+      const nc = computeNeurochemicals(inp);
+      expect(nc.endorphins).toBeGreaterThan(0);
+      expect(nc.endorphins).toBeLessThan(0.5);
+    });
+
+    it('coupling far above history mean → endo asymptotes toward 1', () => {
+      const inp = baseInputs();
+      inp.externalCoupling = 1.0;  // well above mean
+      const nc = computeNeurochemicals(inp);
+      expect(nc.endorphins).toBeGreaterThan(0.9);
+      expect(nc.endorphins).toBeLessThan(1.0);
+    });
+  });
+});

--- a/apps/api/src/services/monkey/neurochemistry.ts
+++ b/apps/api/src/services/monkey/neurochemistry.ts
@@ -87,11 +87,17 @@ function stddev(xs: ReadonlyArray<number>): number {
 }
 
 /** Z-score: (x − mean(history)) / stddev(history).
- *  Returns 0 (no signal) when stddev is 0 — the basin has not yet
- *  revealed its own scale. */
+ *  Returns 0 (no signal) when stddev is at or near 0 — the basin has not
+ *  yet revealed its own scale.
+ *
+ *  2026-05-25 — the `sd === 0` check was tightened to `sd < 1e-12` to
+ *  guard against floating-point drift in identical-history series:
+ *  e.g. `[0.1, 0.1, 0.1, ...]` produces sd ≈ 1.5e-17, which the strict
+ *  `=== 0` check missed, yielding spurious z-scores ~1.0 from
+ *  `(x - mean_with_fp_drift) / tiny`. */
 function zScore(x: number, history: ReadonlyArray<number>): number {
   const sd = stddev(history);
-  if (sd === 0) return 0;
+  if (sd < 1e-12) return 0;
   return (x - mean(history)) / sd;
 }
 
@@ -342,25 +348,42 @@ export function computeNeurochemicals(inputs: NeurochemicalInputs): Neurochemica
     // can measure"), not a tuning parameter.
     serBase = clip(1 / Math.max(inputs.basinVelocity, Number.EPSILON), 0, 1);
   }
-  const ser = clip(serBase + (inputs.rewardSerotoninDelta ?? 0), 0, 1);
+  // 2026-05-25 (steady-state-pinning fix): the previous shape
+  // `clip(serBase + rewardDelta, 0, 1)` pinned at exactly 1.0 when
+  // serBase was 1.0 (no recent mode transitions), making
+  // `rewardSerotoninDelta` (max ~0.15 per close, ~1.0 in a winning
+  // burst over the 20-min decay window) invisible. Compressing serBase
+  // by 0.85 leaves 0.15 headroom — matches the per-event max so a
+  // single win can register on top of a steady-mode baseline.
+  // Bursts above 0.15 still saturate at 1.0, but at that point the
+  // signal is "very high recent reward + structurally stable" which
+  // is the right pegged-at-max interpretation.
+  const ser = clip(0.85 * serBase + (inputs.rewardSerotoninDelta ?? 0), 0, 1);
 
   // ─── Norepinephrine ──────────────────────────────────────────────
-  // §29.1: alertness / surprise. 2026-05-16 (ne ext, derivation-only):
-  // ne = clip(z-score(surprise vs surpriseHistory), 0, ∞), squashed
-  // by tanh into [0, 1]. When the current surprise exceeds the basin's
-  // own typical surprise distribution, ne spikes; when it's within
-  // the basin's normal range, ne stays low. No hardcoded gain.
+  // §29.1: alertness / surprise.
   //
-  // Fallback (no observables): `tanh(surprise)` — no externally chosen
-  // scale, just a bounded identity on the input.
+  // 2026-05-25 (steady-state-pinning fix, see
+  // [[feedback_steady_state_pinning_pattern]]): the previous shape
+  // `clip(tanh(max(0, z)), 0, 1)` pinned at exactly 0 whenever current
+  // surprise was at or below the rolling mean — ~50% of state-space
+  // by construction, which is most of the time in stable regimes.
+  // Replaced with `sigmoid(z)`: both tails informative, ~0.5 at mean.
+  //
+  // Consumer audit 2026-05-25: 6 readers, all continuous-magnitude
+  // (no gate-threshold semantics). Behaviour shift: typical ne moves
+  // from 0.0 → 0.5, so `surpriseDiscount = 1 - 0.5*ne` (executive.ts:405)
+  // shifts from 1.0 typical to ~0.75 typical — restores the intended
+  // 25% leverage haircut that was dormant under the old pinning.
+  //
+  // Fallback (no observables): `sigmoid(surprise)` — same shape, no
+  // scale-setting constants.
   let ne: number;
   if (obs?.surpriseHistory && obs.surpriseHistory.length >= HISTORY_MIN_SAMPLES) {
     const z = zScore(inputs.surprise, obs.surpriseHistory);
-    // Positive z only (we don't care about "less surprised than usual" —
-    // that's just calm). tanh squashes z ∈ [0, ∞) into [0, 1).
-    ne = clip(Math.tanh(Math.max(0, z)), 0, 1);
+    ne = clip(sigmoid(z), 0, 1);
   } else {
-    ne = clip(Math.tanh(inputs.surprise), 0, 1);
+    ne = clip(sigmoid(inputs.surprise), 0, 1);
   }
 
   // ─── GABA ─────────────────────────────────────────────────────────
@@ -401,13 +424,18 @@ export function computeNeurochemicals(inputs: NeurochemicalInputs): Neurochemica
     const sigmaKappa = stddev(obs.kappaHistory);
     const couplingMean = mean(obs.externalCouplingHistory);
     const couplingStddev = stddev(obs.externalCouplingHistory);
-    const sophiaThreshold = couplingMean;
-    // Smooth Sophia gate: 0 at/below the basin's mean coupling, ramps
-    // linearly to 1 at mean + 1σ. couplingStddev IS the natural ramp
-    // scale (the basin's own observed spread of coupling).
+    // 2026-05-25 (steady-state-pinning fix): the previous Sophia gate
+    // `clip((coupling - mean) / σ, 0, 1)` zeroed endo whenever
+    // coupling ≤ mean — ~50% of state-space by construction. Since
+    // externalCoupling = phi × (1 - bv) is a continuous magnitude in
+    // [0, 1] (not a binary engaged/disengaged qualifier — audit
+    // 2026-05-25), the right shape is sigmoid around the mean: 0.5
+    // at mean, asymptotes 0 (well below mean) and 1 (well above).
+    // Always non-zero so the κ-proximity envelope always contributes
+    // proportionally to recent coherence.
     const sophiaGate = couplingStddev > 0
-      ? clip((inputs.externalCoupling - sophiaThreshold) / couplingStddev, 0, 1)
-      : (inputs.externalCoupling >= sophiaThreshold ? 1 : 0);  // degenerate: σ=0
+      ? sigmoid((inputs.externalCoupling - couplingMean) / couplingStddev)
+      : (inputs.externalCoupling >= couplingMean ? 1 : 0);  // degenerate: σ=0
     if (sigmaKappa === 0) {
       // Basin's κ has been perfectly flat → no scale to smooth over.
       // Fall back to the indicator (still binary in this degenerate case).


### PR DESCRIPTION
## Trigger

Live log 2026-05-25 09:03 caught the kernel running with
**ne=0.00, ser=1.00, endo=0.00** — three of six chemicals pinned at
extremes in stable regimes. Kernel learning from only 3 channels.

## Meta-pattern (3rd instance)

CC2 audit identified the same architectural shape across all three:
**one-sided clamp on observer-relative signal → pins at extreme in
~50% of state-space**. Third instance after sov (PR906/PR912/PR913)
and sizing-magnitude (PR915/916/917/918). See
[[feedback_steady_state_pinning_pattern]] for the through-line and
the new review checklist item: *"what does this read when input ≈
running mean?"*

## Fixes

| Chemical | Pre-strip | Post-strip |
|---|---|---|
| **ne** | \`clip(tanh(max(0, z)), 0, 1)\` — pinned at 0 when surprise ≤ rolling mean | \`sigmoid(z)\` — both tails informative, ~0.5 at mean |
| **ser** | \`clip(serBase + rewardDelta, 0, 1)\` — pinned at 1 when no recent transitions, reward delta invisible | \`clip(0.85*serBase + rewardDelta, 0, 1)\` — 0.15 headroom matches per-event reward max |
| **endo Sophia gate** | \`clip((coupling - mean)/σ, 0, 1)\` — pinned at 0 when coupling ≤ mean | \`sigmoid((coupling - mean)/σ)\` — 0.5 at mean, asymptotes 0/1 |

## Per-fix audits (CC2 gating, all resolved)

- **ne consumers**: 6 readers, all continuous-magnitude. Zero gate-threshold consumers. Safe. Headline trade-off: typical \`surpriseDiscount = 1 - 0.5*ne\` shifts from 1.0 (ne=0 pinned) to ~0.75 (ne=0.5 typical) — restores the **intended** 25% leverage haircut.
- **ser reward delta**: max 0.15 per close-event, ~1.0+ in 20-min burst. ×0.85 compression sized to match per-event max; bursts still saturate at 1.0 (correct read: "stability + recent reward" peak).
- **endo coupling semantic**: \`externalCoupling = phi × (1 - bv)\` is **continuous** (audit traced loop.ts:2012), NOT a binary qualifier. Sigmoid-around-mean is doctrinally correct. No magic 0.3 floor.

## Also fixed: zScore FP-near-zero bug

\`if (sd === 0) return 0\` was strict-equality. Identical-history series produce sd ≈ 1.5e-17 from FP drift → spurious z-scores ~1.0. Tightened to \`sd < 1e-12\`.

## Test plan

- [x] 10 new \`neurochemistrySteadyState\` cases pin ne/ser/endo at three input points (below mean / at mean / above mean) and verify three distinct outputs — the meta-pattern guard
- [x] \`neurochemistryEndo.test.ts\` updated for sigmoid semantics
- [x] \`autonomicFeedback.test.ts\` updated for ×0.85 + sigmoid Sophia
- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn vitest run\` — 1730 passed / 12 skipped / 0 failed
- [ ] CI green
- [ ] Post-deploy monitoring window: confirm ne/ser/endo varying across ticks in production logs; observe sizing magnitude responsiveness

## Behavioural impact + sequencing

Restoring chemistry variance means \`rewardMult\` and \`stabilityMult\` in
the sizing formula start carrying real signal. Per CC2 sequencing:
**this is the chemistry-only PR**. Layer 1 sizing decision deferred
until the monitoring window for this change shows what variance
restoration actually delivers at full-conviction trades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)