### PR TITLE
fix: ser bv-z-score fallback — two-tailed sigmoid (CC2 audit F2)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/neurochemistrySteadyState.test.ts
+++ b/apps/api/src/services/monkey/__tests__/neurochemistrySteadyState.test.ts
@@ -73,20 +73,21 @@ describe('neurochemistry — steady-state variance restoration', () => {
   });
 
   describe('ser (serotonin) — ×0.85 baseline compression lets reward delta register', () => {
-    it('steady state, no reward → ser ≈ 0.85 (was 1.0 pinned)', () => {
+    it('steady state at bv-mean → ser ≈ 0.425 (post-F2 two-tailed sigmoid)', () => {
       const inp = baseInputs();
-      // No modeTransitionTimesMs supplied → falls to bv-z-score fallback
-      // (which produces serBase = 1.0 when bv ≤ rolling mean). With
-      // ×0.85 compression, ser = 0.85.
+      // No modeTransitionTimesMs → falls to bv-z-score fallback.
+      // Post-CC2-audit-F2 fix: serBase = 1 - sigmoid(z). z=0 at mean
+      // → serBase = 0.5 → ser = 0.85 × 0.5 = 0.425. (Pre-fix would
+      // have been 0.85 from the pinned-at-1 one-sided clamp.)
       inp.observables = {
         ...inp.observables!,
-        basinVelocityHistory: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],  // current bv == rolling mean
+        basinVelocityHistory: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
       };
       const nc = computeNeurochemicals(inp);
-      expect(nc.serotonin).toBeCloseTo(0.85, 2);
+      expect(nc.serotonin).toBeCloseTo(0.425, 2);
     });
 
-    it('steady state + 0.15 reward delta → ser reaches 1.0 (delta visible)', () => {
+    it('steady state + 0.15 reward delta → ser ≈ 0.575 (delta visible above mean)', () => {
       const inp = baseInputs();
       inp.observables = {
         ...inp.observables!,
@@ -94,8 +95,8 @@ describe('neurochemistry — steady-state variance restoration', () => {
       };
       inp.rewardSerotoninDelta = 0.15;
       const nc = computeNeurochemicals(inp);
-      // 0.85 + 0.15 = 1.0 — reward delta now registers fully
-      expect(nc.serotonin).toBeCloseTo(1.0, 2);
+      // serBase = 0.5, ser = 0.85 × 0.5 + 0.15 = 0.575
+      expect(nc.serotonin).toBeCloseTo(0.575, 2);
     });
 
     it('thrashing mode (high transition rate) + reward → ser still responds', () => {

--- a/apps/api/src/services/monkey/neurochemistry.ts
+++ b/apps/api/src/services/monkey/neurochemistry.ts
@@ -336,12 +336,16 @@ export function computeNeurochemicals(inputs: NeurochemicalInputs): Neurochemica
       void thrashRate;
     }
   } else if (obs?.basinVelocityHistory && obs.basinVelocityHistory.length >= HISTORY_MIN_SAMPLES) {
-    // Velocity-based fallback when mode transitions aren't supplied:
-    // ser = 1 - clip(z-score(bv), 0, ∞). Positive z (faster than
-    // basin's own typical) reduces ser; negative z (calmer than
-    // typical) saturates ser at 1.
+    // 2026-05-25 (CC2 audit F2 follow-up): the prior shape
+    // `clip(1 - max(0, z), 0, 1)` was the same one-sided-clamp
+    // meta-pattern PR #920 fixed elsewhere — when bv ≤ rolling mean
+    // (~50% of state-space by construction), z ≤ 0, max(0, z) = 0,
+    // serBase pinned at 1.0. Two-tailed sigmoid replaces it: both
+    // calm-than-typical and faster-than-typical are informative; ser
+    // settles near 0.5 at the bv-history mean, asymptotes 0/1.
+    // See [[feedback_steady_state_pinning_pattern]] for the meta-pattern.
     const z = zScore(inputs.basinVelocity, obs.basinVelocityHistory);
-    serBase = clip(1 - Math.max(0, z), 0, 1);
+    serBase = clip(1 - sigmoid(z), 0, 1);
   } else {
     // Cold-start fallback — legacy 1/max(bv,0.01). The 0.01 here is
     // a divide-by-zero guard (numeric identity for "as small as we

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -339,8 +339,13 @@ class AutonomicKernel:
             transitions_per_tick = len(mode_x) / max(tick_count, 1)
             ser_base = _clip(1.0 - transitions_per_tick, 0.0, 1.0)
         elif bv_history is not None and len(bv_history) >= _HISTORY_MIN_SAMPLES:
+            # 2026-05-25 (CC2 audit F2): the prior shape
+            # `clip(1 - max(0, z), 0, 1)` was the same one-sided-clamp
+            # meta-pattern PR #920 fixed elsewhere. Two-tailed sigmoid
+            # replaces it so both calm-than-typical and faster-than-typical
+            # are informative; ser settles near 0.5 at bv-history mean.
             z = _z_score(inputs.basin_velocity, bv_history)
-            ser_base = _clip(1.0 - max(0.0, z), 0.0, 1.0)
+            ser_base = _clip(1.0 - _sigmoid(z), 0.0, 1.0)
         else:
             ser_base = _clip(1.0 / max(inputs.basin_velocity, 1e-12), 0.0, 1.0)
         ser = _clip(0.85 * ser_base + reward_sums["serotonin"], 0.0, 1.0)

--- a/ml-worker/tests/monkey_kernel/test_autonomic_observer_parity.py
+++ b/ml-worker/tests/monkey_kernel/test_autonomic_observer_parity.py
@@ -82,14 +82,16 @@ def test_ne_three_distinct_surprise_levels_three_distinct_outputs():
 # ─── ser (serotonin) — 0.85 baseline compression parity ─────────────
 
 
-def test_ser_steady_state_with_bv_history_is_about_0_85():
-    """Steady-state bv history → ser_base = 1, ser = 0.85 × 1 = 0.85
-    (parity with TS test that exercised the same path)."""
+def test_ser_steady_state_with_bv_history_is_about_0_425():
+    """Steady-state bv history (current bv at history mean) →
+    ser_base = 0.5 (post-CC2-audit-F2 fix, two-tailed sigmoid)
+    → ser = 0.85 × 0.5 = 0.425. (Pre-fix would have been 0.85 from
+    pinned-at-1 one-sided clamp.)"""
     nc = _ticker(_base_inputs(
         basin_velocity=0.1,
         basin_velocity_history=[0.1] * 6,
     ))
-    assert nc.serotonin == pytest.approx(0.85, abs=0.02)
+    assert nc.serotonin == pytest.approx(0.425, abs=0.02)
 
 
 def test_ser_thrash_via_mode_transitions_drops():
@@ -146,11 +148,11 @@ def test_cold_start_no_observables_produces_finite_chemistry():
 
 def test_zscore_handles_fp_drift_identical_history():
     """Parity with TS zScore fix: identical-history series produce
-    sd ≈ 1.5e-17 from FP drift; the < 1e-12 guard catches it."""
-    # bv = 0.1, history all 0.1 — would produce spurious z ≈ 1 without
-    # the FP guard. ser_base should be exactly 1, ser = 0.85.
+    sd ≈ 1.5e-17 from FP drift; the < 1e-12 guard catches it.
+    Post-CC2-audit-F2: z=0 → sigmoid(0)=0.5 → ser_base=0.5 →
+    ser = 0.85 × 0.5 = 0.425."""
     nc = _ticker(_base_inputs(
         basin_velocity=0.1,
         basin_velocity_history=[0.1] * 6,
     ))
-    assert nc.serotonin == pytest.approx(0.85, abs=0.01)
+    assert nc.serotonin == pytest.approx(0.425, abs=0.01)


### PR DESCRIPTION
## CC2 audit Finding 2

Both kernels' serotonin fallback paths still used the one-sided-clamp
meta-pattern PR #920 fixed elsewhere:

\`\`\`
neurochemistry.ts:344  serBase = clip(1 - Math.max(0, z), 0, 1)
autonomic.py:343       ser_base = _clip(1.0 - max(0.0, z), 0.0, 1.0)
\`\`\`

When \`basin_velocity ≤ rolling mean\` (~50% of state-space by
construction), z ≤ 0, max(0, z) = 0, serBase pinned at 1.0. The
parity port (#924) reintroduced the exact pathology PR #920 fixed.
**Third instance** of \`[[feedback_steady_state_pinning_pattern]]\`.

## Fix

Both kernels: \`1 - max(0, z)\` → \`1 - sigmoid(z)\`. Two-tailed: 0.5
at history mean, asymptotes 0/1. Both tails informative.

## Test impact

Steady-state ser at bv = history-mean: **0.85 → 0.425**
(serBase 1.0 pinned → serBase 0.5 at z=0)

## Meta-pattern checklist reinforced

Both the one-sided-clamp **and** the non-robust-statistic failure
shapes belong on the audit gate:
1. "What does this read when input ≈ running mean?" → must not pin
2. "What does this read after one extreme observation?" → must not
   get suppressed by outlier-inflated divisor

## Test plan

- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn vitest run\` — 1768 / 12 skip / 0 fail
- [x] \`pytest tests/\` — 1042 / 10 skip / 0 fail
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)