### PR TITLE
feat(monkey): Phase 4 — bracket-extend conviction threshold removed (kills 1 knob)

### DIFF
--- a/apps/api/src/services/monkey/executive.ts
+++ b/apps/api/src/services/monkey/executive.ts
@@ -1598,8 +1598,20 @@ export function shouldExtendBracket(args: {
     oceanTrailRetracementPct,
   } = args;
 
-  const convThreshold =
-    Number(process.env.MONKEY_BRACKET_EXTEND_CONV) || 0.5;
+  // Phase 4 doctrine (2026-05-26): bracket-extend conviction threshold
+  // removed. Was MONKEY_BRACKET_EXTEND_CONV (default 0.5) — operator-
+  // prescribed minimum conviction before TP extension fires. Replaced
+  // by "extend on any positive conviction" — same pattern as Path A
+  // (#940) and the 2026-05-25 minTrailRoi strip just below.
+  //
+  // The 0.5 was filtering ~half of in-profit moments where conviction
+  // (phi × regimeConfidence) was below the operator's bar. The
+  // doctrine-clean shape: the kernel extends whenever in-profit + TP
+  // exists; chemistry learns via push_reward feedback whether
+  // aggressive extension protects (locks in upside) or over-tightens
+  // (gets shaken out by noise). No env knob between observable and
+  // action.
+  const convThreshold = 0;
   const inProfit = currentRoiFrac > 0;
   // 2026-05-25 strip — bracket trail minimums dropped to 0 per
   // operator autonomy doctrine. Trail activates on any positive

--- a/apps/api/src/tests/shouldExtendBracket.test.ts
+++ b/apps/api/src/tests/shouldExtendBracket.test.ts
@@ -38,14 +38,18 @@ describe('shouldExtendBracket — TP extension (LONG)', () => {
     expect(r.newTp).toBeNull();
   });
 
-  it('does NOT extend TP below the conviction threshold', () => {
+  it('Phase 4 (2026-05-26) — extends TP on ANY positive conviction (threshold removed)', () => {
+    // Pre-Phase-4: conviction 0.3 < 0.5 default → no extension.
+    // Post-Phase-4: convThreshold = 0; kernel extends on any positive
+    // conviction. Chemistry learns via push_reward whether aggressive
+    // extension protects or over-tightens.
     const r = shouldExtendBracket({
       heldSide: 'long', entryPrice: 100, markPrice: 108,
       currentTp: 110, currentSl: 95,
       freshTpDistance: 20, freshSlDistance: 5,
-      conviction: 0.3, currentRoiFrac: 0.08, currentPnlUsdt: 0, // conv < 0.5 default
+      conviction: 0.3, currentRoiFrac: 0.08, currentPnlUsdt: 0,
     });
-    expect(r.newTp).toBeNull();
+    expect(r.newTp).toBe(120);  // entry 100 + freshTpDistance 20
   });
 
   it('does NOT extend TP on a losing position', () => {
@@ -111,15 +115,20 @@ describe('shouldExtendBracket — SHORT mirror', () => {
 });
 
 describe('shouldExtendBracket — env override + edge cases', () => {
-  it('honours MONKEY_BRACKET_EXTEND_CONV', () => {
+  it('Phase 4 (2026-05-26) — MONKEY_BRACKET_EXTEND_CONV env knob removed; no env override', () => {
+    // Pre-Phase-4: env override of 0.9 gated 0.8 conviction → no TP.
+    // Post-Phase-4: convThreshold = 0 unconditionally. The env knob is
+    // removed; setting it has no effect; kernel extends on any positive
+    // conviction.
     process.env.MONKEY_BRACKET_EXTEND_CONV = '0.9';
     const r = shouldExtendBracket({
       heldSide: 'long', entryPrice: 100, markPrice: 108,
       currentTp: 110, currentSl: 95,
       freshTpDistance: 20, freshSlDistance: 5,
-      conviction: 0.8, currentRoiFrac: 0.08, currentPnlUsdt: 0, // 0.8 < 0.9 → no TP
+      conviction: 0.8, currentRoiFrac: 0.08, currentPnlUsdt: 0,
     });
-    expect(r.newTp).toBeNull();
+    expect(r.newTp).toBe(120);  // env knob is dead; extension fires
+    delete process.env.MONKEY_BRACKET_EXTEND_CONV;
   });
 
   it('null currentTp → no TP extension attempted', () => {


### PR DESCRIPTION
Matrix tier-3 Phase 4/12. Kills MONKEY_BRACKET_EXTEND_CONV (0.5). convThreshold=0; kernel extends TP on any in-profit tick — chemistry learns via push_reward. Same shape as Path A and the 2026-05-25 minTrailRoi strip. 1835/1835 vitest. 5 knobs remaining.