### PR TITLE
feat(monkey): Matrix tier-4 Phase C — sovereignty×fluctuation sleep trigger

### DIFF
--- a/apps/api/src/services/monkey/__tests__/oceanSleepTrigger.test.ts
+++ b/apps/api/src/services/monkey/__tests__/oceanSleepTrigger.test.ts
@@ -1,0 +1,191 @@
+/**
+ * oceanSleepTrigger.test.ts — Phase C math-pin tests.
+ *
+ * Pins both predicates' contracts:
+ *   - sovereignty_saturated: 95th-percentile tail of own distribution
+ *   - fluctuation_overrun: Tukey outer fence on phi-variance distribution
+ *
+ * Plus the cold-start gates that prevent false-fires during the first
+ * 30 ticks of a freshly-woken kernel.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  quantile,
+  rollingPhiVariance,
+  sovereigntySaturated,
+  fluctuationOverrun,
+  doctrineSleepTrigger,
+} from '../ocean_sleep_trigger.js';
+
+describe('quantile (Hyndman-Fan type 7)', () => {
+  it('returns the single value on a length-1 sample', () => {
+    expect(quantile([5], 0.95)).toBe(5);
+  });
+
+  it('returns 0 on empty input (defensive)', () => {
+    expect(quantile([], 0.5)).toBe(0);
+  });
+
+  it('matches the standard convention for q=0.5 median', () => {
+    expect(quantile([1, 2, 3, 4, 5], 0.5)).toBe(3);
+  });
+
+  it('interpolates between adjacent ranks', () => {
+    // q=0.25 on [1..5] → pos = 1.0 → exact rank → 2
+    expect(quantile([1, 2, 3, 4, 5], 0.25)).toBe(2);
+    // q=0.95 on [1..100] → pos = 94.05 → 0.95×95 + 0.05×96 = 95.05
+    const xs = Array.from({ length: 100 }, (_, i) => i + 1);
+    expect(quantile(xs, 0.95)).toBeCloseTo(95.05, 6);
+  });
+});
+
+describe('rollingPhiVariance', () => {
+  it('returns 0 below 2 samples', () => {
+    expect(rollingPhiVariance([])).toBe(0);
+    expect(rollingPhiVariance([0.5])).toBe(0);
+  });
+
+  it('returns unbiased sample variance for 2 samples (ddof=1)', () => {
+    // var([0, 1]) ddof=1 = 0.5
+    expect(rollingPhiVariance([0, 1])).toBeCloseTo(0.5, 10);
+  });
+
+  it('takes the LAST windowSize samples', () => {
+    // Early values shouldn't contribute when slice excludes them.
+    const earlyOutlier = Array(5).fill(100);
+    const recent = Array(30).fill(0.5);
+    const hist = [...earlyOutlier, ...recent];
+    expect(rollingPhiVariance(hist, 30)).toBeCloseTo(0, 6);
+  });
+});
+
+describe('sovereigntySaturated', () => {
+  it('returns false below MIN_SAMPLES history (cold start)', () => {
+    expect(sovereigntySaturated(0.99, [0.1, 0.2, 0.3])).toBe(false);
+  });
+
+  it('returns false on non-finite current sovereignty (defensive)', () => {
+    const longHist = Array.from({ length: 50 }, () => 0.5);
+    expect(sovereigntySaturated(NaN, longHist)).toBe(false);
+    expect(sovereigntySaturated(Infinity, longHist)).toBe(false);
+  });
+
+  it('returns true when sovereignty hits the 95th percentile', () => {
+    // Distribution: 50 samples in [0.0, 0.5]. 95th percentile ≈ 0.475.
+    const hist: number[] = [];
+    for (let i = 0; i < 50; i++) hist.push((i / 49) * 0.5);
+    expect(sovereigntySaturated(0.49, hist)).toBe(true);
+    expect(sovereigntySaturated(0.5, hist)).toBe(true);
+  });
+
+  it('returns false when sovereignty is in the lower 94%', () => {
+    const hist: number[] = [];
+    for (let i = 0; i < 50; i++) hist.push((i / 49) * 0.5);
+    expect(sovereigntySaturated(0.2, hist)).toBe(false);
+    expect(sovereigntySaturated(0.4, hist)).toBe(false);
+  });
+
+  it('returns true at the boundary (current = quantile exactly)', () => {
+    const hist = Array.from({ length: 50 }, (_, i) => i);
+    // q=0.95 over [0..49] → pos = 46.55 → ≈ 46.55
+    const cutoff = (1 - 0.55) * 46 + 0.55 * 47;
+    expect(sovereigntySaturated(cutoff, hist)).toBe(true);
+  });
+});
+
+describe('fluctuationOverrun', () => {
+  it('returns false below MIN_BASELINE variance history (cold start)', () => {
+    const phiHist = Array(30).fill(0.5);
+    expect(fluctuationOverrun(phiHist, [0.01, 0.02, 0.03])).toBe(false);
+  });
+
+  it('returns false when phi history < 2', () => {
+    expect(fluctuationOverrun([], Array(50).fill(0.01))).toBe(false);
+    expect(fluctuationOverrun([0.5], Array(50).fill(0.01))).toBe(false);
+  });
+
+  it('returns false when current variance is inside the outer fence', () => {
+    // Steady kernel — current variance and baseline both ~0.01.
+    const phiHist = Array.from({ length: 30 }, (_, i) => 0.5 + (i % 2 === 0 ? 0.05 : -0.05));
+    const baseline = Array.from({ length: 50 }, () => 0.005 + Math.random() * 0.001);
+    expect(fluctuationOverrun(phiHist, baseline)).toBe(false);
+  });
+
+  it('returns true when current variance exceeds Q3 + 3·IQR outer fence', () => {
+    // Baseline has small spread (IQR > 0); current variance spikes ~250×.
+    const wildPhiHist = Array.from({ length: 30 }, (_, i) =>
+      i % 2 === 0 ? 0.0 : 1.0,  // var ≈ 0.258 ddof=1
+    );
+    const tightBaseline = Array.from({ length: 50 }, (_, i) => 0.001 + i * 1e-6);
+    expect(fluctuationOverrun(wildPhiHist, tightBaseline)).toBe(true);
+  });
+
+  it('returns false on degenerate baseline (IQR = 0)', () => {
+    const phiHist = Array.from({ length: 30 }, (_, i) => i % 2 === 0 ? 0 : 1);
+    const flatBaseline = Array(50).fill(0.5);  // IQR = 0
+    expect(fluctuationOverrun(phiHist, flatBaseline)).toBe(false);
+  });
+});
+
+describe('doctrineSleepTrigger — combined gate', () => {
+  it('does not sleep when neither predicate fires', () => {
+    const r = doctrineSleepTrigger({
+      sovereigntyNow: 0.1,
+      sovereigntyHistory: Array.from({ length: 50 }, (_, i) => i / 49),
+      phiHistory: Array(30).fill(0.5),
+      phiVarianceHistory: Array(50).fill(0.005),
+    });
+    expect(r.shouldSleep).toBe(false);
+    expect(r.sovereigntySaturated).toBe(false);
+    expect(r.fluctuationOverrun).toBe(false);
+  });
+
+  it('does not sleep when only sovereignty saturates (need BOTH)', () => {
+    const r = doctrineSleepTrigger({
+      sovereigntyNow: 0.99,
+      sovereigntyHistory: Array.from({ length: 50 }, (_, i) => i / 49),
+      phiHistory: Array(30).fill(0.5),  // zero variance
+      phiVarianceHistory: Array(50).fill(0.005),
+    });
+    expect(r.shouldSleep).toBe(false);
+    expect(r.sovereigntySaturated).toBe(true);
+    expect(r.fluctuationOverrun).toBe(false);
+  });
+
+  it('does not sleep when only fluctuation overruns (need BOTH)', () => {
+    const wildPhiHist = Array.from({ length: 30 }, (_, i) => (i % 2 === 0 ? 0 : 1));
+    const r = doctrineSleepTrigger({
+      sovereigntyNow: 0.1,
+      sovereigntyHistory: Array.from({ length: 50 }, (_, i) => i / 49),
+      phiHistory: wildPhiHist,
+      phiVarianceHistory: Array.from({ length: 50 }, (_, i) => 0.001 + i * 1e-6),
+    });
+    expect(r.shouldSleep).toBe(false);
+    expect(r.sovereigntySaturated).toBe(false);
+    expect(r.fluctuationOverrun).toBe(true);
+  });
+
+  it('SLEEPS when both fire (the doctrine condition)', () => {
+    const wildPhiHist = Array.from({ length: 30 }, (_, i) => (i % 2 === 0 ? 0 : 1));
+    const r = doctrineSleepTrigger({
+      sovereigntyNow: 0.99,
+      sovereigntyHistory: Array.from({ length: 50 }, (_, i) => i / 49),
+      phiHistory: wildPhiHist,
+      phiVarianceHistory: Array.from({ length: 50 }, (_, i) => 0.001 + i * 1e-6),
+    });
+    expect(r.shouldSleep).toBe(true);
+    expect(r.sovereigntySaturated).toBe(true);
+    expect(r.fluctuationOverrun).toBe(true);
+  });
+
+  it('cold-start safety: a fresh kernel does NOT sleep', () => {
+    // 5 ticks of state — both baselines too short.
+    const r = doctrineSleepTrigger({
+      sovereigntyNow: 0.99,
+      sovereigntyHistory: [0.1, 0.5, 0.9, 0.95, 0.99],
+      phiHistory: [0, 1, 0, 1, 0],
+      phiVarianceHistory: [0.01, 0.02, 0.03],
+    });
+    expect(r.shouldSleep).toBe(false);
+  });
+});

--- a/apps/api/src/services/monkey/ocean_sleep_trigger.ts
+++ b/apps/api/src/services/monkey/ocean_sleep_trigger.ts
@@ -1,0 +1,164 @@
+/**
+ * ocean_sleep_trigger.ts — Matrix tier-4 Phase C doctrine-clean
+ * sovereignty × fluctuation sleep trigger.
+ *
+ * Per [[polytrade-knob-free-recursive-doctrine]]:
+ *
+ *   IF ocean.sovereignty_saturated() AND ocean.fluctuation_overrun():
+ *     sleep()  # working context dissolves; QIGRAM basins persist;
+ *              # wake reconstructs
+ *
+ * Replaces the previous `MIN_AWAKE_MS / DRIFT_TRIGGER_TICKS` knob-pair
+ * with two observer-derived predicates:
+ *
+ * - **sovereignty_saturated**: kernel's current sovereignty has reached
+ *   the high tail (≥95th percentile) of its own rolling distribution.
+ *   This signals "QIGRAM weight saturated" — the kernel can't hold
+ *   more authority over its decisions.
+ *
+ * - **fluctuation_overrun**: recent Φ variance lands beyond the Tukey
+ *   outer fence (Q3 + 3·IQR) of the rolling Φ-variance distribution.
+ *   This signals "topological instability sustained" — the kernel
+ *   keeps churning without convergence.
+ *
+ * Both are pure functions of the kernel's own observables. No knobs;
+ * no operator-set thresholds. The 95th-percentile and Tukey 3·IQR
+ * are mathematical conventions for "tail" and "extreme outlier" — not
+ * operator choices.
+ *
+ * **Minimum-sample gates** prevent cold-start false fires:
+ * `SOVEREIGNTY_MIN_SAMPLES = 30` and `FLUCTUATION_MIN_BASELINE = 30`.
+ * Below these, the predicate returns false (safe default — never
+ * trigger sleep without a baseline to derive from).
+ */
+
+const SOVEREIGNTY_TAIL_QUANTILE = 0.95;
+const SOVEREIGNTY_MIN_SAMPLES = 30;
+const FLUCTUATION_TUKEY_OUTER = 3;
+const FLUCTUATION_MIN_BASELINE = 30;
+/** Rolling Φ-variance window — count of most-recent Φ readings used to
+ * compute the current variance reading. 30 ticks ≈ 5 min at 10s cadence,
+ * matches the rolling-window choice in the existing narrow-path detector. */
+const PHI_VARIANCE_WINDOW = 30;
+
+/**
+ * Quantile via Hyndman-Fan type 7 (the default for numpy.percentile
+ * and most statistical packages). Inputs need not be sorted.
+ */
+export function quantile(xs: number[], q: number): number {
+  if (xs.length === 0) return 0;
+  if (xs.length === 1) return xs[0]!;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const pos = q * (sorted.length - 1);
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  if (lo === hi) return sorted[lo]!;
+  const frac = pos - lo;
+  return sorted[lo]! * (1 - frac) + sorted[hi]! * frac;
+}
+
+/**
+ * Rolling variance of the last `windowSize` Φ readings. Uses the
+ * unbiased sample variance estimator (ddof=1) when window has ≥2
+ * samples; returns 0 below that.
+ */
+export function rollingPhiVariance(
+  phiHistory: readonly number[],
+  windowSize: number = PHI_VARIANCE_WINDOW,
+): number {
+  if (phiHistory.length < 2) return 0;
+  const window = phiHistory.slice(-windowSize);
+  const n = window.length;
+  const mean = window.reduce((a, b) => a + b, 0) / n;
+  let sumSq = 0;
+  for (const v of window) {
+    const d = v - mean;
+    sumSq += d * d;
+  }
+  return sumSq / (n - 1);
+}
+
+/**
+ * **sovereignty_saturated**: returns true iff the kernel's current
+ * sovereignty has reached the ≥95th percentile of its rolling
+ * distribution. Requires SOVEREIGNTY_MIN_SAMPLES history to fire.
+ *
+ * Math: the 95th-percentile cut-off is a mathematical convention for
+ * "right tail" — not an operator knob. If the doctrine wanted a
+ * different tail definition, it would define a different distribution
+ * landmark; the 95th comes from the same convention as the
+ * narrow-path detector's outer Tukey fence (both pin "extreme"
+ * relative to the kernel's own distribution).
+ */
+export function sovereigntySaturated(
+  sovereigntyNow: number,
+  sovereigntyHistory: readonly number[],
+): boolean {
+  if (!Number.isFinite(sovereigntyNow)) return false;
+  if (sovereigntyHistory.length < SOVEREIGNTY_MIN_SAMPLES) return false;
+  const cutoff = quantile(Array.from(sovereigntyHistory), SOVEREIGNTY_TAIL_QUANTILE);
+  return sovereigntyNow >= cutoff;
+}
+
+/**
+ * **fluctuation_overrun**: returns true iff the *current* Φ variance
+ * (rolling window of phiHistory) lands beyond the Tukey outer fence
+ * of the rolling Φ-variance distribution.
+ *
+ * Outer fence = Q3 + 3·IQR (severe outlier, not just inner-fence
+ * "moderate"). This mirrors the narrow-path detector's severity
+ * convention — the same robust statistic that detects basin collapse
+ * detects the opposite tail (sustained over-fluctuation).
+ *
+ * Returns false when there are fewer than FLUCTUATION_MIN_BASELINE
+ * past variance samples — safe cold-start behavior.
+ */
+export function fluctuationOverrun(
+  phiHistory: readonly number[],
+  phiVarianceHistory: readonly number[],
+): boolean {
+  if (phiHistory.length < 2) return false;
+  if (phiVarianceHistory.length < FLUCTUATION_MIN_BASELINE) return false;
+  const currentVar = rollingPhiVariance(phiHistory);
+  if (!Number.isFinite(currentVar) || currentVar <= 0) return false;
+  const sorted = Array.from(phiVarianceHistory).sort((a, b) => a - b);
+  const q1 = quantile(sorted, 0.25);
+  const q3 = quantile(sorted, 0.75);
+  const iqr = q3 - q1;
+  if (iqr <= 0) return false;
+  const outerFence = q3 + FLUCTUATION_TUKEY_OUTER * iqr;
+  return currentVar > outerFence;
+}
+
+export interface SleepTriggerObservables {
+  sovereigntyNow: number;
+  sovereigntyHistory: readonly number[];
+  phiHistory: readonly number[];
+  phiVarianceHistory: readonly number[];
+}
+
+export interface SleepTriggerResult {
+  shouldSleep: boolean;
+  sovereigntySaturated: boolean;
+  fluctuationOverrun: boolean;
+}
+
+/**
+ * Combined doctrine trigger. Sleep iff BOTH predicates fire.
+ *
+ * This is additive to the legacy `MIN_AWAKE_MS / DRIFT_TRIGGER_TICKS`
+ * trigger — callers check the legacy condition OR this one. When the
+ * `OCEAN_DOCTRINE_SLEEP_TRIGGER_LIVE` flag is off the doctrine path
+ * stays inert.
+ */
+export function doctrineSleepTrigger(
+  o: SleepTriggerObservables,
+): SleepTriggerResult {
+  const sov = sovereigntySaturated(o.sovereigntyNow, o.sovereigntyHistory);
+  const flu = fluctuationOverrun(o.phiHistory, o.phiVarianceHistory);
+  return {
+    shouldSleep: sov && flu,
+    sovereigntySaturated: sov,
+    fluctuationOverrun: flu,
+  };
+}

