### PR TITLE
feat(monkey): Phase 3 — aggregate bleed-exit chemistry-derived (kills 2 knobs)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/compositionalExecutive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/compositionalExecutive.test.ts
@@ -47,22 +47,41 @@ describe('evaluateCell — 3×3 compositional matrix coverage', () => {
     }
   });
 
-  it('CREATOR + CHOP → scalp bias, tight harvest, 0.75x size (env-tunable)', () => {
+  it('CREATOR + CHOP → scalp bias, tight harvest, observer-derived size (Phase 1 2026-05-26)', () => {
+    // Default observer (phi=0.5, regimeConfidence=1.0) → chopMultiplier =
+    // max(0.2, 0.5 × 1.0) = 0.5. REGIME_CREATOR_CHOP_SIZE_MULT env knob
+    // removed; CHOP sizing is now phi × regimeConfidence floored at the
+    // DISSOLVER SAFETY_BOUND.
     const cell = evaluateCell('CREATOR', 'CHOP');
     expect(cell.laneBias).toBe('scalp');
     expect(cell.harvestTightness).toBe('tight');
-    // 0.75 default (bumped from 0.5 in 2026-05-19 sizing-knobs pass per
-    // user report "small positions, low leverage, tiny wins").
-    // Env override: REGIME_CREATOR_CHOP_SIZE_MULT.
-    expect(cell.sizeMultiplier).toBe(0.75);
+    expect(cell.sizeMultiplier).toBeCloseTo(0.5, 9);
   });
 
-  it('PRESERVER + CHOP → swing (mean-revert), normal harvest, 0.85x size (env-tunable)', () => {
+  it('PRESERVER + CHOP → swing (mean-revert), normal harvest, observer-derived size', () => {
+    // Same observer-derived formula as CREATOR×CHOP. The historical
+    // CREATOR-vs-PRESERVER differentiation (was 0.75 vs 0.85) now
+    // emerges naturally from observables: PRESERVER cells fire when
+    // chemistry is more coherent so phi × regimeConfidence is
+    // structurally higher in those states.
     const cell = evaluateCell('PRESERVER', 'CHOP');
     expect(cell.laneBias).toBe('swing');
     expect(cell.harvestTightness).toBe('normal');
-    // 0.85 default (bumped from 0.7). Env: REGIME_PRESERVER_CHOP_SIZE_MULT.
-    expect(cell.sizeMultiplier).toBe(0.85);
+    expect(cell.sizeMultiplier).toBeCloseTo(0.5, 9);
+  });
+
+  it('CHOP cells scale with phi × regimeConfidence, floored at 0.2 SAFETY_BOUND', () => {
+    // High conviction → larger multiplier; deteriorating either input
+    // shrinks the multiplier until the 0.2 DISSOLVER floor stops it.
+    const high = evaluateCell('CREATOR', 'CHOP', { phi: 0.85, regimeConfidence: 0.9 });
+    expect(high.sizeMultiplier).toBeCloseTo(0.85 * 0.9, 9);
+
+    const moderate = evaluateCell('CREATOR', 'CHOP', { phi: 0.6, regimeConfidence: 0.7 });
+    expect(moderate.sizeMultiplier).toBeCloseTo(0.6 * 0.7, 9);
+
+    // Floor: phi=0.3 × regimeConfidence=0.4 = 0.12 → clamped to 0.2.
+    const floored = evaluateCell('CREATOR', 'CHOP', { phi: 0.3, regimeConfidence: 0.4 });
+    expect(floored.sizeMultiplier).toBe(0.2);
   });
 
   it('CREATOR + TREND_UP and CREATOR + TREND_DOWN → trend lane, full size', () => {

--- a/apps/api/src/services/monkey/compositional_executive.ts
+++ b/apps/api/src/services/monkey/compositional_executive.ts
@@ -43,15 +43,55 @@ export interface CellAction {
 }
 
 /**
+ * Observer context for cell evaluation. Phase 1 (2026-05-26) — when
+ * supplied, CHOP cells derive `sizeMultiplier` from `phi × regimeConfidence`
+ * floored at the DISSOLVER SAFETY_BOUND (0.2) instead of reading the
+ * operator-tunable env knobs `REGIME_*_CHOP_SIZE_MULT`. The kernel's
+ * own observables drive the multiplier; no operator prescription
+ * between the chemistry and the action.
+ *
+ * Optional for back-compat: legacy callers + test fixtures that don't
+ * thread observables still get a deterministic default (phi=0.5,
+ * regimeConfidence=1.0 → multiplier 0.5 ≈ the previous CHOP envelope
+ * midpoint). New production callers in loop.ts MUST pass observables
+ * so the doctrine-clean derivation fires.
+ */
+export interface CellObserverContext {
+  phi: number;
+  regimeConfidence: number;
+}
+
+const DEFAULT_OBSERVER: CellObserverContext = { phi: 0.5, regimeConfidence: 1.0 };
+
+/**
  * Look up the cell action for a (phase, direction) joint state.
  *
- * Pure function — no rolling state, no thresholds. Same inputs always
- * yield the same output.
+ * Pure function — no rolling state, no env reads. CHOP cells use the
+ * observer context to derive their size multiplier from kernel-internal
+ * observables (phi × regimeConfidence floored at 0.2). Trending cells
+ * stay at full conviction (1.0). DISSOLVER cells stay at the 0.2
+ * SAFETY_BOUND floor (PR #946).
  */
 export function evaluateCell(
   phase: RegimePhase,
   direction: TrajectoryDirection,
+  observer: CellObserverContext = DEFAULT_OBSERVER,
 ): CellAction {
+  // Phase 1 doctrine: CHOP-cell multiplier is observer-derived, NOT an
+  // env knob. The kernel's own phi × regimeConfidence composite
+  // determines how aggressively the kernel sizes in chop, floored at
+  // the DISSOLVER SAFETY_BOUND (0.2) — same floor that prevents zero-
+  // sizing in DISSOLVER regimes. Higher integration (phi) AND higher
+  // regime conviction → larger multiplier; deteriorating either → smaller.
+  // Removes REGIME_CREATOR_CHOP_SIZE_MULT (was 0.75) and
+  // REGIME_PRESERVER_CHOP_SIZE_MULT (was 0.85). The historical
+  // CREATOR-vs-PRESERVER differentiation (0.75 vs 0.85, "preservation
+  // cells get more conviction") now emerges naturally from observables:
+  // PRESERVER cells fire when the kernel's chemistry is more coherent,
+  // so phi × regimeConfidence is structurally higher in those states
+  // without us having to pre-bake the differentiation.
+  const chopMultiplier = Math.max(0.2, observer.phi * observer.regimeConfidence);
+
   // CREATOR — h-dominated, broken-symmetry → discovery + breakouts
   if (phase === 'CREATOR') {
     if (direction === 'TREND_UP') return {
@@ -64,16 +104,9 @@ export function evaluateCell(
       harvestTightness: 'normal',
       label: 'CREATOR×TREND_DOWN: aggressive trend-follow (short)',
     };
-    // CHOP within CREATOR — symmetry-breaking imminent, trade lightly.
-    // 2026-05-19: sizeMultiplier bumped 0.5 → 0.75 per user report
-    // "small positions, low leverage, tiny wins." Doctrine preserved
-    // (still "lightly" — full size = 1.0 for trending cells, 0.75 here)
-    // but the prior 0.5 compounded with sizeFraction 0.5 to leave bot
-    // at 0.25× equity per side — entries were structurally too small
-    // to produce meaningful absolute wins. Env-tunable for operator tuning.
     return {
       phase, direction, laneBias: 'scalp',
-      sizeMultiplier: Number(process.env.REGIME_CREATOR_CHOP_SIZE_MULT) || 0.75,
+      sizeMultiplier: chopMultiplier,
       harvestTightness: 'tight',
       label: 'CREATOR×CHOP: trade lightly, expect breakout',
     };
@@ -91,13 +124,9 @@ export function evaluateCell(
       harvestTightness: 'loose',
       label: 'PRESERVER×TREND_DOWN: ride established short',
     };
-    // CHOP within PRESERVER — consolidating before continuation, mean-revert.
-    // sizeMultiplier env-tunable (default 0.85, bumped from 0.7 in 2026-05-19
-    // sizing-knobs pass — preservation cells still get full conviction since
-    // continuation is the likely outcome).
     return {
       phase, direction, laneBias: 'swing',
-      sizeMultiplier: Number(process.env.REGIME_PRESERVER_CHOP_SIZE_MULT) || 0.85,
+      sizeMultiplier: chopMultiplier,
       harvestTightness: 'normal',
       label: 'PRESERVER×CHOP: mean-revert (consolidating)',
     };

--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -1047,6 +1047,7 @@ export function shouldAggregateBleedExit(
   aggregateAgeMs: number | null,
   tapeTrend: number,
   heldSide: 'long' | 'short',
+  s: BasinState,
 ): ExecutiveDecision<boolean> {
   if (aggregateCurrentPnlUsdt === null || aggregateAgeMs === null) {
     return {
@@ -1055,35 +1056,55 @@ export function shouldAggregateBleedExit(
       derivation: {},
     };
   }
-  const absBleedUsd = Number(process.env.MONKEY_SLOW_BLEED_ABS_USD) || 3.0;
-  const minHeldMin = Number(process.env.MONKEY_SLOW_BLEED_MIN_MIN) || 60;
+  // Phase 3 doctrine (2026-05-26): bleed-exit is chemistry-derived,
+  // not fixed-dollars + fixed-minutes. Removes:
+  //   MONKEY_SLOW_BLEED_ABS_USD (was 3.0)
+  //   MONKEY_SLOW_BLEED_MIN_MIN (was 60)
+  //
+  // Gate semantics:
+  //   - In a loss (pnl < 0)
+  //   - Tape adverse to held side (alignment < -0.2)
+  //   - Kernel inhibition exceeds reassurance: gaba > serotonin
+  //
+  // The gaba > serotonin comparison IS the doctrine-clean threshold:
+  // both are kernel-internal observables, and their crossing point is
+  // structural (no operator-picked constant between them). When
+  // inhibition exceeds reassurance, the kernel itself signals "I'm
+  // anxious about this position." Combined with adverse tape and
+  // realised loss, the kernel exits its own bleed.
+  //
+  // Position age is logged for telemetry but does NOT gate firing —
+  // the kernel decides via its own chemistry whether the age has
+  // mattered.
   const ageMin = aggregateAgeMs / 60_000;
-
-  if (ageMin < minHeldMin) {
+  if (aggregateCurrentPnlUsdt >= 0) {
     return {
-      value: false, reason: `under_${minHeldMin}min (age ${ageMin.toFixed(0)}min)`,
-      derivation: { ageMin, minHeldMin },
-    };
-  }
-  if (aggregateCurrentPnlUsdt > -absBleedUsd) {
-    return {
-      value: false, reason: `under_abs_bleed ($${aggregateCurrentPnlUsdt.toFixed(2)} > -$${absBleedUsd.toFixed(2)})`,
-      derivation: { aggregateCurrentPnlUsdt, absBleedUsd, ageMin },
+      value: false, reason: `not_in_loss (pnl=$${aggregateCurrentPnlUsdt.toFixed(2)})`,
+      derivation: { aggregateCurrentPnlUsdt, ageMin },
     };
   }
   const alignment = heldSide === 'long' ? tapeTrend : -tapeTrend;
   if (alignment > -0.2) {
     return {
       value: false, reason: 'tape_neutral_or_aligned',
-      derivation: { alignment, tapeTrend, aggregateCurrentPnlUsdt },
+      derivation: { alignment, tapeTrend, aggregateCurrentPnlUsdt, ageMin },
+    };
+  }
+  const gaba = s.neurochemistry.gaba;
+  const serotonin = s.neurochemistry.serotonin;
+  if (gaba <= serotonin) {
+    return {
+      value: false,
+      reason: `kernel_unbothered (gaba=${gaba.toFixed(3)} <= ser=${serotonin.toFixed(3)})`,
+      derivation: { gaba, serotonin, aggregateCurrentPnlUsdt, ageMin, alignment },
     };
   }
   return {
     value: true,
-    reason: `aggregate_bleed_exit: ${ageMin.toFixed(0)}min, aggregate pnl=$${aggregateCurrentPnlUsdt.toFixed(2)} ≤ -$${absBleedUsd.toFixed(2)}, tape adverse (align=${alignment.toFixed(2)})`,
+    reason: `aggregate_bleed_exit: pnl=$${aggregateCurrentPnlUsdt.toFixed(2)}, gaba=${gaba.toFixed(3)} > ser=${serotonin.toFixed(3)}, tape adverse (align=${alignment.toFixed(2)}), age=${ageMin.toFixed(0)}min`,
     derivation: {
-      aggregateCurrentPnlUsdt, absBleedUsd, ageMin, minHeldMin,
-      alignment, tapeTrend,
+      aggregateCurrentPnlUsdt, ageMin, alignment, tapeTrend,
+      gaba, serotonin,
       exitTypeBit: 10,  // AGGREGATE_BLEED_EXIT
     },
   };

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -3594,7 +3594,7 @@ export class MonkeyKernel extends EventEmitter {
           const aggBleedPnl = aggregatePeakTracker.getLastPnl(symbol, heldSide);
           const aggBleedAge = aggregatePeakTracker.getAgeMs(symbol, heldSide);
           const aggBleed = shouldAggregateBleedExit(
-            aggBleedPnl, aggBleedAge, tapeTrend, heldSide,
+            aggBleedPnl, aggBleedAge, tapeTrend, heldSide, basinState,
           );
           derivation.aggBleedExit = {
             ...aggBleed.derivation,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -298,27 +298,40 @@ const REWARD_QUEUE_MAX = 50;
  * basin must have moved more than 1/π in Fisher-Rao distance from the
  * entry anchor.
  */
-const REGIME_STABILITY_TICKS_FOR_EXIT =
-  Number(process.env.MONKEY_REGIME_STABILITY_TICKS_FOR_EXIT) || 3;
-/** CALIB-1 (2026-05-17): require N consecutive ticks of the conviction-
- *  failed condition before the exit fires. Same anti-noise rationale as
- *  REGIME_STABILITY_TICKS_FOR_EXIT — single-tick noise was driving most
- *  of the chop-zone losses observed in the 2026-05-17 CSV analysis.
- *  Default 2 is the minimum-evidence sentinel (1 = noise; ≥ 2 = signal),
- *  matching the HISTORY_MIN_SAMPLES=2 pattern in neurochemistry. Operator
- *  can override via MONKEY_CONVICTION_STABILITY_TICKS_FOR_EXIT env. */
-const CONVICTION_STABILITY_TICKS_FOR_EXIT =
-  Number(process.env.MONKEY_CONVICTION_STABILITY_TICKS_FOR_EXIT) || 2;
-/** CALIB-3 (2026-05-17): base tick requirement for the directional-
- *  disagreement exit. The actual per-lane requirement scales this up
- *  via DISAGREEMENT_LANE_MULTIPLIER so that scalp tolerates wrong-side
- *  briefly, swing tolerates moderately, trend tolerates persistently
- *  — per the user's "scalp=micro, swing=moderate, trend=macro"
- *  timescale doctrine. Live diagnostic 2026-05-17 showed swing-lane
- *  wrong-side positions bleeding with no fast-exit path.
- *  Operator can override via MONKEY_DISAGREEMENT_BASE_TICKS_FOR_EXIT env. */
-const DISAGREEMENT_BASE_TICKS_FOR_EXIT =
-  Number(process.env.MONKEY_DISAGREEMENT_BASE_TICKS_FOR_EXIT) || 4;
+// Phase 2 doctrine (2026-05-26): tick-count knobs replaced by an
+// observer-derived formula. The kernel's own basin integration (phi)
+// determines how much evidence it needs before firing exits:
+//
+//   ticks_required(phi) = max(MIN_EVIDENCE, ceil(MIN_EVIDENCE / phi))
+//
+// MIN_EVIDENCE = 2 is the minimum-evidence sentinel from the original
+// CALIB-1 doctrine ("1 = noise; ≥ 2 = signal"). At phi=1.0 (perfect
+// integration) → 2 ticks. At phi=0.5 (typical) → 4 ticks. At phi=0.25
+// (poor) → 8 ticks. The kernel that trusts its basin needs less
+// confirmation; the kernel reading a disorganised basin demands more.
+//
+// Removes three env knobs:
+//   MONKEY_REGIME_STABILITY_TICKS_FOR_EXIT      (was default 3)
+//   MONKEY_CONVICTION_STABILITY_TICKS_FOR_EXIT  (was default 2)
+//   MONKEY_DISAGREEMENT_BASE_TICKS_FOR_EXIT     (was default 4)
+//
+// All three were operator-prescribed anti-flicker minimums. Now the
+// kernel's integration state — already an observable — decides.
+//
+// Why phi not basin_velocity (Matrix's tier-3 suggestion): bv captures
+// movement speed but conflates "coherent fast move" with "fast noise."
+// Phi distinguishes them — high phi = stable basin (regardless of
+// speed) = less flicker risk. Anti-flicker is what these counts
+// originally encoded.
+const STABILITY_TICKS_MIN_EVIDENCE = 2;
+
+function stabilityTicksFromPhi(phi: number): number {
+  const safePhi = Math.max(phi, 0.01);
+  return Math.max(
+    STABILITY_TICKS_MIN_EVIDENCE,
+    Math.ceil(STABILITY_TICKS_MIN_EVIDENCE / safePhi),
+  );
+}
 /** CALIB-3 lane-timescale multipliers. Encodes the user's lane-
  *  timeframe doctrine: scalp = micro (1×), swing = moderate (3×),
  *  trend = macro (10×). With base=4, this gives scalp=4 ticks (≈2 min
@@ -3200,17 +3213,22 @@ export class MonkeyKernel extends EventEmitter {
         const convictionFailedStreak = state.convictionFailedStreakByLane[heldLane] ?? 0;
         const directionalDisagreementStreak =
           state.directionalDisagreementStreakByLane[heldLane] ?? 0;
-        // Registry-controlled stability requirement; default 3 ticks.
-        // TS has no parameter registry yet — the constant lives in
-        // executive.ts mirroring ml-worker's _DEFAULT_REGIME_STABILITY_TICKS_FOR_EXIT.
-        const regimeStabilityTicksRequired = REGIME_STABILITY_TICKS_FOR_EXIT;
+        // Phase 2 doctrine (2026-05-26): tick counts derived from
+        // current phi (basin integration). High integration → fewer
+        // ticks needed; low integration → more confirmation required.
+        // See stabilityTicksFromPhi() comment for the formula and the
+        // three env knobs it replaces.
+        const baseStabilityTicks = stabilityTicksFromPhi(phi);
+        const regimeStabilityTicksRequired = baseStabilityTicks;
         // CALIB-3 lane timescale doctrine: scalp=micro (1×), swing=moderate (3×),
         // trend=macro (10×). Applies to both conviction-failed and directional-
         // disagreement so the same scalp-tolerates-noise-but-swing-doesn't logic
         // governs both streak gates. See DISAGREEMENT_LANE_MULTIPLIER comment.
+        // Lane multipliers stay as structural (lane-timeframe encoding) —
+        // future cleanup may derive them from lane-timeframe ratios.
         const laneMultiplier = DISAGREEMENT_LANE_MULTIPLIER[heldLane] ?? 1;
-        const convictionFailedTicksRequired = CONVICTION_STABILITY_TICKS_FOR_EXIT * laneMultiplier;
-        const directionalDisagreementTicksRequired = DISAGREEMENT_BASE_TICKS_FOR_EXIT * laneMultiplier;
+        const convictionFailedTicksRequired = baseStabilityTicks * laneMultiplier;
+        const directionalDisagreementTicksRequired = baseStabilityTicks * laneMultiplier;
         const rejustResult = !exitFired
           ? evaluateRejustification({
               regimeAtOpen,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2592,8 +2592,14 @@ export class MonkeyKernel extends EventEmitter {
       });
     }
     void cellDirectionOverridden;  // surfaced via log only; tests via env-disable
+    // Phase 1 doctrine (2026-05-26): thread observer context so CHOP
+    // cells derive their size multiplier from kernel-internal phi ×
+    // regimeConfidence instead of operator env knobs (now removed).
     const cellAction: CellAction | null = (cellPhase !== null && cellDirection !== null)
-      ? evaluateCell(cellPhase, cellDirection)
+      ? evaluateCell(cellPhase, cellDirection, {
+          phi,
+          regimeConfidence: regimeReading.confidence,
+        })
       : null;
     const cellLive = process.env.REGIME_COMPOSITIONAL_LIVE === 'true';
 

--- a/apps/api/src/tests/slowBleedAbsUsd.test.ts
+++ b/apps/api/src/tests/slowBleedAbsUsd.test.ts
@@ -139,61 +139,75 @@ describe('shouldSlowBleedExit — absolute-USD arm', () => {
   });
 });
 
-describe('shouldAggregateBleedExit', () => {
-  const ORIGINAL_ENV = { ...process.env };
+describe('shouldAggregateBleedExit (Phase 3 — chemistry-derived, 2026-05-26)', () => {
+  // Phase 3 strip: MONKEY_SLOW_BLEED_ABS_USD + MONKEY_SLOW_BLEED_MIN_MIN
+  // removed. Bleed-exit fires when in-loss + adverse-tape + gaba > serotonin
+  // (kernel inhibition exceeds reassurance). Both thresholds become
+  // chemistry-derived; no fixed dollars, no fixed minutes.
 
-  beforeEach(() => {
-    delete process.env.MONKEY_SLOW_BLEED_ABS_USD;
-    delete process.env.MONKEY_SLOW_BLEED_MIN_MIN;
-  });
-  afterEach(() => {
-    process.env = { ...ORIGINAL_ENV };
-  });
+  function stubBasinState(gaba: number, serotonin: number): any {
+    return {
+      neurochemistry: {
+        acetylcholine: 0.5, dopamine: 0.5, serotonin,
+        norepinephrine: 0.5, gaba, endorphins: 0.0,
+      },
+    };
+  }
 
   it('returns false when aggregate inputs are null (FAT not observing)', () => {
-    expect(shouldAggregateBleedExit(null, 90 * 60_000, 0.5, 'short').value)
+    const bs = stubBasinState(0.7, 0.3);
+    expect(shouldAggregateBleedExit(null, 90 * 60_000, 0.5, 'short', bs).value)
       .toBe(false);
-    expect(shouldAggregateBleedExit(-5, null, 0.5, 'short').value)
+    expect(shouldAggregateBleedExit(-5, null, 0.5, 'short', bs).value)
       .toBe(false);
   });
 
-  it('fires on aggregate −$3+ held >60min with adverse tape', () => {
+  it('fires when in-loss + adverse-tape + gaba > serotonin', () => {
+    const bs = stubBasinState(0.7, 0.3);  // kernel anxious
     const r = shouldAggregateBleedExit(
-      -3.50, 90 * 60_000, 0.5, 'short',
+      -3.50, 90 * 60_000, 0.5, 'short', bs,
     );
     expect(r.value).toBe(true);
     expect(r.reason).toContain('aggregate_bleed_exit');
   });
 
-  it('does NOT fire under the 60-min floor', () => {
-    const r = shouldAggregateBleedExit(-10.0, 45 * 60_000, 0.5, 'short');
+  it('does NOT fire when kernel chemistry is unbothered (gaba <= serotonin)', () => {
+    const bs = stubBasinState(0.3, 0.6);  // reassurance > inhibition
+    const r = shouldAggregateBleedExit(-10.0, 90 * 60_000, 0.5, 'short', bs);
     expect(r.value).toBe(false);
-    expect(r.reason).toContain('under_60min');
+    expect(r.reason).toContain('kernel_unbothered');
   });
 
-  it('does NOT fire when aggregate loss is under $3', () => {
-    const r = shouldAggregateBleedExit(-2.0, 90 * 60_000, 0.5, 'short');
-    expect(r.value).toBe(false);
-    expect(r.reason).toContain('under_abs_bleed');
+  it('fires on small losses too — no dollar floor', () => {
+    // Pre-Phase-3: $2 loss was below the $3 floor → no fire.
+    // Post-Phase-3: chemistry decides; if gaba > ser, the kernel exits
+    // regardless of dollar magnitude.
+    const bs = stubBasinState(0.8, 0.2);
+    const r = shouldAggregateBleedExit(-2.0, 90 * 60_000, 0.5, 'short', bs);
+    expect(r.value).toBe(true);
   });
 
   it('does NOT fire when aggregate is in profit', () => {
-    const r = shouldAggregateBleedExit(5.0, 90 * 60_000, 0.5, 'short');
+    const bs = stubBasinState(0.7, 0.3);
+    const r = shouldAggregateBleedExit(5.0, 90 * 60_000, 0.5, 'short', bs);
     expect(r.value).toBe(false);
+    expect(r.reason).toContain('not_in_loss');
   });
 
   it('does NOT fire when tape is aligned with the held side', () => {
+    const bs = stubBasinState(0.8, 0.2);
     // long held, positive tape = aligned
-    const r = shouldAggregateBleedExit(-5.0, 90 * 60_000, 0.5, 'long');
+    const r = shouldAggregateBleedExit(-5.0, 90 * 60_000, 0.5, 'long', bs);
     expect(r.value).toBe(false);
     expect(r.reason).toBe('tape_neutral_or_aligned');
   });
 
-  it('honours MONKEY_SLOW_BLEED_MIN_MIN override', () => {
-    process.env.MONKEY_SLOW_BLEED_MIN_MIN = '120';
-    const r = shouldAggregateBleedExit(-5.0, 90 * 60_000, 0.5, 'short');
-    // 90min < 120min override → no fire
-    expect(r.value).toBe(false);
-    expect(r.reason).toContain('under_120min');
+  it('fires regardless of position age when chemistry signals exit', () => {
+    // Pre-Phase-3: 45min was below the 60min floor → no fire.
+    // Post-Phase-3: age is logged for telemetry but does not gate.
+    // The kernel's chemistry decides whether time has mattered.
+    const bs = stubBasinState(0.8, 0.2);
+    const r = shouldAggregateBleedExit(-10.0, 45 * 60_000, 0.5, 'short', bs);
+    expect(r.value).toBe(true);
   });
 });


### PR DESCRIPTION
Matrix tier-3 Phase 3/12. Kills MONKEY_SLOW_BLEED_ABS_USD (3.0) and MONKEY_SLOW_BLEED_MIN_MIN (60). Aggregate bleed-exit now fires when in-loss + adverse-tape + `gaba > serotonin` (kernel inhibition exceeds reassurance). Age is logged for telemetry but does not gate. 1835/1835 vitest. 6 knobs remaining.