### PR TITLE
feat(monkey): Cascade bleed-stop PR — 6 commits (Findings 1-3 + JOINT-A)

### DIFF
--- a/apps/api/src/services/backfillStackedGhostPnl.ts
+++ b/apps/api/src/services/backfillStackedGhostPnl.ts
@@ -130,20 +130,9 @@ export async function runStackedGhostPnlBackfill(opts: {
     }
 
     if (apply) {
-      for (const u of updates) {
-        try {
-          await pool.query(`UPDATE autonomous_trades SET pnl = $1 WHERE id = $2`, [
-            u.newPnl,
-            u.id,
-          ]);
-          totalRowsUpdated++;
-        } catch (updErr) {
-          logger.error('[BACKFILL] row update failed', {
-            id: u.id,
-            err: updErr instanceof Error ? updErr.message : String(updErr),
-          });
-        }
-      }
+      logger.error('[LIVED ONLY] refusing aggregate backfill apply — this path is a known phantom vector (Finding 1). Use per-row safe repair only.');
+      // Do not apply aggregate-derived pnl. This protects the canonical table.
+      // totalRowsUpdated stays 0 for this group.
     }
   }
 

--- a/apps/api/src/services/monkey/__tests__/adoptedPositionGate.test.ts
+++ b/apps/api/src/services/monkey/__tests__/adoptedPositionGate.test.ts
@@ -1,0 +1,191 @@
+/**
+ * adoptedPositionGate.test.ts — Commit 3 (Cascade brief 2026-05-27).
+ *
+ * Adopted positions (origin='adopted') skip the regime / phi /
+ * conviction / stale_bleed gates. Only directional_disagreement
+ * stays eligible — that gate doesn't depend on entry-basin anchors.
+ *
+ * Own positions (origin='own' or undefined) keep all gates active.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateRejustification } from '../held_position_rejustification.js';
+import { uniformBasin } from '../basin.js';
+
+const baseEmotions = {
+  curiosity: 0.5,
+  surprise: 0.3,
+  investigation: 0.5,
+  integration: 0.5,
+  transcendence: 0.5,
+  basinDistance: 0.2,
+  fundingDrag: 0,
+  // Emotion field used by conviction gate (low confidence + high anxiety+confusion):
+  confidence: 0.1,
+  anxiety: 0.4,
+  confusion: 0.4,
+  wonder: 0.2,
+  frustration: 0.5,
+  satisfaction: 0.2,
+  clarity: 0.3,
+  flow: 0.2,
+};
+
+const basinAtOpen = uniformBasin(64);
+const basinNow = uniformBasin(64);
+
+describe('Commit 3 — adopted positions skip regime / phi / conviction / stale_bleed', () => {
+  it('adopted: regime change condition active → NO fire', () => {
+    const result = evaluateRejustification({
+      origin: 'adopted',
+      regimeAtOpen: 'investigation',
+      phiAtOpen: 0.5,
+      regimeNow: 'exploration',   // different from regime_at_open
+      phiNow: 0.5,
+      emotions: baseEmotions,
+      regimeConfidence: 0.9,
+      regimeChangeStreak: 10,
+      regimeStabilityTicksRequired: 2,
+      basinAtOpen, basinNow,
+      heldDurationS: 60,
+      currentRoi: 0,
+    });
+    expect(result.fired).toBeNull();
+    expect(result.reason).toMatch(/adopted_position/);
+  });
+
+  it('adopted: phi collapsed below floor → NO fire', () => {
+    const result = evaluateRejustification({
+      origin: 'adopted',
+      regimeAtOpen: 'investigation',
+      phiAtOpen: 0.8,
+      regimeNow: 'investigation',
+      phiNow: 0.1,   // way below floor
+      emotions: baseEmotions,
+      basinAtOpen, basinNow,
+      heldDurationS: 60,
+      currentRoi: 0,
+    });
+    expect(result.fired).toBeNull();
+  });
+
+  it('adopted: conviction failed (conf < anx+conf, streak satisfied) → NO fire', () => {
+    const result = evaluateRejustification({
+      origin: 'adopted',
+      regimeAtOpen: 'investigation',
+      phiAtOpen: 0.5,
+      regimeNow: 'investigation',
+      phiNow: 0.5,
+      emotions: baseEmotions,
+      convictionFailedStreak: 10,
+      convictionFailedTicksRequired: 2,
+      basinAtOpen, basinNow,
+      heldDurationS: 60,
+      currentRoi: 0,
+    });
+    expect(result.fired).toBeNull();
+  });
+
+  it('adopted: stale-bleed condition (30+ min at -1% ROI) → NO fire', () => {
+    const result = evaluateRejustification({
+      origin: 'adopted',
+      regimeAtOpen: 'investigation',
+      phiAtOpen: 0.5,
+      regimeNow: 'investigation',
+      phiNow: 0.5,
+      emotions: baseEmotions,
+      basinAtOpen, basinNow,
+      heldDurationS: 60 * 60,  // 1h
+      currentRoi: -0.05,        // -5%
+    });
+    expect(result.fired).toBeNull();
+  });
+
+  it('adopted: directional_disagreement DOES fire (basinDir flipped vs held side)', () => {
+    const result = evaluateRejustification({
+      origin: 'adopted',
+      regimeAtOpen: 'investigation',
+      phiAtOpen: 0.5,
+      regimeNow: 'investigation',
+      phiNow: 0.5,
+      emotions: baseEmotions,
+      directionalDisagreementStreak: 5,
+      directionalDisagreementTicksRequired: 4,
+      basinAtOpen, basinNow,
+      heldDurationS: 60,
+      currentRoi: 0,
+    });
+    expect(result.fired).toBe('directional_disagreement');
+    expect(result.reason).toMatch(/adopted/);
+  });
+});
+
+describe('Commit 3 — own positions retain all gates (regression protection)', () => {
+  it('own: regime change condition active → fires regime_change', () => {
+    const result = evaluateRejustification({
+      origin: 'own',
+      regimeAtOpen: 'investigation',
+      phiAtOpen: 0.5,
+      regimeNow: 'exploration',
+      phiNow: 0.5,
+      emotions: baseEmotions,
+      regimeConfidence: 0.9,
+      regimeChangeStreak: 10,
+      regimeStabilityTicksRequired: 2,
+      basinAtOpen,
+      basinNow: uniformBasin(64).map((_, i) => i === 0 ? 1.0 : 0),  // moved
+      heldDurationS: 60,
+      currentRoi: 0,
+    });
+    expect(result.fired).toBe('regime_change');
+  });
+
+  it('own: phi collapsed → fires phi_collapse', () => {
+    const result = evaluateRejustification({
+      origin: 'own',
+      regimeAtOpen: 'investigation',
+      phiAtOpen: 0.8,
+      regimeNow: 'investigation',
+      phiNow: 0.1,
+      emotions: baseEmotions,
+      basinAtOpen, basinNow,
+      heldDurationS: 60,
+      currentRoi: 0,
+    });
+    expect(result.fired).toBe('phi_collapse');
+  });
+
+  it('own: conviction failed (streak satisfied) → fires conviction_failed', () => {
+    const result = evaluateRejustification({
+      origin: 'own',
+      regimeAtOpen: 'investigation',
+      phiAtOpen: 0.5,
+      regimeNow: 'investigation',
+      phiNow: 0.5,
+      emotions: baseEmotions,
+      convictionFailedStreak: 10,
+      convictionFailedTicksRequired: 2,
+      basinAtOpen, basinNow,
+      heldDurationS: 60,
+      currentRoi: 0,
+    });
+    expect(result.fired).toBe('conviction_failed');
+  });
+
+  it('omitted origin defaults to "own" (back-compat)', () => {
+    const result = evaluateRejustification({
+      // origin omitted
+      regimeAtOpen: 'investigation',
+      phiAtOpen: 0.5,
+      regimeNow: 'investigation',
+      phiNow: 0.5,
+      emotions: baseEmotions,
+      convictionFailedStreak: 10,
+      convictionFailedTicksRequired: 2,
+      basinAtOpen, basinNow,
+      heldDurationS: 60,
+      currentRoi: 0,
+    });
+    expect(result.fired).toBe('conviction_failed');
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/checkNotionalConsistency.test.ts
+++ b/apps/api/src/services/monkey/__tests__/checkNotionalConsistency.test.ts
@@ -1,0 +1,111 @@
+/**
+ * checkNotionalConsistency.test.ts — Finding 1 / LIVED ONLY 5.
+ *
+ * Pins the centralized notional self-consistency assertion. Any new
+ * row entering `autonomous_trades` must have `entry_price * quantity`
+ * match the originating order's declared notional within 0.1%.
+ * Mismatch = unit error (contracts vs base-asset) = phantom-PnL root cause.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkNotionalConsistency } from '../safePnlSql.js';
+
+describe('checkNotionalConsistency — base case', () => {
+  it('exact match → consistent', () => {
+    const c = checkNotionalConsistency(2000, 0.5, 1000);
+    expect(c.consistent).toBe(true);
+    expect(c.rowNotional).toBe(1000);
+    expect(c.divergencePct).toBe(0);
+  });
+
+  it('within 0.099% tolerance → consistent (slippage band)', () => {
+    // 1000 vs 999.05 = 0.095% — well inside tolerance
+    const c = checkNotionalConsistency(2000, 0.499525, 1000);
+    expect(c.consistent).toBe(true);
+    expect(c.divergencePct).toBeLessThan(0.001);
+  });
+
+  it('exactly at 0.1% boundary → still consistent (≤ tolerance)', () => {
+    // 2000 × 0.4995 = 999.0 → divergence = 0.001 (exactly at boundary)
+    const c = checkNotionalConsistency(2000, 0.4995, 1000);
+    expect(c.divergencePct).toBeCloseTo(0.001, 5);
+    expect(c.consistent).toBe(true);
+  });
+
+  it('above 0.101% → MISMATCH (out of tolerance)', () => {
+    // 1000 vs 998.5 = 0.15%
+    const c = checkNotionalConsistency(2000, 0.49925, 1000);
+    expect(c.consistent).toBe(false);
+    expect(c.diagnostic).toMatch(/MISMATCH/);
+  });
+});
+
+describe('checkNotionalConsistency — phantom-PnL root cause (contracts vs base-asset)', () => {
+  it('ETH 100× contracts inflation → MISMATCH', () => {
+    // Bug: kernel stored 13 contracts instead of 0.13 ETH (lot size 0.01 ETH/contract)
+    // entry_price=2080, "quantity"=13 (contracts) → rowNotional = $27,040
+    // expected notional from order = $270.4
+    // Ratio: 100×
+    const c = checkNotionalConsistency(2080, 13, 270.4);
+    expect(c.consistent).toBe(false);
+    expect(c.divergencePct).toBeGreaterThan(50);  // 100× → 99×
+    expect(c.diagnostic).toMatch(/unit mismatch/);
+  });
+
+  it('BTC 1000× contracts inflation → MISMATCH', () => {
+    // BTC lot size 0.001 → if 4 contracts stored vs 0.004 BTC: 1000× inflation
+    const c = checkNotionalConsistency(80000, 4, 320);
+    expect(c.consistent).toBe(false);
+    expect(c.divergencePct).toBeGreaterThan(900);
+    expect(c.diagnostic).toMatch(/unit mismatch/);
+  });
+
+  it('user incident: +$315 phantom on $1.03 real (~300× ratio)', () => {
+    // Real notional was ~$210 (entry 2080 × 0.1 ETH); kernel-written stored
+    // raw contracts as base-asset, blowing up notional ~300×.
+    const c = checkNotionalConsistency(2080, 30, 210);  // 30 cont stored as base
+    expect(c.consistent).toBe(false);
+    expect(c.divergencePct).toBeGreaterThan(200);
+  });
+});
+
+describe('checkNotionalConsistency — fall-open boundary cases', () => {
+  it('expectedNotional = 0 → consistent (no expected → assertion bypassed)', () => {
+    // Legacy callers that don't yet thread expected notional fall open
+    // so they keep working until threaded. Live INSERT paths MUST thread
+    // a real value; this is for boundary code only.
+    const c = checkNotionalConsistency(2000, 0.5, 0);
+    expect(c.consistent).toBe(true);
+    expect(c.diagnostic).toMatch(/no expected notional/);
+  });
+
+  it('expectedNotional < 0 → fall-open', () => {
+    expect(checkNotionalConsistency(2000, 0.5, -100).consistent).toBe(true);
+  });
+
+  it('expectedNotional NaN → fall-open', () => {
+    expect(checkNotionalConsistency(2000, 0.5, NaN).consistent).toBe(true);
+  });
+
+  it('expectedNotional Infinity → fall-open', () => {
+    expect(checkNotionalConsistency(2000, 0.5, Infinity).consistent).toBe(true);
+  });
+});
+
+describe('checkNotionalConsistency — tolerance parameter', () => {
+  it('tighter tolerance (0.05%) catches what default would allow', () => {
+    // 0.08% drift — passes default 0.1%, fails 0.05%
+    const c1 = checkNotionalConsistency(2000, 0.4996, 1000);
+    expect(c1.consistent).toBe(true);
+    const c2 = checkNotionalConsistency(2000, 0.4996, 1000, 0.0005);
+    expect(c2.consistent).toBe(false);
+  });
+
+  it('looser tolerance (1%) tolerates what default rejects', () => {
+    // 0.5% drift — fails default 0.1%, passes 1%
+    const c1 = checkNotionalConsistency(2000, 0.4975, 1000);
+    expect(c1.consistent).toBe(false);
+    const c2 = checkNotionalConsistency(2000, 0.4975, 1000, 0.01);
+    expect(c2.consistent).toBe(true);
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/emotions.test.ts
+++ b/apps/api/src/services/monkey/__tests__/emotions.test.ts
@@ -51,9 +51,28 @@ describe('Per-emotion formula', () => {
     const e = computeEmotions(m({ transcendence: 3.5 }), 0, 0, 0.4);
     APPROX(e.anxiety, 3.5 * 0.4);
   });
-  it('confidence = (1 − transcendence) × phi', () => {
+  it('confidence = phi × max(0, heldAlignment) (Commit 6 / JOINT-A — trans decoupled)', () => {
+    // Default heldAlignment=1.0 → confidence = phi (transcendence
+    // no longer multiplies into the conviction gate). Per Cascade
+    // brief 2026-05-27: confidence reflects "kernel's geometric
+    // view supports the held direction"; trans stays live in anxiety
+    // as the regime-change detector.
     const e = computeEmotions(m({ transcendence: 0.3 }), 0, 0.7, 0);
-    APPROX(e.confidence, (1 - 0.3) * 0.7);
+    APPROX(e.confidence, 0.7);
+  });
+
+  it('confidence = phi × heldAlignment when heldAlignment is supplied', () => {
+    // basinDir 50% aligned with held side → confidence = phi × 0.5.
+    const aligned = computeEmotions(m({ transcendence: 0.3 }), 0, 0.7, 0,
+      { heldAlignment: 0.5 });
+    APPROX(aligned.confidence, 0.7 * 0.5);
+  });
+
+  it('confidence = 0 when basinDir fully opposes held side', () => {
+    // max(0, -1) = 0 → confidence collapses to zero, gate trips.
+    const opposed = computeEmotions(m({ transcendence: 0.3 }), 0, 0.7, 0,
+      { heldAlignment: -1 });
+    APPROX(opposed.confidence, 0);
   });
   it('boredom = (1 − surprise) × (1 − curiosity)', () => {
     const e = computeEmotions(m({ surprise: 0.1, curiosity: 0.4 }), 0, 0, 0);
@@ -69,10 +88,14 @@ describe('Regime reporting (no clipping)', () => {
     APPROX(e.anxiety, 4.0);
     expect(e.anxiety).toBeGreaterThan(1.0);
   });
-  it('confidence can go negative when transcendence > 1', () => {
-    const e = computeEmotions(m({ transcendence: 5.0 }), 0, 0.6, 0);
-    APPROX(e.confidence, -2.4);
-    expect(e.confidence).toBeLessThan(0);
+  it('confidence is bounded ≥ 0 (Commit 6 — max(0, heldAlignment) clamp)', () => {
+    // Pre-JOINT-A this fired negative when trans > 1. Post-decouple
+    // the trans channel doesn't touch confidence at all; the only
+    // way confidence can be 0 is heldAlignment ≤ 0 (basinDir flipped).
+    const e = computeEmotions(m({ transcendence: 5.0 }), 0, 0.6, 0,
+      { heldAlignment: -1 });
+    APPROX(e.confidence, 0);
+    expect(e.confidence).toBeGreaterThanOrEqual(0);
   });
   it('satisfaction can go negative when far from identity', () => {
     const e = computeEmotions(m({ integration: 0.5 }), 1.4, 0, 0);
@@ -94,10 +117,13 @@ describe('UCP §6.5 reference values (typical operating regime)', () => {
     expect(e.satisfaction).toBeGreaterThanOrEqual(0.849 - 0.021);
     expect(e.satisfaction).toBeLessThanOrEqual(0.849 + 0.021);
   });
-  it('Confidence anticorrelates with transcendence (UCP −0.690)', () => {
+  it('Confidence DECOUPLED from transcendence post-JOINT-A (Commit 6)', () => {
+    // Pre-decouple confidence anticorrelated with trans (UCP −0.690).
+    // Post-decouple: same phi + same heldAlignment ⇒ same confidence
+    // regardless of trans. This pins the doctrine inversion.
     const lo = computeEmotions(m({ transcendence: 0.1 }), 0, 0.5, 0);
     const hi = computeEmotions(m({ transcendence: 0.9 }), 0, 0.5, 0);
-    expect(lo.confidence).toBeGreaterThan(hi.confidence);
+    APPROX(lo.confidence, hi.confidence);
   });
 });
 
@@ -143,7 +169,7 @@ const PARITY_ROWS: ParityRow[] = [
   { motivators: { surprise: 0.5, curiosity: 0.0, investigation: 0.5, integration: 0.0, transcendence: 3.0 },
     basinDistance: 0.0, phi: 0.4, basinVelocity: 0.0,
     expected: { wonder: 0.0, frustration: 0.25, satisfaction: 0.0, confusion: 0.0,
-      clarity: 0.25, anxiety: 0.0, confidence: -0.8, boredom: 0.5 } },
+      clarity: 0.25, anxiety: 0.0, confidence: 0.4, boredom: 0.5 } },  // Commit 6: phi (was -0.8 = (1-3)*0.4)
   { motivators: { surprise: 0.5, curiosity: 1.0, investigation: 0.5, integration: 0.0, transcendence: 0.0 },
     basinDistance: 0.7, phi: 0.5, basinVelocity: 0.0,
     expected: { wonder: 0.7, frustration: 0.25, satisfaction: 0.0, confusion: 0.35,
@@ -151,7 +177,7 @@ const PARITY_ROWS: ParityRow[] = [
   { motivators: { surprise: 0.5, curiosity: 0.5, investigation: 0.5, integration: 1.0, transcendence: 0.5 },
     basinDistance: 0.3, phi: 0.5, basinVelocity: 0.2,
     expected: { wonder: 0.15, frustration: 0.25, satisfaction: 0.7, confusion: 0.15,
-      clarity: 0.25, anxiety: 0.1, confidence: 0.25, boredom: 0.25 } },
+      clarity: 0.25, anxiety: 0.1, confidence: 0.5, boredom: 0.25 } },  // Commit 6: phi (was 0.25 = (1-0.5)*0.5)
   { motivators: { surprise: 0.0, curiosity: 0.0, investigation: 0.5, integration: 0.94, transcendence: 0.0 },
     basinDistance: 0.097, phi: 0.5, basinVelocity: 0.1,
     expected: { wonder: 0.0, frustration: 0.0, satisfaction: 0.94 * (1 - 0.097),

--- a/apps/api/src/services/monkey/__tests__/kernelDirectUnitInvariant.test.ts
+++ b/apps/api/src/services/monkey/__tests__/kernelDirectUnitInvariant.test.ts
@@ -1,0 +1,77 @@
+/**
+ * kernelDirectUnitInvariant.test.ts — Commit 5 (Cascade brief 2026-05-27).
+ *
+ * Regression guard pinning the kernel-direct INSERT path's unit invariant:
+ * `formattedSize` is BASE ASSET (BTC, ETH, ...) and `entryPrice * formattedSize`
+ * is USDT notional. The contracts/base-asset boundary lives in
+ * `poloniexFuturesService.placeOrder` — the kernel never sees contracts.
+ *
+ * If a future change accidentally stores contracts in `quantity` (the
+ * historic phantom-PnL 100×/1000× class of bug), Commit 1's
+ * checkNotionalConsistency assertion immediately catches it. These tests
+ * pin the catch behavior at the unit boundary on realistic Polo-scale inputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkNotionalConsistency } from '../safePnlSql.js';
+
+describe('Commit 5 — kernel-direct INSERT unit invariant (regression guard)', () => {
+  describe('correct base-asset quantity passes the gate', () => {
+    it('ETH 0.5 base-asset at $2080 → notional $1040 matches intended', () => {
+      const c = checkNotionalConsistency(2080, 0.5, 1040);
+      expect(c.consistent).toBe(true);
+    });
+
+    it('BTC 0.012 base-asset at $80000 → notional $960 matches intended', () => {
+      const c = checkNotionalConsistency(80000, 0.012, 960);
+      expect(c.consistent).toBe(true);
+    });
+
+    it('typical Polo slippage (0.05%) stays consistent', () => {
+      // Intended notional $1000; actual fill at slightly worse price.
+      // entry $2080 × 0.4805 = $999.44 (0.056% drift) — within tolerance.
+      const c = checkNotionalConsistency(2080, 0.4805, 1000);
+      expect(c.consistent).toBe(true);
+    });
+  });
+
+  describe('contracts-stored-as-base-asset regression patterns are rejected', () => {
+    it('ETH lot=0.01 contracts-as-quantity → 100× inflation rejected', () => {
+      // Bug: writer wrote 13 contracts (≈0.13 ETH) into the base-asset column.
+      // entry $2080 × 13 = $27,040 vs intended $270.4 → 100× ratio.
+      const c = checkNotionalConsistency(2080, 13, 270.4);
+      expect(c.consistent).toBe(false);
+      expect(c.diagnostic).toMatch(/unit mismatch/);
+    });
+
+    it('BTC lot=0.001 contracts-as-quantity → 1000× inflation rejected', () => {
+      // Bug: 4 contracts (≈0.004 BTC) stored as base-asset.
+      // entry $80000 × 4 = $320,000 vs intended $320 → 1000× ratio.
+      const c = checkNotionalConsistency(80000, 4, 320);
+      expect(c.consistent).toBe(false);
+      expect(c.diagnostic).toMatch(/unit mismatch/);
+    });
+
+    it('historic +$374.12 phantom on +$0.0026 real (~144000× ratio)', () => {
+      // Reconciler scalp_exit phantom from the 2026-05-26 audit. Such
+      // ratios are absurd by construction; the assertion catches them
+      // wherever they originate.
+      const c = checkNotionalConsistency(2080, 100, 0.005);
+      expect(c.consistent).toBe(false);
+      expect(c.divergencePct).toBeGreaterThan(1000);
+    });
+  });
+
+  describe('the partial-fill / slippage band — caught when > 0.1%', () => {
+    it('0.05% drift (within slippage band) → consistent', () => {
+      const c = checkNotionalConsistency(2080, 0.4998, 1040);
+      expect(c.consistent).toBe(true);
+    });
+
+    it('0.15% drift (above tolerance) → caught', () => {
+      // entry $2080 × 0.49925 = $1038.44 vs $1040 → 0.15% drift.
+      const c = checkNotionalConsistency(2080, 0.49925, 1040);
+      expect(c.consistent).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/laneMultiplierFromTickPeriod.test.ts
+++ b/apps/api/src/services/monkey/__tests__/laneMultiplierFromTickPeriod.test.ts
@@ -1,0 +1,106 @@
+/**
+ * laneMultiplierFromTickPeriod.test.ts — Commit 2 (Cascade brief 2026-05-27).
+ *
+ * Replaces the hardcoded DISAGREEMENT_LANE_MULTIPLIER table {scalp:1,
+ * swing:3, trend:10} with a derivation from the substrate's actual
+ * tick period. Lane definitions encode the wall-clock decision window;
+ * dividing by tick period gives the streak length in ticks that
+ * occupies that window. Floor 2 prevents single-tick fires.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock env config so importing loop.ts (→ encryptionService → env)
+// doesn't blow up on missing DATABASE_URL / JWT_SECRET in the test env.
+vi.mock('../../../config/env.js', () => ({
+  env: {
+    NODE_ENV: 'test',
+    PORT: 8765,
+    DATABASE_URL: 'postgresql://test:5432/test',
+    JWT_SECRET: 'test-jwt-secret-32-characters-xxxxxxxxxx',
+  },
+}));
+vi.mock('../../../db/connection.js', () => ({
+  pool: { query: vi.fn() },
+}));
+
+import { laneMultiplierFromTickPeriod } from '../loop.js';
+
+// LANE_DECISION_PERIOD_MS values (must stay in sync with loop.ts):
+// scalp 60s, swing 180s, trend 600s.
+
+describe('laneMultiplierFromTickPeriod — canonical adaptive-tick cadences', () => {
+  describe('canonical 30s tick (default base cadence)', () => {
+    it('scalp → 2 (= 60/30)', () => {
+      expect(laneMultiplierFromTickPeriod('scalp', 30_000)).toBe(2);
+    });
+    it('swing → 6 (= 180/30)', () => {
+      expect(laneMultiplierFromTickPeriod('swing', 30_000)).toBe(6);
+    });
+    it('trend → 20 (= 600/30)', () => {
+      expect(laneMultiplierFromTickPeriod('trend', 30_000)).toBe(20);
+    });
+  });
+
+  describe('fast tick 15s (EXPLORATION mode) — more confirmation per lane', () => {
+    it('scalp → 4', () => {
+      expect(laneMultiplierFromTickPeriod('scalp', 15_000)).toBe(4);
+    });
+    it('swing → 12', () => {
+      expect(laneMultiplierFromTickPeriod('swing', 15_000)).toBe(12);
+    });
+    it('trend → 40', () => {
+      expect(laneMultiplierFromTickPeriod('trend', 15_000)).toBe(40);
+    });
+  });
+
+  describe('slow tick 60s (INTEGRATION/DRIFT) — matches legacy hardcoded {1, 3, 10}', () => {
+    it('scalp → 2 (floor — would be 1, floored)', () => {
+      expect(laneMultiplierFromTickPeriod('scalp', 60_000)).toBe(2);
+    });
+    it('swing → 3', () => {
+      expect(laneMultiplierFromTickPeriod('swing', 60_000)).toBe(3);
+    });
+    it('trend → 10', () => {
+      expect(laneMultiplierFromTickPeriod('trend', 60_000)).toBe(10);
+    });
+  });
+});
+
+describe('laneMultiplierFromTickPeriod — floor and defensive behaviour', () => {
+  it('floor at 2 — degenerate fast tick still requires ≥ 2 ticks', () => {
+    // Hypothetical scalp at 100s tick (faster than scalp decision window):
+    // 60/100 = 0.6 → rounds to 1 → floored to 2
+    expect(laneMultiplierFromTickPeriod('scalp', 100_000)).toBe(2);
+  });
+
+  it('zero tick period → floor (defensive)', () => {
+    expect(laneMultiplierFromTickPeriod('scalp', 0)).toBe(2);
+    expect(laneMultiplierFromTickPeriod('swing', 0)).toBe(2);
+    expect(laneMultiplierFromTickPeriod('trend', 0)).toBe(2);
+  });
+
+  it('negative tick period → floor (defensive)', () => {
+    expect(laneMultiplierFromTickPeriod('scalp', -1000)).toBe(2);
+  });
+
+  it('NaN tick period → floor (defensive)', () => {
+    expect(laneMultiplierFromTickPeriod('scalp', NaN)).toBe(2);
+  });
+
+  it('Infinity tick period → floor (1 second tick would be 1 → floored to 2)', () => {
+    expect(laneMultiplierFromTickPeriod('scalp', Infinity)).toBe(2);
+  });
+});
+
+describe('laneMultiplierFromTickPeriod — round-trip with the legacy multiplier', () => {
+  it('at 60s tick all three lanes match legacy {1, 3, 10}, except scalp which floors to 2', () => {
+    // The legacy table {scalp:1, swing:3, trend:10} encoded behaviour
+    // at tickMs=60s. The new derivation matches swing/trend exactly
+    // and tightens scalp from 1 → 2 (which removes the single-tick
+    // fire that was identified as a source of noise harvest).
+    expect(laneMultiplierFromTickPeriod('swing', 60_000)).toBe(3);
+    expect(laneMultiplierFromTickPeriod('trend', 60_000)).toBe(10);
+    expect(laneMultiplierFromTickPeriod('scalp', 60_000)).toBe(2);
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/observerConvictionStreak.test.ts
+++ b/apps/api/src/services/monkey/__tests__/observerConvictionStreak.test.ts
@@ -1,0 +1,92 @@
+/**
+ * observerConvictionStreak.test.ts — Commit 4 (Cascade brief 2026-05-27).
+ *
+ * Pins the observer-derived conviction streak requirement: the floor
+ * (2) for monotonic collapse, the cap (12) for highly oscillatory
+ * emotion telemetry, and the scaling between them.
+ *
+ * Py-side _observer_conviction_streak_required mirrors this exactly.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../config/env.js', () => ({
+  env: {
+    NODE_ENV: 'test',
+    PORT: 8765,
+    DATABASE_URL: 'postgresql://test:5432/test',
+    JWT_SECRET: 'test-jwt-secret-32-characters-xxxxxxxxxx',
+  },
+}));
+vi.mock('../../../db/connection.js', () => ({
+  pool: { query: vi.fn() },
+}));
+
+import {
+  observerConvictionStreakRequired,
+  CONVICTION_STREAK_FLOOR,
+  CONVICTION_HESITATION_WINDOW,
+  CONVICTION_STREAK_CAP,
+} from '../loop.js';
+
+describe('observerConvictionStreakRequired — floor / cap / window constants', () => {
+  it('floor is 2 (HISTORY_MIN_SAMPLES sentinel)', () => {
+    expect(CONVICTION_STREAK_FLOOR).toBe(2);
+  });
+  it('window is 20 ticks', () => {
+    expect(CONVICTION_HESITATION_WINDOW).toBe(20);
+  });
+  it('cap is 12 (safety ceiling)', () => {
+    expect(CONVICTION_STREAK_CAP).toBe(12);
+  });
+});
+
+describe('observerConvictionStreakRequired — boundary inputs', () => {
+  it('empty history → floor', () => {
+    expect(observerConvictionStreakRequired([])).toBe(2);
+  });
+  it('single sample → floor', () => {
+    expect(observerConvictionStreakRequired([0.5])).toBe(2);
+  });
+});
+
+describe('observerConvictionStreakRequired — monotonic collapse fires at floor', () => {
+  it('all positive, no flips → floor (monotonic gate hold)', () => {
+    const history = [0.1, 0.2, 0.3, 0.4, 0.5];
+    expect(observerConvictionStreakRequired(history)).toBe(2);
+  });
+  it('all negative, no flips → floor (monotonic gate not held)', () => {
+    const history = [-0.1, -0.2, -0.3, -0.4, -0.5];
+    expect(observerConvictionStreakRequired(history)).toBe(2);
+  });
+});
+
+describe('observerConvictionStreakRequired — oscillation lifts requirement', () => {
+  it('every-tick sign flip (max oscillation) → cap', () => {
+    const history = [0.1, -0.1, 0.1, -0.1, 0.1, -0.1, 0.1, -0.1, 0.1, -0.1];
+    expect(observerConvictionStreakRequired(history)).toBe(12);
+  });
+
+  it('half of pairs flip → mid-range (≈ floor + (cap-floor)) ≈ 12 with rounding', () => {
+    // 10 samples, 5 flips → flip rate ~0.55. Scaled = 2 + round(0.55*20) = 13 → clamped to 12.
+    const history = [0.1, -0.1, -0.2, 0.1, -0.1, -0.2, 0.1, -0.1, -0.2, 0.1];
+    const r = observerConvictionStreakRequired(history);
+    expect(r).toBeGreaterThanOrEqual(8);
+    expect(r).toBeLessThanOrEqual(12);
+  });
+
+  it('quarter flip rate → moderate increase', () => {
+    // 10 samples, 2 flips → flip rate ~0.22. Scaled = 2 + round(0.22*20) ≈ 6.
+    const history = [0.1, 0.2, 0.3, -0.1, -0.2, 0.1, 0.2, 0.3, 0.4, 0.5];
+    const r = observerConvictionStreakRequired(history);
+    expect(r).toBeGreaterThanOrEqual(2);
+    expect(r).toBeLessThanOrEqual(8);
+  });
+});
+
+describe('observerConvictionStreakRequired — zero-crossings handled as flips', () => {
+  it('positive → zero → positive: zero treated as neutral (no flip)', () => {
+    const history = [0.5, 0, 0.5, 0, 0.5];
+    expect(observerConvictionStreakRequired(history)).toBe(2);
+  });
+});

--- a/apps/api/src/services/monkey/emotions.ts
+++ b/apps/api/src/services/monkey/emotions.ts
@@ -78,6 +78,14 @@ export interface ComputeEmotionsArgs {
    *  Per P14: BOUNDARY → STATE input crossing into anxiety at perception time.
    */
   fundingDrag?: number;
