### PR TITLE
feat(monkey): exit_gate column + 8-path attribution wiring (#931 follow-up)

### DIFF
--- a/apps/api/database/migrations/057_autonomous_trades_exit_gate.sql
+++ b/apps/api/database/migrations/057_autonomous_trades_exit_gate.sql
@@ -1,0 +1,23 @@
+-- 057_autonomous_trades_exit_gate.sql
+--
+-- Add exit_gate column to autonomous_trades for per-gate attribution
+-- of scalp_exit closes. The outer `exit_reason` is too coarse — it's
+-- typically 'scalp_exit' across many distinct inner gates:
+--   - bracket_tp / bracket_sl / trailing_harvest / trend_flip_harvest
+--   - conviction_failed / regime_change / phi_collapse / stale_bleed
+--     / directional_disagreement
+--   - regime_held_exit, scalp_classic, profit_harvest, aggregate_harvest
+--
+-- Per the 2026-05-26 exit-asymmetry audit: 300 scalp_exit closes, rr_ratio
+-- 0.65 (losses 1.5× wins at average, 2× at median, slightly longer hold).
+-- The cause is gate-attribution-opaque without this column — the audit
+-- can't distinguish whether conviction_failed fires on small wins vs
+-- bracket_sl handling losses.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS.
+ALTER TABLE autonomous_trades ADD COLUMN IF NOT EXISTS exit_gate VARCHAR(40);
+
+-- Index for analysis queries — we'll be grouping by exit_gate often.
+CREATE INDEX IF NOT EXISTS idx_autonomous_trades_exit_gate
+  ON autonomous_trades(exit_gate)
+  WHERE exit_gate IS NOT NULL;

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1755,6 +1755,7 @@ export class MonkeyKernel extends EventEmitter {
               `UPDATE autonomous_trades
                   SET status='closed', exit_time=NOW(),
                       exit_reason='maker_cancelled_unfilled',
+                      exit_gate='maker_cancelled_unfilled',
                       exit_order_id=$1, pnl=0
                 WHERE order_id=$1 AND status='open'`,
               [s.orderId],
@@ -4181,6 +4182,16 @@ export class MonkeyKernel extends EventEmitter {
           exitTypeBit === 2 ? 'trailing_harvest' :
           exitTypeBit === 3 ? 'trend_flip_harvest' :
           'scalp_exit';
+        // #931 exit-attribution: extract the inner gate name from the reason
+        // string prefix (e.g. "conviction_failed: conf=...", "bracket_sl: mark...",
+        // "stale_held: position open ..."). The 12+ inner gates that all surface
+        // as 'scalp_exit' need per-gate distinguishability for the rr-asymmetry
+        // audit (Matrix council 2026-05-26). Parses reason up to first ':' for
+        // the gate name; falls back to exitType.
+        const reasonPrefix = reason.split(':')[0]?.trim() ?? '';
+        const exitGate = reasonPrefix && reasonPrefix !== 'closed_paper'
+          ? reasonPrefix
+          : exitType;
         const pnlAtDecision = Number(scalpDeriv?.unrealizedPnl ?? 0);
         const scalpLane = (
           scalpDeriv?.lane === 'scalp' || scalpDeriv?.lane === 'trend'
@@ -4195,6 +4206,7 @@ export class MonkeyKernel extends EventEmitter {
             markPrice: lastPrice,
             exitReason: exitType,
             pnlAtDecision,
+            exitGate,
             lane: scalpLane,
           });
           executed = closeResult.executed;
@@ -6006,7 +6018,8 @@ export class MonkeyKernel extends EventEmitter {
             await pool.query(
               `UPDATE autonomous_trades
                   SET status = 'closed', exit_price = $1, exit_time = NOW(),
-                      exit_reason = $2, exit_order_id = $3, pnl = $4
+                      exit_reason = $2, exit_order_id = $3, pnl = $4,
+                      exit_gate = 'agent_l_force_harvest'
                 WHERE id = $5`,
               [lastPrice, 'agent_l_force_harvest', closeOrderId, rowPnl, row.id],
             );
@@ -6182,7 +6195,8 @@ export class MonkeyKernel extends EventEmitter {
           const updated = await pool.query<{ pnl: string }>(
             `UPDATE autonomous_trades
                 SET status = 'closed', exit_price = $1, exit_time = NOW(),
-                    exit_reason = $2, exit_order_id = $3, ${SAFE_PNL_FROM_ROW}
+                    exit_reason = $2, exit_order_id = $3, exit_gate = 'agent_l_force_harvest',
+                    ${SAFE_PNL_FROM_ROW}
               WHERE id = $4
               RETURNING pnl`,
             [lastPrice, 'agent_l_force_harvest', orderId, row.id],
@@ -6266,6 +6280,14 @@ export class MonkeyKernel extends EventEmitter {
     markPrice: number;
     exitReason: string;
     pnlAtDecision: number;
+    /**
+     * 2026-05-26 (#931 exit-asymmetry audit): which inner gate fired the
+     * close. `exit_reason` is too coarse — 300 closes labelled 'scalp_exit'
+     * span 10+ distinct gates (conviction_failed, bracket_sl, bracket_tp,
+     * stale_bleed, regime_change, etc.). exit_gate captures the gate name
+     * for downstream attribution. Falls back to exitReason when unspecified.
+     */
+    exitGate?: string;
     /** Proposal #10: when provided, close only autonomous_trades rows
      *  matching this lane (and send ``posSide`` on the exchange close
      *  in HEDGE mode so the other lane stays untouched). When omitted,
@@ -6274,6 +6296,9 @@ export class MonkeyKernel extends EventEmitter {
   }): Promise<{ executed: boolean; orderId: string | null; reason: string }> {
     const { symbol, tradeId, heldSide, markPrice, exitReason, pnlAtDecision } = req;
     const closeLane = req.lane;
+    // #931 exit-attribution: gate name (e.g. 'conviction_failed', 'bracket_sl');
+    // defaults to exitReason for back-compat at call-sites we haven't migrated.
+    const exitGate = req.exitGate ?? exitReason;
     if (this.shouldRouteOrdersToPaper()) {
       if (!Number.isFinite(markPrice) || markPrice <= 0) {
         logger.warn('[Monkey] paper mode invalid mark price, skipping close', {
@@ -6321,10 +6346,10 @@ export class MonkeyKernel extends EventEmitter {
           const updated = await pool.query<{ pnl: string }>(
             `UPDATE autonomous_trades
                 SET status = 'closed', exit_price = $1, exit_time = NOW(),
-                    exit_reason = $2, exit_order_id = $3, ${SAFE_PNL_FROM_ROW}
+                    exit_reason = $2, exit_order_id = $3, exit_gate = $5, ${SAFE_PNL_FROM_ROW}
               WHERE id = $4
               RETURNING pnl`,
-            [markPrice, exitReason, null, tradeId],
+            [markPrice, exitReason, null, tradeId, exitGate],
           );
           const safePnl = updated.rows[0]?.pnl ? Number(updated.rows[0].pnl) : pnlAtDecision;
           this.arbiter.recordSettled('K', safePnl);
@@ -6356,17 +6381,17 @@ export class MonkeyKernel extends EventEmitter {
             explicitPnl !== null
               ? `UPDATE autonomous_trades
                     SET status = 'closed', exit_price = $1, exit_time = NOW(),
-                        exit_reason = $2, exit_order_id = $3, pnl = $4
+                        exit_reason = $2, exit_order_id = $3, pnl = $4, exit_gate = $6
                   WHERE id = $5
                   RETURNING pnl`
               : `UPDATE autonomous_trades
                     SET status = 'closed', exit_price = $1, exit_time = NOW(),
-                        exit_reason = $2, exit_order_id = $3, ${SAFE_PNL_FROM_ROW}
+                        exit_reason = $2, exit_order_id = $3, exit_gate = $5, ${SAFE_PNL_FROM_ROW}
                   WHERE id = $4
                   RETURNING pnl`,
             explicitPnl !== null
-              ? [markPrice, exitReason, closeOrderId, explicitPnl, row.id]
-              : [markPrice, exitReason, closeOrderId, row.id],
+              ? [markPrice, exitReason, closeOrderId, explicitPnl, row.id, exitGate]
+              : [markPrice, exitReason, closeOrderId, row.id, exitGate],
           );
           const rowPnl = updated.rows[0]?.pnl ? Number(updated.rows[0].pnl) : (explicitPnl ?? 0);
           const agentLabel: AgentLabel =
@@ -6418,7 +6443,8 @@ export class MonkeyKernel extends EventEmitter {
       // row by tradeId, producing phantom values when multiple rows existed.
       await pool.query(
         `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
-                exit_reason='race_lost_to_sibling', ${SAFE_PNL_FROM_ROW} WHERE id=$2`,
+                exit_reason='race_lost_to_sibling', exit_gate='race_lost_to_sibling',
+                ${SAFE_PNL_FROM_ROW} WHERE id=$2`,
         [markPrice, tradeId],
       ).catch(() => { /* non-fatal */ });
       const reason = acquired.reason === 'recently_closed'
@@ -6495,7 +6521,7 @@ export class MonkeyKernel extends EventEmitter {
       // #931 safe-pnl — see comment at race_lost_to_sibling above.
       await pool.query(
         `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
-                exit_reason=$2, ${SAFE_PNL_FROM_ROW} WHERE id=$3`,
+                exit_reason=$2, exit_gate=$2, ${SAFE_PNL_FROM_ROW} WHERE id=$3`,
         [markPrice, dbExitReason, tradeId],
       ).catch(() => { /* non-fatal */ });
       return { executed: false, orderId: null, reason };
@@ -6799,7 +6825,8 @@ export class MonkeyKernel extends EventEmitter {
           // #931 safe-pnl — see comment at first race_lost_to_sibling block above.
           await pool.query(
             `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
-                    exit_reason='race_lost_to_sibling', ${SAFE_PNL_FROM_ROW} WHERE id=$2`,
+                    exit_reason='race_lost_to_sibling', exit_gate='race_lost_to_sibling',
+                    ${SAFE_PNL_FROM_ROW} WHERE id=$2`,
             [markPrice, tradeId],
           ).catch(() => { /* non-fatal */ });
           return {
@@ -6839,7 +6866,9 @@ export class MonkeyKernel extends EventEmitter {
             // #931 safe-pnl — see comment at first race_lost_to_sibling block above.
             await pool.query(
               `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
-                      exit_reason='exchange_position_vanished', ${SAFE_PNL_FROM_ROW} WHERE id=$2`,
+                      exit_reason='exchange_position_vanished',
+                      exit_gate='exchange_position_vanished',
+                      ${SAFE_PNL_FROM_ROW} WHERE id=$2`,
               [markPrice, tradeId],
             ).catch(() => { /* non-fatal */ });
             return {
@@ -6940,10 +6969,10 @@ export class MonkeyKernel extends EventEmitter {
         const updated = await pool.query<{ pnl: string }>(
           `UPDATE autonomous_trades
               SET status = 'closed', exit_price = $1, exit_time = NOW(),
-                  exit_reason = $2, exit_order_id = $3, ${SAFE_PNL_FROM_ROW}
+                  exit_reason = $2, exit_order_id = $3, exit_gate = $5, ${SAFE_PNL_FROM_ROW}
             WHERE id = $4
             RETURNING pnl`,
-          [markPrice, exitReason, orderId, tradeId],
+          [markPrice, exitReason, orderId, tradeId, exitGate],
         );
         const safePnl = updated.rows[0]?.pnl ? Number(updated.rows[0].pnl) : pnlAtDecision;
         // Single-row fallback: assume Agent K (the established default).
@@ -6966,10 +6995,10 @@ export class MonkeyKernel extends EventEmitter {
           const updated = await pool.query<{ pnl: string }>(
             `UPDATE autonomous_trades
                 SET status = 'closed', exit_price = $1, exit_time = NOW(),
-                    exit_reason = $2, exit_order_id = $3, ${SAFE_PNL_FROM_ROW}
+                    exit_reason = $2, exit_order_id = $3, exit_gate = $5, ${SAFE_PNL_FROM_ROW}
               WHERE id = $4
               RETURNING pnl`,
-            [markPrice, exitReason, orderId, row.id],
+            [markPrice, exitReason, orderId, row.id, exitGate],
           );
           const rowPnl = updated.rows[0]?.pnl
             ? Number(updated.rows[0].pnl)
@@ -7011,7 +7040,8 @@ export class MonkeyKernel extends EventEmitter {
         await pool.query(
           `UPDATE autonomous_trades
               SET status='closed', exit_price=$1, exit_time=NOW(),
-                  exit_reason=$2, exit_order_id=$3, ${SAFE_PNL_FROM_ROW}
+                  exit_reason=$2, exit_order_id=$3, exit_gate='db_recovery',
+                  ${SAFE_PNL_FROM_ROW}
             WHERE id=$4 AND status='open'`,
           [markPrice, `${exitReason}__db_recovery`, orderId, tradeId],
         );


### PR DESCRIPTION
## Summary

Adds \`exit_gate\` column to \`autonomous_trades\` and populates it across all 8 close paths. Unblocks the rr-asymmetry investigation Matrix flagged in the council exchange — currently 12+ inner gates collapse to a single 'scalp_exit' exit_reason, making per-gate attribution opaque.

Migration 057 applied to production.

## Why now

The May 26 24h audit (n=300 scalp_exit closes) showed rr_ratio 0.65 — losses 1.5× wins at average, 2× at median. Matrix's initial conviction_failed-cuts-early hypothesis was falsified by hold-time data (losses held 488s vs wins 450s). The kernel cuts WINS, not losses. To investigate WHICH gate is firing on small wins, we need per-gate attribution. Without this column, the analysis is stuck at log-scraping.

Matrix's council call: "'deliberate session task, not loop-scope' is deferral language. Ship the schema change now."

## Implementation

- \`057_autonomous_trades_exit_gate.sql\` — ADD COLUMN IF NOT EXISTS + partial index. Already applied to prod.
- \`closeHeldPosition()\` gains optional \`exitGate\` param.
- 8 UPDATE paths plumbed: scalp_exit per-row loop, single-row fallback, paper-mode (single + multi), race_lost_to_sibling ×2, exchange_position_vanished, db_recovery, L-live harvest, L-paper harvest, maker_cancelled_unfilled.
- At the scalp_exit handler (line ~4175), \`exitGate\` is derived from \`reason.split(':')[0]\` — every inner gate already prefixes its name in the reason string. Avoids touching all 11 inner decision sites individually.

## Test plan

- [x] tsc --noEmit clean
- [x] 1003/1003 monkey tests pass
- [x] Migration 057 applied to production (ALTER TABLE + index)
- [ ] Post-deploy: 1h post-merge, re-run rr-ratio audit grouped by exit_gate; confirm or falsify the "conviction_failed-fires-on-wins" hypothesis with n>>2

## Cross-refs

- #931 (parent, merged) — phantom-pnl write-path fix
- #932 (merged) — reconciliation infra
- #934 (merged) — chemistry pinning fix
- Memory: [[polytrade_phantom_pnl_audit_20260525]] — pre-committed analysis cuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce per-gate exit attribution for autonomous trades and wire it through all key close paths to support exit-asymmetry analysis.

New Features:
- Add exit_gate column and partial index on autonomous_trades to record which inner gate triggered each close.
- Propagate an optional exitGate field through closeHeldPosition to capture gate-level attribution across paper and live close paths.

Enhancements:
- Derive exit_gate for scalp_exit flows from the exit reason prefix to distinguish inner gates without touching all decision sites.
- Set explicit exit_gate values for maker-cancel, force-harvest, race-lost, exchange-vanished, and DB recovery close paths for consistent attribution.