### PR TITLE
fix(monkey): CC2 audit tidy cleanup — F3 EXPLORATION_FLOOR + F5 mode + F4 note

### DIFF
--- a/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
+++ b/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
@@ -351,19 +351,18 @@ describe('Flat-account sizing regression (fix/lane-budget-size-zero-regression)'
     expect(notional).toBeGreaterThanOrEqual(75.78);
   });
 
-  it('small account ($5 equity) — lift-to-min now reaches min notional (notional ceiling removed)', () => {
-    // 2026-05-25 strip: notional ceiling removed. On a $5 account
-    // wanting to clear a $22.49 min at 14x lev, requiredFrac = 22.49 ×
-    // 1.05 / (14 × 5) = 0.337. Post-strip the lift-to-min path allows
-    // requiredFrac ≤ 1.0, so the lift fires and the kernel commits
-    // ~$1.69 margin to clear the exchange minimum. Pre-strip this
-    // would have been blocked by the 4× notional ceiling ($20 < $22.49).
+  it('small account ($5 equity) — explorationFloor itself clears min notional (CC2 F3 unification)', () => {
+    // 2026-05-25 (CC2 audit F3): explorationFloor and lift-to-min now
+    // share the same formula. With $5 equity at 14× lev for $22.49 min,
+    // minClearingFrac = 22.49 × 1.05 / (14 × 5) = 0.337. The
+    // explorationFloor at cold-start (maturity=0) is exactly that
+    // 0.337 — no separate lift needed because the floor already
+    // covers the exchange minimum.
     const result = currentPositionSize(
       basinState(0.55, 0.5), 5, 22.49, 14, 0, MonkeyMode.INVESTIGATION, 'swing',
     );
     expect(result.value).toBeGreaterThan(0);
-    expect((result.derivation as Record<string, unknown>).liftedToMin).toBe(1);
-    // Verify notional clears the exchange minimum.
+    // Notional clears the exchange minimum (with 5% buffer).
     const notional = result.value * 14;
     expect(notional).toBeGreaterThanOrEqual(22.49);
   });

--- a/apps/api/src/services/monkey/__tests__/sizingReliefLayer1.test.ts
+++ b/apps/api/src/services/monkey/__tests__/sizingReliefLayer1.test.ts
@@ -59,13 +59,13 @@ describe('MODE_PROFILES sizeFloor — Layer 1 relief', () => {
   });
 });
 
