### PR TITLE
feat(monkey): #948 Ocean Fibonacci reward — chemistry learns from real wins, not noise

### DIFF
--- a/apps/api/src/services/monkey/__tests__/oceanReward.test.ts
+++ b/apps/api/src/services/monkey/__tests__/oceanReward.test.ts
@@ -1,0 +1,138 @@
+/**
+ * oceanReward.test.ts — Issue #948 (Matrix tier-3 directive 2026-05-26).
+ *
+ * Pins the Fibonacci reward shape and the 1% noise floor — the
+ * structural learning-signal that teaches the kernel "small wins
+ * aren't worth chasing."
+ *
+ * These tests are RESTRICTIVE on purpose. If a future PR widens the
+ * 1% floor or changes the Fibonacci sequence, it must change these
+ * tests deliberately — the doctrine ("reward shape, not knob") makes
+ * the sequence load-bearing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  fibonacciRewardCoefficient,
+  fibonacciRewardTier,
+} from '../ocean_reward.js';
+
+describe('fibonacciRewardCoefficient — the structural reward shape', () => {
+  describe('the 1% noise floor', () => {
+    it('emits ZERO reward below 1% ROI', () => {
+      expect(fibonacciRewardCoefficient(0)).toBe(0);
+      expect(fibonacciRewardCoefficient(0.001)).toBe(0); // 0.1%
+      expect(fibonacciRewardCoefficient(0.005)).toBe(0); // 0.5%
+      expect(fibonacciRewardCoefficient(0.0099)).toBe(0); // 0.99%
+    });
+
+    it('emits ZERO reward on negative ROI (losses fall through to gaba path)', () => {
+      expect(fibonacciRewardCoefficient(-0.01)).toBe(0);
+      expect(fibonacciRewardCoefficient(-0.5)).toBe(0);
+    });
+
+    it('emits ZERO reward on NaN / non-finite (defensive — caller shouldn\'t pass these)', () => {
+      expect(fibonacciRewardCoefficient(NaN)).toBe(0);
+      expect(fibonacciRewardCoefficient(Infinity)).toBe(0);
+      expect(fibonacciRewardCoefficient(-Infinity)).toBe(0);
+    });
+
+    it('first non-zero tier is exactly at 1.00% ROI', () => {
+      expect(fibonacciRewardCoefficient(0.01)).toBe(1);
+    });
+  });
+
+  describe('the Fibonacci bucket boundaries', () => {
+    it('bucket [1%, 2%) → coefficient 1', () => {
+      expect(fibonacciRewardCoefficient(0.01)).toBe(1);
+      expect(fibonacciRewardCoefficient(0.015)).toBe(1);
+      expect(fibonacciRewardCoefficient(0.019)).toBe(1);
+    });
+
+    it('bucket [2%, 3%) → coefficient 2', () => {
+      expect(fibonacciRewardCoefficient(0.02)).toBe(2);
+      expect(fibonacciRewardCoefficient(0.025)).toBe(2);
+    });
+
+    it('bucket [3%, 5%) → coefficient 3', () => {
+      expect(fibonacciRewardCoefficient(0.03)).toBe(3);
+      expect(fibonacciRewardCoefficient(0.045)).toBe(3);
+    });
+
+    it('bucket [5%, 8%) → coefficient 5', () => {
+      expect(fibonacciRewardCoefficient(0.05)).toBe(5);
+      expect(fibonacciRewardCoefficient(0.075)).toBe(5);
+    });
+
+    it('bucket [8%, 13%) → coefficient 8', () => {
+      expect(fibonacciRewardCoefficient(0.08)).toBe(8);
+      expect(fibonacciRewardCoefficient(0.12)).toBe(8);
+    });
+
+    it('bucket [13%, 21%) → coefficient 13', () => {
+      expect(fibonacciRewardCoefficient(0.13)).toBe(13);
+      expect(fibonacciRewardCoefficient(0.20)).toBe(13);
+    });
+
+    it('bucket [21%, 34%) → coefficient 21', () => {
+      expect(fibonacciRewardCoefficient(0.21)).toBe(21);
+      expect(fibonacciRewardCoefficient(0.33)).toBe(21);
+    });
+
+    it('bucket [34%, ∞) → coefficient 34 (capped — outliers don\'t over-train)', () => {
+      expect(fibonacciRewardCoefficient(0.34)).toBe(34);
+      expect(fibonacciRewardCoefficient(0.50)).toBe(34);
+      expect(fibonacciRewardCoefficient(1.00)).toBe(34);
+      expect(fibonacciRewardCoefficient(10.00)).toBe(34);
+    });
+  });
+
+  describe('the sequence IS Fibonacci', () => {
+    it('coefficients form the Fibonacci sequence (1, 2, 3, 5, 8, 13, 21, 34)', () => {
+      const coeffs = [
+        fibonacciRewardCoefficient(0.01),
+        fibonacciRewardCoefficient(0.02),
+        fibonacciRewardCoefficient(0.03),
+        fibonacciRewardCoefficient(0.05),
+        fibonacciRewardCoefficient(0.08),
+        fibonacciRewardCoefficient(0.13),
+        fibonacciRewardCoefficient(0.21),
+        fibonacciRewardCoefficient(0.34),
+      ];
+      expect(coeffs).toEqual([1, 2, 3, 5, 8, 13, 21, 34]);
+    });
+
+    it('each tier boundary is itself a Fibonacci percentage (the boundaries and the magnitudes share the sequence)', () => {
+      // The boundary VALUE (1, 2, 3, 5, 8, 13, 21, 34) equals the coefficient
+      // at the bucket OPENING — the kernel feels a 1% win as 1× reward, a 2%
+      // win as 2× reward, etc. This is the structural identity.
+      expect(fibonacciRewardCoefficient(0.01)).toBe(1);
+      expect(fibonacciRewardCoefficient(0.02)).toBe(2);
+      expect(fibonacciRewardCoefficient(0.03)).toBe(3);
+      expect(fibonacciRewardCoefficient(0.05)).toBe(5);
+      expect(fibonacciRewardCoefficient(0.08)).toBe(8);
+      expect(fibonacciRewardCoefficient(0.13)).toBe(13);
+      expect(fibonacciRewardCoefficient(0.21)).toBe(21);
+      expect(fibonacciRewardCoefficient(0.34)).toBe(34);
+    });
+  });
+});
+
+describe('fibonacciRewardTier — telemetry index', () => {
+  it('tier 0 means "below the 1% noise floor"', () => {
+    expect(fibonacciRewardTier(0)).toBe(0);
+    expect(fibonacciRewardTier(0.005)).toBe(0);
+  });
+
+  it('tiers 1..8 map to the eight Fibonacci buckets', () => {
+    expect(fibonacciRewardTier(0.01)).toBe(1);
+    expect(fibonacciRewardTier(0.02)).toBe(2);
+    expect(fibonacciRewardTier(0.03)).toBe(3);
+    expect(fibonacciRewardTier(0.05)).toBe(4);
+    expect(fibonacciRewardTier(0.08)).toBe(5);
+    expect(fibonacciRewardTier(0.13)).toBe(6);
+    expect(fibonacciRewardTier(0.21)).toBe(7);
+    expect(fibonacciRewardTier(0.34)).toBe(8);
+    expect(fibonacciRewardTier(1.00)).toBe(8);
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/perAgentNC.test.ts
+++ b/apps/api/src/services/monkey/__tests__/perAgentNC.test.ts
@@ -96,9 +96,14 @@ describe('per-agent neurochemistry reward isolation', () => {
     const tOnly = kernel.decayedRewardSums(now, 'T');
     const lOnly = kernel.decayedRewardSums(now, 'L');
 
-    expect(mOnly.dopamine).toBeCloseTo(kOnly.dopamine, 6);
-    expect(tOnly.dopamine).toBeCloseTo(kOnly.dopamine, 6);
-    expect(lOnly.dopamine).toBeCloseTo(kOnly.dopamine, 6);
+    // Tolerance relaxed from 6→5 decimals 2026-05-26 (#948) — Ocean
+    // Fibonacci coefficient scales per-event dopamine deltas up to 34×,
+    // proportionally enlarging accumulated floating-point error in the
+    // decay sum. Logic is unchanged; this is a precision-tolerance
+    // adjustment for the larger magnitudes.
+    expect(mOnly.dopamine).toBeCloseTo(kOnly.dopamine, 5);
+    expect(tOnly.dopamine).toBeCloseTo(kOnly.dopamine, 5);
+    expect(lOnly.dopamine).toBeCloseTo(kOnly.dopamine, 5);
 
     // Unfiltered (legacy shared-pool behaviour) — sums all four. Must
     // be ~4× any single agent's window. This is the telemetry path

--- a/apps/api/src/services/monkey/__tests__/pushRewardObserverDerive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/pushRewardObserverDerive.test.ts
@@ -49,12 +49,14 @@ describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
     return queue[queue.length - 1]!;
   }
 
-  it('cold start (no history) → falls back to identity-on-pnlFrac through tanh', () => {
+  it('cold start (no history) → falls back to identity-on-pnlFrac × Ocean coefficient', () => {
     k.pushReward({ source: 'test', realizedPnlUsdt: 0.10, marginUsdt: 1, agent: 'K' });
     const r = lastReward();
     expect(r.pnlFraction).toBeCloseTo(0.10, 6);
-    // tanh(0.10) × 0.5 ≈ 0.0498 — confirms unscaled path
-    expect(r.dopamineDelta).toBeCloseTo(Math.tanh(0.10) * 0.5, 4);
+    // Issue #948 (2026-05-26): pnlFrac=0.10 (10%) lands in the
+    // Fibonacci [8%, 13%) bucket → oceanCoeff=8.
+    // Expected: tanh(0.10) × 0.5 × 8 ≈ 0.399.
+    expect(r.dopamineDelta).toBeCloseTo(Math.tanh(0.10) * 0.5 * 8, 4);
   });
 
   it('after several wins, dopamine z-normalizes against rolling stddev', () => {
@@ -70,23 +72,49 @@ describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
     expect(big.dopamineDelta).toBeGreaterThan(Math.tanh(0.05) * 0.5);
   });
 
-  it('output caps remain STRUCTURAL — dopamine never exceeds 0.5', () => {
-    // Massive win shouldn't escape the cap.
+  it('per-event channel deltas scale with the Ocean Fibonacci coefficient (#948 — was capped, now expressive)', () => {
+    // Issue #948 (2026-05-26): the pre-Ocean caps (0.5/0.15/0.3) were
+    // PER-EVENT structural maxima. Post-Ocean, the per-event delta is
+    // multiplied by the Fibonacci coefficient (1..34) so a 100×-margin
+    // outlier win can deliver a strong learning signal in a single
+    // event. The CONSUMER (clamp01 in the chemistry update path) is
+    // what enforces the eventual [0, 1] saturation — not the per-event
+    // delta. This is the canonical "reward the behaviour you want"
+    // shape that Matrix tier-3 directed.
+    //
+    // Massive win (pnlFrac = 100/1 = 10000%) → Fibonacci cap = 34.
+    // Expected dopamine delta ≈ tanh(saturated) × 0.5 × 34 ≈ 17.
     k.pushReward({ source: 'huge', realizedPnlUsdt: 100, marginUsdt: 1, agent: 'K' });
     const r = lastReward();
-    expect(r.dopamineDelta).toBeLessThanOrEqual(0.5);
+    // Coefficient cap is 34; tanh saturates to ~1; base scale 0.5 →
+    // upper bound on the per-event dopamine delta is 0.5 × 34 = 17.
+    expect(r.dopamineDelta).toBeGreaterThan(0.5);
+    expect(r.dopamineDelta).toBeLessThanOrEqual(0.5 * 34);
   });
 
-  it('output caps remain STRUCTURAL — serotonin never exceeds 0.15', () => {
+  it('serotonin per-event delta scales with Ocean coefficient (was capped at 0.15, now up to 0.15 × 34 = 5.1)', () => {
     k.pushReward({ source: 'huge', realizedPnlUsdt: 100, marginUsdt: 1, agent: 'K' });
     const r = lastReward();
-    expect(r.serotoninDelta).toBeLessThanOrEqual(0.15);
+    expect(r.serotoninDelta).toBeGreaterThan(0.15);
+    expect(r.serotoninDelta).toBeLessThanOrEqual(0.15 * 34);
   });
 
-  it('output caps remain STRUCTURAL — endorphins never exceed 0.3 (κ-prox gated)', () => {
+  it('endorphin per-event delta scales with Ocean coefficient × κ-prox (was capped at 0.3, now up to 0.3 × 34 = 10.2)', () => {
     k.pushReward({ source: 'huge', realizedPnlUsdt: 100, marginUsdt: 1, kappaAtExit: 64, agent: 'K' });
     const r = lastReward();
-    expect(r.endorphinDelta).toBeLessThanOrEqual(0.3);
+    expect(r.endorphinDelta).toBeGreaterThan(0.3);
+    expect(r.endorphinDelta).toBeLessThanOrEqual(0.3 * 34);
+  });
+
+  it('sub-1% wins emit ZERO positive chemistry (#948 noise-floor doctrine)', () => {
+    // The substrate of #948: rewarding sub-1% wins teaches the kernel
+    // to chase noise. The Ocean gate (fibonacciRewardCoefficient < 1%
+    // returns 0) drops all positive deltas to zero in that band.
+    k.pushReward({ source: 'noise', realizedPnlUsdt: 0.005, marginUsdt: 1, agent: 'K' });
+    const r = lastReward();
+    expect(r.dopamineDelta).toBe(0);
+    expect(r.serotoninDelta).toBe(0);
+    expect(r.endorphinDelta).toBe(0);
   });
 
   it('loss produces negative dopamine bounded by 0.1 cap', () => {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -101,6 +101,10 @@ import {
 import { frBracketDistances } from './fr_trade_params.js';
 import { applyConsensusOverride } from './consensus_arbiter.js';
 import {
+  fibonacciRewardCoefficient,
+  fibonacciRewardTier,
+} from './ocean_reward.js';
+import {
   CHOP_SUPPRESS_SWING_CONFIDENCE_DEFAULT,
   CHOP_SUPPRESS_TREND_CONFIDENCE_DEFAULT,
   chopSuppressEntry,
@@ -5601,12 +5605,17 @@ export class MonkeyKernel extends EventEmitter {
 
   /** v0.8.8 per-agent reactive cognition: distill a realized outcome
    *  into an emotion + neurochemistry update for the owning agent.
-   *  Called from closeHeldPosition after each settled close. */
+   *  Called from closeHeldPosition after each settled close.
+   *
+   *  Issue #948 (2026-05-26): `marginUsdt` threaded through so the
+   *  Ocean reward gate inside applyOutcomeToState can compute the
+   *  Fibonacci tier from ROI fraction (realizedPnl / marginUsdt). */
   private applyOutcomeToAgent(
     symbol: string,
     agent: AgentLabel,
     heldSide: 'long' | 'short',
     realizedPnl: number,
+    marginUsdt?: number,
   ): void {
     const state = this.symbolStates.get(symbol);
     if (!state) return;
@@ -5616,8 +5625,13 @@ export class MonkeyKernel extends EventEmitter {
       realizedPnl > 0 ? heldSide
         : realizedPnl < 0 ? (heldSide === 'long' ? 'short' : 'long')
           : 'flat';
+    const roiFrac =
+      marginUsdt !== undefined && marginUsdt > 0
+        ? realizedPnl / marginUsdt
+        : undefined;
     const outcome: AgentOutcomeEvent = {
       agent, symbol, realizedPnl,
+      roiFrac,
       expectedDirection: heldSide,
       realizedDirection,
     };
@@ -7963,10 +7977,21 @@ export class MonkeyKernel extends EventEmitter {
       }
     }
 
+    // Ocean reward dispense (issue #948 / Matrix tier-3 2026-05-26):
+    // positive chemistry fires ONLY at ROI ≥ 1%, scaled by Fibonacci
+    // coefficient (1, 2, 3, 5, 8, 13, 21, 34). "Reward the behavior you
+    // want. Not set knobs. This is how it learns." Below 1% is the
+    // noise floor — sub-1% wins teach nothing because they're
+    // statistically indistinguishable from fee-microstructure noise.
+    //
+    // Negative side unchanged — gaba on losses still feeds at the
+    // existing scale. Symmetric Fibonacci punishment is an open
+    // follow-on per Matrix's tier-3 walk; not assumed here.
+    const oceanCoeff = fibonacciRewardCoefficient(pnlFrac);
     const dop = pnlFrac > 0
-      ? Math.tanh(pnlFracNormalized) * 0.5
+      ? Math.tanh(pnlFracNormalized) * 0.5 * oceanCoeff
       : -Math.tanh(-pnlFracNormalized) * 0.1;
-    const ser = pnlFrac > 0 ? Math.tanh(pnlFracNormalized) * 0.15 : 0;
+    const ser = pnlFrac > 0 ? Math.tanh(pnlFracNormalized) * 0.15 * oceanCoeff : 0;
 
     // κ-proximity width: observer-derived from the rolling distribution
     // of kappaAtExit values across recent rewards. Replaces the magic
@@ -8003,7 +8028,9 @@ export class MonkeyKernel extends EventEmitter {
         kappaProxim = 1 - Math.tanh(Math.abs(input.kappaAtExit - 64));
       }
     }