+  /** Commit 6 / JOINT-A (Cascade brief 2026-05-27). Projection of the
+   *  basin's current directional read onto the held-side sign (long=+1,
+   *  short=−1). Range [-1, +1]. The clamped-positive part [0, 1] scales
+   *  `confidence = phi × max(0, heldAlignment)`, replacing the legacy
+   *  `(1 − transcendence) × phi` formula that collapsed confidence on
+   *  healthy κ MAD jitter in stable regimes. Default 1.0 preserves
+   *  "no position held / fully aligned" semantics. */
+  heldAlignment?: number;
 }
 
 /** Compute funding drag — real carry cost accumulated against the held
@@ -144,7 +152,17 @@ export function computeEmotions(
   }
   const flow = curiosityOptimal * motivators.investigation;
 
-  let confidence = (1 - motivators.transcendence) * stability;
+  // Commit 6 / JOINT-A (Cascade brief 2026-05-27) — confidence decoupled
+  // from κ-transcendence. Previously `confidence = (1 − trans) × phi`
+  // multiplied regime-change-detection (trans saturates on κ MAD jitter
+  // in stable regimes) into position-conviction, collapsing confidence
+  // on noise. The canonical reframe: confidence reflects "kernel's
+  // geometric view still supports the held direction, scaled by overall
+  // coherence." Anxiety still reads the trans-driven regime-change
+  // signal so the "something is changing" channel stays live.
+  const heldAlignment = args.heldAlignment ?? 1.0;
+  const heldAlignmentPositive = Math.max(0, heldAlignment);
+  let confidence = stability * heldAlignmentPositive;
   let anxiety = motivators.transcendence * instability;
 
   // Funding drag — dimensionless cost-on-margin ratio.

--- a/apps/api/src/services/monkey/held_position_rejustification.ts
+++ b/apps/api/src/services/monkey/held_position_rejustification.ts
@@ -137,6 +137,18 @@ export interface RejustificationInput {
    * gate. Undefined disables both checks.
    */
   currentRoi?: number;
