### PR TITLE
feat(monkey): auto-promotion gate for kernel paper-rotation

### DIFF
--- a/apps/api/src/services/monkey/__tests__/kernelRotation.test.ts
+++ b/apps/api/src/services/monkey/__tests__/kernelRotation.test.ts
@@ -12,8 +12,12 @@ import {
   promoteToLive,
   recordClose,
   rollingWinRate,
+  shouldAutoPromote,
   ROTATION_LOSS_STREAK_THRESHOLD,
+  ROTATION_PROMOTION_WR_GAP,
+  ROTATION_WR_MIN_SAMPLES,
   ROTATION_WR_WINDOW,
+  type RotationPeerSnapshot,
 } from '../kernel_rotation.js';
 
 describe('kernel_rotation — state machine', () => {
@@ -112,6 +116,89 @@ describe('kernel_rotation — promotion', () => {
     recordClose(s, -1.0);
     expect(s.consecutiveLosses).toBe(1);
     expect(s.mode).toBe('live');
+  });
+});
+
+describe('kernel_rotation — auto-promotion gate', () => {
+  function paperKernelWithWR(targetWR: number, n: number = ROTATION_WR_MIN_SAMPLES) {
+    const s = makeRotationState();
+    // First demote it: 5 consecutive losses.
+    for (let i = 0; i < ROTATION_LOSS_STREAK_THRESHOLD; i++) recordClose(s, -1);
+    // Clear the losses out of the rolling window by adding `n` more closes
+    // with the desired WR. Demotion already fired; further closes don't
+    // re-demote.
+    s.rollingPnls = [];  // reset window so synthetic stats are clean
+    const wins = Math.round(targetWR * n);
+    for (let i = 0; i < wins; i++) s.rollingPnls.push(+1);
+    for (let i = wins; i < n; i++) s.rollingPnls.push(-1);
+    return s;
+  }
+
+  function liveKernelWithWR(targetWR: number, n: number = ROTATION_WR_MIN_SAMPLES): RotationPeerSnapshot {
+    return {
+      mode: 'live',
+      rollingWinRate: targetWR,
+      rollingSampleCount: n,
+    };
+  }
+
+  it('does NOT promote when candidate is already live (only paper → live)', () => {
+    const live = makeRotationState();
+    for (let i = 0; i < ROTATION_WR_MIN_SAMPLES; i++) recordClose(live, +1);
+    const reason = shouldAutoPromote(live, [liveKernelWithWR(0.50)]);
+    expect(reason).toBeNull();
+  });
+
+  it('does NOT promote when candidate has < ROTATION_WR_MIN_SAMPLES closes', () => {
+    const s = paperKernelWithWR(0.80, ROTATION_WR_MIN_SAMPLES - 1);
+    const reason = shouldAutoPromote(s, [liveKernelWithWR(0.50)]);
+    expect(reason).toBeNull();
+  });
+
+  it('does NOT promote when no live peer has informative stats', () => {
+    const s = paperKernelWithWR(0.90);
+    const reason = shouldAutoPromote(s, [
+      { mode: 'paper', rollingWinRate: 0.50, rollingSampleCount: 50 },  // wrong mode
+      { mode: 'live', rollingWinRate: 0.90, rollingSampleCount: ROTATION_WR_MIN_SAMPLES - 1 },  // not enough samples
+    ]);
+    expect(reason).toBeNull();
+  });
+
+  it('promotes when candidate WR matches the best live WR (gap = 0)', () => {
+    const s = paperKernelWithWR(0.60);
+    const reason = shouldAutoPromote(s, [liveKernelWithWR(0.60)]);
+    expect(reason).not.toBeNull();
+    expect(reason).toContain('60.0%');
+  });
+
+  it('promotes when candidate WR is exactly at the gate (best - gap)', () => {
+    // Best live = 0.50; gate = 0.50 - 0.10 = 0.40. Candidate at 0.40 promotes.
+    const s = paperKernelWithWR(0.40);
+    const reason = shouldAutoPromote(s, [liveKernelWithWR(0.50)]);
+    expect(reason).not.toBeNull();
+  });
+
+  it('does NOT promote when candidate WR is just below the gate', () => {
+    // Best live = 0.60; gate = 0.50. Candidate at 0.45 fails.
+    // Use n=20 to make the 0.45 WR representable.
+    const s = paperKernelWithWR(0.45, 20);
+    const reason = shouldAutoPromote(s, [liveKernelWithWR(0.60, 20)]);
+    expect(reason).toBeNull();
+  });
+
+  it('compares against the BEST live peer, not the average', () => {
+    const s = paperKernelWithWR(0.55);
+    // Best live is 0.80, gap=0.10 → gate at 0.70. Candidate at 0.55 fails
+    // even though one live peer has only 0.40 (lower than candidate).
+    const reason = shouldAutoPromote(s, [
+      liveKernelWithWR(0.80),
+      liveKernelWithWR(0.40),
+    ]);
+    expect(reason).toBeNull();
+  });
+
+  it('ROTATION_PROMOTION_WR_GAP is the documented 10pp', () => {
+    expect(ROTATION_PROMOTION_WR_GAP).toBeCloseTo(0.10, 6);
   });
 });
 