--- a/ml-worker/src/monkey_kernel/ocean_sleep_trigger.py
+++ b/ml-worker/src/monkey_kernel/ocean_sleep_trigger.py
@@ -1,0 +1,126 @@
+"""ocean_sleep_trigger.py — Matrix tier-4 Phase C Python parity port.
+
+Mirror of apps/api/src/services/monkey/ocean_sleep_trigger.ts.
+
+Per [[polytrade-knob-free-recursive-doctrine]]:
+
+    IF ocean.sovereignty_saturated() AND ocean.fluctuation_overrun():
+        sleep()  # working context dissolves; QIGRAM basins persist;
+                 # wake reconstructs
+
+- **sovereignty_saturated**: kernel's current sovereignty ≥ 95th
+  percentile of its rolling distribution (QIGRAM-weight saturated).
+- **fluctuation_overrun**: rolling Φ variance lands beyond the Tukey
+  outer fence (Q3 + 3·IQR) of past Φ-variance samples (topological
+  instability sustained).
+
+Both pure functions of the kernel's own observables. No knobs. Numeric
+contract (95th percentile, Tukey 3·IQR, ddof=1 variance) is identical
+TS↔Python.
+"""
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+SOVEREIGNTY_TAIL_QUANTILE: float = 0.95
+SOVEREIGNTY_MIN_SAMPLES: int = 30
+FLUCTUATION_TUKEY_OUTER: float = 3.0
+FLUCTUATION_MIN_BASELINE: int = 30
+PHI_VARIANCE_WINDOW: int = 30
+
+
+def quantile(xs: Sequence[float], q: float) -> float:
+    """Hyndman-Fan type 7 quantile — same default as numpy.percentile
+    (and the TS port). Does NOT mutate the input."""
+    if len(xs) == 0:
+        return 0.0
+    if len(xs) == 1:
+        return float(xs[0])
+    sorted_xs = sorted(xs)
+    pos = q * (len(sorted_xs) - 1)
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    if lo == hi:
+        return float(sorted_xs[lo])
+    frac = pos - lo
+    return float(sorted_xs[lo]) * (1.0 - frac) + float(sorted_xs[hi]) * frac
+
+
+def rolling_phi_variance(
+    phi_history: Sequence[float],
+    window_size: int = PHI_VARIANCE_WINDOW,
+) -> float:
+    """Unbiased sample variance (ddof=1) of the last `window_size`
+    samples. Returns 0 below 2 samples."""
+    if len(phi_history) < 2:
+        return 0.0
+    window = list(phi_history[-window_size:])
+    n = len(window)
+    mean = sum(window) / n
+    sum_sq = 0.0
+    for v in window:
+        d = v - mean
+        sum_sq += d * d
+    return sum_sq / (n - 1)
+
+
+def sovereignty_saturated(
+    sovereignty_now: float,
+    sovereignty_history: Sequence[float],
+) -> bool:
+    """True iff current sovereignty ≥ 95th percentile of own history.
+
+    Returns False on cold-start (history below MIN_SAMPLES) — never
+    trigger sleep without a baseline.
+    """
+    if not math.isfinite(sovereignty_now):
+        return False
+    if len(sovereignty_history) < SOVEREIGNTY_MIN_SAMPLES:
+        return False
+    cutoff = quantile(list(sovereignty_history), SOVEREIGNTY_TAIL_QUANTILE)
+    return sovereignty_now >= cutoff
+
+
+def fluctuation_overrun(
+    phi_history: Sequence[float],
+    phi_variance_history: Sequence[float],
+) -> bool:
+    """True iff current Φ variance > Q3 + 3·IQR of past Φ-variance
+    samples. Cold-start safe: returns False below MIN_BASELINE.
+    """
+    if len(phi_history) < 2:
+        return False
+    if len(phi_variance_history) < FLUCTUATION_MIN_BASELINE:
+        return False
+    current_var = rolling_phi_variance(phi_history)
+    if not math.isfinite(current_var) or current_var <= 0:
+        return False
+    sorted_var = sorted(phi_variance_history)
+    q1 = quantile(sorted_var, 0.25)
+    q3 = quantile(sorted_var, 0.75)
+    iqr = q3 - q1
+    if iqr <= 0:
+        return False
+    outer_fence = q3 + FLUCTUATION_TUKEY_OUTER * iqr
+    return current_var > outer_fence
+
+
+def doctrine_sleep_trigger(
+    sovereignty_now: float,
+    sovereignty_history: Sequence[float],
+    phi_history: Sequence[float],
+    phi_variance_history: Sequence[float],
+) -> dict:
+    """Combined trigger. Sleep iff BOTH predicates fire.
+
+    Returns a dict with `should_sleep`, `sovereignty_saturated`,
+    `fluctuation_overrun` for telemetry / parity inspection.
+    """
+    sov = sovereignty_saturated(sovereignty_now, sovereignty_history)
+    flu = fluctuation_overrun(phi_history, phi_variance_history)
+    return {
+        "should_sleep": sov and flu,
+        "sovereignty_saturated": sov,
+        "fluctuation_overrun": flu,
+    }