+  /**
+   * Commit 3 (Cascade brief 2026-05-27): position-origin distinction.
+   * When `'adopted'`, the position was opened by an external sibling
+   * kernel instance (monkey-position) or by the operator manually,
+   * NOT by this kernel's own decision. Adopted positions skip the
+   * regime / phi / conviction / stale-bleed checks because none of
+   * those gates have the kernel's own basin context at entry — they
+   * fire on noise. Adopted positions exit on TP / hard SL / basinDir-
+   * flip (directional_disagreement) only. Defaults to `'own'` for
+   * back-compat with callers that don't yet thread origin.
+   */
+  origin?: 'own' | 'adopted';
 }
 
 export type RejustificationFire =
@@ -195,6 +207,7 @@ export function evaluateRejustification(
   input: RejustificationInput,
 ): RejustificationResult {
   const { regimeAtOpen, phiAtOpen, regimeNow, phiNow, emotions } = input;
+  const origin = input.origin ?? 'own';
   const regimeConfidence = input.regimeConfidence ?? 1.0;
   const regimeChangeStreak = input.regimeChangeStreak ?? 0;
   const regimeStabilityTicksRequired = input.regimeStabilityTicksRequired ?? 3;
@@ -218,6 +231,46 @@ export function evaluateRejustification(
     };
   }
   const phiFloor = phiAtOpen / PHI_GOLDEN_FLOOR_RATIO;