--- a/apps/api/src/services/monkey/kernel_rotation.ts
+++ b/apps/api/src/services/monkey/kernel_rotation.ts
@@ -32,10 +32,18 @@
 /** Default loss streak that triggers demotion. */
 export const ROTATION_LOSS_STREAK_THRESHOLD = 5;
 
-/** Rolling window over which a kernel's WR is tracked. Used by the
- *  follow-up auto-promotion PR; included here so the data is being
- *  accumulated from day one. */
+/** Rolling window over which a kernel's WR is tracked. */
 export const ROTATION_WR_WINDOW = 50;
+
+/** Minimum WR sample count before a kernel's rolling WR is considered
+ *  authoritative — used by the auto-promotion gate so a paper kernel
+ *  can't promote on a single lucky close. */
+export const ROTATION_WR_MIN_SAMPLES = 10;
+
+/** Auto-promotion gap: paper kernel's WR must be within this many
+ *  percentage points of the best live kernel's WR to graduate back
+ *  to live. The operator's pre-cutover spec was "within 10%". */
+export const ROTATION_PROMOTION_WR_GAP = 0.10;
 
 export type KernelOperationalMode = 'live' | 'paper';
 
@@ -139,4 +147,61 @@ export function rollingWinRate(state: RotationState): number {
   let wins = 0;
   for (const pnl of state.rollingPnls) if (pnl > 0) wins += 1;
   return wins / n;
+}
+
+/**
+ * Snapshot of the data a kernel exposes to peers for cross-kernel
+ * auto-promotion. Decoupled from MonkeyKernel so this module stays
+ * pure-state (no circular imports).
+ */
+export interface RotationPeerSnapshot {
+  mode: KernelOperationalMode;
+  rollingWinRate: number;        // NaN if no samples yet
+  rollingSampleCount: number;
+}
+
+/**
+ * Decide whether a paper-mode kernel has earned re-promotion to live.
+ *
+ * The rule (matches the pre-cutover spec the operator described):
+ *
+ *   1. The candidate must be in paper mode.
+ *   2. The candidate must have at least ROTATION_WR_MIN_SAMPLES closes
+ *      in its rolling window (no promotion on a single lucky close).
+ *   3. There must exist at least one peer kernel in 'live' mode with
+ *      a CI-firm rolling WR (≥ ROTATION_WR_MIN_SAMPLES samples). If no
+ *      live peer has stats yet, the gate cannot fire — the system has
+ *      no reference WR to compare against.
+ *   4. The candidate's rolling WR must be within
+ *      ROTATION_PROMOTION_WR_GAP of the BEST live peer's WR.
+ *
+ * Returns the reason string when promotion should fire, null otherwise.
+ */
+export function shouldAutoPromote(
+  candidate: RotationState,
+  peers: ReadonlyArray<RotationPeerSnapshot>,
+): string | null {
+  if (candidate.mode !== 'paper') return null;
+  const myN = candidate.rollingPnls.length;
+  if (myN < ROTATION_WR_MIN_SAMPLES) return null;
+
+  let myWins = 0;
+  for (const p of candidate.rollingPnls) if (p > 0) myWins += 1;
+  const myWR = myWins / myN;
+
+  let bestLiveWR = Number.NaN;
+  for (const peer of peers) {
+    if (peer.mode !== 'live') continue;
+    if (peer.rollingSampleCount < ROTATION_WR_MIN_SAMPLES) continue;
+    if (!Number.isFinite(peer.rollingWinRate)) continue;
+    if (!Number.isFinite(bestLiveWR) || peer.rollingWinRate > bestLiveWR) {
+      bestLiveWR = peer.rollingWinRate;
+    }
+  }
+
+  if (!Number.isFinite(bestLiveWR)) return null;  // no informative live peer
+  if (myWR < bestLiveWR - ROTATION_PROMOTION_WR_GAP) return null;
+
+  return `auto-promotion: rolling WR ${(myWR * 100).toFixed(1)}% >= ` +
+    `best live ${(bestLiveWR * 100).toFixed(1)}% - ${(ROTATION_PROMOTION_WR_GAP * 100).toFixed(0)}pp`;
 }

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -72,6 +72,8 @@ import {
   promoteToLive,
   recordClose as recordRotationClose,
   rollingWinRate,
+  shouldAutoPromote,
+  type RotationPeerSnapshot,
   type RotationState,
 } from './kernel_rotation.js';
 import { isPhiLeakyEnabled, updateLeakyPhi } from './phi_integrator.js';
