### PR TITLE
fix(monkey): restore 0.5 frac survival cap (CC2 audit + Braden directive)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/sizingReliefLayer1.test.ts
+++ b/apps/api/src/services/monkey/__tests__/sizingReliefLayer1.test.ts
@@ -118,14 +118,10 @@ describe('currentPositionSize maturity ramp', () => {
 });
 
 describe('currentPositionSize stability multiplier re-centered', () => {
-  it('neutral serotonin (0.5) yields stabilityMult ≈ 1.0 — was 0.75', () => {
+  it('neutral serotonin (0.5) yields stabilityMult ≈ 1.0; frac clamped at 0.5 survival cap', () => {
     // Mature kernel, neutral chemistry, full sov, Φ=0.6: baseFrac =
     // 0.6 × 1 × 1 = 0.6, rewardMult = 1.0, stabilityMult = 1.0,
-    // product 0.6. Post-strip (2026-05-25): frac clamp is 1.0 not 0.5,
-    // lane budgetFrac is 1.0 not 0.5, notional ceiling removed. So
-    // frac = 0.6 directly → margin = $60. The only restraint is the
-    // exchange-enforced margin requirement; the kernel commits 60%
-    // of equity at chemistry-fired sizing.
+    // product 0.6. The 0.5 survival cap binds → frac = 0.5.
     const out = currentPositionSize(
       basinState(1.0, 0.6),
       100,
@@ -135,8 +131,8 @@ describe('currentPositionSize stability multiplier re-centered', () => {
       MonkeyMode.INVESTIGATION,
       'swing',
     );
-    expect(out.derivation.frac).toBeCloseTo(0.6, 6);
-    expect(out.value).toBeCloseTo(60, 1);
+    expect(out.derivation.frac).toBe(0.5);
+    expect(out.value).toBeCloseTo(50, 1);
   });
 
   it('low serotonin (0.0) still produces 0.75 floor, not 0.5', () => {
@@ -157,14 +153,13 @@ describe('currentPositionSize stability multiplier re-centered', () => {
 });
 
 describe('currentPositionSize reward multiplier widened band', () => {
-  it('dopamine spike (dop=1, gaba=0) hits high rewardMult', () => {
-    // rewardMult = 1 + (1 - 0) × 1.0 = 2.0. baseFrac × 2.0 × stabilityMult
-    // = 0.6 × 2.0 × 1.0 = 1.2, clamped at 1.0 (post-strip cap). The
-    // kernel commits full equity on peak conviction.
+  it('dopamine spike (dop=1, gaba=0) saturates rewardMult; frac clamped at 0.5 survival cap', () => {
+    // rewardMult = 1 + (1 - 0) = 2.0. baseFrac × 2.0 × stabilityMult =
+    // 0.6 × 2.0 × 1.0 = 1.2 → would exceed survival cap. Clamped to 0.5.
     const state = basinState(1.0, 0.6);
     state.neurochemistry = { ...NEUTRAL_NC, dopamine: 1.0, gaba: 0.0, serotonin: 0.5 };
     const out = currentPositionSize(state, 100, 5, 10, 20, MonkeyMode.INVESTIGATION, 'swing');
-    expect(out.derivation.frac).toBe(1.0);
+    expect(out.derivation.frac).toBe(0.5);
   });
 
   it('gaba spike (dop=0, gaba=1) pulls rewardMult to 0 — formula contributes nothing', () => {

--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -263,24 +263,35 @@ export function currentPositionSize(
   void mode;  // mode-specific sizing now expressed via chemistry, not floor differentiation
 
   const rawFrac = Math.max(explorationFloor, baseFrac * rewardMult * stabilityMult);
-  // 2026-05-25 — frac clamp raised from 0.5 to 1.0 per operator
-  // autonomy doctrine. The kernel can commit up to full available
-  // equity in margin; the exchange's maintenance margin and the
-  // kernel's own chemistry feedback (push_reward → gaba on losses
-  // → smaller next size) are the real restraints. Going above 1.0
-  // is structurally impossible (margin > equity is rejected by the
-  // exchange).
-  let frac = Math.min(1.0, Math.max(0, rawFrac));
+  // 2026-05-25 — frac clamp at 0.5: BOUNDARY (survival) not PARAMETER.
+  //
+  // History: an earlier same-day strip (#916) raised this to 1.0 on
+  // the theory "the exchange rejects margin > equity anyway." CC2
+  // audit + operator (Braden) directive restored it to 0.5. The
+  // earlier strip confused two different boundaries:
+  //   * Exchange margin requirement bounds absolute commitment
+  //     (equity × exchangeMaxLev).
+  //   * THIS survival cap bounds the KERNEL's own self-imposed risk:
+  //     at most half of available equity in any single position so
+  //     an adverse move doesn't create unrecoverable states
+  //     regardless of how strong the Φ signal looked.
+  // Exchange rejection is structurally downstream; this is upstream
+  // policy. They are not substitutes for each other.
+  //
+  // Sizing magnitude relief comes from chemistry variance restoration
+  // (#920/#927), maturity rate (#925, bankSize / ROTATION_WR_MIN_SAMPLES),
+  // and per-lane / cell sizing — NOT from removing this survival cap.
+  let frac = Math.min(0.5, Math.max(0, rawFrac));
   let margin = frac * availableEquityUsdt;
   let notional = margin * Math.max(1, leverage);
 
   // v0.6.6 "lift to minimum" — if we're below exchange min notional but
-  // a fraction up to 1.0 CAN clear it, auto-raise to just enough.
+  // a fraction up to 0.5 CAN clear it, auto-raise to just enough.
   let liftedToMin = false;
   if (notional < minNotionalUsdt && availableEquityUsdt > 0 && leverage > 0) {
     const BUFFER = 1.05;  // 5% headroom so lot-rounding doesn't put us just under
     const requiredFrac = (minNotionalUsdt * BUFFER) / (leverage * availableEquityUsdt);
-    if (requiredFrac <= 1.0) {
+    if (requiredFrac <= 0.5) {
       frac = Math.max(frac, requiredFrac);
       margin = frac * availableEquityUsdt;
       notional = margin * leverage;


### PR DESCRIPTION
## CC2 audit Finding 1 — Braden directive: restore

PR #916 raised the frac clamp from 0.5 to 1.0 with a justification
that confused two different boundary conditions:

- **Exchange margin rejection** (caps absolute commitment at
  \`equity × exchangeMaxLev\`) — downstream, structural
- **The upstream policy cap** (limits the kernel's own self-imposed
  risk to half of available equity per position so adverse moves
  can't create unrecoverable states regardless of Φ signal strength)

The original comment was explicit: *"BOUNDARY (survival) not PARAMETER
— exceeding it creates unrecoverable states regardless of Φ."*

The strip removed a stated survival doctrine for sizing-magnitude
reasons without naming the replacement chain. CC2 audit flagged it;
Braden directed restore.

## Where sizing relief actually comes from

Not from removing this cap. From:

- Chemistry variance restoration (#920 + #927)
- Maturity rate observer-derive (#925, \`bankSize / ROTATION_WR_MIN_SAMPLES\`)
- Per-lane / cell sizing

## Changes

- \`executive.ts\` frac clamp: 1.0 → 0.5 with full doctrine rationale
- Lift-to-min ceiling: 1.0 → 0.5 (matches the survival cap)

## Test plan

- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn vitest run\` — 1768 passing / 12 skipped / 0 failed
- [x] sizingReliefLayer1 expectations updated for 0.5 cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)