### PR TITLE
fix(monkey): MAD-based reward normalization (regression from #926)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/pushRewardObserverDerive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/pushRewardObserverDerive.test.ts
@@ -109,6 +109,63 @@ describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
   });
 });
 
+describe('pushReward observer-derive — outlier robustness (MAD)', () => {
+  let k: MonkeyKernel;
+
+  beforeEach(() => {
+    k = new MonkeyKernel({ instanceId: 'test-rew-outlier', timeframe: '5m', tickMs: 30_000 });
+  });
+
+  function lastReward(): { dopamineDelta: number; pnlFraction: number } {
+    const queue = (k as unknown as { pendingRewards: Array<{ dopamineDelta: number; pnlFraction: number }> }).pendingRewards;
+    return queue[queue.length - 1]!;
+  }
+
+  it('outlier win does NOT suppress chemistry response to subsequent normal losses', () => {
+    // Production regression 2026-05-25: a single +$78 outlier win
+    // inflated stddev(pnlFraction) ~5×, suppressing chemistry response
+    // to subsequent normal-magnitude losses (kernel couldn't "feel"
+    // -$5 losses as bad). MAD doesn't blow up under outliers.
+    //
+    // Seed 6 typical wins/losses around 1% pnlFrac.
+    for (let i = 0; i < 6; i++) {
+      k.pushReward({
+        source: 'seed',
+        realizedPnlUsdt: i % 2 === 0 ? 0.01 : -0.01,
+        marginUsdt: 1,
+        agent: 'K',
+      });
+    }
+    // Inject a massive outlier win (+50% pnlFrac, like the live +$78).
+    k.pushReward({ source: 'outlier-win', realizedPnlUsdt: 0.5, marginUsdt: 1, agent: 'K' });
+    // Now a normal-magnitude loss (-2% pnlFrac).
+    k.pushReward({ source: 'normal-loss', realizedPnlUsdt: -0.02, marginUsdt: 1, agent: 'K' });
+    const lossDop = lastReward().dopamineDelta;
+    // Loss should produce measurable negative dopamine — NOT crushed to
+    // near-zero by the outlier-inflated normalizer.
+    expect(Math.abs(lossDop)).toBeGreaterThan(0.01);
+  });
+
+  it('MAD normalization keeps chemistry response stable across outlier injection', () => {
+    // Build a baseline: 6 small wins of 1% pnlFrac.
+    for (let i = 0; i < 6; i++) {
+      k.pushReward({ source: 'pre', realizedPnlUsdt: 0.01, marginUsdt: 1, agent: 'K' });
+    }
+    // Record dopamine for a typical 1% win pre-outlier.
+    k.pushReward({ source: 'typical-pre', realizedPnlUsdt: 0.01, marginUsdt: 1, agent: 'K' });
+    const dopPre = lastReward().dopamineDelta;
+    // Inject outlier.
+    k.pushReward({ source: 'outlier', realizedPnlUsdt: 1.0, marginUsdt: 1, agent: 'K' });
+    // Same typical 1% win post-outlier — dopamine should be similar
+    // (MAD didn't move; under stddev it would be much smaller).
+    k.pushReward({ source: 'typical-post', realizedPnlUsdt: 0.01, marginUsdt: 1, agent: 'K' });
+    const dopPost = lastReward().dopamineDelta;
+    // Ratio should be close to 1 — outlier didn't suppress response.
+    // (Under stddev the ratio would be ~5-10×.)
+    expect(dopPost).toBeGreaterThan(dopPre * 0.5);
+  });
+});
+
 describe('pushReward observer-derive — kappaProxim from rolling kappa stddev', () => {
   let k: MonkeyKernel;
 

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -7856,24 +7856,31 @@ export class MonkeyKernel extends EventEmitter {
     //     owns loss-side learning; chemistry treats losses as small mood
     //     dips, not punishments).
     //
-    // pnlFrac z-score: normalize against the rolling distribution of
-    // recent pnlFractions. "Above-average win for this kernel" produces
-    // proportionally more dopamine; absolute pnlFrac scale becomes
-    // adaptive to the kernel's observed volatility regime.
+    // pnlFrac normalization: use MAD (Median Absolute Deviation) — a
+    // robust statistic that doesn't blow up under outliers — instead of
+    // stddev. Production evidence 2026-05-25: a single +$78 outlier win
+    // spiked the rolling stddev ~5×, suppressing chemistry response to
+    // every subsequent normal-magnitude close (the kernel couldn't
+    // "feel" -$5 losses as bad because they looked small relative to
+    // the outlier-inflated stddev). MAD is bounded by the median's
+    // breakdown point (50%) — a single outlier can't move it.
+    //
+    // MAD × 1.4826 ≈ stddev under Gaussian assumption; using raw MAD
+    // is fine here because the multiplier would cancel in the
+    // normalization ratio (and we're not making distributional claims).
     const PNL_STDDEV_MIN_SAMPLES = 5;
     let pnlFracNormalized: number = pnlFrac;
     if (this.pendingRewards.length >= PNL_STDDEV_MIN_SAMPLES) {
-      let sum = 0;
-      for (const r of this.pendingRewards) sum += r.pnlFraction;
-      const mean = sum / this.pendingRewards.length;
-      let sq = 0;
-      for (const r of this.pendingRewards) {
-        const d = r.pnlFraction - mean;
-        sq += d * d;
-      }
-      const stddev = Math.sqrt(sq / Math.max(this.pendingRewards.length - 1, 1));
-      if (stddev > 1e-12) {
-        pnlFracNormalized = pnlFrac / stddev;
+      const pnls = this.pendingRewards.map((r) => r.pnlFraction).sort((a, b) => a - b);
+      const median = pnls.length % 2 === 0
+        ? (pnls[pnls.length / 2 - 1]! + pnls[pnls.length / 2]!) / 2
+        : pnls[Math.floor(pnls.length / 2)]!;
+      const deviations = pnls.map((p) => Math.abs(p - median)).sort((a, b) => a - b);
+      const mad = deviations.length % 2 === 0
+        ? (deviations[deviations.length / 2 - 1]! + deviations[deviations.length / 2]!) / 2
+        : deviations[Math.floor(deviations.length / 2)]!;
+      if (mad > 1e-12) {
+        pnlFracNormalized = pnlFrac / mad;
       }
     }
 
@@ -7886,6 +7893,10 @@ export class MonkeyKernel extends EventEmitter {
     // of kappaAtExit values across recent rewards. Replaces the magic
     // `/10` decay width. When stats are insufficient, falls back to a
     // bounded identity on κ-distance (tanh-squashed).
+    // 2026-05-25 — same MAD-based robust normalization. Outlier κ
+    // values (e.g. a single trade that closed at κ=120) would have
+    // inflated stddev under the previous formulation, suppressing the
+    // κ-proximity envelope for everything else.
     let kappaProxim: number;
     if (input.kappaAtExit == null) {
       kappaProxim = 0.5;
@@ -7896,17 +7907,16 @@ export class MonkeyKernel extends EventEmitter {
         if (typeof k === 'number' && Number.isFinite(k)) kappaHistory.push(k);
       }
       if (kappaHistory.length >= PNL_STDDEV_MIN_SAMPLES) {
-        let kSum = 0;
-        for (const k of kappaHistory) kSum += k;
-        const kMean = kSum / kappaHistory.length;
-        let kSq = 0;
-        for (const k of kappaHistory) {
-          const d = k - kMean;
-          kSq += d * d;
-        }
-        const kStddev = Math.sqrt(kSq / Math.max(kappaHistory.length - 1, 1));
-        if (kStddev > 1e-12) {
-          kappaProxim = Math.exp(-Math.abs(input.kappaAtExit - 64) / kStddev);
+        const sorted = [...kappaHistory].sort((a, b) => a - b);
+        const kMedian = sorted.length % 2 === 0
+          ? (sorted[sorted.length / 2 - 1]! + sorted[sorted.length / 2]!) / 2
+          : sorted[Math.floor(sorted.length / 2)]!;
+        const kDevs = sorted.map((k) => Math.abs(k - kMedian)).sort((a, b) => a - b);
+        const kMad = kDevs.length % 2 === 0
+          ? (kDevs[kDevs.length / 2 - 1]! + kDevs[kDevs.length / 2]!) / 2
+          : kDevs[Math.floor(kDevs.length / 2)]!;
+        if (kMad > 1e-12) {
+          kappaProxim = Math.exp(-Math.abs(input.kappaAtExit - 64) / kMad);
         } else {
           kappaProxim = 1 - Math.tanh(Math.abs(input.kappaAtExit - 64));
         }


### PR DESCRIPTION
## Regression detected from #926 + production evidence

User flagged kernel losing more than prior. Trade-history check
confirmed it: in the last 24 min of monitoring, **2W/5L** with three
bracket_sl events totaling **−\$16.46** vs only **+\$0.63** in wins.
Strip the single +\$78 outlier and the post-#926 window is **net
−\$18.64 across 14 closes**.

## Root cause

\`#926\` z-score normalization uses \`stddev(pnlFraction)\` over the
rolling reward queue. A single +\$78.35 outlier win at 12:31 UTC
blew up the rolling stddev ~5×. Every subsequent close's chemistry
response got dampened by this inflated divisor — the kernel
literally could not "feel" −\$5 losses as bad, because the divisor
made them look tiny.

This is the classic non-robust-statistic failure mode applied to
reward magnitude.

## Fix

Replace \`stddev\` with **MAD (Median Absolute Deviation)** — a robust
statistic bounded by the median's 50% breakdown point. A single
outlier can't move it. Used in:

- pnlFrac normalization (dop / ser / endo response shapes)
- kappaProxim width derivation (same outlier shape on κ history)

\`MAD × 1.4826 ≈ stddev\` under Gaussian assumption, but the
multiplier would cancel in the ratio so raw MAD is fine.

## Meta-pattern

Adding to the review checklist alongside "what does this read when
input ≈ running mean?": **"what does this read after one extreme
observation?"** Non-robust statistics are a separate failure shape
from one-sided clamps but produce similar degenerate-signal outcomes.

## Test plan

- [x] 2 new outlier-robustness cases in \`pushRewardObserverDerive\`
- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn vitest run\` — 1768 passed / 12 skipped / 0 failed
- [ ] CI green
- [ ] Post-deploy: monitor next bracket_sl event — chemistry should
      respond with measurable gaba, not muted dampening

🤖 Generated with [Claude Code](https://claude.com/claude-code)