@@ -7895,6 +7897,53 @@ export class MonkeyKernel extends EventEmitter {
           kind: 'kernel_rotation_demotion',
           mode: this.rotation.mode,
           reason: rotationResult.reason,
+          rollingWinRate: rollingWinRate(this.rotation),
+        },
+      });
+    }
+    // 2026-05-25 — auto-promotion check. If this is a paper-mode kernel
+    // and its rolling WR has caught up to within ROTATION_PROMOTION_WR_GAP
+    // (10pp) of the best live peer, promote back. Idempotent: returns
+    // null for live kernels or paper kernels still under the gate.
+    if (this.rotation.mode === 'paper') {
+      this.tryAutoPromote(input.symbol);
+    }
+  }
+
+  /**
+   * Auto-promotion check called after a virtual close. Walks the peer
+   * registry (allMonkeyKernels) to find the best live WR; if this
+   * kernel's paper-mode WR has reached the gate, promotes.
+   */
+  private tryAutoPromote(symbol: string | undefined): void {
+    const peers: RotationPeerSnapshot[] = [];
+    for (const peer of allMonkeyKernels) {
+      if (peer === this) continue;
+      const r = peer.rotation;
+      peers.push({
+        mode: r.mode,
+        rollingWinRate: rollingWinRate(r),
+        rollingSampleCount: r.rollingPnls.length,
+      });
+    }
+    const reason = shouldAutoPromote(this.rotation, peers);
+    if (!reason) return;
+    const result = promoteToLive(this.rotation, reason);
+    if (result.promoted) {
+      logger.info(`[${this.label}] kernel-rotation AUTO-PROMOTED to live`, {
+        instanceId: this.instanceId,
+        reason: result.reason,
+        rollingWinRate: rollingWinRate(this.rotation),
+        rollingTrades: this.rotation.rollingPnls.length,
+      });
+      this.bus.publish({
+        type: BusEventType.OUTCOME,
+        source: this.instanceId,
+        symbol,
+        payload: {
+          kind: 'kernel_rotation_promotion',
+          mode: this.rotation.mode,
+          reason: result.reason,
           rollingWinRate: rollingWinRate(this.rotation),
         },
       });


### PR DESCRIPTION
## Completes the kernel paper-rotation feature trio

| PR | Adds |
|---|---|
| #921 | scaffold (state machine, demotion at 5 consec losses) |
| #922 | placeOrder → paperPlaceOrder when rotation.mode='paper' |
| **#923 (this)** | **auto-promotion when paper WR ≥ best_live_WR - 0.10** |

The operator's pre-cutover allocation pattern is now fully re-implemented.

## Promotion contract

A paper-mode kernel promotes back to live when ALL hold:

1. Candidate is in paper mode
2. Candidate has ≥ \`ROTATION_WR_MIN_SAMPLES\` (10) closes in its
   rolling window — no flips on a single lucky close
3. At least one live peer has ≥ \`ROTATION_WR_MIN_SAMPLES\` closes —
   no informative live reference → no promotion fires
4. Candidate's rolling WR ≥ \`best_live_WR - 0.10\` (the 10pp gap from
   the operator's spec)

Best-of, not avg-of: a paper kernel must catch the **leader**, not the
median.

## Architecture notes

- New pure function \`shouldAutoPromote(candidate, peers)\` in
  \`kernel_rotation.ts\` — keeps the rotation module free of
  circular deps with \`loop.ts\`
- New type \`RotationPeerSnapshot\` decouples the peer-comparison
  contract from \`MonkeyKernel\`
- \`MonkeyKernel.tryAutoPromote()\` called from \`pushReward\` whenever a
  paper-mode close lands; walks \`allMonkeyKernels\` (already exported)
  to find the best live peer
- Emits kernel-bus OUTCOME event with \`kind='kernel_rotation_promotion'\`

## Test plan

- [x] 8 new auto-promotion cases pin: already-live ineligible,
  insufficient candidate samples, no informative peer, exact-WR-match,
  exact-at-gate, just-below-gate, best-of-not-avg-of peers, documented
  10pp constant
- [x] 4 existing paper-routing composition tests still green
- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn vitest run\` — 1755 passing / 12 skipped / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)