### PR TITLE
feat(monkey-py): fully wire kappa_history + deprecate modes.py shadow motivators

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1737,6 +1737,8 @@ def _symbol_state_to_dict(st: SymbolState) -> dict:
         "phi_history": list(st.phi_history),
         "fhealth_history": list(st.fhealth_history),
         "drift_history": list(st.drift_history),
+        "integration_history": list(st.integration_history),
+        "kappa_history": list(st.kappa_history),
         "dca_add_count": st.dca_add_count,
         "last_entry_at_ms": st.last_entry_at_ms,
         "peak_pnl_usdt": st.peak_pnl_usdt,
@@ -1764,6 +1766,10 @@ def _symbol_state_from_dict(d: dict) -> SymbolState:
         phi_history=[float(x) for x in d.get("phi_history", [])],
         fhealth_history=[float(x) for x in d.get("fhealth_history", [])],
         drift_history=[float(x) for x in d.get("drift_history", [])],
+        integration_history=[
+            (float(p), float(i)) for p, i in d.get("integration_history", [])
+        ],
+        kappa_history=[float(x) for x in d.get("kappa_history", [])],
         dca_add_count=int(d.get("dca_add_count", 0)),
         last_entry_at_ms=d.get("last_entry_at_ms"),
         peak_pnl_usdt=d.get("peak_pnl_usdt"),
@@ -1928,12 +1934,16 @@ async def monkey_tick_run(request: Request):
             drift_hist = persistence.load_drift_history(sym)
             fhealth_hist = persistence.load_fhealth_history(sym)
             integration_hist = persistence.load_integration_history(sym)
+            kappa_hist_tuples = persistence.load_kappa_history(sym)
             if phi_hist or basin_hist:
                 state.phi_history = phi_hist
                 state.basin_history = basin_hist
                 state.drift_history = drift_hist
                 state.fhealth_history = fhealth_hist
                 state.integration_history = integration_hist
+                # kappa_history for the observer-derived transcendence anchor
+                # (median/MAD). Load the values only (timestamps are for heart/HRV).
+                state.kappa_history = [float(k) for k, _ in kappa_hist_tuples]
                 # Restore last_basin from the most recent basin in history
                 if basin_hist:
                     state.last_basin = basin_hist[-1]

--- a/ml-worker/src/monkey_kernel/modes.py
+++ b/ml-worker/src/monkey_kernel/modes.py
@@ -445,6 +445,13 @@ def detect_mode(
             neurochemistry=neurochemistry,
         )
 
+    # Frustration is a legacy mode-specific derived field ("persistent drift
+    # without investigation"). Compute it here from available data so we are
+    # independent of the legacy Motivators shape (which the canonical one
+    # does not have). This addresses the contract mismatch flagged in review.
+    investigation_val = getattr(mot, "investigation", 0.0)
+    frustration = abs(drift_now) if investigation_val <= 0 else 0.0
+
     # v0.6.5 gate — basinDirection blocks DRIFT. A clear directional
     # reading means she is NOT in an ambiguous state, regardless of
     # fHealth (which is structurally pinned ≥ 0.97 by noise-floor dims).
@@ -487,6 +494,6 @@ def detect_mode(
             "investigation": mot.investigation,
             "integration": mot.integration,
             "surprise": mot.surprise,
-            "frustration": mot.frustration,
+            "frustration": frustration,
         },
     }

--- a/ml-worker/src/monkey_kernel/modes.py
+++ b/ml-worker/src/monkey_kernel/modes.py
@@ -300,6 +300,16 @@ def compute_motivators(
     fhealth_history: list[float],
     neurochemistry: NeurochemicalState,
 ) -> Motivators:
+    """DEPRECATED — internal shadow copy.
+
+    Use the canonical implementation in monkey_kernel.motivators instead
+    (the one wired in tick.py with full kappa_history median/MAD transcendence
+    and the pure soft-saturation dopamine path).
+
+    This local version only exists for direct calls to detect_mode in tests
+    and will be removed once those are updated to pass the canonical motivators
+    object.
+    """
     # Curiosity = ΔΦ this tick (perception-volume expansion).
     # Fix 2026-05-16 (#718): use the current tick's phi_now vs the
     # most recent stored history value. The prior formulation
