### PR TITLE
fix(monkey): observer-derive reward magnitude — z-score pnlFrac, observed κ-stddev

### DIFF
--- a/apps/api/src/services/monkey/__tests__/pushRewardObserverDerive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/pushRewardObserverDerive.test.ts
@@ -1,0 +1,192 @@
+/**
+ * pushRewardObserverDerive.test.ts — pins the 2026-05-25 reward-magnitude
+ * observer-derive PR.
+ *
+ * Pre-strip: magic input scales 1.5/0.5/1.0/2.0 on tanh, magic /10 on
+ * kappaProxim. Post-strip: pnlFrac normalized against the kernel's own
+ * rolling pnlFraction distribution; kappaProxim width derives from
+ * rolling kappa-at-exit stddev.
+ *
+ * Output caps (0.5/0.3/0.15/0.1) stay as STRUCTURAL design — they
+ * encode "how much each chemical can lift" and are documented in
+ * pushReward.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock the env config so importing loop.ts (→ encryptionService → env)
+// doesn't blow up on missing DATABASE_URL / JWT_SECRET in the test
+// environment. Mirrors perAgentNC.test.ts.
+vi.mock('../../../config/env.js', () => ({
+  env: {
+    NODE_ENV: 'test',
+    PORT: 8765,
+    DATABASE_URL: 'postgresql://test:5432/test',
+    JWT_SECRET: 'test-jwt-secret-32-characters-xxxxxxxxxx',
+  },
+}));
+vi.mock('../../../db/connection.js', () => ({
+  pool: { query: vi.fn() },
+}));
+
+// We test pushReward via a thin test harness — instantiating
+// MonkeyKernel is heavy (it opens DB pool etc), so we use a private
+// type-cast shim that calls pushReward then inspects pendingRewards.
+import { MonkeyKernel } from '../loop.js';
+
+describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
+  let k: MonkeyKernel;
+
+  beforeEach(() => {
+    k = new MonkeyKernel({ instanceId: 'test-rew-obs', timeframe: '5m', tickMs: 30_000 });
+  });
+
+  afterEach(() => {
+    // Test kernel has no background timers in this path.
+  });
+
+  function lastReward(): { dopamineDelta: number; serotoninDelta: number; endorphinDelta: number; pnlFraction: number } {
+    const queue = (k as unknown as { pendingRewards: Array<{ dopamineDelta: number; serotoninDelta: number; endorphinDelta: number; pnlFraction: number }> }).pendingRewards;
+    return queue[queue.length - 1]!;
+  }
+
+  it('cold start (no history) → falls back to identity-on-pnlFrac through tanh', () => {
+    k.pushReward({ source: 'test', realizedPnlUsdt: 0.10, marginUsdt: 1, agent: 'K' });
+    const r = lastReward();
+    expect(r.pnlFraction).toBeCloseTo(0.10, 6);
+    // tanh(0.10) × 0.5 ≈ 0.0498 — confirms unscaled path
+    expect(r.dopamineDelta).toBeCloseTo(Math.tanh(0.10) * 0.5, 4);
+  });
+
+  it('after several wins, dopamine z-normalizes against rolling stddev', () => {
+    // Seed history with 10 wins of ~5% ROI
+    for (let i = 0; i < 10; i++) {
+      k.pushReward({ source: 'seed', realizedPnlUsdt: 0.05, marginUsdt: 1, agent: 'K' });
+    }
+    // Now a 10% win — should be "above average" relative to the
+    // kernel's own observed distribution → higher dopamine.
+    k.pushReward({ source: 'bigger', realizedPnlUsdt: 0.10, marginUsdt: 1, agent: 'K' });
+    const big = lastReward();
+    // Big win produces higher dopamine than the seeded "typical" win
+    expect(big.dopamineDelta).toBeGreaterThan(Math.tanh(0.05) * 0.5);
+  });
+
+  it('output caps remain STRUCTURAL — dopamine never exceeds 0.5', () => {
+    // Massive win shouldn't escape the cap.
+    k.pushReward({ source: 'huge', realizedPnlUsdt: 100, marginUsdt: 1, agent: 'K' });
+    const r = lastReward();
+    expect(r.dopamineDelta).toBeLessThanOrEqual(0.5);
+  });
+
+  it('output caps remain STRUCTURAL — serotonin never exceeds 0.15', () => {
+    k.pushReward({ source: 'huge', realizedPnlUsdt: 100, marginUsdt: 1, agent: 'K' });
+    const r = lastReward();
+    expect(r.serotoninDelta).toBeLessThanOrEqual(0.15);
+  });
+
+  it('output caps remain STRUCTURAL — endorphins never exceed 0.3 (κ-prox gated)', () => {
+    k.pushReward({ source: 'huge', realizedPnlUsdt: 100, marginUsdt: 1, kappaAtExit: 64, agent: 'K' });
+    const r = lastReward();
+    expect(r.endorphinDelta).toBeLessThanOrEqual(0.3);
+  });
+
+  it('loss produces negative dopamine bounded by 0.1 cap', () => {
+    k.pushReward({ source: 'loss', realizedPnlUsdt: -10, marginUsdt: 1, agent: 'K' });
+    const r = lastReward();
+    expect(r.dopamineDelta).toBeLessThan(0);
+    expect(Math.abs(r.dopamineDelta)).toBeLessThanOrEqual(0.1);
+  });
+
+  it('losses produce zero serotonin (wins-only path)', () => {
+    k.pushReward({ source: 'loss', realizedPnlUsdt: -10, marginUsdt: 1, agent: 'K' });
+    const r = lastReward();
+    expect(r.serotoninDelta).toBe(0);
+  });
+
+  it('losses produce zero endorphins (wins-only path)', () => {
+    k.pushReward({ source: 'loss', realizedPnlUsdt: -10, marginUsdt: 1, kappaAtExit: 64, agent: 'K' });
+    const r = lastReward();
+    expect(r.endorphinDelta).toBe(0);
+  });
+});
+
+describe('pushReward observer-derive — kappaProxim from rolling kappa stddev', () => {
+  let k: MonkeyKernel;
+
+  beforeEach(() => {
+    k = new MonkeyKernel({ instanceId: 'test-kappa-obs', timeframe: '5m', tickMs: 30_000 });
+  });
+
+  function lastReward(): { endorphinDelta: number } {
+    const queue = (k as unknown as { pendingRewards: Array<{ endorphinDelta: number }> }).pendingRewards;
+    return queue[queue.length - 1]!;
+  }
+
+  it('κ at κ* (=64) produces full endorphins (proximity = 1)', () => {
+    // Seed kappa history near 64 so the rolling stddev is small but
+    // non-degenerate.
+    for (let i = 0; i < 6; i++) {
+      k.pushReward({
+        source: 'seed',
+        realizedPnlUsdt: 0.05,
+        marginUsdt: 1,
+        kappaAtExit: 63 + (i % 2),  // alternating 63/64
+        agent: 'K',
+      });
+    }
+    // Now a win exactly at κ*.
+    k.pushReward({
+      source: 'peak',
+      realizedPnlUsdt: 0.05,
+      marginUsdt: 1,
+      kappaAtExit: 64,
+      agent: 'K',
+    });
+    const peak = lastReward();
+    expect(peak.endorphinDelta).toBeGreaterThan(0);
+  });
+
+  it('κ far from κ* dampens endorphins relative to κ at κ*', () => {
+    // Seed history
+    for (let i = 0; i < 6; i++) {
+      k.pushReward({
+        source: 'seed',
+        realizedPnlUsdt: 0.05,
+        marginUsdt: 1,
+        kappaAtExit: 60 + (i % 3),
+        agent: 'K',
+      });
+    }
+    // κ at κ*
+    k.pushReward({
+      source: 'at-star',
+      realizedPnlUsdt: 0.05,
+      marginUsdt: 1,
+      kappaAtExit: 64,
+      agent: 'K',
+    });
+    const at = lastReward();
+    // κ far from κ*
+    k.pushReward({
+      source: 'far',
+      realizedPnlUsdt: 0.05,
+      marginUsdt: 1,
+      kappaAtExit: 80,
+      agent: 'K',
+    });
+    const far = lastReward();
+    expect(far.endorphinDelta).toBeLessThan(at.endorphinDelta);
+  });
+
+  it('kappaAtExit missing → kappaProxim falls to 0.5 (legacy fallback preserved)', () => {
+    k.pushReward({
+      source: 'no-kappa',
+      realizedPnlUsdt: 0.05,
+      marginUsdt: 1,
+      // kappaAtExit omitted
+      agent: 'K',
+    });
+    const r = lastReward();
+    // endorphin = tanh(pnlFrac) × 0.3 × 0.5 = positive
+    expect(r.endorphinDelta).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -7836,19 +7836,85 @@ export class MonkeyKernel extends EventEmitter {
     const pnlFrac = input.marginUsdt > 0
       ? input.realizedPnlUsdt / input.marginUsdt
       : 0;
-    // Dopamine: positive only, saturates at 3× margin win (pnlFrac ≥ 3).
-    // Scales by tanh so losses don't punish via dopamine (that path is
-    // self_observation's job).
+
+    // 2026-05-25 (observer-derive PR) — replaces magic input scales
+    // (1.5×, 0.5×, 2×, /10) with observer-derived normalization against
+    // the kernel's own rolling reward + κ distributions. Same MAPPING
+    // shape (tanh); same OUTPUT CAPS (which are STRUCTURAL design
+    // choices documented below); only the SCALES adapt to observed
+    // distributions.
+    //
+    // Output caps (structural):
+    //   - Dopamine cap 0.5 — biggest signal because dopamine directly
+    //     drives reward learning (rewardMult in sizing).
+    //   - Endorphin cap 0.3 — peak-state reward, smaller than dopamine
+    //     so it doesn't dominate the chemistry mix; gated by κ-proximity.
+    //   - Serotonin cap 0.15 — smallest because serotonin is the
+    //     slow-mood-shift signal, not the per-event reward.
+    //   - Loss mood-dip cap 0.1 — much smaller than the win-side dop
+    //     cap so losses don't punish via dopamine (self_observation
+    //     owns loss-side learning; chemistry treats losses as small mood
+    //     dips, not punishments).
+    //
+    // pnlFrac z-score: normalize against the rolling distribution of
+    // recent pnlFractions. "Above-average win for this kernel" produces
+    // proportionally more dopamine; absolute pnlFrac scale becomes
+    // adaptive to the kernel's observed volatility regime.
+    const PNL_STDDEV_MIN_SAMPLES = 5;
+    let pnlFracNormalized: number = pnlFrac;
+    if (this.pendingRewards.length >= PNL_STDDEV_MIN_SAMPLES) {
+      let sum = 0;
+      for (const r of this.pendingRewards) sum += r.pnlFraction;
+      const mean = sum / this.pendingRewards.length;
+      let sq = 0;
+      for (const r of this.pendingRewards) {
+        const d = r.pnlFraction - mean;
+        sq += d * d;
+      }
+      const stddev = Math.sqrt(sq / Math.max(this.pendingRewards.length - 1, 1));
+      if (stddev > 1e-12) {
+        pnlFracNormalized = pnlFrac / stddev;
+      }
+    }
+
     const dop = pnlFrac > 0
-      ? Math.tanh(pnlFrac * 1.5) * 0.5  // 1 % win → 0.01, 10 % → 0.07, 100 % → 0.45
-      : -Math.tanh(-pnlFrac * 0.5) * 0.1;  // small mood dip on loss
-    // Serotonin: stable wins reinforce calm. Only positive on wins.
-    const ser = pnlFrac > 0 ? Math.tanh(pnlFrac) * 0.15 : 0;
-    // Endorphins: peak-state reward. Fires if closed near κ* with a win.
-    const kappaProxim = input.kappaAtExit != null
-      ? Math.exp(-Math.abs(input.kappaAtExit - 64) / 10)
-      : 0.5;
-    const endo = pnlFrac > 0 ? Math.tanh(pnlFrac * 2) * 0.3 * kappaProxim : 0;
+      ? Math.tanh(pnlFracNormalized) * 0.5
+      : -Math.tanh(-pnlFracNormalized) * 0.1;
+    const ser = pnlFrac > 0 ? Math.tanh(pnlFracNormalized) * 0.15 : 0;
+
+    // κ-proximity width: observer-derived from the rolling distribution
+    // of kappaAtExit values across recent rewards. Replaces the magic
+    // `/10` decay width. When stats are insufficient, falls back to a
+    // bounded identity on κ-distance (tanh-squashed).
+    let kappaProxim: number;
+    if (input.kappaAtExit == null) {
+      kappaProxim = 0.5;
+    } else {
+      const kappaHistory: number[] = [];
+      for (const r of this.pendingRewards) {
+        const k = (r as { kappaAtExit?: number }).kappaAtExit;
+        if (typeof k === 'number' && Number.isFinite(k)) kappaHistory.push(k);
+      }
+      if (kappaHistory.length >= PNL_STDDEV_MIN_SAMPLES) {
+        let kSum = 0;
+        for (const k of kappaHistory) kSum += k;
+        const kMean = kSum / kappaHistory.length;
+        let kSq = 0;
+        for (const k of kappaHistory) {
+          const d = k - kMean;
+          kSq += d * d;
+        }
+        const kStddev = Math.sqrt(kSq / Math.max(kappaHistory.length - 1, 1));
+        if (kStddev > 1e-12) {
+          kappaProxim = Math.exp(-Math.abs(input.kappaAtExit - 64) / kStddev);
+        } else {
+          kappaProxim = 1 - Math.tanh(Math.abs(input.kappaAtExit - 64));
+        }
+      } else {
+        kappaProxim = 1 - Math.tanh(Math.abs(input.kappaAtExit - 64));
+      }
+    }
+    const endo = pnlFrac > 0 ? Math.tanh(pnlFracNormalized) * 0.3 * kappaProxim : 0;
 
     this.pendingRewards.push({
       source: input.source,


### PR DESCRIPTION
## Closes the third deferred item

Per CLAUDE.md anti-deferral. Last of the three observer-derive items
from session-end: pnlFrac scaling and κ-proximity width are now
observer-derived against the kernel's own rolling distributions.

## Changes

### pnlFrac scaling — magic input multipliers removed

| Before | After |
|---|---|
| \`tanh(pnlFrac × 1.5) × 0.5\` | \`tanh(pnlFrac / stddev(history)) × 0.5\` |
| \`-tanh(-pnlFrac × 0.5) × 0.1\` | \`-tanh(-pnlFrac / stddev) × 0.1\` |
| \`tanh(pnlFrac × 1.0) × 0.15\` | \`tanh(pnlFrac / stddev) × 0.15\` |
| \`tanh(pnlFrac × 2.0) × 0.3\` | \`tanh(pnlFrac / stddev) × 0.3\` |

Cold start (< 5 samples): falls back to identity-on-pnlFrac through
tanh (same shape, no scaling). "Above-average win for this kernel"
now produces proportionally more dopamine.

### κ-proximity width — magic /10 removed

| Before | After |
|---|---|
| \`exp(-|κ - κ*| / 10)\` | \`exp(-|κ - κ*| / stddev(kappa_history))\` |

Parity with the #920 endo Sophia gate fix in neurochemistry.ts.

## What stays STRUCTURAL (documented, not derived)

Output caps (0.5 / 0.3 / 0.15 / 0.1) — these encode "how much each
chemical can lift" and are design choices about the relative weight
of each reward channel:
- Dopamine biggest (0.5) — directly drives reward learning
- Endorphin (0.3) — peak-state, κ-prox gated
- Serotonin smallest (0.15) — slow-mood-shift
- Loss mood dip (0.1) — losses don't punish via dopamine

## Test plan

- [x] 11 new \`pushRewardObserverDerive\` cases — cold-start fallback,
  z-normalization, output cap preservation, loss semantics, κ-prox
  from rolling stddev
- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn vitest run\` — 1766 passing / 12 skipped / 0 failed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)