### PR TITLE
feat(monkey): #941 Phase 3 — prediction-residual chemistry channel

### DIFF
--- a/apps/api/src/services/monkey/__tests__/predictionRewardEmitter.test.ts
+++ b/apps/api/src/services/monkey/__tests__/predictionRewardEmitter.test.ts
@@ -1,0 +1,174 @@
+/**
+ * predictionRewardEmitter.test.ts — pure-function tests for the
+ * prediction-residual chemistry emitter (#941 Phase 3).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  summariseFromRows,
+  medianAbsoluteDeviation,
+  predictionChemistryDeltas,
+} from '../predictionRewardEmitter.js';
+
+describe('medianAbsoluteDeviation', () => {
+  it('returns zero on empty input', () => {
+    expect(medianAbsoluteDeviation([])).toBe(0);
+  });
+
+  it('returns zero on a constant sample', () => {
+    expect(medianAbsoluteDeviation([3, 3, 3, 3])).toBe(0);
+  });
+
+  it('matches the textbook example MAD([1,2,3,4,5]) = 1', () => {
+    expect(medianAbsoluteDeviation([1, 2, 3, 4, 5])).toBe(1);
+  });
+
+  it('is unaffected by a single outlier (50% breakdown)', () => {
+    // Without outlier: MAD([1,2,3,4,5]) = 1
+    // With outlier 1000: median still 3 or near, MAD bounded.
+    const without = medianAbsoluteDeviation([1, 2, 3, 4, 5]);
+    const withOutlier = medianAbsoluteDeviation([1, 2, 3, 4, 5, 1000]);
+    expect(withOutlier).toBeLessThan(without * 3);
+  });
+});
+
+describe('summariseFromRows', () => {
+  it('returns empty summary on empty input', () => {
+    const s = summariseFromRows([]);
+    expect(s.n).toBe(0);
+    expect(s.directionMatchRate).toBe(0);
+    expect(s.within1SigmaRate).toBe(0);
+    expect(s.madResidualNormalized).toBe(0);
+  });
+
+  it('computes rates and MAD for mixed rows', () => {
+    const s = summariseFromRows([
+      { direction_match: true,  within_1_sigma: true,  residual_normalized: 0.5 },
+      { direction_match: true,  within_1_sigma: false, residual_normalized: -0.5 },
+      { direction_match: false, within_1_sigma: true,  residual_normalized: 1.0 },
+      { direction_match: false, within_1_sigma: true,  residual_normalized: -1.0 },
+    ]);
+    expect(s.n).toBe(4);
+    expect(s.directionMatchRate).toBeCloseTo(0.5);
+    expect(s.within1SigmaRate).toBeCloseTo(0.75);
+    expect(s.madResidualNormalized).toBeGreaterThan(0);
+  });
+
+  it('coerces string residual_normalized (Postgres numeric returns)', () => {
+    const s = summariseFromRows([
+      { direction_match: true, within_1_sigma: true, residual_normalized: '0.5' },
+      { direction_match: true, within_1_sigma: true, residual_normalized: '-0.5' },
+    ]);
+    expect(s.madResidualNormalized).toBeCloseTo(0.5);
+  });
+});
+
+describe('predictionChemistryDeltas', () => {
+  it('returns zero deltas below MIN_SAMPLES (n=4 < 5)', () => {
+    const d = predictionChemistryDeltas({
+      n: 4,
+      directionMatchRate: 1.0,
+      within1SigmaRate: 1.0,
+      madResidualNormalized: 0.6745,
+    });
+    expect(d.dopamineDelta).toBe(0);
+    expect(d.serotoninDelta).toBe(0);
+    expect(d.source).toContain('insufficient');
+  });
+
+  it('zero dop at chance-rate direction-match (0.5)', () => {
+    const d = predictionChemistryDeltas({
+      n: 20,
+      directionMatchRate: 0.5,
+      within1SigmaRate: 0.68,
+      madResidualNormalized: 0.6745,
+    });
+    expect(d.dopamineDelta).toBeCloseTo(0, 6);
+  });
+
+  it('positive dop when direction-match beats chance', () => {
+    const d = predictionChemistryDeltas({
+      n: 20,
+      directionMatchRate: 0.9,
+      within1SigmaRate: 0.7,
+      madResidualNormalized: 0.6745,
+    });
+    expect(d.dopamineDelta).toBeGreaterThan(0);
+    // tanh(0.4) * 0.5 ≈ 0.190
+    expect(d.dopamineDelta).toBeCloseTo(0.190, 2);
+  });
+
+  it('negative dop when direction-match is worse than chance', () => {
+    const d = predictionChemistryDeltas({
+      n: 20,
+      directionMatchRate: 0.1,
+      within1SigmaRate: 0.7,
+      madResidualNormalized: 0.6745,
+    });
+    expect(d.dopamineDelta).toBeLessThan(0);
+    expect(d.dopamineDelta).toBeCloseTo(-0.190, 2);
+  });
+
+  it('dop bounded by DOPAMINE_CAP=0.5 even at perfect prediction', () => {
+    const d = predictionChemistryDeltas({
+      n: 20,
+      directionMatchRate: 1.0,
+      within1SigmaRate: 1.0,
+      madResidualNormalized: 0.6745,
+    });
+    expect(d.dopamineDelta).toBeLessThanOrEqual(0.5);
+    expect(d.dopamineDelta).toBeGreaterThan(0.2);
+  });
+
+  it('zero ser at perfect calibration (MAD = std-normal MAD 0.6745)', () => {
+    const d = predictionChemistryDeltas({
+      n: 20,
+      directionMatchRate: 0.5,
+      within1SigmaRate: 0.68,
+      madResidualNormalized: 0.6745,
+    });
+    expect(d.serotoninDelta).toBeCloseTo(0, 6);
+  });
+
+  it('negative ser on under-confident (MAD too small) forecasts', () => {
+    // Tight residuals (MAD << 0.6745) = forecasts too wide = under-confident
+    const d = predictionChemistryDeltas({
+      n: 20,
+      directionMatchRate: 0.5,
+      within1SigmaRate: 0.9,
+      madResidualNormalized: 0.1,
+    });
+    expect(d.serotoninDelta).toBeLessThan(0);
+  });
+
+  it('negative ser on over-confident (MAD too large) forecasts', () => {
+    // Wide residuals (MAD >> 0.6745) = forecasts too narrow = over-confident
+    const d = predictionChemistryDeltas({
+      n: 20,
+      directionMatchRate: 0.5,
+      within1SigmaRate: 0.3,
+      madResidualNormalized: 3.0,
+    });
+    expect(d.serotoninDelta).toBeLessThan(0);
+  });
+
+  it('ser bounded by SEROTONIN_CAP=0.2', () => {
+    const d = predictionChemistryDeltas({
+      n: 20,
+      directionMatchRate: 0.5,
+      within1SigmaRate: 0.0,
+      madResidualNormalized: 100,
+    });
+    expect(d.serotoninDelta).toBeGreaterThanOrEqual(-0.2);
+    expect(d.serotoninDelta).toBeLessThan(-0.15);
+  });
+
+  it('source string carries the sample size', () => {
+    const d = predictionChemistryDeltas({
+      n: 17,
+      directionMatchRate: 0.5,
+      within1SigmaRate: 0.68,
+      madResidualNormalized: 0.6745,
+    });
+    expect(d.source).toContain('n=17');
+  });
+});

--- a/apps/api/src/services/monkey/autonomic_client.ts
+++ b/apps/api/src/services/monkey/autonomic_client.ts
@@ -140,6 +140,50 @@ export async function callAutonomicReward(req: RewardPush): Promise<void> {
   }
 }
 
+/**
+ * #941 Phase 3 parity client. Pushes the latest prediction-error
+ * chemistry deltas to the Python autonomic kernel so its NC
+ * derivation sees the same prediction-feedback signal the TS NC sees.
+ *
+ * Fire-and-forget: failure is non-fatal — Python NC simply lacks the
+ * prediction channel until the next refresh succeeds.
+ */
+export async function callAutonomicPredictionReward(req: {
+  instanceId: string;
+  dopamineDelta: number;
+  serotoninDelta: number;
+  n: number;
+}): Promise<void> {
+  const body = JSON.stringify({
+    instance_id: req.instanceId,
+    dopamine_delta: req.dopamineDelta,
+    serotonin_delta: req.serotoninDelta,
+    n: req.n,
+  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${ML_WORKER_URL}/monkey/autonomic/prediction_reward`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      logger.warn('[autonomic_client] prediction_reward push failed', {
+        status: res.status,
+        body: await res.text(),
+      });
+    }
+  } catch (err) {
+    logger.warn('[autonomic_client] prediction_reward push threw', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /** Feature-flag helper. */
 export function isPythonKernelEnabled(): boolean {
   return process.env.MONKEY_KERNEL_PY === 'true';

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -55,7 +55,11 @@ import {
   velocity,
   type Basin,
 } from './basin.js';
-import { callAutonomicTick, callAutonomicReward } from './autonomic_client.js';
+import {
+  callAutonomicTick,
+  callAutonomicReward,
+  callAutonomicPredictionReward,
+} from './autonomic_client.js';
 import { aggregatePeakTracker } from './aggregate_peak.js';
 import { wsPositionCache } from './ws_position_cache.js';
 import { marketIntelCache } from './market_intel.js';
@@ -158,6 +162,11 @@ import {
 import { planCloseChunks } from './closeChunker.js';
 import { SAFE_PNL_FROM_ROW, verifyPnl } from './safePnlSql.js';
 import { runPeriodicPnlScan } from './pnlReconciliationPeriodic.js';
+import { startPredictionResidualJob } from './predictionResidualJob.js';
+import {
+  computePredictionChemistry,
+  type PredictionChemistryDeltas,
+} from './predictionRewardEmitter.js';
 import { tryAcquireClose, releaseClose, isLikelyRaceLoss } from './close_coordinator.js';
 import { observeEquity, sizeDeflection } from './equity_gradient.js';
 import {
@@ -837,6 +846,15 @@ export class MonkeyKernel extends EventEmitter {
   private timer: ReturnType<typeof setInterval> | null = null;
   /** #932 row-level pnl divergence scanner timer. Runs independent of tick(). */
   private pnlScanTimer: ReturnType<typeof setInterval> | null = null;
+  /** #941 Phase 2 prediction-residual scanner timer. Runs independent of tick(). */
+  private residualScanTimer: ReturnType<typeof setInterval> | null = null;
+  /** #941 Phase 3 prediction-reward emitter timer. Refreshes the cached
+   *  prediction-error chemistry deltas every 30s; the tick loop reads
+   *  the cache and adds the deltas into computeNeurochemicals inputs. */
+  private predictionEmitterTimer: ReturnType<typeof setInterval> | null = null;
+  /** Cached prediction-error chemistry deltas, refreshed by
+   *  predictionEmitterTimer. Null until the first emitter pass. */
+  private cachedPredictionChemistry: PredictionChemistryDeltas | null = null;
   private tickMs: number;
   private readonly baseTickMs: number;
   private readonly symbols: string[];
@@ -1312,6 +1330,44 @@ export class MonkeyKernel extends EventEmitter {
       });
     }, 60_000);
     this.pnlScanTimer.unref?.();
+
+    // #941 Phase 2: prediction-residual job. Scans elapsed predictions every
+    // 60s, computes residuals at the actual elapsed horizon, writes
+    // kernel_outcome_residuals rows. Backfills final_residual_* on closed
+    // trades. P15-safe: try/catch per row, never blocks the tick loop.
+    // Cadence is structural (matches kernel tick × 2).
+    this.residualScanTimer = startPredictionResidualJob();
+    this.residualScanTimer.unref?.();
+
+    // #941 Phase 3: prediction-reward emitter. Refreshes the cached
+    // chemistry delta from residual rows every 30s (half the residual
+    // scan cadence, so the cache is never older than ~90s end-to-end).
+    // Cadence is structural — it bounds how quickly prediction-error
+    // chemistry catches up after a regime shift. Fire once immediately
+    // on start so the cache isn't null for the first 30s. Also mirror
+    // the deltas to the Python autonomic kernel so its NC sees the
+    // same prediction-feedback signal (#941 Step 6 parity).
+    const refreshPredictionCache = async (): Promise<void> => {
+      try {
+        const next = await computePredictionChemistry();
+        this.cachedPredictionChemistry = next;
+        void callAutonomicPredictionReward({
+          instanceId: this.instanceId,
+          dopamineDelta: next.dopamineDelta,
+          serotoninDelta: next.serotoninDelta,
+          n: next.summary.n,
+        });
+      } catch (err) {
+        logger.warn('[Monkey] prediction-chemistry refresh failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    };
+    void refreshPredictionCache();
+    this.predictionEmitterTimer = setInterval(() => {
+      void refreshPredictionCache();
+    }, 30_000);
+    this.predictionEmitterTimer.unref?.();
   }
 
   stop(): void {
@@ -1322,6 +1378,14 @@ export class MonkeyKernel extends EventEmitter {
     if (this.pnlScanTimer) {
       clearInterval(this.pnlScanTimer);
       this.pnlScanTimer = null;
+    }
+    if (this.residualScanTimer) {
+      clearInterval(this.residualScanTimer);
+      this.residualScanTimer = null;
+    }
+    if (this.predictionEmitterTimer) {
+      clearInterval(this.predictionEmitterTimer);
+      this.predictionEmitterTimer = null;
     }
     logger.info('[Monkey] kernel sleeping');
   }
@@ -2238,6 +2302,15 @@ export class MonkeyKernel extends EventEmitter {
     // and bump their capital share, but K's dopamine is K's only.
     const rewardDeltas = this.decayedRewardSums(Date.now(), 'K');
 
+    // #941 Phase 3: fold prediction-error chemistry into the same
+    // reward-delta channel. The emitter timer (every 30s) writes a
+    // pre-computed aggregate to cachedPredictionChemistry; tick reads
+    // the cache and adds the deltas additively. Null = first tick
+    // before emitter fired, or sustained DB error — treat as zero.
+    const predChem = this.cachedPredictionChemistry;
+    const predDop = predChem?.dopamineDelta ?? 0;
+    const predSer = predChem?.serotoninDelta ?? 0;
+
     // 2026-05-16 (#715/#716/#717 derivation refactor): build the
     // BasinObservables block from the basin's OWN per-tick history.
     // Every chemical's per-tick scale is set by what's typical FOR
@@ -2257,8 +2330,8 @@ export class MonkeyKernel extends EventEmitter {
       quantumWeight: regimeWeights.quantum,
       kappa: state.kappa,
       externalCoupling: couplingHealth,
-      rewardDopamineDelta: rewardDeltas.dopamine,
-      rewardSerotoninDelta: rewardDeltas.serotonin,
+      rewardDopamineDelta: rewardDeltas.dopamine + predDop,
+      rewardSerotoninDelta: rewardDeltas.serotonin + predSer,
       rewardEndorphinDelta: rewardDeltas.endorphin,
       observables: {
         phiHistory: state.phiHistory,
@@ -5509,6 +5582,14 @@ export class MonkeyKernel extends EventEmitter {
       cooldown,  // REGIME-3 postclose cooldown remaining (per side)
       orderId: monkeyOrderId ?? undefined,
       reason,
+      // #941 Phase 3: prediction-error chemistry surface. predN is the
+      // residual sample count in the last 5min window; predDop/predSer
+      // are the deltas being added into rewardDopamineDelta/
+      // rewardSerotoninDelta this tick. Zero before the emitter fires
+      // for the first time and during DB outage (see P15).
+      predN: predChem?.summary.n ?? 0,
+      predDop: predDop.toFixed(3),
+      predSer: predSer.toFixed(3),
     });
 
     // Persist mode observation for later Loop-1 aggregation + UI.

--- a/apps/api/src/services/monkey/predictionResidualJob.ts
+++ b/apps/api/src/services/monkey/predictionResidualJob.ts
@@ -1,0 +1,240 @@
+/**
+ * predictionResidualJob.ts — Phase 2 of issue #941 prediction-corpus.
+ *
+ * Matrix tier-3 directive (2026-05-27): every 60s, scan kernel_predictions
+ * rows whose predicted_horizon_seconds has elapsed and don't yet have a
+ * residual row at that horizon. Compute realised PnL at the horizon from
+ * the trade's actual pnl trajectory; write a kernel_outcome_residuals row.
+ *
+ * **Idempotent**: candidate query filters out any prediction that already
+ * has a residual row, so each prediction gets exactly one residual at the
+ * elapsed-time the job first evaluated it. One process owns the timer, so
+ * there is no concurrent-scan race to defend against.
+ *
+ * **P15-safe**: try/catch per row, log-and-skip on error, never blocks
+ * live writes. The kernel decision path is independent of this job's
+ * success or failure.
+ *
+ * **At trade close**: populate `autonomous_trades.final_residual_usdt`
+ * and `final_residual_normalized` from the prediction closest to the
+ * exit_time (the kernel's most recent forecast before the close).
+ *
+ * Pairs with Phase 3 (`predictionRewardEmitter.ts`), which reads from
+ * the residual rows this job writes to compute MAD-normalised
+ * direction-match and calibration composites for the chemistry feed.
+ *
+ * **Doctrinal anchors**:
+ * - P5 (Observer Sets All Params): no env knobs in this module.
+ *   Scan cadence (60s) is a structural setInterval; thresholds for
+ *   "horizon elapsed" come from the prediction row's own
+ *   predicted_horizon_seconds. No operator-tunable constants.
+ * - P15 (Fail-Closed Safety): every DB call is try/catch wrapped.
+ */
+
+import { pool } from '../../db/connection.js';
+import { logger } from '../../utils/logger.js';
+
+// Structural constants (not operator knobs).
+// 60s scan cadence: matches the typical kernel tick × 2 (30s × 2 ≈ 60s
+// gives a one-tick buffer). Faster scans would multiply DB load without
+// new information; slower scans would delay chemistry feedback.
+const SCAN_INTERVAL_MS = 60_000;
+// Maximum rows per scan — bounded to keep individual scans short.
+// At kernel ~3 snapshots/min × 2 symbols × 2 kernels = 12/min steady
+// state; 200 leaves comfortable headroom for catch-up after downtime.
+const SCAN_LIMIT = 200;
+
+export interface ResidualScanResult {
+  scannedRows: number;
+  residualsWritten: number;
+  errors: number;
+  finalResidualsBackfilled: number;
+}
+
+/**
+ * One scan pass: find ready predictions, compute residuals, write rows.
+ * Returns counts for telemetry.
+ *
+ * "Ready" = `predicted_horizon_seconds` is non-null AND
+ * `now() - snapshot_at >= predicted_horizon_seconds` AND no residual
+ * row exists at the elapsed time horizon.
+ */
+export async function scanPredictionResiduals(): Promise<ResidualScanResult> {
+  const result: ResidualScanResult = {
+    scannedRows: 0,
+    residualsWritten: 0,
+    errors: 0,
+    finalResidualsBackfilled: 0,
+  };
+
+  try {
+    // Find predictions whose horizon has elapsed and lack a residual at
+    // ANY horizon (we write one residual per (prediction, horizon-bucket)
+    // pair; bucket = floor of actual elapsed seconds, so re-running
+    // doesn't duplicate when the elapsed time crosses several "ticks"
+    // of the same bucket).
+    const candidates = await pool.query<{
+      id: string;
+      trade_id: string | null;
+      snapshot_at: Date;
+      predicted_horizon_seconds: number;
+      predicted_terminal_pnl_usdt: number | null;
+      predicted_pnl_stddev_usdt: number | null;
+      predicted_direction: number | null;
+    }>(
+      `SELECT p.id, p.trade_id, p.snapshot_at,
+              p.predicted_horizon_seconds,
+              p.predicted_terminal_pnl_usdt,
+              p.predicted_pnl_stddev_usdt,
+              p.predicted_direction
+         FROM kernel_predictions p
+         WHERE p.predicted_horizon_seconds IS NOT NULL
+           AND p.predicted_horizon_seconds > 0
+           AND EXTRACT(EPOCH FROM (NOW() - p.snapshot_at)) >= p.predicted_horizon_seconds
+           AND NOT EXISTS (
+             SELECT 1 FROM kernel_outcome_residuals r
+              WHERE r.prediction_id = p.id
+           )
+         ORDER BY p.snapshot_at DESC
+         LIMIT $1`,
+      [SCAN_LIMIT],
+    );
+    result.scannedRows = candidates.rows.length;
+
+    for (const row of candidates.rows) {
+      try {
+        const predictionId = row.id;
+        const snapshotMs = row.snapshot_at.getTime();
+        const elapsedSec = (Date.now() - snapshotMs) / 1000;
+        const horizonSec = Number(row.predicted_horizon_seconds);
+        const predictedTerminal = Number(row.predicted_terminal_pnl_usdt ?? 0);
+        const predictedStddev = Math.max(
+          1e-9,
+          Number(row.predicted_pnl_stddev_usdt ?? 1e-9),
+        );
+        const predictedDirection = Number(row.predicted_direction ?? 0);
+
+        // Realised PnL: if there's a parent trade, look up its current
+        // pnl (closed) or the kernel-computed unrealized pnl proxy
+        // (open). For closed trades, `pnl` is authoritative. For open
+        // trades, we use 0 as a baseline — the residual still gets a
+        // row so downstream telemetry sees the prediction's status,
+        // but the realised value is "not yet decided."
+        let realisedPnl = 0;
+        if (row.trade_id) {
+          const tradeQ = await pool.query<{ pnl: string | null; status: string }>(
+            `SELECT pnl, status FROM autonomous_trades WHERE id = $1`,
+            [row.trade_id],
+          );
+          if (tradeQ.rows[0]?.status === 'closed') {
+            realisedPnl = Number(tradeQ.rows[0].pnl ?? 0);
+          }
+        }
+
+        // Compute residual at the actual elapsed time (the horizon may
+        // have been overshot by some seconds depending on scan cadence).
+        // The predicted_pnl_at_eval is a linear interpolation toward
+        // the terminal forecast based on the elapsed/horizon ratio.
+        // This is the simplest faithful interpolation; future revisions
+        // could use the kernel's actual forecast curve if exposed.
+        const linearProgress = Math.min(1, elapsedSec / Math.max(1e-9, horizonSec));
+        const predictedAtEval = predictedTerminal * linearProgress;
+        const residual = realisedPnl - predictedAtEval;
+        const residualNormalized = residual / predictedStddev;
+        const directionMatch =
+          Math.sign(realisedPnl) === Math.sign(predictedDirection)
+          && predictedDirection !== 0;
+        const within1Sigma = Math.abs(residualNormalized) <= 1;
+        const within2Sigma = Math.abs(residualNormalized) <= 2;
+
+        await pool.query(
+          `INSERT INTO kernel_outcome_residuals (
+             prediction_id, time_since_prediction_s,
+             predicted_pnl_at_eval_usdt, realised_pnl_at_eval_usdt,
+             residual_usdt, residual_normalized,
+             direction_match, within_1_sigma, within_2_sigma
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+          [
+            predictionId,
+            elapsedSec,
+            predictedAtEval,
+            realisedPnl,
+            residual,
+            residualNormalized,
+            directionMatch,
+            within1Sigma,
+            within2Sigma,
+          ],
+        );
+        result.residualsWritten += 1;
+      } catch (err) {
+        result.errors += 1;
+        logger.warn('[predictionResidualJob] row scan failed — skipped', {
+          predictionId: row.id,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // Backfill autonomous_trades.final_residual_* for any trade that just
+    // closed and has residual data from this scan. The "closest prediction
+    // to exit_time" is the kernel's most recent forecast before close.
+    try {
+      const backfill = await pool.query<{ id: string }>(
+        `UPDATE autonomous_trades t
+            SET final_residual_usdt =
+                  (SELECT r.residual_usdt
+                     FROM kernel_outcome_residuals r
+                     JOIN kernel_predictions p ON p.id = r.prediction_id
+                    WHERE p.trade_id = t.id
+                    ORDER BY p.snapshot_at DESC
+                    LIMIT 1),
+                final_residual_normalized =
+                  (SELECT r.residual_normalized
+                     FROM kernel_outcome_residuals r
+                     JOIN kernel_predictions p ON p.id = r.prediction_id
+                    WHERE p.trade_id = t.id
+                    ORDER BY p.snapshot_at DESC
+                    LIMIT 1)
+          WHERE t.status = 'closed'
+            AND t.final_residual_usdt IS NULL
+            AND EXISTS (
+              SELECT 1 FROM kernel_predictions p2
+                WHERE p2.trade_id = t.id
+            )
+          RETURNING id`,
+      );
+      result.finalResidualsBackfilled = backfill.rowCount ?? 0;
+    } catch (err) {
+      logger.warn('[predictionResidualJob] final-residual backfill failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    if (result.residualsWritten > 0 || result.finalResidualsBackfilled > 0) {
+      logger.info('[predictionResidualJob] scan complete', result);
+    }
+  } catch (err) {
+    logger.warn('[predictionResidualJob] scan errored — next pass will retry', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    result.errors += 1;
+  }
+
+  return result;
+}
+
+/**
+ * Start the periodic scanner. Returns the timer handle so callers can
+ * cancel during shutdown.
+ *
+ * Cadence is structural (60s); not exposed as a knob.
+ */
+export function startPredictionResidualJob(): NodeJS.Timeout {
+  // Run once on start to catch up any residuals that elapsed during
+  // downtime, then schedule periodic re-scans.
+  void scanPredictionResiduals();
+  return setInterval(() => {
+    void scanPredictionResiduals();
+  }, SCAN_INTERVAL_MS);
+}

--- a/apps/api/src/services/monkey/predictionRewardEmitter.ts
+++ b/apps/api/src/services/monkey/predictionRewardEmitter.ts
@@ -1,0 +1,226 @@
+/**
+ * predictionRewardEmitter.ts — Phase 3 of issue #941 prediction-corpus.
+ *
+ * Matrix tier-3 directive (2026-05-27): every chemistry tick, read the
+ * residual rows that the Phase-2 residual job wrote, aggregate them into
+ * (direction-match, calibration) composites, and emit them as chemistry
+ * deltas so the kernel learns from prediction accuracy in addition to
+ * trade outcomes.
+ *
+ * Two channels:
+ *
+ * 1. **Dopamine ← direction-match rate**
+ *    Frozen reference = 0.5 (chance). The kernel earns dopamine when its
+ *    forecasts beat chance and pays back dopamine when they don't. Cap
+ *    matches the trade-outcome dop cap (0.5) because direction accuracy
+ *    is the same class of signal: "the kernel was right about what
+ *    happens next."
+ *
+ * 2. **Serotonin ← calibration quality**
+ *    Frozen reference = MAD of a standard normal (0.6745). The kernel
+ *    earns serotonin when its predicted_pnl_stddev matches realised
+ *    spread (well-calibrated forecast intervals) and pays back serotonin
+ *    when it doesn't (over- or under-confident). Cap 0.2 (smaller than
+ *    dop) because calibration is a slow-mood-shift signal, not a per-
+ *    event reward.
+ *
+ * **Doctrinal anchors**:
+ * - **P1 (Observer sets all params from frozen facts):**
+ *   Reference points (0.5 chance, 0.6745 std-normal MAD) are
+ *   mathematical constants, not operator knobs. The transform shape
+ *   (tanh) and caps mirror the trade-outcome channel's structural
+ *   choices, themselves cited as design constants in `pushReward()`.
+ * - **P14 (Variable Separation):**
+ *   Prediction-accuracy chemistry is its own channel, NOT folded into
+ *   the trade-outcome pnlFrac. A perfect forecaster that takes no
+ *   trades still earns this dopamine; a lucky trader with wrong
+ *   forecasts still feels this loss.
+ * - **P15 (Fail-Closed Safety):**
+ *   On any DB or aggregation error, the emitter returns zero deltas.
+ *   The trade-outcome reward loop continues unaffected.
+ */
+
+import { pool } from '../../db/connection.js';
+import { logger } from '../../utils/logger.js';
+
+// Structural constants (not operator knobs).
+// MIN_SAMPLES = 5: below this the rate estimates have stderr > 0.22 and
+// matching the noise floor in the trade-outcome reward path
+// (PNL_STDDEV_MIN_SAMPLES = 5 in loop.ts pushReward).
+const MIN_SAMPLES = 5;
+
+// Per-tick window: scan residuals evaluated in the last DEFAULT_WINDOW_MS.
+// 5 min is the cache-warm window for the chemistry tick loop; it bounds
+// how much old prediction error keeps reinforcing chemistry after the
+// underlying regime has shifted.
+const DEFAULT_WINDOW_MS = 5 * 60 * 1000;
+
+// Output caps (structural — mirror trade-outcome pushReward caps).
+const DOPAMINE_CAP = 0.5;
+const SEROTONIN_CAP = 0.2;
+
+// Frozen mathematical reference points.
+// CHANCE_RATE = 0.5: the direction-match rate of a coin flip; signed
+// deviation from this is the dopamine-bearing signal.
+const CHANCE_RATE = 0.5;
+// STD_NORMAL_MAD = 0.6745: the median absolute deviation of a standard
+// normal distribution. A perfectly-calibrated forecast (predicted_stddev
+// matching realised spread) produces residual_normalized values whose
+// MAD lands on this number. Deviation is mis-calibration.
+const STD_NORMAL_MAD = 0.6745;
+
+export interface ResidualSummary {
+  n: number;
+  directionMatchRate: number;
+  within1SigmaRate: number;
+  madResidualNormalized: number;
+}
+
+export interface PredictionChemistryDeltas {
+  dopamineDelta: number;
+  serotoninDelta: number;
+  source: string;
+  summary: ResidualSummary;
+}
+
+/**
+ * Read residuals evaluated in the last `windowMs` ms and return summary
+ * statistics. Returns n=0 (no signal) on any DB error.
+ */
+export async function summariseRecentResiduals(
+  windowMs: number = DEFAULT_WINDOW_MS,
+): Promise<ResidualSummary> {
+  const empty: ResidualSummary = {
+    n: 0,
+    directionMatchRate: 0,
+    within1SigmaRate: 0,
+    madResidualNormalized: 0,
+  };
+  try {
+    const rows = await pool.query<{
+      direction_match: boolean;
+      within_1_sigma: boolean;
+      residual_normalized: string | number;
+    }>(
+      `SELECT direction_match, within_1_sigma, residual_normalized
+         FROM kernel_outcome_residuals
+        WHERE evaluated_at >= NOW() - ($1 || ' milliseconds')::INTERVAL
+        ORDER BY evaluated_at DESC
+        LIMIT 500`,
+      [windowMs],
+    );
+    return summariseFromRows(rows.rows);
+  } catch (err) {
+    logger.warn('[predictionRewardEmitter] residual scan failed — zero signal', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return empty;
+  }
+}
+
+/**
+ * Pure aggregation — extracted for testability. Operates on the row
+ * shape returned by `summariseRecentResiduals`.
+ */
+export function summariseFromRows(
+  rows: Array<{
+    direction_match: boolean;
+    within_1_sigma: boolean;
+    residual_normalized: string | number;
+  }>,
+): ResidualSummary {
+  if (rows.length === 0) {
+    return {
+      n: 0,
+      directionMatchRate: 0,
+      within1SigmaRate: 0,
+      madResidualNormalized: 0,
+    };
+  }
+  let matches = 0;
+  let within1 = 0;
+  const resids: number[] = [];
+  for (const r of rows) {
+    if (r.direction_match) matches += 1;
+    if (r.within_1_sigma) within1 += 1;
+    const v = Number(r.residual_normalized);
+    if (Number.isFinite(v)) resids.push(v);
+  }
+  return {
+    n: rows.length,
+    directionMatchRate: matches / rows.length,
+    within1SigmaRate: within1 / rows.length,
+    madResidualNormalized: medianAbsoluteDeviation(resids),
+  };
+}
+
+/**
+ * Median absolute deviation around the median. Robust to outliers
+ * (50% breakdown point) — the same robustness reason the trade-outcome
+ * pushReward channel switched from stddev to MAD on 2026-05-25.
+ */
+export function medianAbsoluteDeviation(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const median = sorted.length % 2 === 0
+    ? (sorted[sorted.length / 2 - 1]! + sorted[sorted.length / 2]!) / 2
+    : sorted[Math.floor(sorted.length / 2)]!;
+  const devs = sorted.map((x) => Math.abs(x - median)).sort((a, b) => a - b);
+  const mad = devs.length % 2 === 0
+    ? (devs[devs.length / 2 - 1]! + devs[devs.length / 2]!) / 2
+    : devs[Math.floor(devs.length / 2)]!;
+  return mad;
+}
+
+/**
+ * Pure transform: residual summary → chemistry deltas.
+ *
+ * - Dopamine: signed deviation of directionMatchRate from chance (0.5),
+ *   tanh-squashed, scaled by DOPAMINE_CAP.
+ * - Serotonin: negative absolute deviation of MAD(residual_normalized)
+ *   from the standard-normal reference (0.6745). Perfect calibration
+ *   gives ser=0; mis-calibration drags ser toward -SEROTONIN_CAP.
+ *
+ * Below MIN_SAMPLES the function returns zero deltas (insufficient
+ * statistical power to update chemistry).
+ */
+export function predictionChemistryDeltas(
+  summary: ResidualSummary,
+): PredictionChemistryDeltas {
+  if (summary.n < MIN_SAMPLES) {
+    return {
+      dopamineDelta: 0,
+      serotoninDelta: 0,
+      source: `prediction_residual_insufficient:n=${summary.n}`,
+      summary,
+    };
+  }
+  const dirSignal = summary.directionMatchRate - CHANCE_RATE;
+  const dopamineDelta = Math.tanh(dirSignal) * DOPAMINE_CAP;
+
+  // Calibration: zero-or-negative score against the std-normal MAD
+  // reference. We don't reward "better than std-normal" because that
+  // means the forecast stddev was too wide (under-confident); the
+  // honest direction is "punish drift from perfect calibration."
+  const calibError = Math.abs(summary.madResidualNormalized - STD_NORMAL_MAD);
+  const serotoninDelta = -Math.tanh(calibError) * SEROTONIN_CAP;
+
+  return {
+    dopamineDelta,
+    serotoninDelta,
+    source: `prediction_residual:n=${summary.n}`,
+    summary,
+  };
+}
+
+/**
+ * Full orchestrator: scan residuals → compute deltas. Used by the
+ * chemistry tick loop in loop.ts. Always returns a result; on error
+ * the deltas are zero (see P15 anchor above).
+ */
+export async function computePredictionChemistry(
+  windowMs: number = DEFAULT_WINDOW_MS,
+): Promise<PredictionChemistryDeltas> {
+  const summary = await summariseRecentResiduals(windowMs);
+  return predictionChemistryDeltas(summary);
+}

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1426,6 +1426,33 @@ async def monkey_autonomic_reward(request: Request):
     }
 
 
+@app.post("/monkey/autonomic/prediction_reward")
+async def monkey_autonomic_prediction_reward(request: Request):
+    """Push the latest prediction-error chemistry deltas (#941 Phase 3).
+
+    Replaces (does not append) the kernel's cached prediction-error
+    chemistry. Folded additively into reward_sums on each tick(), then
+    cleared on wake. P14: kept separate from trade-outcome rewards.
+
+    Request body:
+      { instance_id, dopamine_delta, serotonin_delta, n }
+
+    Response: the cached deltas after replacement (for parity check).
+    """
+    payload = await request.json()
+    instance_id = payload.get("instance_id", "monkey-primary")
+    kernel = _get_autonomic(instance_id)
+    kernel.push_prediction_chemistry(
+        dopamine_delta=float(payload.get("dopamine_delta", 0.0)),
+        serotonin_delta=float(payload.get("serotonin_delta", 0.0)),
+        n=int(payload.get("n", 0)),
+    )
+    return {
+        "cached": kernel._cached_prediction_chemistry,
+        "snapshot": kernel.snapshot(),
+    }
+
+
 @app.get("/monkey/autonomic/snapshot/{instance_id}")
 async def monkey_autonomic_snapshot(instance_id: str):
     """Telemetry snapshot — sleep phase, pending reward count, decayed sums."""

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -198,6 +198,16 @@ class AutonomicKernel:
         self.label = label
         self._persistence = persistence
         self._pending_rewards: deque[ActivityReward] = deque(maxlen=REWARD_QUEUE_MAX)
+        # #941 Phase 3 prediction-error chemistry cache. Populated by the
+        # TS-side emitter via push_prediction_chemistry() and folded
+        # additively into reward_sums on each tick(). Cleared on wake.
+        # P14: kept SEPARATE from the trade-outcome reward queue — a
+        # perfect forecaster with no trades still earns this dopamine.
+        self._cached_prediction_chemistry: dict[str, float] = {
+            "dopamine_delta": 0.0,
+            "serotonin_delta": 0.0,
+            "n": 0.0,
+        }
         # Restore decay-aware reward queue from Redis if available.
         # The persistence layer drops entries whose decay < 0.01 so
         # we don't restore zero-contribution rewards.
@@ -306,6 +316,31 @@ class AutonomicKernel:
             endo,
         )
         return reward
+
+    # ────────── prediction-error chemistry (issue #941 Phase 3) ──────────
+
+    def push_prediction_chemistry(
+        self,
+        *,
+        dopamine_delta: float,
+        serotonin_delta: float,
+        n: int,
+    ) -> None:
+        """Replace the cached prediction-error chemistry delta.
+
+        Mirrors the TS-side emitter (predictionRewardEmitter.ts).
+        Caller passes pre-computed deltas (computed against the
+        kernel_outcome_residuals table). This method REPLACES — does
+        not append — so each refresh cycle's signal contributes once
+        per tick, not compounding across the refresh interval.
+
+        n is carried for telemetry / parity check only.
+        """
+        self._cached_prediction_chemistry = {
+            "dopamine_delta": float(dopamine_delta),
+            "serotonin_delta": float(serotonin_delta),
+            "n": float(n),
+        }
 
     # ─────────────────────── decayed reward sums ───────────────────────
 
@@ -448,13 +483,29 @@ class AutonomicKernel:
               inputs.woke from Ocean)
         """
         reward_sums = self._decayed_reward_sums(inputs.now_ms)
-        nc = self._compute_nc(inputs, reward_sums, inputs.is_awake)
+        # #941 Phase 3: fold cached prediction-error chemistry deltas
+        # into the same reward channel. Additive — same shape as the
+        # TS-side wiring in loop.ts tick() (cf. predDop / predSer).
+        pred = self._cached_prediction_chemistry
+        reward_sums_combined = {
+            "dopamine": reward_sums["dopamine"] + pred["dopamine_delta"],
+            "serotonin": reward_sums["serotonin"] + pred["serotonin_delta"],
+            "endorphin": reward_sums["endorphin"],
+        }
+        nc = self._compute_nc(inputs, reward_sums_combined, inputs.is_awake)
 
-        # Fresh mood on wake — clear stale reward events.
+        # Fresh mood on wake — clear stale reward events AND prediction
+        # cache (the residual rows underlying the cached delta are now
+        # stale relative to the new wake-state regime).
         if inputs.woke:
             self._pending_rewards.clear()
+            self._cached_prediction_chemistry = {
+                "dopamine_delta": 0.0,
+                "serotonin_delta": 0.0,
+                "n": 0.0,
+            }
 
-        return AutonomicTickResult(nc=nc, reward_sums=reward_sums)
+        return AutonomicTickResult(nc=nc, reward_sums=reward_sums_combined)
 
     # ───────────────────────── telemetry ─────────────────────────
 

--- a/ml-worker/tests/monkey_kernel/test_prediction_chemistry_parity.py
+++ b/ml-worker/tests/monkey_kernel/test_prediction_chemistry_parity.py
@@ -1,0 +1,114 @@
+"""test_prediction_chemistry_parity.py — parity tests for the prediction-
+error chemistry cache (#941 Phase 3).
+
+Pins the structural contract:
+  - push_prediction_chemistry REPLACES (not appends) the cached delta
+  - tick() folds the cached delta additively into reward_sums
+  - wake clears the cache (stale signal post-sleep)
+
+Mirror of apps/api/src/services/monkey/__tests__/predictionRewardEmitter.test.ts
+(pure-transform tests). The TS side computes the deltas from DB and POSTs
+them to /monkey/autonomic/prediction_reward, which calls
+push_prediction_chemistry on this kernel.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from monkey_kernel.autonomic import (  # noqa: E402
+    AutonomicKernel,
+    AutonomicTickInputs,
+)
+
+
+def _base_inputs(**overrides) -> AutonomicTickInputs:
+    defaults = {
+        "phi_delta": 0.0,
+        "basin_velocity": 0.1,
+        "surprise": 0.0,
+        "quantum_weight": 0.5,
+        "kappa": 64.0,
+        "external_coupling": 0.5,
+        "is_awake": True,
+        "now_ms": None,
+        "woke": False,
+        "surprise_history": [0.30, 0.45, 0.50, 0.55, 0.60, 0.65, 0.50],
+        "basin_velocity_history": None,
+        "kappa_history": [63.8, 64.0, 64.2],
+        "external_coupling_history": [0.30, 0.45, 0.50, 0.55, 0.70],
+        "mode_transition_times_ms": None,
+    }
+    defaults.update(overrides)
+    return AutonomicTickInputs(**defaults)
+
+
+def test_cache_initialised_to_zero():
+    k = AutonomicKernel(label="t")
+    assert k._cached_prediction_chemistry == {
+        "dopamine_delta": 0.0,
+        "serotonin_delta": 0.0,
+        "n": 0.0,
+    }
+
+
+def test_push_replaces_not_appends():
+    k = AutonomicKernel(label="t")
+    k.push_prediction_chemistry(dopamine_delta=0.3, serotonin_delta=-0.1, n=12)
+    k.push_prediction_chemistry(dopamine_delta=0.1, serotonin_delta=-0.05, n=15)
+    # Second call REPLACES — first call's delta is gone.
+    assert k._cached_prediction_chemistry["dopamine_delta"] == pytest.approx(0.1)
+    assert k._cached_prediction_chemistry["serotonin_delta"] == pytest.approx(-0.05)
+    assert k._cached_prediction_chemistry["n"] == pytest.approx(15.0)
+
+
+def test_tick_folds_cached_delta_into_reward_sums():
+    k = AutonomicKernel(label="t")
+    # Baseline tick with zero cache.
+    baseline = k.tick(_base_inputs())
+    assert baseline.reward_sums["dopamine"] == pytest.approx(0.0)
+    assert baseline.reward_sums["serotonin"] == pytest.approx(0.0)
+
+    # Push a positive dop delta, negative ser delta.
+    k.push_prediction_chemistry(dopamine_delta=0.25, serotonin_delta=-0.1, n=20)
+    after = k.tick(_base_inputs())
+    assert after.reward_sums["dopamine"] == pytest.approx(0.25)
+    assert after.reward_sums["serotonin"] == pytest.approx(-0.1)
+
+
+def test_wake_clears_cached_prediction_chemistry():
+    k = AutonomicKernel(label="t")
+    k.push_prediction_chemistry(dopamine_delta=0.4, serotonin_delta=0.1, n=30)
+    # Tick with woke=True signals wake transition.
+    k.tick(_base_inputs(woke=True))
+    assert k._cached_prediction_chemistry == {
+        "dopamine_delta": 0.0,
+        "serotonin_delta": 0.0,
+        "n": 0.0,
+    }
+
+
+def test_cache_does_not_compound_across_ticks():
+    """Per-tick reads do NOT accumulate. A pushed delta of +0.2 is the same
+    signal on tick 1 and tick 2; it doesn't compound."""
+    k = AutonomicKernel(label="t")
+    k.push_prediction_chemistry(dopamine_delta=0.2, serotonin_delta=0.0, n=10)
+    t1 = k.tick(_base_inputs())
+    t2 = k.tick(_base_inputs())
+    assert t1.reward_sums["dopamine"] == pytest.approx(t2.reward_sums["dopamine"])
+
+
+def test_endorphin_is_untouched_by_prediction_channel():
+    """P14 — prediction-error channel only routes to dop + ser; endorphin
+    stays as-is from the trade-outcome reward queue (here: empty = 0)."""
+    k = AutonomicKernel(label="t")
+    k.push_prediction_chemistry(dopamine_delta=0.5, serotonin_delta=0.5, n=50)
+    res = k.tick(_base_inputs())
+    assert res.reward_sums["endorphin"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

Closes the corpus-capture → chemistry feedback loop from #941. The kernel now learns from prediction accuracy in addition to trade outcomes.

- **Residual job**: 60s scanner finds elapsed predictions, computes residuals at actual elapsed horizon, writes `kernel_outcome_residuals` rows, backfills `final_residual_*` on closed trades.
- **Reward emitter**: pure-function summariser + transform — direction-match rate drives dopamine, MAD(residual_normalized) deviation from std-normal MAD (0.6745) drives serotonin. Cached every 30s and folded additively into the per-tick chemistry inputs.
- **Python parity**: `push_prediction_chemistry` method + `/monkey/autonomic/prediction_reward` route. TS emitter mirrors deltas to Python on each refresh so both kernels' NC sees the same signal.
- **Telemetry**: tick log now surfaces `predN` / `predDop` / `predSer`.

## Doctrinal anchors

- **P1** — reference points (0.5 chance, 0.6745 std-normal MAD) are mathematical constants, not knobs.
- **P14 (Variable Separation)** — prediction-accuracy chemistry kept separate from trade-outcome chemistry. A perfect forecaster with no trades still earns this dopamine.
- **P15 (Fail-Closed Safety)** — DB or aggregation failure returns zero deltas; trade-outcome loop unaffected.

## Test plan

- [x] TS pure-transform tests (17): MAD bounds, rate-from-rows, dop sign + cap at chance/perfect/zero/anti, ser sign + cap at perfect/over/under-confident, MIN_SAMPLES gate, string-coercion for Postgres numeric returns.
- [x] Python parity tests (6): cache initialised zero, push replaces (not appends), tick folds additively, wake clears cache, no compounding across ticks, endorphin untouched.
- [x] Full TS suite: 1053 / 1053 green; tsc clean.
- [x] Python autonomic-observer parity (17 existing tests): still green after autonomic.py edits.
- [ ] Live deploy: confirm `predN` rises above 0 in tick logs within ~5min of merge; confirm Python `/autonomic/snapshot` reflects non-zero `_cached_prediction_chemistry` after first refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)