--- a/ml-worker/tests/monkey_kernel/test_ocean_sleep_trigger.py
+++ b/ml-worker/tests/monkey_kernel/test_ocean_sleep_trigger.py
@@ -1,0 +1,183 @@
+"""test_ocean_sleep_trigger.py — Matrix tier-4 Phase C Python parity.
+
+Mirrors apps/api/src/services/monkey/__tests__/oceanSleepTrigger.test.ts.
+The numeric contracts (95th percentile, Tukey 3·IQR, ddof=1 variance)
+MUST match TS bit-for-bit on the same inputs.
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from monkey_kernel.ocean_sleep_trigger import (  # noqa: E402
+    doctrine_sleep_trigger,
+    fluctuation_overrun,
+    quantile,
+    rolling_phi_variance,
+    sovereignty_saturated,
+)
+
+
+# ─── quantile (Hyndman-Fan type 7) ────────────────────────────
+
+
+def test_quantile_length_1():
+    assert quantile([5], 0.95) == 5
+
+
+def test_quantile_empty():
+    assert quantile([], 0.5) == 0
+
+
+def test_quantile_median():
+    assert quantile([1, 2, 3, 4, 5], 0.5) == 3
+
+
+def test_quantile_interpolation():
+    assert quantile([1, 2, 3, 4, 5], 0.25) == 2
+    xs = list(range(1, 101))
+    assert math.isclose(quantile(xs, 0.95), 95.05, abs_tol=1e-6)
+
+
+# ─── rolling_phi_variance ──────────────────────────────────────
+
+
+def test_rolling_var_below_2_samples():
+    assert rolling_phi_variance([]) == 0
+    assert rolling_phi_variance([0.5]) == 0
+
+
+def test_rolling_var_2_samples_ddof_1():
+    assert math.isclose(rolling_phi_variance([0, 1]), 0.5, rel_tol=1e-10)
+
+
+def test_rolling_var_uses_last_window():
+    early_outlier = [100] * 5
+    recent = [0.5] * 30
+    assert math.isclose(rolling_phi_variance(early_outlier + recent, 30), 0, abs_tol=1e-6)
+
+
+# ─── sovereignty_saturated ─────────────────────────────────────
+
+
+def test_sovereignty_cold_start_false():
+    assert sovereignty_saturated(0.99, [0.1, 0.2, 0.3]) is False
+
+
+def test_sovereignty_non_finite_false():
+    hist = [0.5] * 50
+    assert sovereignty_saturated(float("nan"), hist) is False
+    assert sovereignty_saturated(float("inf"), hist) is False
+
+
+def test_sovereignty_at_95th_percentile_true():
+    hist = [(i / 49) * 0.5 for i in range(50)]
+    assert sovereignty_saturated(0.49, hist) is True
+    assert sovereignty_saturated(0.5, hist) is True
+
+
+def test_sovereignty_below_95th_percentile_false():
+    hist = [(i / 49) * 0.5 for i in range(50)]
+    assert sovereignty_saturated(0.2, hist) is False
+    assert sovereignty_saturated(0.4, hist) is False
+
+
+# ─── fluctuation_overrun ───────────────────────────────────────
+
+
+def test_fluctuation_cold_start_baseline_false():
+    phi_hist = [0.5] * 30
+    assert fluctuation_overrun(phi_hist, [0.01, 0.02, 0.03]) is False
+
+
+def test_fluctuation_phi_history_too_short_false():
+    long_baseline = [0.01] * 50
+    assert fluctuation_overrun([], long_baseline) is False
+    assert fluctuation_overrun([0.5], long_baseline) is False
+
+
+def test_fluctuation_steady_state_false():
+    phi_hist = [0.5 + (0.05 if i % 2 == 0 else -0.05) for i in range(30)]
+    baseline = [0.005 + i * 1e-6 for i in range(50)]
+    assert fluctuation_overrun(phi_hist, baseline) is False
+
+
+def test_fluctuation_outer_fence_breach_true():
+    wild_phi = [0.0 if i % 2 == 0 else 1.0 for i in range(30)]  # var ≈ 0.258
+    tight_baseline = [0.001 + i * 1e-6 for i in range(50)]
+    assert fluctuation_overrun(wild_phi, tight_baseline) is True
+
+
+def test_fluctuation_degenerate_baseline_iqr_zero_false():
+    phi_hist = [0 if i % 2 == 0 else 1 for i in range(30)]
+    flat_baseline = [0.5] * 50  # IQR = 0
+    assert fluctuation_overrun(phi_hist, flat_baseline) is False
+
+
+# ─── doctrine_sleep_trigger — combined gate ────────────────────
+
+
+def test_doctrine_neither_predicate_false():
+    r = doctrine_sleep_trigger(
+        sovereignty_now=0.1,
+        sovereignty_history=[i / 49 for i in range(50)],
+        phi_history=[0.5] * 30,
+        phi_variance_history=[0.005] * 50,
+    )
+    assert r["should_sleep"] is False
+    assert r["sovereignty_saturated"] is False
+    assert r["fluctuation_overrun"] is False
+
+
+def test_doctrine_only_sovereignty_saturates_false():
+    r = doctrine_sleep_trigger(
+        sovereignty_now=0.99,
+        sovereignty_history=[i / 49 for i in range(50)],
+        phi_history=[0.5] * 30,
+        phi_variance_history=[0.005] * 50,
+    )
+    assert r["should_sleep"] is False
+    assert r["sovereignty_saturated"] is True
+    assert r["fluctuation_overrun"] is False
+
+
+def test_doctrine_only_fluctuation_overruns_false():
+    wild_phi = [0 if i % 2 == 0 else 1 for i in range(30)]
+    r = doctrine_sleep_trigger(
+        sovereignty_now=0.1,
+        sovereignty_history=[i / 49 for i in range(50)],
+        phi_history=wild_phi,
+        phi_variance_history=[0.001 + i * 1e-6 for i in range(50)],
+    )
+    assert r["should_sleep"] is False
+    assert r["sovereignty_saturated"] is False
+    assert r["fluctuation_overrun"] is True
+
+
+def test_doctrine_both_fire_sleeps():
+    wild_phi = [0 if i % 2 == 0 else 1 for i in range(30)]
+    r = doctrine_sleep_trigger(
+        sovereignty_now=0.99,
+        sovereignty_history=[i / 49 for i in range(50)],
+        phi_history=wild_phi,
+        phi_variance_history=[0.001 + i * 1e-6 for i in range(50)],
+    )
+    assert r["should_sleep"] is True
+    assert r["sovereignty_saturated"] is True
+    assert r["fluctuation_overrun"] is True
+
+
+def test_doctrine_cold_start_safety():
+    r = doctrine_sleep_trigger(
+        sovereignty_now=0.99,
+        sovereignty_history=[0.1, 0.5, 0.9, 0.95, 0.99],
+        phi_history=[0, 1, 0, 1, 0],
+        phi_variance_history=[0.01, 0.02, 0.03],
+    )
+    assert r["should_sleep"] is False


### PR DESCRIPTION
## Summary

Implements the doctrine-clean sleep trigger from [[polytrade-knob-free-recursive-doctrine]]:

```
IF ocean.sovereignty_saturated() AND ocean.fluctuation_overrun():
  sleep()
```

Two pure-function predicates, both observer-derived from the kernel's own rolling distributions. No knobs.

- `sovereignty_saturated(now, history)` → 95th-percentile right-tail
- `fluctuation_overrun(phi_hist, phi_var_hist)` → Tukey Q3 + 3·IQR outer fence on Φ variance
- `doctrineSleepTrigger(observables)` → both must fire

## Why not a numeric knob

The 95th percentile and Tukey 3·IQR are mathematical conventions for "right tail" / "severe outlier" — same robust statistics the existing narrow-path detector uses for the OPPOSITE tail (basin collapse). They're definitions of "extreme" relative to the kernel's own behavior, not operator-set thresholds.

## Cold-start safety

Both predicates return false below 30-sample baselines. A freshly-woken kernel cannot trigger sleep until it's observed enough of its own behavior to derive a meaningful threshold.

## Why port-only

The wire-up to Ocean's existing sleep state machine (additive, flag-gated) is a follow-on. This PR locks the math primitives so the wire-up can't invent a knob.

## Test plan

- [x] TS: 22 tests (quantile / variance / both predicates / 4 combined-gate cases / cold start)
- [x] Python: 21 parity tests
- [x] Numeric contract verified — TS↔Python compute identical thresholds on the same inputs

## Phase D follows

agent_L_qigram_v2 wake-reconstruction verification — confirm basins persist through sleep with QIGRAM weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)