### PR TITLE
feat(monkey): Phase 9 — max-contracts kernel-derived (kills FINAL knob)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/positionContractsBound.test.ts
+++ b/apps/api/src/services/monkey/__tests__/positionContractsBound.test.ts
@@ -1,38 +1,75 @@
 /**
  * positionContractsBound.test.ts — pure-helper tests for the per-position
- * contracts cap that prevents 21010-class oversized-position bugs at the
- * source rather than via the chunker downstream.
+ * contracts cap.
+ *
+ * Phase 9 (2026-05-27): MONKEY_MAX_CONTRACTS_PER_POSITION env knob and
+ * `getMaxContractsPerPosition()` removed. The venue-derived ceiling
+ * `VENUE_CONTRACTS_CEILING` (8000 = 10000 venue cap − 2000 chunker buffer)
+ * remains as a structural wall. The typical operating cap is now
+ * `kernelDerivedContractCap()`, computed from observables.
  */
 import { describe, it, expect } from 'vitest';
 import {
-  MAX_CONTRACTS_PER_POSITION_DEFAULT,
-  getMaxContractsPerPosition,
+  VENUE_CONTRACTS_CEILING,
+  kernelDerivedContractCap,
   headroomContracts,
   clampNewContractsToCap,
 } from '../positionContractsBound.js';
 