-describe('currentPositionSize cold-start (bankSize=0)', () => {
-  it('cold-start floor is the unified EXPLORATION_FLOOR (0.20) across all modes (was per-mode 0.20/0.25/0.30)', () => {
-    // 2026-05-25 observer-derive PR: per-mode magic floors removed in
-    // favor of a single principled floor. baseFrac = 0.6 × 0.8 × 0
-    // (maturity=0 at bankSize=0) = 0; explorationFloor = 0.20 × 1 = 0.20.
-    // margin = 0.20 × $100 = $20, but the notional ceiling has been
-    // stripped so frac sticks at 0.20.
+describe('currentPositionSize cold-start (bankSize=0) — observer-derived floor', () => {
+  it('cold-start floor derives from min-notional-clearing fraction at current leverage', () => {
+    // 2026-05-25 (CC2 audit F3): magic EXPLORATION_FLOOR=0.20 replaced
+    // with observer-derived `minClearingFrac = (min × 1.05) / (lev × equity)`.
+    // With min=$5, lev=10, equity=$100:
+    //   minClearingFrac = (5 × 1.05) / (10 × 100) = 0.00525
+    //   explorationFloor = minClearingFrac × (1 - maturity) = 0.00525 × 1
     const out = currentPositionSize(
       basinState(),
       /* availableEquityUsdt */ 100,
@@ -75,16 +75,31 @@ describe('currentPositionSize cold-start (bankSize=0)', () => {
       MonkeyMode.INVESTIGATION,
       /* lane */ 'swing',
     );
-    expect(out.derivation.explorationFloor).toBeCloseTo(0.20, 6);
+    expect(out.derivation.explorationFloor).toBeCloseTo(0.00525, 6);
   });
 
-  it('explorationFloor is identical across modes (no per-mode differentiation)', () => {
+  it('explorationFloor is mode-independent (chemistry expresses mode differentiation)', () => {
     const exp = currentPositionSize(basinState(), 100, 5, 10, 0, MonkeyMode.EXPLORATION, 'swing');
     const inv = currentPositionSize(basinState(), 100, 5, 10, 0, MonkeyMode.INVESTIGATION, 'swing');
     const int_ = currentPositionSize(basinState(), 100, 5, 10, 0, MonkeyMode.INTEGRATION, 'swing');
-    expect(exp.derivation.explorationFloor).toBeCloseTo(0.20, 6);
-    expect(inv.derivation.explorationFloor).toBeCloseTo(0.20, 6);
-    expect(int_.derivation.explorationFloor).toBeCloseTo(0.20, 6);
+    // Same observer-derived floor across modes — mode-specific sizing
+    // expressed via chemistry response patterns, not floor differentiation.
+    expect(exp.derivation.explorationFloor).toBeCloseTo(inv.derivation.explorationFloor, 6);
+    expect(inv.derivation.explorationFloor).toBeCloseTo(int_.derivation.explorationFloor, 6);
+  });
+
+  it('floor capped at 0.5 survival cap even with large min × low leverage × small equity', () => {
+    // min=$50, lev=1, equity=$10 → raw minClearingFrac = (50 × 1.05) / 10 = 5.25
+    // Clamped to 0.5 by the survival-cap logic.
+    const out = currentPositionSize(basinState(), 10, 50, 1, 0, MonkeyMode.INVESTIGATION, 'swing');
+    expect(out.derivation.explorationFloor).toBeLessThanOrEqual(0.5);
+  });
+
+  it('mode is wired into derivation telemetry (CC2 audit F5)', () => {
+    const inv = currentPositionSize(basinState(), 100, 5, 10, 0, MonkeyMode.INVESTIGATION, 'swing');
+    expect(inv.derivation.mode).toBe(1);  // INVESTIGATION
+    const exp = currentPositionSize(basinState(), 100, 5, 10, 0, MonkeyMode.EXPLORATION, 'swing');
+    expect(exp.derivation.mode).toBe(0);  // EXPLORATION
   });
 });
 

--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -152,6 +152,17 @@ export const LANE_PARAMETER_DEFAULTS: Record<
   // from per-lane reward queue). slPct / tpPct retain their roles
   // (per-lane retreat / target ROI on margin); only the static
   // budgetFrac haircut is dropped to 1.0.
+  //
+  // 2026-05-25 (CC2 audit F4 doctrinal note): the prior "trend is
+  // opt-in by operator" doctrine (budgetFrac = 0 for trend) is
+  // explicitly RETIRED with this change. Lanes no longer encode a
+  // sizing-allocation constraint; they encode entry-threshold scale
+  // and exit envelope (slPct / tpPct) only. If a future operator
+  // wants to re-disable a lane as an opt-in, the cleanest mechanism
+  // is a `MONKEY_TREND_LANE_LIVE` env-flag check at the call site
+  // (similar to other operator MANDATEs), NOT restoring per-lane
+  // budgetFrac differentiation — that mixed two concepts (sizing
+  // allocation + behavioral envelope) into one field.
   scalp: { slPct: 0.03, tpPct: 0.03, budgetFrac: 1.0 },
   swing: { slPct: 0.15, tpPct: 0.15, budgetFrac: 1.0 },
   trend: { slPct: 0.40, tpPct: 0.40, budgetFrac: 1.0 },
@@ -249,18 +260,23 @@ export function currentPositionSize(
   const rewardMult = 1 + (nc.dopamine - nc.gaba);
   const stabilityMult = 0.75 + nc.serotonin * 0.5;
 
-  // Exploration floor — Pillar 1 FLUCTUATIONS. 2026-05-25 observer-
-  // derive PR: collapsed per-mode magic floors (0.20/0.25/0.30) to a
-  // single principled floor. EXPLORATION_FLOOR is the smallest
-  // commitment the kernel makes when chemistry-driven baseFrac is
-  // collapsed — chosen to clear typical exchange minimums on small
-  // accounts at any leverage (the lift-to-min path expands further
-  // when the floor itself is insufficient). Scales inversely with
-  // maturity: fresh kernels explore at the floor; mature kernels let
-  // chemistry drive without floor support.
-  const EXPLORATION_FLOOR = 0.20;
-  const explorationFloor = EXPLORATION_FLOOR * (1 - maturity);
-  void mode;  // mode-specific sizing now expressed via chemistry, not floor differentiation
+  // Exploration floor — Pillar 1 FLUCTUATIONS. 2026-05-25 (CC2 audit
+  // F3): the previous `EXPLORATION_FLOOR = 0.20` magic constant is
+  // replaced by the fraction that clears the exchange minimum
+  // notional at current leverage — the SAME observer-derived quantity
+  // that lift-to-min uses. This unifies two paths into one and grounds
+  // the floor in actual exchange state, not a guessed constant.
+  //
+  // Fresh kernels (maturity ≈ 0) explore at exactly the min-clearing
+  // frac; mature kernels let chemistry drive without floor support.
+  // The floor is capped at 0.5 (the survival cap) so a tiny equity
+  // pool combined with a large min-notional doesn't override the
+  // upstream policy bound.
+  const minClearingFrac =
+    availableEquityUsdt > 0 && leverage > 0
+      ? Math.min(0.5, (minNotionalUsdt * 1.05) / (leverage * availableEquityUsdt))
+      : 0;
+  const explorationFloor = minClearingFrac * (1 - maturity);
 
   const rawFrac = Math.max(explorationFloor, baseFrac * rewardMult * stabilityMult);
   // 2026-05-25 — frac clamp at 0.5: BOUNDARY (survival) not PARAMETER.
@@ -333,6 +349,16 @@ export function currentPositionSize(
       notionalCeilingRatio: 0,
       notionalCeiling: 0,
       cappedByNotional,
+      // 2026-05-25 (CC2 audit F5): mode wired into derivation for
+      // telemetry rather than left as a `void mode;` code smell. The
+      // formula itself is mode-agnostic — mode-specific sizing now
+      // expressed via chemistry — but downstream consumers (logs,
+      // dashboards) record which mode was active for the entry.
+      mode: mode === MonkeyMode.EXPLORATION ? 0
+        : mode === MonkeyMode.INVESTIGATION ? 1
+        : mode === MonkeyMode.INTEGRATION ? 2
+        : mode === MonkeyMode.DRIFT ? 3
+        : 4,
     },
   };
 }


### PR DESCRIPTION
## CC2 audit Findings 3, 4, 5 — tidy cleanup

### F3 — EXPLORATION_FLOOR observer-derive (was magic 0.20)

Replace \`EXPLORATION_FLOOR = 0.20\` with the same min-clearing
formula \`lift-to-min\` already uses:

\`\`\`ts
const minClearingFrac = min(0.5,
  (minNotionalUsdt * 1.05) / (leverage * availableEquityUsdt));
const explorationFloor = minClearingFrac * (1 - maturity);
\`\`\`

Two paths unified into one, magic constant retired, floor capped at
the survival 0.5 bound. The floor IS the min-clearing fraction at
cold-start; mature kernels let chemistry drive without floor support.

### F4 — lane budgetFrac doctrinal note

CC2 framing correction acknowledged: the all-1.0 change WAS documented
in code. Adding an explicit doctrinal note that "trend is opt-in by
operator" is RETIRED. If future operator wants to re-disable a lane,
the cleanest mechanism is an env-flag check at the call site, not
restoring budgetFrac differentiation (which mixed two concepts:
sizing allocation + behavioral envelope).

### F5 — `void mode;` cleanup

Wire \`mode\` into the derivation telemetry (numeric code: 0=EXP,
1=INV, 2=INT, 3=DRIFT). The formula remains mode-agnostic (chemistry
expresses mode differentiation); the parameter is now used for
telemetry rather than silently discarded. Removes the \`void mode;\`
code smell.

## Test plan

- [x] \`yarn tsc --noEmit\` clean
- [x] \`yarn vitest run\` — 1770 / 12 skip / 0 fail
- [x] sizingReliefLayer1 cold-start expectations updated to derived floor
- [x] laneIsolation small-account test re-targeted (floor itself now
      covers min-clearing, no separate lift-to-min flag expected)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)