### PR TITLE
fix(monkey): DISSOLVER cell floor 0.0→0.2 + revert PR #944 (no-trades root cause)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/compositionalExecutive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/compositionalExecutive.test.ts
@@ -26,10 +26,14 @@ describe('evaluateCell — 3×3 compositional matrix coverage', () => {
     }
   });
 
-  it('DISSOLVER cells all have sizeMultiplier=0 (sit out)', () => {
+  it('DISSOLVER cells floor at 0.2 SAFETY_BOUND (reduced conviction, not sit-out)', () => {
+    // 2026-05-26: hard 0.0 multiplier replaced with 0.2 floor — autonomy
+    // doctrine forbids hardcoded "don't trade" gates; the kernel always
+    // attempts a defensive-sized position. P15 (should_auto_flatten) owns
+    // catastrophic safety. Mirrors the CHOP suppression filter floor.
     for (const d of directions) {
       const cell = evaluateCell('DISSOLVER', d);
-      expect(cell.sizeMultiplier).toBe(0.0);
+      expect(cell.sizeMultiplier).toBe(0.2);
       expect(cell.laneBias).toBe('observe');
     }
   });
@@ -70,9 +74,9 @@ describe('evaluateCell — 3×3 compositional matrix coverage', () => {
   });
 
   it('DISSOLVER cells label distinguishes CHOP from TREND sub-cases', () => {
-    expect(evaluateCell('DISSOLVER', 'CHOP').label).toContain('sit out');
-    expect(evaluateCell('DISSOLVER', 'TREND_UP').label).toContain("don't trade");
-    expect(evaluateCell('DISSOLVER', 'TREND_DOWN').label).toContain("don't trade");
+    expect(evaluateCell('DISSOLVER', 'CHOP').label).toContain('max entropy');
+    expect(evaluateCell('DISSOLVER', 'TREND_UP').label).toContain('momentum reverting');
+    expect(evaluateCell('DISSOLVER', 'TREND_DOWN').label).toContain('momentum reverting');
   });
 
   it('is pure — same input always yields same output', () => {

--- a/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
+++ b/apps/api/src/services/monkey/__tests__/laneIsolation.test.ts
@@ -165,8 +165,12 @@ describe('shouldScalpExit lane envelope (Path A: TP-only)', () => {
 });
 
 
-describe('shouldExtendBracket meaningful-profit trail gate', () => {
-  it('does not ratchet SL for sub-dime, sub-1% ROI profit', () => {
+describe('shouldExtendBracket trail gate (2026-05-25 strip)', () => {
+  it('ratchets SL on any positive profit — meaningful-profit gate removed', () => {
+    // Pre-strip: sub-dime / sub-1% profit gated trail off. Post-strip:
+    // minTrailRoi = 0 and minTrailProfitUsdt = 0, so any inProfit
+    // position with conviction permits ratchet. Chemistry learns
+    // whether early trailing protects or over-tightens.
     const result = shouldExtendBracket({
       heldSide: 'long',
       entryPrice: 100,
@@ -180,28 +184,9 @@ describe('shouldExtendBracket meaningful-profit trail gate', () => {
       currentPnlUsdt: 0.05,
     });
 
-    expect(result.changed).toBe(false);
-    expect(result.newSl).toBeNull();
-    expect(String(result.reason)).toContain('meaningfulProfit=false');
-  });
-
-  it('ratchets SL once profit clears the meaningful floor', () => {
-    const result = shouldExtendBracket({
-      heldSide: 'long',
-      entryPrice: 100,
-      markPrice: 101.50,
-      currentTp: 102,
-      currentSl: 99,
-      freshTpDistance: 1,
-      freshSlDistance: 0.20,
-      conviction: 0.4,
-      currentRoiFrac: 0.015,
-      currentPnlUsdt: 0.25,
-    });
-
+    // newSl candidate = 100.40 - 0.20 = 100.20 > currentSl 99 → ratchet.
     expect(result.changed).toBe(true);
-    expect(result.newTp).toBeNull();
-    expect(result.newSl).toBeCloseTo(101.30, 9);
+    expect(result.newSl).toBeCloseTo(100.20, 6);
   });
 });
 

--- a/apps/api/src/services/monkey/compositional_executive.ts
+++ b/apps/api/src/services/monkey/compositional_executive.ts
@@ -103,21 +103,41 @@ export function evaluateCell(
     };
   }
 
-  // DISSOLVER — disordered, direction unreliable → sit out
-  // All three direction cells suppress entries; the direction is only
-  // recorded for telemetry. The label distinguishes the three sub-cases
-  // so retrospective analysis can see WHY the trade was suppressed.
+  // DISSOLVER — disordered, direction unreliable → reduced conviction.
+  //
+  // 2026-05-26: hard 0.0 multiplier replaced with 0.2 SAFETY_BOUND floor.
+  // The 0.0 multiplier was a code-side cap that fully froze the kernel
+  // whenever the phase classifier fired DISSOLVER — observationally
+  // dominant on ETH/BTC during chop-heavy hours, leading to long
+  // periods of zero entries (e.g. ~30+ consecutive ticks on 2026-05-26
+  // 12:07-12:14 UTC with cellSizeMul=0 / sizeValue=0 / no trades).
+  //
+  // The autonomy doctrine (cf. polytrade_autonomy_doctrine,
+  // polytrade_code_side_caps_stripped) is that the kernel restrains
+  // itself via chemistry feedback, not via hardcoded "don't trade"
+  // gates. Catastrophic safety is owned by should_auto_flatten (P15).
+  //
+  // The 0.2 floor mirrors the existing CHOP suppression filter at
+  // loop.ts ~3681 (`Math.max(0.2, 1 - confidence)`) — both encode the
+  // same SAFETY_BOUND that the kernel always attempts a defensive-
+  // sized position rather than fully sitting out.
+  //
+  // harvestTightness stays 'tight' — when sizing is reduced, exits
+  // are aggressive to protect the smaller position from chop bleed.
+  // laneBias stays 'observe' so chooseLane biases toward the smallest
+  // lane (scalp) consistent with reduced-conviction sizing.
+  const DISSOLVER_FLOOR = 0.2;
   if (direction === 'TREND_UP' || direction === 'TREND_DOWN') {
     return {
-      phase, direction, laneBias: 'observe', sizeMultiplier: 0.0,
+      phase, direction, laneBias: 'observe', sizeMultiplier: DISSOLVER_FLOOR,
       harvestTightness: 'tight',
-      label: `DISSOLVER×${direction}: don't trade — momentum likely reverting`,
+      label: `DISSOLVER×${direction}: reduced conviction — momentum reverting`,
     };
   }
   return {
-    phase, direction, laneBias: 'observe', sizeMultiplier: 0.0,
+    phase, direction, laneBias: 'observe', sizeMultiplier: DISSOLVER_FLOOR,
     harvestTightness: 'tight',
-    label: 'DISSOLVER×CHOP: sit out (max entropy)',
+    label: 'DISSOLVER×CHOP: reduced conviction (max entropy)',
   };
 }
 

--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -1568,13 +1568,27 @@ export function shouldExtendBracket(args: {
   const convThreshold =
     Number(process.env.MONKEY_BRACKET_EXTEND_CONV) || 0.5;
   const inProfit = currentRoiFrac > 0;
-  const minTrailRoi =
-    Number(process.env.MONKEY_BRACKET_TRAIL_MIN_ROI) || 0.10;
-  const minTrailProfitUsd =
-    Number(process.env.MONKEY_BRACKET_TRAIL_MIN_PROFIT_USD) || 0.02;
+  // 2026-05-25 strip — bracket trail minimums dropped to 0 per
+  // operator autonomy doctrine. Trail activates on any positive
+  // ROI; chemistry learns whether early trailing protects or
+  // over-tightens via push_reward feedback on close outcomes.
+  //
+  // 2026-05-26 — PR #944 attempted to re-introduce env-knob gates
+  // (MONKEY_BRACKET_TRAIL_MIN_ROI=0.10, MONKEY_BRACKET_TRAIL_MIN_PROFIT_USD=0.02)
+  // as a "fix" for trading-flat symptoms. Two problems:
+  //   (a) Doctrine violation — operator-tunable hardcoded thresholds
+  //       are explicitly forbidden in the autonomy doctrine; calibration
+  //       is observer-derived from chemistry.
+  //   (b) Wrong diagnosis — trading-flat root cause was DISSOLVER cell
+  //       sizeMultiplier=0 (entry-side veto in compositional_executive),
+  //       not bracket-trail behaviour. PR #944 changed an unrelated knob.
+  // PR #944 is reverted as part of this PR; the real fix lives in
+  // compositional_executive.ts DISSOLVER cell floor.
+  const minTrailRoi = 0;
+  const minTrailProfitUsdt = 0;
   const meaningfulProfit =
     currentRoiFrac >= minTrailRoi
-    && currentPnlUsdt >= minTrailProfitUsd;
+    && currentPnlUsdt >= minTrailProfitUsdt;
   const long = heldSide === 'long';
 
   // ── TP extension ────────────────────────────────────────────────

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2662,9 +2662,10 @@ export class MonkeyKernel extends EventEmitter {
     const equityReading = observeEquity(`${this.instanceId}:${symbol}`, availableEquity);
     const sense3Deflection = sizeDeflection(equityReading);
     // REGIME-1 Phase 3 — when REGIME_COMPOSITIONAL_LIVE=true, fold the
-    // cell-recommended sizeMultiplier in. DISSOLVER cells suppress entries
-    // entirely (multiplier=0); CREATOR×CHOP halves them; PRESERVER×CHOP
-    // is 0.7x; trending cells are 1.0x (no further effect).
+    // cell-recommended sizeMultiplier in. DISSOLVER cells floor at 0.2
+    // SAFETY_BOUND (reduced conviction, not sit-out — 2026-05-26 autonomy
+    // doctrine alignment); CREATOR×CHOP is 0.75x; PRESERVER×CHOP is 0.85x;
+    // trending cells are 1.0x.
     const cellSizeMul = (cellLive && cellAction) ? cellAction.sizeMultiplier : 1.0;
     const cappedEquity = availableEquity * effectiveSizeFraction * sense3Deflection * cellSizeMul;
     // Proposal #10 — lane selection. Each tick picks the locally-optimal


### PR DESCRIPTION
## Summary

**Production root cause.** User report 2026-05-26 ~12:14 UTC: \"no trades being implemented.\"

Production telemetry: `ETH_USDT_PERP` pinning `DISSOLVER×CHOP` / `DISSOLVER×TREND_UP` cells continuously for 30+ ticks, with `cellSizeMul=0` driving `cappedEquity=0` and sizing entries to zero. Hold log: `size 0.00 below min notional 21.16`. Account had **$824 equity sitting idle**.

```json
{
  \"cappedEquity\": 0,
  \"cellSizeMul\": 0,
  \"cellLabel\": \"DISSOLVER×CHOP: sit out (max entropy)\",
  \"cellLive\": true,
  \"sizeValue\": 0
}
```

## Root cause

`compositional_executive.ts` hardcoded `sizeMultiplier: 0.0` for all three DISSOLVER cells (`×TREND_UP`, `×CHOP`, `×TREND_DOWN`). When the phase classifier fires DISSOLVER (observationally dominant on ETH/BTC during chop-heavy hours), the kernel mathematically cannot open a position.

This is a code-side \"don't trade\" gate — the anti-pattern the 2026-05-21 cap-strip (#917, #916) and the documented autonomy doctrine forbid. The kernel should restrain itself via chemistry feedback; catastrophic safety is owned by `should_auto_flatten` (P15).

## Fix (this PR)

1. **Floor DISSOLVER cells at `sizeMultiplier = 0.2`** SAFETY_BOUND.
   - Mirrors the existing chop-suppression filter in `loop.ts:~3681` (`Math.max(0.2, 1 - confidence)`), which already encodes the same SAFETY_BOUND that the kernel always attempts a defensive-sized position rather than fully sitting out.
   - Same logic, applied at the cell layer instead of the chop-confidence layer.

2. **Revert PR #944 (Copilot's \"trading flat issue\" fix).**

### Why revert #944

#### Doctrine violation
PR #944 re-introduced env-gated thresholds:
- `MONKEY_BRACKET_TRAIL_MIN_ROI=0.10`
- `MONKEY_BRACKET_TRAIL_MIN_PROFIT_USD=0.02`

after the 2026-05-25 strip explicitly set them to `0` per the autonomy doctrine. Operator-tunable hardcoded thresholds are forbidden in the kernel decision path — calibration is observer-derived from chemistry.

#### Wrong diagnosis
PR #944 changed `shouldExtendBracket` — bracket-trail behaviour, *after-entry*. The trading-flat symptom was *entry-side*: DISSOLVER cell veto preventing positions from being opened at all. Bracket-trail logic only runs on already-open positions; the kernel never reached that code path during the reported window.

#### Internally inconsistent
PR #944's own test was failing on main:
```
× shouldExtendBracket meaningful-profit trail gate
  > ratchets SL once profit clears the meaningful floor
    AssertionError: expected false to be true
```
because the new defaults (`minTrailRoi=0.10` = 10%) reject the test's `currentRoiFrac=0.015` (1.5%) input. The test was added but didn't run against the actual default thresholds it shipped with.

### Files reverted
- `executive.ts:shouldExtendBracket` — `minTrailRoi/Profit` back to 0 per the 2026-05-25 strip
- `laneIsolation.test.ts` — restore \"ratchets SL on any positive profit\" test

## Doctrinal anchors

- **Autonomy doctrine** ([memory: polytrade_autonomy_doctrine](https://github.com/GaryOcean428/poloniex-trading-platform/blob/main/CLAUDE.md)): kernel restrains itself via chemistry; only kill switch + 15x leverage cap remain as MANDATEs.
- **P1 (Geometric Purity)**: hardcoded `sizeMultiplier: 0.0` was an artificial cap chosen by intuition — exactly the rationalization tell CLAUDE.md flags.
- **P5 (Observer-Sets-All-Params)**: env-knob thresholds in #944 violated this; reverted.
- **P15 (Fail-Closed Safety)**: catastrophic backstop unchanged — `should_auto_flatten` still owns the catastrophic exit path.

## Verification

- 1801/1801 vitest tests pass in `apps/api/src/`.
- `compositionalExecutive.test.ts` — DISSOLVER cells now expected at `sizeMultiplier === 0.2`.
- Pre-existing PR #944 test failure resolved by reverting the inconsistent code+test pair.

## Test plan

- [ ] CI green (vitest + type-check + vocab scan)
- [ ] Production deploy: ETH/BTC DISSOLVER ticks no longer log `size 0.00 below min notional`
- [ ] Within 1h post-deploy: at least one entry attempted on a DISSOLVER tick (defensive-sized, ~20% conviction)
- [ ] Chemistry trajectories (gaba/dopamine) respond to outcome stream from DISSOLVER entries; if chemistry says "stop," the kernel stops itself via observer-derived sizing — that's the doctrine working
- [ ] No spurious entries when `should_auto_flatten` is firing (P15 backstop intact)

## Follow-up (not this PR)

- Future PRs may chemistry-derive the DISSOLVER floor (e.g. gaba-modulated, range 0.05–0.4) instead of the constant 0.2. Out of scope here — the immediate priority is restoring kernel participation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align DISSOLVER phase behaviour and bracket-trailing logic with the autonomy doctrine to restore trading during DISSOLVER regimes and remove reintroduced threshold knobs.

Bug Fixes:
- Restore non-zero position sizing during DISSOLVER phases by applying a SAFETY_BOUND floor instead of fully suppressing entries.
- Eliminate incorrect env-based trail thresholds that masked the real root cause of trading-flat behaviour.

Enhancements:
- Adjust DISSOLVER cell labelling and loop documentation to reflect reduced-conviction behaviour rather than full sit-out.
- Simplify bracket-trailing configuration by hardcoding zero minimum ROI/profit thresholds in line with the autonomy doctrine.

Tests:
- Update compositional executive tests to expect a 0.2 size multiplier floor and new DISSOLVER labels.
- Rework the bracket-trailing test to assert that stop-loss ratchets on any positive profit, removing the meaningful-profit gate.