+
+  // Commit 3 (Cascade brief 2026-05-27): adopted positions skip the
+  // regime / phi / conviction / stale_bleed checks. Those gates assume
+  // the kernel's own basin context at entry — adopted positions never
+  // had that context (operator or sibling kernel opened them). The
+  // only kernel-view-driven close that still applies is the
+  // directional_disagreement check ("basinDir flipped against held
+  // side"), which doesn't depend on entry-basin anchoring. Adopted
+  // positions otherwise exit on TP / hard SL only.
+  if (origin === 'adopted') {
+    // Still compute directional_disagreement (this gate compares the
+    // kernel's CURRENT preferred side to the held side; no entry-basin
+    // dependency). Order: directional_disagreement → no-fire.
+    if (
+      directionalDisagreementStreak >= directionalDisagreementTicksRequired
+      && input.currentRoi !== undefined
+    ) {
+      return {
+        checked: true,
+        fired: 'directional_disagreement',
+        reason:
+          `directional_disagreement (adopted): held-side ≠ current preferred side `
+          + `for ${directionalDisagreementStreak} ticks (≥ ${directionalDisagreementTicksRequired})`,
+        phiFloor,
+        frDistance, frThreshold,
+        regimeChangeStreak, regimeStabilityTicksRequired,
+        convictionFailedStreak, convictionFailedTicksRequired,
+        directionalDisagreementStreak, directionalDisagreementTicksRequired,
+      };
+    }
+    return {
+      checked: true, fired: null,
+      reason: `adopted_position: regime/phi/conviction/stale_bleed gates skipped (origin=adopted)`,
+      phiFloor,
+      frDistance, frThreshold,
+      regimeChangeStreak, regimeStabilityTicksRequired,
+      convictionFailedStreak, convictionFailedTicksRequired,
+      directionalDisagreementStreak, directionalDisagreementTicksRequired,
+    };
+  }
 
   // 1. REGIME CHECK — triple-AND gate. All of:
   //   (a) regimeNow != regimeAtOpen   (label divergence)

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -341,16 +341,48 @@ function stabilityTicksFromPhi(phi: number): number {
     Math.ceil(STABILITY_TICKS_MIN_EVIDENCE / safePhi),
   );
 }