@@ -398,6 +408,10 @@ def detect_mode(
     drift_history: list[float],
     stud_reading: Any = None,
     stud_live: bool = False,
+    # When the caller (tick.py) passes the canonical motivators (now fully
+    # wired with history-derived transcendence), we use it directly instead
+    # of the legacy local copy below. This deprecates the shadow implementation.
+    motivators: Any = None,
 ) -> dict[str, Any]:
     """Classify current cognitive mode from derived state.
 
@@ -415,13 +429,21 @@ def detect_mode(
 
     drift_now = fisher_rao_distance(basin, identity_basin)
     fh_now = fhealth_history[-1] if fhealth_history else 0.5
-    mot = compute_motivators(
-        phi_now=phi,
-        phi_history=phi_history,
-        drift_history=drift_history,
-        fhealth_history=fhealth_history,
-        neurochemistry=neurochemistry,
-    )
+
+    if motivators is not None:
+        # Preferred path: use the fully-wired canonical motivators from tick.py
+        # (includes observer-derived transcendence, correct kappa_history, etc.).
+        mot = motivators
+    else:
+        # Legacy / direct-call path (tests, old callers). Will be removed
+        # once all call sites are updated.
+        mot = compute_motivators(
+            phi_now=phi,
+            phi_history=phi_history,
+            drift_history=drift_history,
+            fhealth_history=fhealth_history,
+            neurochemistry=neurochemistry,
+        )
 
     # v0.6.5 gate — basinDirection blocks DRIFT. A clear directional
     # reading means she is NOT in an ambiguous state, regardless of

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -252,6 +252,11 @@ class SymbolState:
     # Tier 1 motivators integration history — (phi, i_q) tuples per tick.
     # Used by compute_motivators for the CV(Φ × I_Q) integration motivator.
     integration_history: list[tuple[float, float]] = field(default_factory=list)
+    # Rolling κ observations for the observer-derived transcendence anchor
+    # (median/MAD). Mirrors the TS side and the accumulation already
+    # present for autonomic/sensations (dop/ser). Populated every tick
+    # after the kappa update; capped with other histories.
+    kappa_history: list[float] = field(default_factory=list)
     # Pre-#10 scalar bookkeeping — preserved as the "default lane"
     # (swing) view so existing tests + back-compat callers keep working.
     dca_add_count: int = 0
@@ -510,6 +515,10 @@ def run_tick(
     state.kappa = max(20.0, min(
         120.0, state.kappa * 0.8 + (kappa_star + kappa_delta) * 0.2,
     ))
+    # Feed the observer-derived transcendence formula (the canonical
+    # motivators.py path). This is what was missing — without it the
+    # Python kernel was falling back to transcendence=0 every tick.
+    state.kappa_history.append(state.kappa)
 
     w_q, w_e, w_eq = float(basin[0]), float(basin[1]), float(basin[2])
     reg_total = w_q + w_e + w_eq
@@ -579,14 +588,16 @@ def run_tick(
         kernel_state,
         prev_basin=state.last_basin,
         integration_history=state.integration_history,
+        kappa_history=state.kappa_history,
     )
     # Tier 4 sensations + drives. Auxiliary fields (compressed/expanded/
     # pressure/stillness/drift/resonance + approach/avoidance/conservation)
     # and UCP §6.1/§6.2 canonical fields (unified/fragmented/activated/
     # dampened/grounded/drifting + homeostasis/curiosity_drive). Threading
     # drift_history in lets the canonical Grounded/Drifting/Homeostasis
-    # derivations use the observed drift scale; kappa_history is not yet
-    # accumulated, so Activated/Dampened fall through to scale-free tanh.
+    # derivations use the observed drift scale. kappa_history is now
+    # accumulated and passed to the canonical motivators (transcendence
+    # uses median/MAD); sensations still have their own copy for dop/ser.
     sen = compute_sensations(
         kernel_state,
         prev_basin=state.last_basin,
@@ -708,6 +719,9 @@ def run_tick(
         drift_history=state.drift_history,
         stud_reading=stud_reading,
         stud_live=stud_live,
+        # Pass the canonical motivators (now fully wired with observer-derived
+        # transcendence) so detect_mode does not need its own shadow copy.
+        motivators=mot,
     )
     mode = mode_result["mode"]
     mode_changed = state.last_mode is not None and state.last_mode != mode
@@ -1415,6 +1429,8 @@ def run_tick(
         state.fhealth_history = state.fhealth_history[-history_max:]
     if len(state.integration_history) > history_max:
         state.integration_history = state.integration_history[-history_max:]
+    if len(state.kappa_history) > history_max:
+        state.kappa_history = state.kappa_history[-history_max:]
 
     # Persistence completion — write-through SymbolState histories
     # to qig-cache so they survive Railway redeploys. Without this,


### PR DESCRIPTION
Completes the Python-side wiring for the observer-derived transcendence anchor (median/MAD) and pure soft-saturation dopamine path from #974.

## What was missing / now wired

- `kappa_history` accumulation in the main `tick.py` loop (after kappa mutation, capped with other histories).
- Passed to the canonical `compute_motivators` (the one with the real formula).
- Persistence load on cold start / redeploy via the existing Redis `load_kappa_history` path (so restarts aren't fully cold for the new transcendence value).
- Round-tripping through `_symbol_state_to/from_dict` for shadow / independent-state / bus payloads.
- `detect_mode` (mode classifier) now receives the canonical motivators object instead of recomputing with the old shadow copy.

## Duplicate removal / deprecation

The legacy `compute_motivators` + `Motivators` inside `modes.py` (different contract, no transcendence, no kappa_history support) is now only a fallback for direct test calls to `detect_mode`. It is heavily deprecated and isolated. The hot path uses the single canonical implementation.

## Scope ("yes all")
- Persistence load on SymbolState cold start
- Deprecate / isolate the modes.py shadow implementation
- Full audit for other call sites + cleanup of stale comments

## Verification
- All relevant Python kernel tests pass (motivators, modes, autonomic parity, tick paths).
- Cold-start + restart paths now carry `kappa_history`.
- End-to-end parity with the TS side for the new formula.

## Related
- Builds directly on #974 (the merged transcendence + dop P1 PR).
- References the same memory keys.
- Removes the last "shadow path" feeling for the Python motivators layer.

Draft so we can wait for CI / bot comments, address them, then merge cleanly. Ready for review once bots are happy.

## Summary by Sourcery

Wire canonical motivators and kappa-based transcendence through the Python tick and mode-detection paths while isolating the legacy shadow implementation in modes.py.

New Features:
- Track and expose kappa_history on SymbolState to support observer-derived transcendence using the canonical motivators path.

Bug Fixes:
- Ensure transcendence is correctly computed each tick instead of defaulting to zero by feeding accumulated kappa_history into the canonical motivators.
- Derive frustration inside detect_mode from drift and investigation so it no longer depends on the legacy Motivators shape.

Enhancements:
- Persist kappa_history and integration_history through symbol state serialization and Redis-backed cold-start restores.
- Pass the canonical Motivators instance from tick.py into detect_mode, deprecating the local shadow compute_motivators implementation in modes.py.