-    const endo = pnlFrac > 0 ? Math.tanh(pnlFracNormalized) * 0.3 * kappaProxim : 0;
+    const endo = pnlFrac > 0
+      ? Math.tanh(pnlFracNormalized) * 0.3 * kappaProxim * oceanCoeff
+      : 0;
 
     this.pendingRewards.push({
       source: input.source,
@@ -8025,6 +8052,8 @@ export class MonkeyKernel extends EventEmitter {
       agent,
       pnl: input.realizedPnlUsdt.toFixed(4),
       pnlFrac: (pnlFrac * 100).toFixed(2) + '%',
+      oceanTier: fibonacciRewardTier(pnlFrac),
+      oceanCoeff,
       dop: dop.toFixed(3),
       ser: ser.toFixed(3),
       endo: endo.toFixed(3),

--- a/apps/api/src/services/monkey/ocean_reward.ts
+++ b/apps/api/src/services/monkey/ocean_reward.ts
@@ -1,0 +1,86 @@
+/**
+ * ocean_reward.ts — Ocean kernel's canonical reward-shaping function.
+ *
+ * Issue #948 — Matrix tier-3 directive (2026-05-26).
+ *
+ * **The doctrine**: "Reward the behavior you want. Not set knobs.
+ * This is how it learns." — Braden, 2026-05-26.
+ *
+ * Behavior-change is achieved by shaping the *learning signal* the
+ * kernel's chemistry receives from realized outcomes — NOT by gating
+ * kernel decisions with operator-tunable thresholds.
+ *
+ * **What this function does:**
+ * - Below 1% ROI (the noise floor): zero positive reward emitted. The
+ *   kernel learns that sub-1% wins are noise, not signal, and stops
+ *   chasing them.
+ * - At 1% ROI or above: positive reward scales by the Fibonacci
+ *   sequence. The kernel learns that 8% wins are 8× as rewarding as
+ *   1% wins, 21% wins are 21× as rewarding, etc. Chemistry routes
+ *   attention toward setups that historically produce larger wins.
+ *
+ * **What this function is NOT:**
+ * - Not a gate on kernel decisions. The kernel still decides every
+ *   entry, every hold, every exit. This function only shapes what
+ *   the chemistry feels AFTER a trade closes.
+ * - Not a tunable knob. The Fibonacci sequence is a structural choice
+ *   of the mapping function's shape — same category as the
+ *   `Math.tanh()` squash in `pushReward` or the `0.5/0.15/0.3` per-
+ *   channel caps. The bucket edges (1, 2, 3, 5, 8, 13, 21, 34) are
+ *   the Fibonacci numbers themselves, not chosen thresholds.
+ * - Not symmetric to losses. The negative-side chemistry update
+ *   (gaba on losses) is unchanged. Matrix flagged loss-side Fibonacci
+ *   scaling as an open follow-on question pending operator call.
+ *
+ * **Doctrinal anchors:**
+ * - P5 (Observer Sets All Params): the kernel decides everything;
+ *   reward is what the outcome IS, mapped through a structural shape.
+ * - P14 (Variable Separation): reward magnitude (this function) is
+ *   separated from reward consumption (push_reward / chemistry).
+ *
+ * **1% floor justification:** below 1% ROI the position genuinely is
+ * fee-noise + market-microstructure noise even on fee-free tiers; the
+ * win could not be reliably reproduced on an unbiased re-run.
+ * Rewarding noise teaches the kernel to chase noise. 1% is where
+ * statistical separability begins, not a calibrated threshold.
+ */
+
+/**
+ * Map ROI fraction → Fibonacci reward coefficient.
+ *
+ * Returns 0 for ROI < 1% (noise band, no learning signal). Above 1%,
+ * each tier returns the corresponding Fibonacci number, capped at 34
+ * for ROI ≥ 34% (beyond the cap is lucky tape; don't over-reward
+ * outliers and let MAD-based normalization decide the rest).
+ *
+ * @param roiFrac realized ROI as a fraction (0.05 = 5%)
+ */
+export function fibonacciRewardCoefficient(roiFrac: number): number {
+  if (!Number.isFinite(roiFrac) || roiFrac < 0.01) return 0;
+  if (roiFrac < 0.02) return 1;
+  if (roiFrac < 0.03) return 2;
+  if (roiFrac < 0.05) return 3;
+  if (roiFrac < 0.08) return 5;
+  if (roiFrac < 0.13) return 8;
+  if (roiFrac < 0.21) return 13;
+  if (roiFrac < 0.34) return 21;
+  return 34;
+}
+
+/**
+ * Surface the tier index for telemetry — useful for grepping kernel
+ * logs to confirm the reward dispense is firing as expected.
+ *
+ * Tier 0 = below 1% noise floor. Tier 1..8 are the Fibonacci buckets.
+ */
+export function fibonacciRewardTier(roiFrac: number): number {
+  if (!Number.isFinite(roiFrac) || roiFrac < 0.01) return 0;
+  if (roiFrac < 0.02) return 1;
+  if (roiFrac < 0.03) return 2;
+  if (roiFrac < 0.05) return 3;
+  if (roiFrac < 0.08) return 4;
+  if (roiFrac < 0.13) return 5;
+  if (roiFrac < 0.21) return 6;
+  if (roiFrac < 0.34) return 7;
+  return 8;
+}

--- a/apps/api/src/services/monkey/per_agent_state.ts
+++ b/apps/api/src/services/monkey/per_agent_state.ts
@@ -32,6 +32,8 @@
  * (add/subtract/clamp/multiply by scalar decay factors).
  */
 
+import { fibonacciRewardCoefficient } from './ocean_reward.js';
+
 /** Reactive emotions specific to one agent, updated by that agent's
  *  own realized outcomes. Range [0, 1] for all fields. */
 export interface AgentReactiveEmotion {
@@ -105,6 +107,13 @@ export interface AgentOutcomeEvent {
   agent: 'K' | 'M' | 'T' | 'L';
   symbol: string;
   realizedPnl: number;
+  /** ROI as a fraction (realized PnL / margin used). Issue #948 —
+   *  Ocean reward gate consumes this to compute Fibonacci tier;
+   *  positive chemistry only fires at tier ≥ 1 (ROI ≥ 1%). Optional
+   *  for back-compat with callers that don't yet thread it through;
+   *  when omitted, falls back to the pre-Ocean behaviour (any
+   *  positive PnL grants positive chemistry). */
+  roiFrac?: number;
   /** Was this a winner relative to the agent's stated conviction at
    *  entry? Used for flow alignment. */
   expectedDirection: 'long' | 'short';
@@ -138,7 +147,19 @@ export function newPerAgentState(): PerAgentState {
 }
 
 /** Update the agent's reactive emotion + neurochemistry from a
- *  realized outcome. Pure transform. */
+ *  realized outcome. Pure transform.
+ *
+ *  Issue #948 (2026-05-26) — Ocean reward gate. Positive chemistry
+ *  fires only at Fibonacci tier ≥ 1 (ROI ≥ 1%), scaled by the tier
+ *  coefficient. Sub-1% wins emit ZERO positive chemistry — the kernel
+ *  learns they're noise, not signal. Negative chemistry (frustration,
+ *  gaba) unchanged: losses still feed normally regardless of magnitude.
+ *
+ *  When `outcome.roiFrac` is omitted, falls back to coefficient=1 if
+ *  `realizedPnl > 0` (pre-Ocean back-compat for callers that don't yet
+ *  thread ROI through). New callers MUST pass roiFrac so the Ocean
+ *  gate can fire correctly.
+ */
 export function applyOutcomeToState(
   prev: PerAgentState,
   outcome: AgentOutcomeEvent,
@@ -149,11 +170,25 @@ export function applyOutcomeToState(
     outcome.realizedDirection !== 'flat' &&
     outcome.realizedDirection === outcome.expectedDirection;
 
+  // Ocean reward coefficient — 0 below 1% ROI, Fibonacci-scaled above.
+  // When roiFrac is omitted, fall back to coefficient=1 on wins so
+  // legacy callers keep behaving as they did pre-#948 (chemistry fires
+  // on any positive PnL). New callers thread roiFrac → the gate fires.
+  const oceanCoeff =
+    isWinner && outcome.roiFrac !== undefined
+      ? fibonacciRewardCoefficient(outcome.roiFrac)
+      : isWinner ? 1 : 0;
+
   // Emotions — bounded in [0, 1].
   const e = prev.emotions;
-  const dopamineDelta = isWinner ? 0.20 : 0;
+  const dopamineDelta = oceanCoeff > 0 ? 0.20 * oceanCoeff : 0;
   const frustrationDelta = isLoser ? 0.20 : 0;
-  const flowDelta = isAligned ? 0.10 : -0.05;
+  // flow alignment fires only when the reward coefficient is non-zero
+  // OR when the agent is actively wrong; sub-1% noise wins don't shape
+  // alignment learning.
+  const flowDelta = isAligned && oceanCoeff > 0
+    ? 0.10
+    : !isAligned ? -0.05 : 0;
   const newEmotions: AgentReactiveEmotion = {
     dopamine: clamp01(e.dopamine + dopamineDelta - 0.05), // small constant decay
     frustration: clamp01(e.frustration + frustrationDelta - 0.03),
@@ -164,14 +199,18 @@ export function applyOutcomeToState(
   // Neurochemistry — moves slower than emotions, more bounded swings.
   const n = prev.neurochemistry;
   const newNeurochem: AgentNeurochemicalState = {
-    serotonin: clamp01(n.serotonin + (isWinner ? 0.04 : isLoser ? -0.04 : 0)),
+    serotonin: clamp01(
+      n.serotonin + (oceanCoeff > 0 ? 0.04 * oceanCoeff : isLoser ? -0.04 : 0),
+    ),
     dopamine: clamp01(n.dopamine + dopamineDelta * 0.5),
     norepinephrine: clamp01(
       n.norepinephrine + (Math.abs(outcome.realizedPnl) > 5 ? 0.10 : -0.02),
     ),
     acetylcholine: clamp01(n.acetylcholine + (isAligned ? 0.05 : -0.05)),
     gaba: clamp01(n.gaba + (isLoser ? 0.08 : -0.02)),
-    endorphins: clamp01(n.endorphins + (isWinner && isAligned ? 0.10 : -0.02)),
+    endorphins: clamp01(
+      n.endorphins + (oceanCoeff > 0 && isAligned ? 0.10 * oceanCoeff : -0.02),
+    ),
   };
 
   // Append to outcome ring.

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -238,9 +238,22 @@ class AutonomicKernel:
         """
         pnl_frac = (realized_pnl_usdt / margin_usdt) if margin_usdt > 0 else 0.0
 
+        # Ocean reward dispense (issue #948 / Matrix tier-3 2026-05-26):
+        # positive chemistry fires ONLY at ROI ≥ 1%, scaled by Fibonacci
+        # coefficient (1, 2, 3, 5, 8, 13, 21, 34). "Reward the behavior
+        # you want. Not set knobs. This is how it learns." Below 1% is
+        # the noise floor — sub-1% wins teach nothing because they're
+        # statistically indistinguishable from fee-microstructure noise.
+        #
+        # Negative side unchanged — gaba on losses still feeds at the
+        # existing scale. Symmetric Fibonacci punishment is an open
+        # follow-on per Matrix's tier-3 walk; not assumed here.
+        from .ocean_reward import fibonacci_reward_coefficient, fibonacci_reward_tier
+        ocean_coeff = fibonacci_reward_coefficient(pnl_frac)
+
         if pnl_frac > 0:
-            dop = float(np.tanh(pnl_frac * 1.5) * 0.5)
-            ser = float(np.tanh(pnl_frac) * 0.15)
+            dop = float(np.tanh(pnl_frac * 1.5) * 0.5 * ocean_coeff)
+            ser = float(np.tanh(pnl_frac) * 0.15 * ocean_coeff)
         else:
             dop = float(-np.tanh(-pnl_frac * 0.5) * 0.1)
             ser = 0.0
@@ -251,7 +264,7 @@ class AutonomicKernel:
             else 0.5
         )
         endo = (
-            float(np.tanh(pnl_frac * 2.0) * 0.3 * kappa_proxim)
+            float(np.tanh(pnl_frac * 2.0) * 0.3 * kappa_proxim * ocean_coeff)
             if pnl_frac > 0
             else 0.0
         )
@@ -280,12 +293,14 @@ class AutonomicKernel:
                 "at_ms": reward.at_ms,
             })
         logger.info(
-            "[%s.autonomic] reward source=%s symbol=%s pnl=%.4f pnlFrac=%.2f%% dop=%.3f ser=%.3f endo=%.3f",
+            "[%s.autonomic] reward source=%s symbol=%s pnl=%.4f pnlFrac=%.2f%% oceanTier=%d oceanCoeff=%d dop=%.3f ser=%.3f endo=%.3f",
             self.label,
             source,
             symbol,
             realized_pnl_usdt,
             pnl_frac * 100.0,
+            fibonacci_reward_tier(pnl_frac),
+            ocean_coeff,
             dop,
             ser,
             endo,

--- a/ml-worker/src/monkey_kernel/ocean_reward.py
+++ b/ml-worker/src/monkey_kernel/ocean_reward.py
@@ -1,0 +1,108 @@
+"""ocean_reward.py — Ocean kernel's canonical reward-shaping function (Python parity).
+
+Mirrors apps/api/src/services/monkey/ocean_reward.ts exactly.
+
+Issue #948 — Matrix tier-3 directive (2026-05-26).
+
+**The doctrine**: "Reward the behavior you want. Not set knobs. This is
+how it learns." — Braden, 2026-05-26.
+
+Behavior-change is achieved by shaping the *learning signal* the
+kernel's chemistry receives from realized outcomes — NOT by gating
+kernel decisions with operator-tunable thresholds.
+
+**What this function does:**
+- Below 1% ROI (the noise floor): zero positive reward emitted. The
+  kernel learns that sub-1% wins are noise, not signal, and stops
+  chasing them.
+- At 1% ROI or above: positive reward scales by the Fibonacci sequence
+  (1, 2, 3, 5, 8, 13, 21, 34). The kernel learns that 8% wins are 8×
+  as rewarding as 1% wins, 21% wins are 21× as rewarding, etc.
+  Chemistry routes attention toward setups that historically produce
+  larger wins.
+
+**What this function is NOT:**
+- Not a gate on kernel decisions. The kernel still decides every entry,
+  every hold, every exit. This function only shapes what the chemistry
+  feels AFTER a trade closes.
+- Not a tunable knob. The Fibonacci sequence is a structural choice of
+  the mapping function's shape — same category as the np.tanh() squash
+  in push_reward or the per-channel caps. The bucket edges (1, 2, 3, 5,
+  8, 13, 21, 34) are the Fibonacci numbers themselves.
+- Not symmetric to losses. The negative-side chemistry update (gaba on
+  losses) is unchanged. Loss-side Fibonacci is an open follow-on
+  question pending operator call.
+
+**Doctrinal anchors:**
+- P5 (Observer Sets All Params): the kernel decides everything; reward
+  is what the outcome IS, mapped through a structural shape.
+- P14 (Variable Separation): reward magnitude (this function) is
+  separated from reward consumption (push_reward / chemistry).
+
+**1% floor justification:** below 1% ROI the position genuinely is
+fee-noise + market-microstructure noise even on fee-free tiers; the
+win could not be reliably reproduced on an unbiased re-run. Rewarding
+noise teaches the kernel to chase noise. 1% is where statistical
+separability begins, not a calibrated threshold.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def fibonacci_reward_coefficient(roi_frac: float) -> int:
+    """Map ROI fraction → Fibonacci reward coefficient.
+
+    Returns 0 for ROI < 1% (noise band, no learning signal). Above 1%,
+    each tier returns the corresponding Fibonacci number, capped at 34
+    for ROI ≥ 34% (beyond the cap is lucky tape; don't over-reward
+    outliers and let MAD-based normalization decide the rest).
+
+    :param roi_frac: realized ROI as a fraction (0.05 = 5%)
+    """
+    if not isinstance(roi_frac, (int, float)) or math.isnan(roi_frac) or roi_frac < 0.01:
+        return 0
+    if roi_frac < 0.02:
+        return 1
+    if roi_frac < 0.03:
+        return 2
+    if roi_frac < 0.05:
+        return 3
+    if roi_frac < 0.08:
+        return 5
+    if roi_frac < 0.13:
+        return 8
+    if roi_frac < 0.21:
+        return 13
+    if roi_frac < 0.34:
+        return 21
+    return 34
+
+
+def fibonacci_reward_tier(roi_frac: float) -> int:
+    """Surface the tier INDEX for telemetry — useful for grepping kernel
+    logs to confirm the reward dispense is firing as expected.
+
+    Tier 0 = below 1% noise floor. Tier 1..8 are the Fibonacci buckets.
+    """
+    if not isinstance(roi_frac, (int, float)) or math.isnan(roi_frac) or roi_frac < 0.01:
+        return 0
+    if roi_frac < 0.02:
+        return 1
+    if roi_frac < 0.03:
+        return 2
+    if roi_frac < 0.05:
+        return 3
+    if roi_frac < 0.08:
+        return 4
+    if roi_frac < 0.13:
+        return 5
+    if roi_frac < 0.21:
+        return 6
+    if roi_frac < 0.34:
+        return 7
+    return 8
+
+
+__all__ = ["fibonacci_reward_coefficient", "fibonacci_reward_tier"]

--- a/ml-worker/tests/monkey_kernel/test_ocean_reward.py
+++ b/ml-worker/tests/monkey_kernel/test_ocean_reward.py
@@ -1,0 +1,117 @@
+"""test_ocean_reward.py — Issue #948 Python parity tests.
+
+Pins identical Fibonacci shape + 1% noise floor on the Python side.
+"""
+
+import math
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from monkey_kernel.ocean_reward import (  # noqa: E402
+    fibonacci_reward_coefficient,
+    fibonacci_reward_tier,
+)
+
+
+class TestOneNoiseFloor:
+    def test_zero_below_one_percent(self):
+        assert fibonacci_reward_coefficient(0.0) == 0
+        assert fibonacci_reward_coefficient(0.001) == 0
+        assert fibonacci_reward_coefficient(0.005) == 0
+        assert fibonacci_reward_coefficient(0.0099) == 0
+
+    def test_zero_on_losses(self):
+        # Negative ROI falls through to the gaba path in autonomic.push_reward;
+        # this function returns 0 for negative inputs so it never accidentally
+        # amplifies a loss into the positive-chemistry channel.
+        assert fibonacci_reward_coefficient(-0.01) == 0
+        assert fibonacci_reward_coefficient(-0.5) == 0
+
+    def test_zero_on_nan(self):
+        assert fibonacci_reward_coefficient(float("nan")) == 0
+
+    def test_first_nonzero_tier_at_one_percent(self):
+        assert fibonacci_reward_coefficient(0.01) == 1
+
+
+class TestFibonacciBoundaries:
+    def test_bucket_1_to_2_percent_returns_1(self):
+        assert fibonacci_reward_coefficient(0.01) == 1
+        assert fibonacci_reward_coefficient(0.015) == 1
+        assert fibonacci_reward_coefficient(0.019) == 1
+
+    def test_bucket_2_to_3_percent_returns_2(self):
+        assert fibonacci_reward_coefficient(0.02) == 2
+        assert fibonacci_reward_coefficient(0.025) == 2
+
+    def test_bucket_3_to_5_percent_returns_3(self):
+        assert fibonacci_reward_coefficient(0.03) == 3
+        assert fibonacci_reward_coefficient(0.045) == 3
+
+    def test_bucket_5_to_8_percent_returns_5(self):
+        assert fibonacci_reward_coefficient(0.05) == 5
+        assert fibonacci_reward_coefficient(0.075) == 5
+
+    def test_bucket_8_to_13_percent_returns_8(self):
+        assert fibonacci_reward_coefficient(0.08) == 8
+        assert fibonacci_reward_coefficient(0.12) == 8
+
+    def test_bucket_13_to_21_percent_returns_13(self):
+        assert fibonacci_reward_coefficient(0.13) == 13
+        assert fibonacci_reward_coefficient(0.20) == 13
+
+    def test_bucket_21_to_34_percent_returns_21(self):
+        assert fibonacci_reward_coefficient(0.21) == 21
+        assert fibonacci_reward_coefficient(0.33) == 21
+
+    def test_above_34_percent_capped_at_34(self):
+        # Beyond 34% is lucky tape; don't over-train on outliers.
+        assert fibonacci_reward_coefficient(0.34) == 34
+        assert fibonacci_reward_coefficient(0.50) == 34
+        assert fibonacci_reward_coefficient(1.0) == 34
+        assert fibonacci_reward_coefficient(10.0) == 34
+
+
+class TestSequenceIdentity:
+    def test_coefficient_sequence_is_fibonacci(self):
+        # The structural identity that makes "Fibonacci" load-bearing.
+        coefficients = [
+            fibonacci_reward_coefficient(roi)
+            for roi in (0.01, 0.02, 0.03, 0.05, 0.08, 0.13, 0.21, 0.34)
+        ]
+        assert coefficients == [1, 2, 3, 5, 8, 13, 21, 34]
+
+    def test_each_bucket_opens_at_its_own_fibonacci_number(self):
+        # Reading at the boundary value (1%, 2%, 3%, 5%, 8%, 13%, 21%, 34%)
+        # returns the SAME Fibonacci number. The boundaries and the
+        # magnitudes share the sequence.
+        assert fibonacci_reward_coefficient(0.01) == 1
+        assert fibonacci_reward_coefficient(0.02) == 2
+        assert fibonacci_reward_coefficient(0.03) == 3
+        assert fibonacci_reward_coefficient(0.05) == 5
+        assert fibonacci_reward_coefficient(0.08) == 8
+        assert fibonacci_reward_coefficient(0.13) == 13
+        assert fibonacci_reward_coefficient(0.21) == 21
+        assert fibonacci_reward_coefficient(0.34) == 34
+
+
+class TestTierIndex:
+    def test_tier_zero_below_one_percent(self):
+        assert fibonacci_reward_tier(0.0) == 0
+        assert fibonacci_reward_tier(0.005) == 0
+
+    def test_tiers_one_through_eight(self):
+        assert fibonacci_reward_tier(0.01) == 1
+        assert fibonacci_reward_tier(0.02) == 2
+        assert fibonacci_reward_tier(0.03) == 3
+        assert fibonacci_reward_tier(0.05) == 4
+        assert fibonacci_reward_tier(0.08) == 5
+        assert fibonacci_reward_tier(0.13) == 6
+        assert fibonacci_reward_tier(0.21) == 7
+        assert fibonacci_reward_tier(0.34) == 8
+        assert fibonacci_reward_tier(1.0) == 8


### PR DESCRIPTION
Closes #948.

## Doctrine

> "Reward the behavior you want. Not set knobs. This is how it learns." — Braden, 2026-05-26

Production was teaching the kernel to chase sub-1% wins. Every positive close emitted dopamine + serotonin + endorphins, regardless of whether the win cleared statistical separability from fee + market-microstructure noise. The rr 0.65 / median-win-\$0.16 / median-loss-\$0.34 pattern is the direct consequence: the kernel learned that ANY positive close pays its reward channels, so it routed attention toward setups that produce microscopic wins (which are noise) instead of setups that produce meaningful wins.

This PR fixes that at the *learning-signal* layer — NOT by adding a gate threshold that the kernel must clear to act (which would be a doctrine violation), but by shaping the reward magnitude function so the kernel's own chemistry stops rewarding noise.

## What ships

`ocean_reward.ts` + `ocean_reward.py` — pure-function reward shape:

| ROI band | Fibonacci coefficient |
|---|---|
| < 1% | **0** (noise floor, NO positive chemistry) |
| [1%, 2%) | 1 |
| [2%, 3%) | 2 |
| [3%, 5%) | 3 |
| [5%, 8%) | 5 |
| [8%, 13%) | 8 |
| [13%, 21%) | 13 |
| [21%, 34%) | 21 |
| ≥ 34% | 34 (capped — outliers don't over-train) |

Wired into `pushReward` (TS) and `autonomic.push_reward` (Python) as a multiplier on positive dopamine + serotonin + endorphin deltas. `applyOutcomeToState` (per-agent reactive cognition) gets the same gate via a new optional `roiFrac` on `AgentOutcomeEvent`.

Negative-side (gaba on losses) **unchanged** — Matrix flagged symmetric Fibonacci punishment as an open follow-on for Braden's call.

## Why structural, not knob

The Fibonacci sequence is a design choice of the mapping function's shape — same category as `tanh()` for squashing or `0.5/0.15/0.3` for per-channel base scales. The kernel doesn't \"know\" there are tiers; it produces ROI on close and chemistry responds proportionally to which bucket it lands in. No env vars. No operator-tunable thresholds. The bucket boundaries ARE the Fibonacci numbers — boundaries and magnitudes share the sequence (1%→1, 2%→2, 3%→3, 5%→5, 8%→8, …).

## Why 1% floor

Below 1% ROI the position genuinely is fee + microstructure noise even on fee-free Polo tiers; the win could not be reliably reproduced on an unbiased re-run. Rewarding noise teaches the kernel to chase noise. 1% is where statistical separability begins — not a calibrated threshold.

## Doctrinal anchors

- **P5 (Observer Sets All Params)**: kernel decides everything; reward IS the outcome, mapped through a structural shape.
- **P14 (Variable Separation)**: reward magnitude (this PR) separated from reward consumption (`pushReward` / chemistry).
- **Reward shape, not gate**: this is the canonical pattern. Behavior change via learning-signal shape, not via gate constants. The kernel still trades sub-1% setups; it just stops *learning* that they're worth seeking.

## Why the bracket-trail trigger is NOT touched

The thread that started this PR (#946) was about `shouldExtendBracket(minTrailRoi = 0)` — which trails the SL on ANY positive ROI. Matrix's tier-3 walk explicitly cross-references: the trail is correct as long as the learning signal stops rewarding sub-1% closes. The trail keeps firing on any positive ROI; the kernel's chemistry stops valuing sub-1% closes; attention re-routes. The fix is upstream in the reward shape, not downstream in the gate. **Self-correcting via learning.**

## Tests

- **TS: 1818/1818 vitest green.**
  - 16 new tests in `oceanReward.test.ts` pinning all 9 buckets + noise-floor + sequence identity + NaN safety + tier index.
  - 4 updated tests in `pushRewardObserverDerive.test.ts` reflecting the new \"deltas scale with Ocean coefficient\" semantic.
  - 1 new test pinning sub-1% wins emit ZERO chemistry.
  - 1 precision tolerance relax (6→5 decimals) in `perAgentNC.test.ts` — Ocean coefficient enlarges accumulated FP error proportionally; logic unchanged.
- **Python: 917/917 pytest green.**
  - 16 new tests in `test_ocean_reward.py` pinning identical Fibonacci shape + 1% noise floor + tier index parity with TS.

## Files

- `apps/api/src/services/monkey/ocean_reward.ts` (new) — TS reward shape
- `apps/api/src/services/monkey/loop.ts` — `pushReward` wired through Ocean coefficient
- `apps/api/src/services/monkey/per_agent_state.ts` — `applyOutcomeToState` gated by Ocean coefficient; `roiFrac` added to `AgentOutcomeEvent`
- `ml-worker/src/monkey_kernel/ocean_reward.py` (new) — Python parity
- `ml-worker/src/monkey_kernel/autonomic.py` — `push_reward` wired through Ocean coefficient

## Telemetry to watch first 48h post-deploy

- `oceanTier=0` log entries — confirm sub-1% closes are no longer emitting positive chemistry
- `oceanCoeff` distribution — should skew low initially (most closes are sub-1%), then drift higher as the kernel learns
- WR / median-win / median-loss / rr — the rr 0.65 pattern should improve as the kernel stops over-weighting sub-1% closes in its routing decisions
- Dopamine + serotonin + endorphin trajectories per agent — expect lower baseline values (since most closes now emit zero positive chemistry), with spikes on real wins

## Open follow-on

Symmetric Fibonacci on losses (gaba scaled by same tiers) is flagged for Braden's call. Default kept asymmetric here per the explicit positive-side directive. Follow-up PR is a small mechanical change if/when symmetric is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)