-describe('MAX_CONTRACTS_PER_POSITION_DEFAULT', () => {
-  it('is 8000 (2000-contract buffer below Poloniex 10000 cap)', () => {
-    expect(MAX_CONTRACTS_PER_POSITION_DEFAULT).toBe(8000);
+describe('VENUE_CONTRACTS_CEILING', () => {
+  it('is 8000 (venue 10000 − 2000 chunker buffer)', () => {
+    expect(VENUE_CONTRACTS_CEILING).toBe(8000);
   });
 });
 
-describe('getMaxContractsPerPosition', () => {
-  it('returns default when env var is unset', () => {
-    delete process.env.MONKEY_MAX_CONTRACTS_PER_POSITION;
-    expect(getMaxContractsPerPosition()).toBe(8000);
+describe('kernelDerivedContractCap', () => {
+  const baseObservers = {
+    availableEquityUsdt: 1000,
+    markPrice: 2000,    // ETH-ish
+    contractSize: 0.01, // ETH contract size
+    leverage: 10,
+    dopamine: 0.5,
+    phi: 0.5,
+    gaba: 0.5,
+  };
+
+  it('scales with risk fraction × equity × leverage / (mark × contractSize)', () => {
+    // risk_fraction = max(0.1, 0.5 × 0.5 × 0.5) = max(0.1, 0.125) = 0.125
+    // cap = floor((1000 × 0.125 × 10) / (2000 × 0.01)) = floor(1250 / 20) = 62
+    expect(kernelDerivedContractCap(baseObservers)).toBe(62);
   });
 
-  it('honors env var override', () => {
-    process.env.MONKEY_MAX_CONTRACTS_PER_POSITION = '5000';
-    expect(getMaxContractsPerPosition()).toBe(5000);
-    delete process.env.MONKEY_MAX_CONTRACTS_PER_POSITION;
+  it('floors risk fraction at 0.1 SAFETY_BOUND', () => {
+    // gaba=0.95 → (1 - 0.95) = 0.05 → 0.5 × 0.5 × 0.05 = 0.0125 → clamped to 0.1
+    // cap = floor((1000 × 0.1 × 10) / (2000 × 0.01)) = floor(1000 / 20) = 50
+    expect(kernelDerivedContractCap({ ...baseObservers, gaba: 0.95 })).toBe(50);
   });
 
-  it('falls back to default on non-numeric env', () => {
-    process.env.MONKEY_MAX_CONTRACTS_PER_POSITION = 'abc';
-    expect(getMaxContractsPerPosition()).toBe(8000);
-    delete process.env.MONKEY_MAX_CONTRACTS_PER_POSITION;
+  it('caps at VENUE_CONTRACTS_CEILING regardless of kernel envelope', () => {
+    // Huge equity + max risk-fraction → kernel cap exceeds venue ceiling.
+    // Result: clamped to 8000.
+    expect(kernelDerivedContractCap({
+      ...baseObservers,
+      availableEquityUsdt: 1_000_000,
+      dopamine: 1, phi: 1, gaba: 0,
+    })).toBe(VENUE_CONTRACTS_CEILING);
+  });
+
+  it('zero equity → zero cap (kernel cannot open anything)', () => {
+    expect(kernelDerivedContractCap({ ...baseObservers, availableEquityUsdt: 0 }))
+      .toBe(0);
+  });
+
+  it('higher dopamine → larger cap (kernel willing to expose more)', () => {
+    const low = kernelDerivedContractCap({ ...baseObservers, dopamine: 0.2 });
+    const high = kernelDerivedContractCap({ ...baseObservers, dopamine: 0.9 });
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('higher gaba → smaller cap (kernel more inhibited)', () => {
+    const calm = kernelDerivedContractCap({ ...baseObservers, gaba: 0.1 });
+    const anxious = kernelDerivedContractCap({ ...baseObservers, gaba: 0.8 });
+    expect(anxious).toBeLessThan(calm);
   });
 });
 

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -211,7 +211,8 @@ import {
 import { foresightVeto } from './per_agent_foresight.js';
 import {
   clampNewContractsToCap,
-  getMaxContractsPerPosition,
+  kernelDerivedContractCap,
+  VENUE_CONTRACTS_CEILING,
 } from './positionContractsBound.js';
 
 /** Default Monkey watchlist. */
@@ -4346,6 +4347,10 @@ export class MonkeyKernel extends EventEmitter {
           phi,
           kappa: state.kappa,
           sovereignty,
+          // Phase 9 — kernel-derived contract cap observables.
+          availableEquityUsdt: availableEquity,
+          dopamine: nc.dopamine,
+          gaba: nc.gaba,
           trajectoryId: null,
           isDCAAdd: isDCA,
           dcaAddIndex: isDCA ? state.dcaAddCount + 1 : 0,
@@ -7522,6 +7527,12 @@ export class MonkeyKernel extends EventEmitter {
     phi: number;
     kappa: number;
     sovereignty: number;
+    /** Phase 9 (2026-05-27) — observables threaded for kernel-derived
+     *  contract cap. The kernel's own risk envelope from chemistry +
+     *  equity; replaces MONKEY_MAX_CONTRACTS_PER_POSITION env knob. */
+    availableEquityUsdt?: number;
+    dopamine?: number;
+    gaba?: number;
     trajectoryId: number | null;
     /** v0.6.2: true when this is a DCA add, not an initial entry. */
     isDCAAdd?: boolean;
@@ -7869,13 +7880,12 @@ export class MonkeyKernel extends EventEmitter {
       };
     }
 
-    // Per-position contracts cap (#11) — keep cumulative open contracts
-    // for (agent, symbol, side, lane) below MAX_CONTRACTS_PER_POSITION
-    // (default 8000, with 2000-contract buffer below Poloniex's 10000
-    // per-order rejection threshold). When already-open contracts plus
-    // this new entry's contracts would exceed the cap, clamp the new
-    // entry; if no headroom, suppress the entry entirely. Independent
-    // per-agent — K, M, T each get their own envelope.
+    // Per-position contracts cap (#11) — Phase 9 (2026-05-27):
+    // kernel-derived from observables (chemistry × equity × leverage)
+    // instead of operator env knob MONKEY_MAX_CONTRACTS_PER_POSITION.
+    // The 8000 venue-derived ceiling (10000 venue cap − 2000 chunker
+    // buffer) remains as a structural wall but is no longer the typical
+    // operating cap — kernel's own risk envelope sits below it.
     if (symbolLotSize > 0) {
       const effectiveAgent = (req.agent ?? 'K') as 'K' | 'M' | 'T';
       const effectiveLane = (req.lane ?? 'swing') as 'scalp' | 'swing' | 'trend';
@@ -7883,7 +7893,21 @@ export class MonkeyKernel extends EventEmitter {
       const currentContracts = await this.sumOpenContractsForPosition(
         symbol, effectiveAgent, side, effectiveLane, symbolLotSize,
       );
-      const cap = getMaxContractsPerPosition();
+      // Phase 9 — kernel-derived cap when observables are threaded;
+      // fall back to venue ceiling (8000) when caller hasn't supplied
+      // equity yet. Old call sites that don't thread the new observables
+      // keep working at the venue-ceiling level.
+      const cap = req.availableEquityUsdt && req.availableEquityUsdt > 0
+        ? kernelDerivedContractCap({
+            availableEquityUsdt: req.availableEquityUsdt,
+            markPrice: req.entryPrice,
+            contractSize: symbolLotSize,
+            leverage: req.leverage,
+            dopamine: req.dopamine ?? 0.5,
+            phi: req.phi,
+            gaba: req.gaba ?? 0.5,
+          })
+        : VENUE_CONTRACTS_CEILING;
       const clampedNewContracts = clampNewContractsToCap(
         newContracts, currentContracts, cap,
       );

--- a/apps/api/src/services/monkey/positionContractsBound.ts
+++ b/apps/api/src/services/monkey/positionContractsBound.ts
@@ -25,19 +25,63 @@
  */
 
 /**
- * Default ceiling. 8,000 contracts at BTC's 0.0001 lot size = 0.8 BTC
- * (~ \$80k notional at typical prices); at ETH's 0.01 lot = 80 ETH
- * (~ \$200k). These are large but within typical Poloniex retail
- * tolerances. The 2,000-contract buffer below the exchange's 10,000
- * cap leaves room for one-shot full closes (no chunking needed).
+ * Venue-derived structural ceiling. Poloniex v3 hard-rejects single
+ * orders > 10,000 contracts (code 21010). The 2,000-contract buffer
+ * below that leaves room for one-shot full closes without chunking.
+ * 8,000 = 10,000 venue cap − 2,000 chunker buffer. Both numbers are
+ * structural (venue-fact + chunker-arithmetic), not operator knobs.
  */
-export const MAX_CONTRACTS_PER_POSITION_DEFAULT = 8000;
+export const VENUE_CONTRACTS_CEILING = 8000;
 
-/** Env override: set ``MONKEY_MAX_CONTRACTS_PER_POSITION`` to tune. */
-export function getMaxContractsPerPosition(): number {
-  const raw = Number(process.env.MONKEY_MAX_CONTRACTS_PER_POSITION);
-  if (Number.isFinite(raw) && raw > 0) return raw;
-  return MAX_CONTRACTS_PER_POSITION_DEFAULT;
+/**
+ * Phase 9 (2026-05-27) — kernel-derived per-position contract cap.
+ *
+ * MONKEY_MAX_CONTRACTS_PER_POSITION removed. Operator-prescribed
+ * fractions between the kernel and the venue wall were the anti-
+ * pattern. Now the kernel computes its own cap from observables:
+ *
+ *   risk_fraction = max(0.1, dopamine × phi × (1 - gaba))
+ *   kernel_cap    = floor((equity × risk_fraction × leverage) /
+ *                         (mark_price × contract_size))
+ *   final_cap     = min(VENUE_CONTRACTS_CEILING, kernel_cap)
+ *
+ * Risk-fraction observables:
+ * - dopamine (reward expectation) — high → kernel willing to expose more
+ * - phi (basin integration) — high → kernel trusts its own perception
+ * - (1 - gaba) (inverse inhibition) — low gaba → kernel less anxious
+ *
+ * The 0.1 floor ensures the kernel always retains *some* exposure
+ * envelope even when chemistry is bleak (otherwise stressed kernel
+ * can't trade its way out). 0.1 is the same SAFETY_BOUND floor as
+ * the DISSOLVER cell size multiplier (#946) — same structural rationale.
+ *
+ * The venue ceiling stays as a structural wall (10,000 contracts is
+ * a venue-imposed fact; 2,000 chunker buffer is arithmetic). What's
+ * gone is the operator-imposed fraction between the kernel and the wall.
+ */
+export interface ContractCapObservers {
+  availableEquityUsdt: number;
+  markPrice: number;
+  contractSize: number;
+  leverage: number;
+  dopamine: number;
+  phi: number;
+  gaba: number;
+}
+
+export function kernelDerivedContractCap(o: ContractCapObservers): number {
+  const safeDop = Math.max(0, Math.min(1, o.dopamine));
+  const safePhi = Math.max(0, Math.min(1, o.phi));
+  const safeGaba = Math.max(0, Math.min(1, o.gaba));
+  const riskFraction = Math.max(0.1, safeDop * safePhi * (1 - safeGaba));
+
+  const denom = Math.max(o.markPrice * o.contractSize, 1e-9);
+  const equityHeadroom = Math.max(0, o.availableEquityUsdt);
+  const leverageMultiplier = Math.max(1, o.leverage);
+  const kernelCap = Math.floor(
+    (equityHeadroom * riskFraction * leverageMultiplier) / denom,
+  );
+  return Math.min(VENUE_CONTRACTS_CEILING, Math.max(0, kernelCap));
 }
 
 /**


### PR DESCRIPTION
Matrix Phase 9/12. Kills MONKEY_MAX_CONTRACTS_PER_POSITION. Replaced by kernelDerivedContractCap from observables (equity × dopamine × phi × (1-gaba) × leverage / (mark × contractSize)), bounded by VENUE_CONTRACTS_CEILING (venue 10000 - 2000 chunker buffer = 8000 structural wall). **All 13 original knobs killed.** 1838/1838 vitest.