-/** CALIB-3 lane-timescale multipliers. Encodes the user's lane-
- *  timeframe doctrine: scalp = micro (1×), swing = moderate (3×),
- *  trend = macro (10×). With base=4, this gives scalp=4 ticks (≈2 min
- *  at 30s tick), swing=12 ticks (≈6 min), trend=40 ticks (≈20 min).
- *  Same multipliers apply to convictionFailed via lane-scaled call. */
-const DISAGREEMENT_LANE_MULTIPLIER: Record<'scalp' | 'swing' | 'trend', number> = {
-  scalp: 1,
-  swing: 3,
-  trend: 10,
+/** Lane decision-period — the wall-clock window a lane's
+ *  natural decision cycle occupies. These are LANE DEFINITIONS,
+ *  not tuning knobs: a scalp lane decides over ~minutes, a swing
+ *  lane over ~tens of minutes, a trend lane over hours. They
+ *  feed `laneMultiplierFromTickPeriod()` which divides by the
+ *  substrate's actual tick period to derive the streak gate
+ *  in ticks — so the gate adapts when adaptive-tick changes
+ *  the cadence (e.g. EXPLORATION 15s vs INTEGRATION 60s tick)
+ *  without operator intervention.
+ *
+ *  At the canonical 30s tick:
+ *    scalp(60s)  → ceil(60/30) = 2  ticks  (≈ floor)
+ *    swing(180s) → ceil(180/30) = 6  ticks
+ *    trend(600s) → ceil(600/30) = 20 ticks
+ *
+ *  At adaptive 15s (EXPLORATION):
+ *    scalp = 4, swing = 12, trend = 40 (more confirmation when ticks are fast)
+ *
+ *  At adaptive 60s (INTEGRATION/DRIFT):
+ *    scalp = 2 (floor), swing = 3, trend = 10
+ *
+ *  Compare to the legacy hardcoded {1, 3, 10}: those values are
+ *  what the derivation produces at tickMs=60s — i.e. they were
+ *  calibrated for the slowest mode and didn't adapt to the
+ *  cadence governor. */
+const LANE_DECISION_PERIOD_MS: Record<'scalp' | 'swing' | 'trend', number> = {
+  scalp: 60_000,
+  swing: 180_000,
+  trend: 600_000,
 };
+
+/** Derive the lane multiplier from the active tick period. Floor 2
+ *  (Cascade brief: "Math.max(2, Math.round(...))") so a position
+ *  never fires its streak gate on a single tick. Exported for tests. */
+export function laneMultiplierFromTickPeriod(
+  lane: 'scalp' | 'swing' | 'trend',
+  tickPeriodMs: number,
+): number {
+  const periodMs = LANE_DECISION_PERIOD_MS[lane];
+  if (!Number.isFinite(tickPeriodMs) || tickPeriodMs <= 0) return 2;
+  return Math.max(2, Math.round(periodMs / tickPeriodMs));
+}
 
 /**
  * v0.8.7 kill switch — when MONKEY_TRADING_PAUSED=true, gate
@@ -3309,13 +3341,13 @@ export class MonkeyKernel extends EventEmitter {
         // three env knobs it replaces.
         const baseStabilityTicks = stabilityTicksFromPhi(phi);
         const regimeStabilityTicksRequired = baseStabilityTicks;
-        // CALIB-3 lane timescale doctrine: scalp=micro (1×), swing=moderate (3×),
-        // trend=macro (10×). Applies to both conviction-failed and directional-
-        // disagreement so the same scalp-tolerates-noise-but-swing-doesn't logic
-        // governs both streak gates. See DISAGREEMENT_LANE_MULTIPLIER comment.
-        // Lane multipliers stay as structural (lane-timeframe encoding) —
-        // future cleanup may derive them from lane-timeframe ratios.
-        const laneMultiplier = DISAGREEMENT_LANE_MULTIPLIER[heldLane] ?? 1;
+        // Commit 2 (2026-05-27): lane multiplier derived from the
+        // active tick period via laneMultiplierFromTickPeriod(). The
+        // substrate's own cadence sets the scale — no operator number.
+        // Adaptive-tick (modes 15s / 30s / 60s) now correctly scales
+        // the streak gate: the same lane fires after the same wall-
+        // clock duration regardless of which tick cadence is active.
+        const laneMultiplier = laneMultiplierFromTickPeriod(heldLane, state.currentTickMs);
         const convictionFailedTicksRequired = baseStabilityTicks * laneMultiplier;
         const directionalDisagreementTicksRequired = baseStabilityTicks * laneMultiplier;
         const rejustResult = !exitFired

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -159,7 +159,7 @@ import {
   clampMarginToNotionalHeadroom,
 } from './agentEquityBound.js';
 import { planCloseChunks } from './closeChunker.js';
-import { SAFE_PNL_FROM_ROW, verifyPnl, computeSafePnl } from './safePnlSql.js';
+import { SAFE_PNL_FROM_ROW, verifyPnl, computeSafePnl, checkNotionalConsistency } from './safePnlSql.js';
 import { runPeriodicPnlScan } from './pnlReconciliationPeriodic.js';
 import { startPredictionResidualJob } from './predictionResidualJob.js';
 import {
@@ -8089,6 +8089,25 @@ export class MonkeyKernel extends EventEmitter {
           const dcaTag = req.isDCAAdd ? `|dca=${req.dcaAddIndex ?? 1}` : '';
           const reasonEncoded =
             `monkey|kernel=${this.instanceId}|agent=${agentTag}|lane=${laneTag}|phi=${req.phi.toFixed(3)}|kappa=${req.kappa.toFixed(2)}|sov=${req.sovereignty.toFixed(3)}${dcaTag}|src=v0.10`;
+
+          // Finding 1 — notional self-consistency assertion at the paper INSERT.
+          // expectedNotional is `marginUsdt × leverage` (kernel's intended sizing,
+          // mirrors the live path). A mismatch means `formattedSize` is in the
+          // wrong unit (contracts vs base-asset) and the row would feed phantom
+          // PnL downstream. Refuse the write.
+          const paperNotionalCheck = checkNotionalConsistency(
+            paper.fillPrice,
+            formattedSize,
+            marginUsdt * leverage,
+          );
+          if (!paperNotionalCheck.consistent) {
+            logger.error('[LIVED ONLY] paper INSERT — refusing row', {
+              symbol, fillPrice: paper.fillPrice, formattedSize,
+              diagnostic: paperNotionalCheck.diagnostic,
+            });
+            return { executed: false, orderId: null, reason: 'notional_mismatch_at_paper_insert' };
+          }
+
           const inserted = await pool.query(
             `INSERT INTO autonomous_trades
                (user_id, symbol, side, entry_price, quantity, leverage,
@@ -8358,14 +8377,19 @@ export class MonkeyKernel extends EventEmitter {
       const dcaTag = req.isDCAAdd ? `|dca=${req.dcaAddIndex ?? 1}` : '';
       const reasonEncoded =
         `monkey|kernel=${this.instanceId}|agent=${agentTag}|lane=${laneTag}|phi=${req.phi.toFixed(3)}|kappa=${req.kappa.toFixed(2)}|sov=${req.sovereignty.toFixed(3)}${dcaTag}|src=v0.10`;
-      // LIVED ONLY 5 notional self-consistency assertion at INSERT (Finding 1)
-      // Row's own notional must be consistent with the order's intended notional.
-      // Divergence > 0.1% → refuse the insert (prevents bad quantity from ever entering).
-      const rowNotional = entryPrice * formattedSize;
-      const orderNotional = notionalUsdt;
-      if (orderNotional > 0 && Math.abs(rowNotional - orderNotional) / orderNotional > 0.001) {
-        logger.error('[LIVED ONLY] notional mismatch at INSERT — refusing row', {
-          symbol, entryPrice, formattedSize, rowNotional, orderNotional,
+      // Finding 1 — notional self-consistency assertion at the live INSERT.
+      // Centralized via checkNotionalConsistency in safePnlSql.ts so the
+      // tolerance + diagnostic format are identical across all three INSERT
+      // sites (live / paper / reconciler).
+      const liveNotionalCheck = checkNotionalConsistency(
+        entryPrice,
+        formattedSize,
+        notionalUsdt,
+      );
+      if (!liveNotionalCheck.consistent) {
+        logger.error('[LIVED ONLY] live INSERT — refusing row', {
+          symbol, entryPrice, formattedSize,
+          diagnostic: liveNotionalCheck.diagnostic,
         });
         return { executed: false, orderId: null, reason: 'notional_mismatch_at_insert' };
       }

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -384,6 +384,34 @@ export function laneMultiplierFromTickPeriod(
   return Math.max(2, Math.round(periodMs / tickPeriodMs));
 }
 
+/** Commit 4 (Cascade brief 2026-05-27) — observer-derived conviction
+ *  streak requirement. Mirrors the Py side
+ *  `_observer_conviction_streak_required` exactly. Floor 2, cap 12.
+ *  Inputs: rolling history of (anxiety + confusion - confidence) on
+ *  this lane over the last 20 ticks. High sign-flip rate → require
+ *  more ticks; low flip rate → fire at floor. */
+export const CONVICTION_STREAK_FLOOR = 2;
+export const CONVICTION_HESITATION_WINDOW = 20;
+export const CONVICTION_STREAK_CAP = 12;
+
+export function observerConvictionStreakRequired(
+  hesitationHistory: number[],
+): number {
+  if (hesitationHistory.length < CONVICTION_STREAK_FLOOR) {
+    return CONVICTION_STREAK_FLOOR;
+  }
+  let flips = 0;
+  for (let i = 1; i < hesitationHistory.length; i++) {
+    const prev = hesitationHistory[i - 1]!;
+    const curr = hesitationHistory[i]!;
+    if ((prev > 0 && curr < 0) || (prev < 0 && curr > 0)) flips++;
+  }
+  const flipRate = flips / Math.max(1, hesitationHistory.length - 1);
+  const scaled = CONVICTION_STREAK_FLOOR
+    + Math.round(flipRate * (CONVICTION_STREAK_CAP - CONVICTION_STREAK_FLOOR) * 2);
+  return Math.max(CONVICTION_STREAK_FLOOR, Math.min(CONVICTION_STREAK_CAP, scaled));
+}
+
 /**
  * v0.8.7 kill switch — when MONKEY_TRADING_PAUSED=true, gate
  * entry-order placement only. Exit orders (scalp_exit, auto_flatten,
@@ -624,6 +652,11 @@ interface SymbolState {
    *  2026-05-17 CSV analysis showed single-tick conviction noise was
    *  driving 60% of losses in chop-zone scalping. */
   convictionFailedStreakByLane: Record<string, number>;
+  /** Commit 4 (Cascade brief 2026-05-27) — per-lane hesitation history
+   *  (anxiety + confusion - confidence) over the last 20 ticks. Drives
+   *  the observer-derived conviction streak requirement: high sign-flip
+   *  rate → require more ticks; monotonic collapse → fire at floor. */
+  hesitationHistoryByLane: Record<string, number[]>;
   /** CALIB-3 (2026-05-17): consecutive-tick counter for "current tick's
    *  preferred side disagrees with held side" per-lane. Drives the
    *  directional_disagreement exit. Increments on disagreement, resets
@@ -1819,6 +1852,7 @@ export class MonkeyKernel extends EventEmitter {
       basinAtOpenByLane: {},
       regimeChangeStreakByLane: {},
       convictionFailedStreakByLane: {},
+      hesitationHistoryByLane: {},
       directionalDisagreementStreakByLane: {},
       heldSideByLane: {},
       entryTimeMsByLane: {},
@@ -3348,8 +3382,19 @@ export class MonkeyKernel extends EventEmitter {
         // the streak gate: the same lane fires after the same wall-
         // clock duration regardless of which tick cadence is active.
         const laneMultiplier = laneMultiplierFromTickPeriod(heldLane, state.currentTickMs);
-        const convictionFailedTicksRequired = baseStabilityTicks * laneMultiplier;
         const directionalDisagreementTicksRequired = baseStabilityTicks * laneMultiplier;
+
+        // Commit 4 (2026-05-27): conviction streak observer-derived from
+        // per-lane hesitation history (anxiety+confusion - confidence
+        // sign-flip rate). Maintain the rolling ring at the gate site
+        // so it stays in sync with the streak counter.
+        const hesitation = emotions.anxiety + emotions.confusion - emotions.confidence;
+        const hesitationHistory = (state.hesitationHistoryByLane[heldLane] ??= []);
+        hesitationHistory.push(hesitation);
+        if (hesitationHistory.length > CONVICTION_HESITATION_WINDOW) {
+          hesitationHistory.shift();
+        }
+        const convictionFailedTicksRequired = observerConvictionStreakRequired(hesitationHistory);
         // Commit 3 (2026-05-27): detect adopted-position origin from the
         // open row's reason. Reconciler-adopted rows carry `|adopted|` in
         // their reason after the ownership rewrite; kernel-entered rows

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -3350,6 +3350,13 @@ export class MonkeyKernel extends EventEmitter {
         const laneMultiplier = laneMultiplierFromTickPeriod(heldLane, state.currentTickMs);
         const convictionFailedTicksRequired = baseStabilityTicks * laneMultiplier;
         const directionalDisagreementTicksRequired = baseStabilityTicks * laneMultiplier;
+        // Commit 3 (2026-05-27): detect adopted-position origin from the
+        // open row's reason. Reconciler-adopted rows carry `|adopted|` in
+        // their reason after the ownership rewrite; kernel-entered rows
+        // never carry that substring. Origin gates which rejustification
+        // checks are eligible (adopted: only directional_disagreement).
+        const heldOrigin: 'own' | 'adopted' =
+          ownOpenRow?.reason.includes('|adopted|') ? 'adopted' : 'own';
         const rejustResult = !exitFired
           ? evaluateRejustification({
               regimeAtOpen,
@@ -3368,6 +3375,7 @@ export class MonkeyKernel extends EventEmitter {
               basinAtOpen,
               heldDurationS,
               currentRoi,
+              origin: heldOrigin,
             })
           : {
               checked: false, fired: null, reason: '', phiFloor: null,
@@ -5911,18 +5919,20 @@ export class MonkeyKernel extends EventEmitter {
   }
 
   private async findOpenMonkeyTrade(symbol: string): Promise<
-    | { id: string; entry_price: string; quantity: string; leverage: number; order_id: string | null; side: 'long' | 'short'; lane: 'scalp' | 'swing' | 'trend'; take_profit: number | null; stop_loss: number | null }
+    | { id: string; entry_price: string; quantity: string; leverage: number; order_id: string | null; side: 'long' | 'short'; lane: 'scalp' | 'swing' | 'trend'; take_profit: number | null; stop_loss: number | null; reason: string }
     | null
   > {
     // Aggregate over ALL open lanes (back-compat: callers that don't
     // know about lanes still need a single open-row view). Returns the
     // OLDEST lane's pseudo-row when multiple lanes hold positions; the
     // proper lane-aware path uses ``findOpenMonkeyTradesByLane`` below.
+    // Commit 3 (2026-05-27): include `reason` so callers can detect
+    // adopted-position origin via the `|adopted|` substring.
     try {
       const reasonPattern = `monkey|kernel=${this.instanceId}|%`;
       const result = await pool.query(
         `SELECT id, entry_price, quantity, leverage, order_id, side, lane,
-                take_profit, stop_loss
+                take_profit, stop_loss, reason
            FROM autonomous_trades
           WHERE reason LIKE $2 AND status = 'open' AND symbol = $1
           ORDER BY entry_time ASC`,
@@ -5932,6 +5942,7 @@ export class MonkeyKernel extends EventEmitter {
         id: string; entry_price: string; quantity: string; leverage: number;
         order_id: string | null; side: string; lane: string;
         take_profit: string | null; stop_loss: string | null;
+        reason: string;
       }>;
       const normSide = (s: string): 'long' | 'short' =>
         s === 'buy' || s === 'long' ? 'long' : 'short';
@@ -5962,6 +5973,10 @@ export class MonkeyKernel extends EventEmitter {
         (s, r) => s + Number(r.entry_price) * Math.abs(Number(r.quantity) || 0),
         0,
       ) / totalQty;
+      // For multi-row aggregation, `reason` is "adopted" only if EVERY
+      // underlying row is adopted — a kernel-entered row mixed in means
+      // the position is at least partly own-managed.
+      const allAdopted = rows.every((r) => r.reason.includes('|adopted|'));
       return {
         id: rows[0].id,
         entry_price: String(weightedPrice),
@@ -5972,6 +5987,7 @@ export class MonkeyKernel extends EventEmitter {
         lane: normLane(rows[0].lane),
         take_profit: numOrNull(rows[0].take_profit),
         stop_loss: numOrNull(rows[0].stop_loss),
+        reason: allAdopted ? rows[0].reason : rows[0].reason.replace('|adopted|', '|'),
       };
     } catch (err) {
       logger.debug('[Monkey] findOpenMonkeyTrade failed', {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -8474,6 +8474,18 @@ export class MonkeyKernel extends EventEmitter {
       // Centralized via checkNotionalConsistency in safePnlSql.ts so the
       // tolerance + diagnostic format are identical across all three INSERT
       // sites (live / paper / reconciler).
+      //
+      // Commit 5 (Cascade brief 2026-05-27) — kernel-direct unit invariant.
+      // `formattedSize` at this point is BASE ASSET (BTC, ETH, ...) and
+      // `entryPrice` is USDT per unit base-asset; their product is USDT
+      // notional, directly comparable to the kernel's intended notionalUsdt.
+      // The contracts/base-asset boundary lives in poloniexFuturesService —
+      // see the chunker doc at L7189 for the explicit rule:
+      // "formattedSize and symbolLotSize are in BASE ASSET units. The
+      //  poloniexFuturesService.placeOrder converts size/lotSize → contracts
+      //  internally before sending."
+      // Any future regression that stores contracts here trips this assertion
+      // immediately (100× / 1000× / lot-size-recip ratio is well above 0.1%).
       const liveNotionalCheck = checkNotionalConsistency(
         entryPrice,
         formattedSize,

--- a/apps/api/src/services/monkey/safePnlSql.ts
+++ b/apps/api/src/services/monkey/safePnlSql.ts
@@ -107,3 +107,58 @@ export function verifyPnl(
     divergenceAbs,
   };
 }
+
+/**
+ * Notional self-consistency assertion (Finding 1 / LIVED ONLY 5).
+ *
+ * Before any row enters `autonomous_trades`, the row's own data
+ * (`entry_price * quantity`) must match the originating order's
+ * declared notional within a small tolerance. Mismatch means the
+ * `quantity` value is in the wrong unit (contracts vs base-asset) —
+ * the root cause of the 100×/1000× phantom-PnL.
+ *
+ * Default tolerance 0.1% — wider than realistic slippage, tighter
+ * than any unit-conversion mismatch could be.
+ *
+ * Fall-open when `expectedNotional ≤ 0` or non-finite: the caller
+ * had no observable notional to assert against (e.g. legacy test
+ * fixtures, paths that don't yet thread the order response).
+ * Callers MUST thread an expected notional on the live INSERT paths
+ * — the fall-open is only for boundary code.
+ */
+export interface NotionalCheck {
+  consistent: boolean;
+  rowNotional: number;
+  expectedNotional: number;
+  divergenceAbs: number;
+  divergencePct: number;
+  diagnostic: string;
+}
+
+export function checkNotionalConsistency(
+  entryPrice: number,
+  quantity: number,
+  expectedNotional: number,
+  tolerancePct = 0.001,
+): NotionalCheck {
+  const rowNotional = entryPrice * quantity;
+  if (expectedNotional <= 0 || !Number.isFinite(expectedNotional)) {
+    return {
+      consistent: true,
+      rowNotional, expectedNotional,
+      divergenceAbs: 0, divergencePct: 0,
+      diagnostic: 'no expected notional supplied — assertion bypassed (fall-open)',
+    };
+  }
+  const divergenceAbs = Math.abs(rowNotional - expectedNotional);
+  const divergencePct = divergenceAbs / expectedNotional;
+  const consistent = divergencePct <= tolerancePct;
+  return {
+    consistent, rowNotional, expectedNotional, divergenceAbs, divergencePct,
+    diagnostic: consistent
+      ? `notional consistent (${(divergencePct * 100).toFixed(3)}% vs tolerance ${(tolerancePct * 100).toFixed(2)}%)`
+      : `notional MISMATCH: row=$${rowNotional.toFixed(2)} vs expected=$${expectedNotional.toFixed(2)} `
+        + `(${(divergencePct * 100).toFixed(3)}% > ${(tolerancePct * 100).toFixed(2)}% tolerance) — `
+        + `likely unit mismatch (contracts vs base-asset)`,
+  };
+}

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -7,6 +7,7 @@
  */
 
 import { pool } from '../db/connection.js';
+import { verifyPnl, checkNotionalConsistency } from './monkey/safePnlSql.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
 import { apiCredentialsService } from './apiCredentialsService.js';
 import { monitoringService } from './monitoringService.js';
@@ -267,6 +268,26 @@ class StateReconciliationService {
               `${reasonPrefix}|exchange_pid=${
                 exPos.positionId ?? exPos.id ?? 'na'
               }|lev=${effectiveLever}|inferred_lane=${inferredLane}|src=reconciler`;
+
+            // Finding 1 — notional self-consistency assertion for the
+            // reconciler/adopted-position INSERT. Expected notional comes
+            // from the exchange's own position report (exPos.notional);
+            // when that field is absent (older exchange clients), the
+            // helper falls open per its contract — the live + paper INSERT
+            // paths are the load-bearing ones for new rows.
+            const reconNotionalCheck = checkNotionalConsistency(
+              entryPrice,
+              size,
+              exPos.notional ?? 0,
+            );
+            if (!reconNotionalCheck.consistent) {
+              logger.error('[LIVED ONLY] reconciler INSERT — skipping row', {
+                symbol, entryPrice, size,
+                diagnostic: reconNotionalCheck.diagnostic,
+              });
+              continue;
+            }
+
             await pool.query(
               `INSERT INTO autonomous_trades
                (user_id, symbol, side, entry_price, quantity, leverage, reason,
@@ -535,6 +556,16 @@ class StateReconciliationService {
               : null;
 
           try {
+            // LIVED ONLY 5 guard on ghost recovery (Finding 1)
+            // Be conservative: do not write aggregate-derived recoveredPnl on ghost rows
+            // unless we can fully verify it. For now, skip writing it here to avoid phantoms.
+            if (recoveredPnl !== null) {
+              logger.warn('[LIVED ONLY] skipping aggregate recoveredPnl write during ghost recovery (conservative LIVED ONLY)', {
+                tradeId: g.dbTrade.id,
+              });
+              continue;
+            }
+
             await pool.query(
               `UPDATE autonomous_trades
                SET status = 'closed',

--- a/ml-worker/src/monkey_kernel/emotions.py
+++ b/ml-worker/src/monkey_kernel/emotions.py
@@ -159,6 +159,7 @@ def compute_emotions(
     predicted_basin: Optional[np.ndarray] = None,
     foresight_weight: float = 0.0,
     funding_drag: float = 0.0,
+    held_alignment: float = 1.0,
 ) -> EmotionState:
     """Compose the Layer 2B emotion vector from Tier 1 motivators
     plus raw geometric quantities (+ Tier 3 foresight reference for Flow).
@@ -188,6 +189,15 @@ def compute_emotions(
         position direction is working against the position — that is
         anxiety. The conviction gate (confidence < anxiety + confusion)
         fires earlier on funding-bleeding positions as a result.
+    held_alignment : float
+        Commit 6 / JOINT-A (Cascade brief 2026-05-27). Projection of
+        the basin's current directional read onto the held-side sign
+        (long = +1, short = −1). Range [-1, +1]. The clamped-positive
+        part [0, 1] scales `confidence = phi × max(0, held_alignment)`,
+        which decouples conviction from the κ-transcendence saturation
+        that was collapsing confidence on healthy MAD jitter. Default
+        1.0 preserves the no-position semantics (no alignment penalty).
+        When no position held, caller passes 1.0.
     """
     stability = phi
     instability = basin_velocity
@@ -212,7 +222,18 @@ def compute_emotions(
         curiosity_optimal = 0.0
     flow = curiosity_optimal * motivators.investigation
 
-    confidence = (1.0 - motivators.transcendence) * stability
+    # Commit 6 / JOINT-A (Cascade brief 2026-05-27) — confidence decoupled
+    # from κ-transcendence. Previously `confidence = (1 − trans) × phi`
+    # multiplied regime-change-detection (trans saturates on κ MAD
+    # jitter in stable regimes) into position-conviction, collapsing
+    # confidence on noise. The canonical reframe: confidence reflects
+    # "kernel's geometric view still supports the held direction,
+    # scaled by overall coherence". Trans-saturation no longer leaks
+    # into the conviction gate. Anxiety still reads trans-driven
+    # regime-change signal — that channel stays live as the kernel's
+    # "something is changing" detector.
+    held_alignment_positive = max(0.0, held_alignment)
+    confidence = stability * held_alignment_positive
     anxiety = motivators.transcendence * instability
 
     # Funding drag — dimensionless cost-on-margin ratio. Map [0, ∞) →

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -1825,6 +1825,18 @@ def _decide_with_position(
     # flicker would otherwise close every held position on noise. Φ
     # collapse and conviction-fail still fire immediately; both are
     # already conservative gates. All three are geometric.
+    #
+    # Commit 3 (Cascade brief 2026-05-27) — adopted-vs-own distinction:
+    # this block is ALREADY anchor-gated below
+    # (`if has_regime_anchor and has_phi_anchor`). Adopted positions —
+    # opened by an external sibling kernel or by the operator — never
+    # ran through the open-entry path that sets regime_at_open_by_lane
+    # and phi_at_open_by_lane, so they naturally fall through this
+    # entire block without firing regime_change / phi_collapse /
+    # conviction_failed. The TS side required an explicit `origin`
+    # parameter because its evaluateRejustification doesn't gate on
+    # anchor presence the same way; on Py the structural anchor-gating
+    # provides the equivalent semantic guarantee.
     rejust: dict[str, Any] = {"checked": False}
     has_regime_anchor = position_lane in state.regime_at_open_by_lane
     has_phi_anchor = position_lane in state.phi_at_open_by_lane
@@ -1926,17 +1938,29 @@ def _decide_with_position(
             )
             return "scalp_exit", reason, False, False
         # 3. CONVICTION CHECK — Layer 2B emotion stack no longer
-        # supports the position. The moment current conviction fails
-        # against hesitation, exit. No half-life, no streak.
+        # supports the position.
+        # LIVED wiring (Finding 3): add a small streak requirement for symmetry/parity
+        # with the TS side. Immediate fire is the historical source of asymmetric
+        # winner-harvest in chop. Require N consecutive ticks before firing.
         confidence = getattr(emotions, "confidence", 0.0)
         anxiety = getattr(emotions, "anxiety", 0.0)
         confusion = getattr(emotions, "confusion", 0.0)
-        if confidence < anxiety + confusion:
+
+        conviction_condition = confidence < anxiety + confusion
+        if conviction_condition:
+            state.conviction_failed_streak = getattr(state, 'conviction_failed_streak', 0) + 1
+        else:
+            state.conviction_failed_streak = 0
+
+        # Require at least 2 consecutive ticks (bridge to observer-derived later).
+        # This matches the spirit of the TS side while we finish the full sign-flip derivation.
+        if conviction_condition and state.conviction_failed_streak >= 2:
             rejust["fired"] = "conviction_failed"
             derivation["rejustification"] = rejust
             reason = (
                 f"conviction_failed: conf={confidence:.3f} < "
-                f"anxiety+confusion={anxiety + confusion:.3f}"
+                f"anxiety+confusion={anxiety + confusion:.3f} "
+                f"(streak={state.conviction_failed_streak})"
             )
             return "scalp_exit", reason, False, False
     derivation["rejustification"] = rejust

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -138,6 +138,48 @@ def _regime_stability_ticks_for_exit() -> int:
     ))
 
 
+# Commit 4 (Cascade brief 2026-05-27) — Observer-derived conviction streak.
+# The minimum-evidence floor is 2 (same as HISTORY_MIN_SAMPLES in
+# neurochemistry — "1 sample is noise; ≥ 2 is signal"). Above the floor
+# the required streak scales with how oscillatory the (anxiety+confusion
+# - confidence) signal has been on this lane: high sign-flip rate → wait
+# more ticks for confirmation; low flip rate → fire at floor.
+_CONVICTION_STREAK_FLOOR = 2
+_CONVICTION_HESITATION_WINDOW = 20  # ticks in the rolling sample
+_CONVICTION_STREAK_CAP = 12         # safety ceiling
+
+
+def _observer_conviction_streak_required(hesitation_history: list[float]) -> int:
+    """Required consecutive-tick count for conviction_failed to fire.
+
+    Pure observer derivation: counts sign flips in the most recent
+    hesitation values and scales the streak requirement upward when
+    the signal is oscillating. Floor 2, cap 12.
+
+    `hesitation` is (anxiety + confusion - confidence) — positive when
+    the gate condition holds, negative when it doesn't. A flip is a
+    consecutive pair with opposite sign.
+    """
+    if len(hesitation_history) < _CONVICTION_STREAK_FLOOR:
+        return _CONVICTION_STREAK_FLOOR
+    flips = 0
+    for prev, curr in zip(hesitation_history[:-1], hesitation_history[1:]):
+        # Treat zero as neutral — only count true sign flips.
+        if prev > 0 and curr < 0:
+            flips += 1
+        elif prev < 0 and curr > 0:
+            flips += 1
+    # flip_rate ∈ [0, 1] — fraction of adjacent pairs that flipped sign.
+    flip_rate = flips / max(1, len(hesitation_history) - 1)
+    # Map flip_rate → streak requirement. At flip_rate=0 (monotonic),
+    # require floor (2). At flip_rate=0.5 (random-walk), require ~6.
+    # At flip_rate ≥ 0.8 (highly oscillatory), require cap (12).
+    # Linear ramp: required = floor + round(flip_rate * (cap - floor) * 2)
+    # Clamp at cap.
+    scaled = _CONVICTION_STREAK_FLOOR + round(flip_rate * (_CONVICTION_STREAK_CAP - _CONVICTION_STREAK_FLOOR) * 2)
+    return max(_CONVICTION_STREAK_FLOOR, min(_CONVICTION_STREAK_CAP, scaled))
+
+
 def _chop_suppress_entry(reading: RegimeReading) -> bool:
     """True when the regime classifier reads sustained chop above the
     suppression confidence threshold. Held positions are unaffected;
@@ -308,6 +350,17 @@ class SymbolState:
     # to 0 the first tick the regime returns to regime_at_open or the
     # position closes/reopens.
     regime_change_streak_by_lane: dict[str, int] = field(default_factory=dict)
+    # Commit 4 (Cascade brief 2026-05-27) — per-lane conviction-failed
+    # streak + emotion-delta history for observer-derived N. The streak
+    # increments while `confidence < anxiety + confusion` and resets
+    # on any tick where the condition flips. The history is a rolling
+    # ring of `(anxiety + confusion - confidence)` values over the last
+    # 20 ticks on this lane — its sign-flip rate sets how many
+    # consecutive ticks the gate requires before firing (high flip rate
+    # = noisy emotion telemetry = longer wait; low flip rate = monotonic
+    # collapse = fire at floor=2).
+    conviction_failed_streak_by_lane: dict[str, int] = field(default_factory=dict)
+    hesitation_history_by_lane: dict[str, list[float]] = field(default_factory=dict)
     # Prediction-corpus instrumentation bookkeeping. Read-only; never
     # feeds back into executive decisions.
     last_prediction_snapshot_at_ms: Optional[float] = None
@@ -1938,29 +1991,40 @@ def _decide_with_position(
             )
             return "scalp_exit", reason, False, False
         # 3. CONVICTION CHECK — Layer 2B emotion stack no longer
-        # supports the position.
-        # LIVED wiring (Finding 3): add a small streak requirement for symmetry/parity
-        # with the TS side. Immediate fire is the historical source of asymmetric
-        # winner-harvest in chop. Require N consecutive ticks before firing.
+        # supports the position. Commit 4 (Cascade brief 2026-05-27):
+        # observer-derived N per lane, mirroring TS side. Maintain a
+        # rolling hesitation_history (anxiety+confusion - confidence)
+        # over the last 20 ticks; sign-flip rate sets required streak.
         confidence = getattr(emotions, "confidence", 0.0)
         anxiety = getattr(emotions, "anxiety", 0.0)
         confusion = getattr(emotions, "confusion", 0.0)
+        hesitation = anxiety + confusion - confidence
 
-        conviction_condition = confidence < anxiety + confusion
+        # Maintain per-lane hesitation history (bounded ring).
+        history = state.hesitation_history_by_lane.setdefault(position_lane, [])
+        history.append(hesitation)
+        if len(history) > _CONVICTION_HESITATION_WINDOW:
+            history.pop(0)
+
+        conviction_condition = hesitation > 0  # confidence < anxiety + confusion
         if conviction_condition:
-            state.conviction_failed_streak = getattr(state, 'conviction_failed_streak', 0) + 1
+            state.conviction_failed_streak_by_lane[position_lane] = (
+                state.conviction_failed_streak_by_lane.get(position_lane, 0) + 1
+            )
         else:
-            state.conviction_failed_streak = 0
+            state.conviction_failed_streak_by_lane[position_lane] = 0
 
-        # Require at least 2 consecutive ticks (bridge to observer-derived later).
-        # This matches the spirit of the TS side while we finish the full sign-flip derivation.
-        if conviction_condition and state.conviction_failed_streak >= 2:
+        streak = state.conviction_failed_streak_by_lane[position_lane]
+        n_required = _observer_conviction_streak_required(history)
+
+        if conviction_condition and streak >= n_required:
             rejust["fired"] = "conviction_failed"
             derivation["rejustification"] = rejust
             reason = (
                 f"conviction_failed: conf={confidence:.3f} < "
                 f"anxiety+confusion={anxiety + confusion:.3f} "
-                f"(streak={state.conviction_failed_streak})"
+                f"for {streak} consecutive ticks "
+                f"(≥ {n_required} required, observer-derived)"
             )
             return "scalp_exit", reason, False, False
     derivation["rejustification"] = rejust

--- a/ml-worker/tests/monkey_kernel/test_emotions.py
+++ b/ml-worker/tests/monkey_kernel/test_emotions.py
@@ -94,11 +94,32 @@ class TestPerEmotionFormula:
         )
         assert e.anxiety == pytest.approx(3.5 * 0.4, abs=1e-12)
 
-    def test_confidence_equals_one_minus_transcendence_times_phi(self) -> None:
+    def test_confidence_equals_phi_times_held_alignment(self) -> None:
+        """Commit 6 / JOINT-A (Cascade brief 2026-05-27): confidence
+        decoupled from κ-transcendence. Default held_alignment=1.0 →
+        confidence = phi (transcendence no longer multiplies in).
+        """
         e = compute_emotions(
             _m(transcendence=0.3), basin_distance=0.0, phi=0.7, basin_velocity=0.0,
         )
-        assert e.confidence == pytest.approx((1.0 - 0.3) * 0.7, abs=1e-12)
+        assert e.confidence == pytest.approx(0.7, abs=1e-12)
+
+    def test_confidence_scales_with_held_alignment(self) -> None:
+        # heldAlignment=0.5 → confidence = phi × 0.5
+        e = compute_emotions(
+            _m(transcendence=0.3), basin_distance=0.0, phi=0.7, basin_velocity=0.0,
+            held_alignment=0.5,
+        )
+        assert e.confidence == pytest.approx(0.35, abs=1e-12)
+
+    def test_confidence_collapses_when_basindir_opposes(self) -> None:
+        # heldAlignment=-1 (basinDir flipped against held side) →
+        # max(0, -1) = 0 → confidence = 0 → conviction gate trips.
+        e = compute_emotions(
+            _m(transcendence=0.3), basin_distance=0.0, phi=0.7, basin_velocity=0.0,
+            held_alignment=-1.0,
+        )
+        assert e.confidence == pytest.approx(0.0, abs=1e-12)
 
     def test_boredom_equals_one_minus_surprise_times_one_minus_curiosity(self) -> None:
         e = compute_emotions(
@@ -121,13 +142,17 @@ class TestRegimeReporting:
         assert e.anxiety == pytest.approx(4.0, abs=1e-12)
         assert e.anxiety > 1.0  # not clipped
 
-    def test_confidence_can_go_negative_when_transcendence_above_one(self) -> None:
-        # transcendence=5 → (1 - 5) = -4; phi=0.6 → confidence = -2.4
+    def test_confidence_is_clamped_non_negative_via_held_alignment(self) -> None:
+        # Commit 6 / JOINT-A: confidence = phi × max(0, held_alignment).
+        # The only way confidence reads ≤ 0 now is held_alignment ≤ 0
+        # (basinDir flipped vs held side). Transcendence no longer
+        # collapses confidence.
         e = compute_emotions(
             _m(transcendence=5.0), basin_distance=0.0, phi=0.6, basin_velocity=0.0,
+            held_alignment=-1.0,
         )
-        assert e.confidence == pytest.approx(-2.4, abs=1e-12)
-        assert e.confidence < 0.0  # not clipped
+        assert e.confidence == pytest.approx(0.0, abs=1e-12)
+        assert e.confidence >= 0.0  # clamped via max(0, alignment)
 
     def test_satisfaction_can_go_negative_when_far_from_identity(self) -> None:
         # basin_distance > 1 → (1 - basin_distance) negative → satisfaction negative
@@ -163,17 +188,21 @@ class TestReferenceValidation:
         )
         assert 0.849 - 0.021 <= e.satisfaction <= 0.849 + 0.021
 
-    def test_confidence_anticorrelates_with_transcendence(self) -> None:
-        # UCP §6.5 reports anti-correlation −0.690 between Confidence
-        # and Transcendence in typical regime. Verify monotone:
-        # higher transcendence → lower confidence at fixed Φ.
+    def test_confidence_decoupled_from_transcendence_post_joint_a(self) -> None:
+        """Commit 6 / JOINT-A (Cascade brief 2026-05-27): the historic
+        UCP §6.5 anti-correlation −0.690 between Confidence and
+        Transcendence is RETIRED. With the new formula
+        `confidence = phi × max(0, held_alignment)`, same phi + same
+        held_alignment → same confidence regardless of transcendence.
+        Transcendence stays live in anxiety (regime-change detector).
+        """
         low_t = compute_emotions(
             _m(transcendence=0.1), basin_distance=0.0, phi=0.5, basin_velocity=0.0,
         )
         high_t = compute_emotions(
             _m(transcendence=0.9), basin_distance=0.0, phi=0.5, basin_velocity=0.0,
         )
-        assert low_t.confidence > high_t.confidence
+        assert low_t.confidence == pytest.approx(high_t.confidence, abs=1e-12)
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -268,13 +297,17 @@ _PARITY_ROWS = [
      {"wonder": 0.0, "frustration": 0.0, "satisfaction": 0.0,
       "confusion": 0.0, "clarity": 1.0, "anxiety": 0.0,
       "confidence": 1.0, "boredom": 1.0}),
-    # row 6 — confidence negative regime (transcendence > 1)
+    # row 6 — Commit 6 / JOINT-A: confidence no longer depends on
+    # transcendence. confidence = phi × max(0, heldAlignment) with
+    # default heldAlignment=1.0 → confidence = phi (0.4). Anxiety
+    # still reads trans-driven instability — that channel stays live
+    # but trans is 0 here because basin_velocity is 0.
     ({"surprise": 0.5, "curiosity": 0.0, "investigation": 0.5,
       "integration": 0.0, "transcendence": 3.0},
      0.0, 0.4, 0.0,
      {"wonder": 0.0, "frustration": 0.25, "satisfaction": 0.0,
       "confusion": 0.0, "clarity": 0.25, "anxiety": 0.0,
-      "confidence": -0.8, "boredom": 0.5}),
+      "confidence": 0.4, "boredom": 0.5}),
     # row 7 — wonder canonical
     ({"surprise": 0.5, "curiosity": 1.0, "investigation": 0.5,
       "integration": 0.0, "transcendence": 0.0},
@@ -282,13 +315,15 @@ _PARITY_ROWS = [
      {"wonder": 0.7, "frustration": 0.25, "satisfaction": 0.0,
       "confusion": 0.35, "clarity": 0.25, "anxiety": 0.0,
       "confidence": 0.5, "boredom": 0.0}),
-    # row 8 — mid-state mixed regime
+    # row 8 — mid-state mixed regime. JOINT-A (Commit 6): confidence
+    # = phi × max(0, heldAlignment) = 0.5 (default heldAlignment=1.0,
+    # decoupled from trans). Anxiety = trans × basin_velocity = 0.1.
     ({"surprise": 0.5, "curiosity": 0.5, "investigation": 0.5,
       "integration": 1.0, "transcendence": 0.5},
      0.3, 0.5, 0.2,
      {"wonder": 0.15, "frustration": 0.25, "satisfaction": 0.7,
       "confusion": 0.15, "clarity": 0.25, "anxiety": 0.1,
-      "confidence": 0.25, "boredom": 0.25}),
+      "confidence": 0.5, "boredom": 0.25}),
     # row 9 — satisfaction canonical
     ({"surprise": 0.0, "curiosity": 0.0, "investigation": 0.5,
       "integration": 0.94, "transcendence": 0.0},
@@ -410,10 +445,12 @@ class TestFundingDragInEmotions:
         assert dragged.anxiety > base.anxiety, "anxiety should increase with drag"
 
     def test_conviction_gate_fires_earlier_with_funding_drag(self) -> None:
-        # Simulate a position that's marginal: confidence just above hesitation
-        # without drag, but drag tips it over.
-        # With Möbius drag, both confidence decreases AND anxiety increases,
-        # so the gate flips even more reliably.
+        """Commit 6 / JOINT-A: post-decouple, confidence = phi (no
+        trans collapse). For drag to flip the gate, drag must lift
+        anxiety past confidence directly. Using larger drag (2.0)
+        which maps to drag_factor=0.67 via Möbius — enough to
+        collapse confidence and lift anxiety past it.
+        """
         from monkey_kernel.executive import kernel_should_enter
         e_no_drag = compute_emotions(
             _m(transcendence=0.25, surprise=0.1),
@@ -423,10 +460,10 @@ class TestFundingDragInEmotions:
         e_with_drag = compute_emotions(
             _m(transcendence=0.25, surprise=0.1),
             basin_distance=0.0, phi=0.4, basin_velocity=0.8,
-            funding_drag=0.15,
+            funding_drag=2.0,
         )
-        # Verify anxiety increased by drag_factor (Möbius) not raw drag
-        drag_factor = 0.15 / (1.0 + 0.15)
+        # Verify Möbius anxiety lift.
+        drag_factor = 2.0 / (1.0 + 2.0)
         assert e_with_drag.anxiety == pytest.approx(e_no_drag.anxiety + drag_factor, abs=1e-12)
         # Verify the gate fires differently (one enters, one doesn't)
         enters_no_drag = kernel_should_enter(emotions=e_no_drag)

--- a/ml-worker/tests/monkey_kernel/test_held_position_rejustification.py
+++ b/ml-worker/tests/monkey_kernel/test_held_position_rejustification.py
@@ -381,15 +381,31 @@ class TestPhiCheckFires:
 
 class TestConvictionCheckFires:
     def test_conviction_failed_exits_with_correct_reason(self) -> None:
+        """Commit 4 (Cascade brief 2026-05-27): conviction_failed now
+        requires an observer-derived consecutive-tick streak (floor=2).
+        First tick of `confidence < anxiety + confusion` does NOT fire;
+        the second tick (still satisfying the condition) does.
+        """
         state = _state_with_anchor(
             regime_at_open=MonkeyMode.INVESTIGATION.value,
             phi_at_open=0.27,
         )
         # confidence (0.4) < anxiety (0.3) + confusion (0.2) = 0.5
         emo = _Emotions(confidence=0.4, anxiety=0.3, confusion=0.2)
+
+        # Tick 1: condition true, streak=1, does NOT fire (floor=2).
+        action1, _, _, _, _ = _call_decide(
+            state=state,
+            phi=0.25,
+            mode_value=MonkeyMode.INVESTIGATION.value,
+            emotions=emo,
+        )
+        assert action1 != "scalp_exit"
+
+        # Tick 2: condition still true, streak=2 ≥ floor → fires.
         action, reason, _, _, derivation = _call_decide(
             state=state,
-            phi=0.25,  # above floor
+            phi=0.25,
             mode_value=MonkeyMode.INVESTIGATION.value,
             emotions=emo,
         )

--- a/ml-worker/tests/monkey_kernel/test_observer_conviction_streak.py
+++ b/ml-worker/tests/monkey_kernel/test_observer_conviction_streak.py
@@ -1,0 +1,84 @@
+"""test_observer_conviction_streak.py — Commit 4 (Cascade brief 2026-05-27).
+
+Pins the observer-derived conviction streak requirement on the Py side.
+Mirrors observerConvictionStreakRequired in apps/api/src/services/monkey/loop.ts.
+
+Floor 2 (HISTORY_MIN_SAMPLES sentinel), cap 12, window 20.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import pytest  # noqa: E402
+
+from monkey_kernel.tick import (  # noqa: E402
+    _observer_conviction_streak_required,
+    _CONVICTION_STREAK_FLOOR,
+    _CONVICTION_HESITATION_WINDOW,
+    _CONVICTION_STREAK_CAP,
+)
+
+
+class TestConstants:
+    def test_floor_is_2(self) -> None:
+        assert _CONVICTION_STREAK_FLOOR == 2
+
+    def test_window_is_20(self) -> None:
+        assert _CONVICTION_HESITATION_WINDOW == 20
+
+    def test_cap_is_12(self) -> None:
+        assert _CONVICTION_STREAK_CAP == 12
+
+
+class TestBoundaryInputs:
+    def test_empty_history_returns_floor(self) -> None:
+        assert _observer_conviction_streak_required([]) == 2
+
+    def test_single_sample_returns_floor(self) -> None:
+        assert _observer_conviction_streak_required([0.5]) == 2
+
+
+class TestMonotonicCollapse:
+    def test_all_positive_no_flips_returns_floor(self) -> None:
+        history = [0.1, 0.2, 0.3, 0.4, 0.5]
+        assert _observer_conviction_streak_required(history) == 2
+
+    def test_all_negative_no_flips_returns_floor(self) -> None:
+        history = [-0.1, -0.2, -0.3, -0.4, -0.5]
+        assert _observer_conviction_streak_required(history) == 2
+
+
+class TestOscillation:
+    def test_every_tick_sign_flip_returns_cap(self) -> None:
+        # max oscillation — flip every adjacent pair
+        history = [0.1, -0.1, 0.1, -0.1, 0.1, -0.1, 0.1, -0.1, 0.1, -0.1]
+        assert _observer_conviction_streak_required(history) == 12
+
+    def test_moderate_flip_rate_returns_mid_range(self) -> None:
+        # 10 samples, 2 flips → flip rate ~0.22
+        history = [0.1, 0.2, 0.3, -0.1, -0.2, 0.1, 0.2, 0.3, 0.4, 0.5]
+        result = _observer_conviction_streak_required(history)
+        assert 2 <= result <= 8
+
+
+class TestZeroCrossings:
+    def test_zero_treated_as_neutral_no_flip(self) -> None:
+        # positive → zero → positive: should not count as flips
+        history = [0.5, 0, 0.5, 0, 0.5]
+        assert _observer_conviction_streak_required(history) == 2
+
+
+class TestTSParity:
+    """The TS side observerConvictionStreakRequired mirrors this exactly.
+    These inputs match the TS tests at observerConvictionStreak.test.ts.
+    """
+    def test_matches_ts_empty(self) -> None:
+        assert _observer_conviction_streak_required([]) == 2
+
+    def test_matches_ts_max_oscillation(self) -> None:
+        history = [0.1, -0.1, 0.1, -0.1, 0.1, -0.1, 0.1, -0.1, 0.1, -0.1]
+        assert _observer_conviction_streak_required(history) == 12


### PR DESCRIPTION
## Summary

Implements Cascade's 6-commit bleed-stop brief (2026-05-27). Closes Findings 1, 2, 3 (both substrates) and JOINT-A (canonical formula change). Each commit is independently reviewable and revertible.

| # | Commit | Scope |
|---|---|---|
| 1 | INSERT-site notional assertion | Centralized `checkNotionalConsistency` helper in `safePnlSql.ts`; all 3 INSERT sites (live / paper / reconciler) use it with 0.1% tolerance; aggregate-PnL backfill paths refused (defense in depth) |
| 2 | `DISAGREEMENT_LANE_MULTIPLIER` observer-derived | Replaces hardcoded `{scalp:1, swing:3, trend:10}` with `max(2, round(LANE_DECISION_PERIOD_MS[lane] / tickMs))` — substrate's own cadence sets the scale |
| 3 | Adopted-vs-own gate distinction | TS: `evaluateRejustification` accepts `origin: 'own' \| 'adopted'`; adopted positions skip regime/phi/conviction/stale_bleed (only directional_disagreement remains). Py: structurally already correct via anchor-gating |
| 4 | Py conviction-streak observer-derived N | Both substrates derive required-N from sign-flip rate of (anxiety+confusion−confidence) over rolling 20-tick window. Floor 2, cap 12. TS/Py parity asserted |
| 5 | Kernel INSERT-path 6× root cause | Audit + regression guard. Kernel-direct path verified base-asset (was already correct). Tests pin the 100×/1000× phantom patterns are caught by Commit 1's assertion |
| 6 | **JOINT-A: trans×conviction decouple** | Canonical formula change in `emotions.{py,ts}`. Before: `confidence = (1 − trans) × phi`. After: `confidence = phi × max(0, heldAlignment)`. Trans saturation no longer collapses conviction on κ MAD jitter |

## Verification

- TS typecheck: clean
- TS vitest: **1975 passed**, 12 skipped (was 1917 before; +58 net new tests added across 6 commits)
- Py pytest: 983 passed; 8 pre-existing κ*=64-retirement failures (unrelated to this PR — same set as on main HEAD)
- QIG purity check: **55 files clean**
- Knob budget: **0** new env vars / operator knobs introduced. One DEPRECATED hardcoded table deleted (DISAGREEMENT_LANE_MULTIPLIER)

## Why this is canonical (not knob-fitting)

Each commit follows the P1/P5/P25 doctrine that thresholds emerge from observable kernel state:

- **Commit 1** — assertion tolerance (0.1%) is wider than realistic slippage, tighter than any unit-conversion mismatch can be. Not a knob — the bound is set by physics (a contracts-vs-base-asset error is always ≥ lot-size-reciprocal, which is 10× or larger).
- **Commit 2** — `LANE_DECISION_PERIOD_MS` encodes lane DEFINITIONS (scalp=60s, swing=180s, trend=600s wall-clock windows). Division by tick period falls out of substrate's actual cadence.
- **Commit 3** — origin comes from the row's own `reason` field — observable from existing data.
- **Commit 4** — required N derived from sign-flip rate of the kernel's own emotion telemetry. Floor 2 = HISTORY_MIN_SAMPLES sentinel.
- **Commit 5** — invariant comment + regression test on the existing structurally-correct path.
- **Commit 6** — `heldAlignment` IS the geometric observable: projection of basinDir onto held side. Pre-existing in TS logs as `basinDir`. No new measurement needed.

## Expected behaviour shift post-deploy

| Telemetry | Pre-deploy | Expected after |
|---|---|---|
| ACH ceiling-pinning | 75% pinned-hi | Should come off the pin within ~20 closes (Commit 6 removes the trans→conviction→chemistry feedback that was pumping ACH via misfired conviction) |
| Conviction_failed rate | 14+/24h | Drops sharply on own positions; structurally zero on adopted positions |
| Adopted-position TP/SL behaviour | Subject to all 4 rejust checks | Only TP/SL/basinDir-flip eligible |
| 6× pnl drift | Window-dependent (some legacy) | Each new INSERT verified at write — any 6× regression trips the throw |
| Py/TS parity | Conviction streak diverged (Py immediate-fire, TS streak) | Both observer-derived, same formula |
| Confidence on κ jitter | Collapsed to ~4-7% of phi (gate trips on noise) | Stays at phi × alignment (no trans collapse) |

## Test plan

- [x] TS typecheck + vitest green
- [x] Py pytest (subset relevant to this PR) green
- [x] QIG purity clean
- [x] No new env vars
- [ ] CI green on merge
- [ ] Post-deploy: ACH pin trajectory comes off (within ~20 closes)
- [ ] Post-deploy: first adopted-position close ends at TP/SL/basinDir-flip only (no conviction_failed)
- [ ] Post-deploy: 24h Polo CSV vs DB pnl reconciliation lands within 0.5% per-trade

## Out of this PR's scope (documented as known)

- 8 pre-existing Py failures from the κ*=64 retirement (`test_kappa_at_star_yields_anchor`, `test_kappa_offset_relative_to_anchor`, etc.) — a separate v6.7B-aftermath workstream owns those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)