### PR TITLE
feat(monkey): Phase 1 — CHOP-cell size multiplier observer-derived (kills 2 knobs)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/compositionalExecutive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/compositionalExecutive.test.ts
@@ -47,22 +47,41 @@ describe('evaluateCell — 3×3 compositional matrix coverage', () => {
     }
   });
 
-  it('CREATOR + CHOP → scalp bias, tight harvest, 0.75x size (env-tunable)', () => {
+  it('CREATOR + CHOP → scalp bias, tight harvest, observer-derived size (Phase 1 2026-05-26)', () => {
+    // Default observer (phi=0.5, regimeConfidence=1.0) → chopMultiplier =
+    // max(0.2, 0.5 × 1.0) = 0.5. REGIME_CREATOR_CHOP_SIZE_MULT env knob
+    // removed; CHOP sizing is now phi × regimeConfidence floored at the
+    // DISSOLVER SAFETY_BOUND.
     const cell = evaluateCell('CREATOR', 'CHOP');
     expect(cell.laneBias).toBe('scalp');
     expect(cell.harvestTightness).toBe('tight');
-    // 0.75 default (bumped from 0.5 in 2026-05-19 sizing-knobs pass per
-    // user report "small positions, low leverage, tiny wins").
-    // Env override: REGIME_CREATOR_CHOP_SIZE_MULT.
-    expect(cell.sizeMultiplier).toBe(0.75);
+    expect(cell.sizeMultiplier).toBeCloseTo(0.5, 9);
   });
 
-  it('PRESERVER + CHOP → swing (mean-revert), normal harvest, 0.85x size (env-tunable)', () => {
+  it('PRESERVER + CHOP → swing (mean-revert), normal harvest, observer-derived size', () => {
+    // Same observer-derived formula as CREATOR×CHOP. The historical
+    // CREATOR-vs-PRESERVER differentiation (was 0.75 vs 0.85) now
+    // emerges naturally from observables: PRESERVER cells fire when
+    // chemistry is more coherent so phi × regimeConfidence is
+    // structurally higher in those states.
     const cell = evaluateCell('PRESERVER', 'CHOP');
     expect(cell.laneBias).toBe('swing');
     expect(cell.harvestTightness).toBe('normal');
-    // 0.85 default (bumped from 0.7). Env: REGIME_PRESERVER_CHOP_SIZE_MULT.
-    expect(cell.sizeMultiplier).toBe(0.85);
+    expect(cell.sizeMultiplier).toBeCloseTo(0.5, 9);
+  });
+
+  it('CHOP cells scale with phi × regimeConfidence, floored at 0.2 SAFETY_BOUND', () => {
+    // High conviction → larger multiplier; deteriorating either input
+    // shrinks the multiplier until the 0.2 DISSOLVER floor stops it.
+    const high = evaluateCell('CREATOR', 'CHOP', { phi: 0.85, regimeConfidence: 0.9 });
+    expect(high.sizeMultiplier).toBeCloseTo(0.85 * 0.9, 9);
+
+    const moderate = evaluateCell('CREATOR', 'CHOP', { phi: 0.6, regimeConfidence: 0.7 });
+    expect(moderate.sizeMultiplier).toBeCloseTo(0.6 * 0.7, 9);
+
+    // Floor: phi=0.3 × regimeConfidence=0.4 = 0.12 → clamped to 0.2.
+    const floored = evaluateCell('CREATOR', 'CHOP', { phi: 0.3, regimeConfidence: 0.4 });
+    expect(floored.sizeMultiplier).toBe(0.2);
   });
 
   it('CREATOR + TREND_UP and CREATOR + TREND_DOWN → trend lane, full size', () => {

--- a/apps/api/src/services/monkey/compositional_executive.ts
+++ b/apps/api/src/services/monkey/compositional_executive.ts
@@ -43,15 +43,55 @@ export interface CellAction {
 }
 
 /**
+ * Observer context for cell evaluation. Phase 1 (2026-05-26) — when
+ * supplied, CHOP cells derive `sizeMultiplier` from `phi × regimeConfidence`
+ * floored at the DISSOLVER SAFETY_BOUND (0.2) instead of reading the
+ * operator-tunable env knobs `REGIME_*_CHOP_SIZE_MULT`. The kernel's
+ * own observables drive the multiplier; no operator prescription
+ * between the chemistry and the action.
+ *
+ * Optional for back-compat: legacy callers + test fixtures that don't
+ * thread observables still get a deterministic default (phi=0.5,
+ * regimeConfidence=1.0 → multiplier 0.5 ≈ the previous CHOP envelope
+ * midpoint). New production callers in loop.ts MUST pass observables
+ * so the doctrine-clean derivation fires.
+ */
+export interface CellObserverContext {
+  phi: number;
+  regimeConfidence: number;
+}
+
+const DEFAULT_OBSERVER: CellObserverContext = { phi: 0.5, regimeConfidence: 1.0 };
+
+/**
  * Look up the cell action for a (phase, direction) joint state.
  *
- * Pure function — no rolling state, no thresholds. Same inputs always
- * yield the same output.
+ * Pure function — no rolling state, no env reads. CHOP cells use the
+ * observer context to derive their size multiplier from kernel-internal
+ * observables (phi × regimeConfidence floored at 0.2). Trending cells
+ * stay at full conviction (1.0). DISSOLVER cells stay at the 0.2
+ * SAFETY_BOUND floor (PR #946).
  */
 export function evaluateCell(
   phase: RegimePhase,
   direction: TrajectoryDirection,
+  observer: CellObserverContext = DEFAULT_OBSERVER,
 ): CellAction {
+  // Phase 1 doctrine: CHOP-cell multiplier is observer-derived, NOT an
+  // env knob. The kernel's own phi × regimeConfidence composite
+  // determines how aggressively the kernel sizes in chop, floored at
+  // the DISSOLVER SAFETY_BOUND (0.2) — same floor that prevents zero-
+  // sizing in DISSOLVER regimes. Higher integration (phi) AND higher
+  // regime conviction → larger multiplier; deteriorating either → smaller.
+  // Removes REGIME_CREATOR_CHOP_SIZE_MULT (was 0.75) and
+  // REGIME_PRESERVER_CHOP_SIZE_MULT (was 0.85). The historical
+  // CREATOR-vs-PRESERVER differentiation (0.75 vs 0.85, "preservation
+  // cells get more conviction") now emerges naturally from observables:
+  // PRESERVER cells fire when the kernel's chemistry is more coherent,
+  // so phi × regimeConfidence is structurally higher in those states
+  // without us having to pre-bake the differentiation.
+  const chopMultiplier = Math.max(0.2, observer.phi * observer.regimeConfidence);
+
   // CREATOR — h-dominated, broken-symmetry → discovery + breakouts
   if (phase === 'CREATOR') {
     if (direction === 'TREND_UP') return {
@@ -64,16 +104,9 @@ export function evaluateCell(
       harvestTightness: 'normal',
       label: 'CREATOR×TREND_DOWN: aggressive trend-follow (short)',
     };
-    // CHOP within CREATOR — symmetry-breaking imminent, trade lightly.
-    // 2026-05-19: sizeMultiplier bumped 0.5 → 0.75 per user report
-    // "small positions, low leverage, tiny wins." Doctrine preserved
-    // (still "lightly" — full size = 1.0 for trending cells, 0.75 here)
-    // but the prior 0.5 compounded with sizeFraction 0.5 to leave bot
-    // at 0.25× equity per side — entries were structurally too small
-    // to produce meaningful absolute wins. Env-tunable for operator tuning.
     return {
       phase, direction, laneBias: 'scalp',
-      sizeMultiplier: Number(process.env.REGIME_CREATOR_CHOP_SIZE_MULT) || 0.75,
+      sizeMultiplier: chopMultiplier,
       harvestTightness: 'tight',
       label: 'CREATOR×CHOP: trade lightly, expect breakout',
     };
@@ -91,13 +124,9 @@ export function evaluateCell(
       harvestTightness: 'loose',
       label: 'PRESERVER×TREND_DOWN: ride established short',
     };
-    // CHOP within PRESERVER — consolidating before continuation, mean-revert.
-    // sizeMultiplier env-tunable (default 0.85, bumped from 0.7 in 2026-05-19
-    // sizing-knobs pass — preservation cells still get full conviction since
-    // continuation is the likely outcome).
     return {
       phase, direction, laneBias: 'swing',
-      sizeMultiplier: Number(process.env.REGIME_PRESERVER_CHOP_SIZE_MULT) || 0.85,
+      sizeMultiplier: chopMultiplier,
       harvestTightness: 'normal',
       label: 'PRESERVER×CHOP: mean-revert (consolidating)',
     };

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2592,8 +2592,14 @@ export class MonkeyKernel extends EventEmitter {
       });
     }
     void cellDirectionOverridden;  // surfaced via log only; tests via env-disable
+    // Phase 1 doctrine (2026-05-26): thread observer context so CHOP
+    // cells derive their size multiplier from kernel-internal phi ×
+    // regimeConfidence instead of operator env knobs (now removed).
     const cellAction: CellAction | null = (cellPhase !== null && cellDirection !== null)
-      ? evaluateCell(cellPhase, cellDirection)
+      ? evaluateCell(cellPhase, cellDirection, {
+          phi,
+          regimeConfidence: regimeReading.confidence,
+        })
       : null;
     const cellLive = process.env.REGIME_COMPOSITIONAL_LIVE === 'true';
 


### PR DESCRIPTION
Matrix tier-3 Phase 1/12. Kills `REGIME_CREATOR_CHOP_SIZE_MULT` (0.75) and `REGIME_PRESERVER_CHOP_SIZE_MULT` (0.85). CHOP cells now compute `max(0.2, phi × regimeConfidence)` — observer-derived from kernel-internal state, floored at the DISSOLVER SAFETY_BOUND from #946. CREATOR-vs-PRESERVER differentiation emerges naturally from chemistry coherence. 1835/1835 vitest green. Eleven knobs remaining; Phases 2-9 sequenced per the cleanup arc.

## Summary by Sourcery

Derive CHOP cell size multipliers from kernel observables instead of environment knobs and thread the new observer context through the monkey kernel loop.

New Features:
- Introduce a CellObserverContext carrying phi and regimeConfidence used when evaluating cells.

Enhancements:
- Make CHOP cell size multipliers observer-derived via phi × regimeConfidence with a safety floor, removing the REGIME_CREATOR_CHOP_SIZE_MULT and REGIME_PRESERVER_CHOP_SIZE_MULT environment knobs.
- Update the monkey kernel loop to pass observable state into evaluateCell so CHOP sizing reflects current regime chemistry.

Tests:
- Adjust existing compositional matrix tests for CREATOR×CHOP and PRESERVER×CHOP to expect observer-derived sizing and add coverage for the new phi × regimeConfidence behavior and safety floor.