### PR TITLE
fix(monkey): stringify tradeId at insertKernelPrediction boundaries (TS2322 hotfix)

### DIFF
--- a/apps/api/src/services/monkey/basin_sync_redis_bridge.ts
+++ b/apps/api/src/services/monkey/basin_sync_redis_bridge.ts
@@ -58,6 +58,9 @@ interface BasinSyncWritePayload {
 }
 
 interface PredictionWritePayload {
+  // trade_id is a UUID string in the new schema (#949 / migration 059).
+  // Legacy `number` type permitted only to absorb stale Redis payloads
+  // emitted before the UUID migration — coerced via tradeIdParam below.
   trade_id?: string | number | null;
   kernel_id: string;
   perception_basin: number[];
@@ -205,8 +208,14 @@ async function handlePredictionMessage(raw: string): Promise<void> {
     return;
   }
   try {
+    // #949 narrowed KernelPredictionSnapshot.tradeId to string|null (UUID
+    // in the new schema). The Redis bridge inherits a payload type that
+    // still permits `number` for legacy emitters; stringify at the boundary.
     await insertKernelPrediction({
-      tradeId: payload.trade_id ?? null,
+      tradeId:
+        payload.trade_id === null || payload.trade_id === undefined
+          ? null
+          : String(payload.trade_id),
       kernelId: payload.kernel_id,
       perceptionBasin: payload.perception_basin,
       strategyForecastBasin: payload.strategy_forecast_basin,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1390,7 +1390,14 @@ export class MonkeyKernel extends EventEmitter {
     const predictedTerminal = predictedDirection * notional * Math.max(0.000001, Number(input.entryThreshold) || 0);
     const predictedStddev = Math.max(0.000001, Math.abs(predictedTerminal) * (1 - confidence));
     recordKernelPrediction({
-      tradeId: input.tradeId ?? null,
+      // #949 narrowed KernelPredictionSnapshot.tradeId to string|null.
+      // Local input type still permits `number` for callsites that derive
+      // tradeId from `execResult` (could be either at compile time).
+      // Stringify at the boundary to satisfy the snapshot contract.
+      tradeId:
+        input.tradeId === null || input.tradeId === undefined
+          ? null
+          : String(input.tradeId),
       kernelId: this.instanceId,
       perceptionBasin: input.basin,
       strategyForecastBasin: input.strategyForecast,


### PR DESCRIPTION
Production hotfix. TS2322 errors blocking #949 deploy. Stringifies at the 2 call sites. Local build clean. See commit body.

## Summary by Sourcery

Bug Fixes:
- Stringify trade IDs from legacy number or mixed-type sources before calling kernel prediction insert/record functions to align with the new string-based schema.