### PR TITLE
fix(reward): kill 9bp + 0.18 fee-estimator knobs in synthetic reward fallback

### DIFF
--- a/apps/api/src/services/monkey/__tests__/perAgentNC.test.ts
+++ b/apps/api/src/services/monkey/__tests__/perAgentNC.test.ts
@@ -51,28 +51,28 @@ describe('per-agent neurochemistry reward isolation', () => {
     // produces an identical dopamine delta — that way per-agent sums are
     // easy to reason about (each = the single-event delta).
     kernel.pushReward({
-      source: 'test_close',
+      source: 'polo_authoritative_close',
       symbol: 'BTC_USDT_PERP',
       realizedPnlUsdt: 1.0,    // 10 % win on 10 USDT margin
       marginUsdt: 10,
       agent: 'K',
     });
     kernel.pushReward({
-      source: 'test_close',
+      source: 'polo_authoritative_close',
       symbol: 'BTC_USDT_PERP',
       realizedPnlUsdt: 1.0,
       marginUsdt: 10,
       agent: 'M',
     });
     kernel.pushReward({
-      source: 'test_close',
+      source: 'polo_authoritative_close',
       symbol: 'BTC_USDT_PERP',
       realizedPnlUsdt: 1.0,
       marginUsdt: 10,
       agent: 'T',
     });
     kernel.pushReward({
-      source: 'test_close',
+      source: 'polo_authoritative_close',
       symbol: 'BTC_USDT_PERP',
       realizedPnlUsdt: 1.0,
       marginUsdt: 10,
@@ -124,7 +124,7 @@ describe('per-agent neurochemistry reward isolation', () => {
     });
 
     kernel.pushReward({
-      source: 'test_close',
+      source: 'polo_authoritative_close',
       symbol: 'BTC_USDT_PERP',
       realizedPnlUsdt: 2.0,
       marginUsdt: 10,
@@ -156,7 +156,7 @@ describe('per-agent neurochemistry reward isolation', () => {
     // pre-2026-05-16 deploys that race a fresh build see no behaviour
     // regression on K.
     kernel.pushReward({
-      source: 'legacy_close',
+      source: 'polo_authoritative_close',
       symbol: 'BTC_USDT_PERP',
       realizedPnlUsdt: 1.5,
       marginUsdt: 10,
@@ -180,14 +180,14 @@ describe('per-agent neurochemistry reward isolation', () => {
     // T loses, K wins — verify the T-only window shows the negative
     // mood dip and K's window shows the positive lift, neither bleeds.
     kernel.pushReward({
-      source: 'test_close',
+      source: 'polo_authoritative_close',
       symbol: 'BTC_USDT_PERP',
       realizedPnlUsdt: -1.0,
       marginUsdt: 10,
       agent: 'T',
     });
     kernel.pushReward({
-      source: 'test_close',
+      source: 'polo_authoritative_close',
       symbol: 'BTC_USDT_PERP',
       realizedPnlUsdt: 1.0,
       marginUsdt: 10,

--- a/apps/api/src/services/monkey/__tests__/pushRewardObserverDerive.test.ts
+++ b/apps/api/src/services/monkey/__tests__/pushRewardObserverDerive.test.ts
@@ -69,7 +69,7 @@ describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
     // kernel builds enough samples to z-score against its own
     // distribution). The legacy hardcoded 1% floor → Fibonacci tier
     // mapping was retired with the deletion of fibonacciRewardCoefficient.
-    k.pushReward({ source: 'test', realizedPnlUsdt: 0.10, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: 0.10, marginUsdt: 1, agent: 'K' });
     const r = lastReward();
     expect(r.pnlFraction).toBeCloseTo(0.10, 6);
     // Cold start: dopamine = tanh(pnlFracNormalized) × 0.5 × 1
@@ -80,11 +80,11 @@ describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
   it('after several wins, dopamine z-normalizes against rolling stddev', () => {
     // Seed history with 10 wins of ~5% ROI
     for (let i = 0; i < 10; i++) {
-      k.pushReward({ source: 'seed', realizedPnlUsdt: 0.05, marginUsdt: 1, agent: 'K' });
+      k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: 0.05, marginUsdt: 1, agent: 'K' });
     }
     // Now a 10% win — should be "above average" relative to the
     // kernel's own observed distribution → higher dopamine.
-    k.pushReward({ source: 'bigger', realizedPnlUsdt: 0.10, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: 0.10, marginUsdt: 1, agent: 'K' });
     const big = lastReward();
     // Big win produces higher dopamine than the seeded "typical" win
     expect(big.dopamineDelta).toBeGreaterThan(Math.tanh(0.05) * 0.5);
@@ -98,7 +98,7 @@ describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
     const history: number[] = [];
     for (let i = 0; i < 8; i++) history.push(0.003 + (i % 5) * 0.001);
     seedSymbolHistory(k, symbol, history);
-    k.pushReward({ source: 'huge', symbol, realizedPnlUsdt: 100, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', symbol, realizedPnlUsdt: 100, marginUsdt: 1, agent: 'K' });
     const r = lastReward();
     expect(r.dopamineDelta).toBeGreaterThan(0.5);
     expect(r.dopamineDelta).toBeLessThanOrEqual(0.5 * 34);
@@ -109,7 +109,7 @@ describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
     const history: number[] = [];
     for (let i = 0; i < 8; i++) history.push(0.003 + (i % 5) * 0.001);
     seedSymbolHistory(k, symbol, history);
-    k.pushReward({ source: 'huge', symbol, realizedPnlUsdt: 100, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', symbol, realizedPnlUsdt: 100, marginUsdt: 1, agent: 'K' });
     const r = lastReward();
     expect(r.serotoninDelta).toBeGreaterThan(0.15);
     expect(r.serotoninDelta).toBeLessThanOrEqual(0.15 * 34);
@@ -120,7 +120,7 @@ describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
     const history: number[] = [];
     for (let i = 0; i < 8; i++) history.push(0.003 + (i % 5) * 0.001);
     seedSymbolHistory(k, symbol, history);
-    k.pushReward({ source: 'huge', symbol, realizedPnlUsdt: 100, marginUsdt: 1, kappaAtExit: 64, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', symbol, realizedPnlUsdt: 100, marginUsdt: 1, kappaAtExit: 64, agent: 'K' });
     const r = lastReward();
     expect(r.endorphinDelta).toBeGreaterThan(0.3);
     expect(r.endorphinDelta).toBeLessThanOrEqual(0.3 * 34);
@@ -134,27 +134,27 @@ describe('pushReward observer-derive — pnlFrac z-score normalization', () => {
     // signal from real-scale wins instead of being structurally muted.
     // After enough history, the gate z-scores against the kernel's
     // own distribution — sub-median wins still emit zero.
-    k.pushReward({ source: 'noise', realizedPnlUsdt: 0.005, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: 0.005, marginUsdt: 1, agent: 'K' });
     const r = lastReward();
     expect(r.dopamineDelta).toBeGreaterThan(0);
     expect(r.dopamineDelta).toBeLessThanOrEqual(0.5);
   });
 
   it('loss produces negative dopamine bounded by 0.1 cap', () => {
-    k.pushReward({ source: 'loss', realizedPnlUsdt: -10, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: -10, marginUsdt: 1, agent: 'K' });
     const r = lastReward();
     expect(r.dopamineDelta).toBeLessThan(0);
     expect(Math.abs(r.dopamineDelta)).toBeLessThanOrEqual(0.1);
   });
 
   it('losses produce zero serotonin (wins-only path)', () => {
-    k.pushReward({ source: 'loss', realizedPnlUsdt: -10, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: -10, marginUsdt: 1, agent: 'K' });
     const r = lastReward();
     expect(r.serotoninDelta).toBe(0);
   });
 
   it('losses produce zero endorphins (wins-only path)', () => {
-    k.pushReward({ source: 'loss', realizedPnlUsdt: -10, marginUsdt: 1, kappaAtExit: 64, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: -10, marginUsdt: 1, kappaAtExit: 64, agent: 'K' });
     const r = lastReward();
     expect(r.endorphinDelta).toBe(0);
   });
@@ -181,16 +181,16 @@ describe('pushReward observer-derive — outlier robustness (MAD)', () => {
     // Seed 6 typical wins/losses around 1% pnlFrac.
     for (let i = 0; i < 6; i++) {
       k.pushReward({
-        source: 'seed',
+        source: 'polo_authoritative_close',
         realizedPnlUsdt: i % 2 === 0 ? 0.01 : -0.01,
         marginUsdt: 1,
         agent: 'K',
       });
     }
     // Inject a massive outlier win (+50% pnlFrac, like the live +$78).
-    k.pushReward({ source: 'outlier-win', realizedPnlUsdt: 0.5, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: 0.5, marginUsdt: 1, agent: 'K' });
     // Now a normal-magnitude loss (-2% pnlFrac).
-    k.pushReward({ source: 'normal-loss', realizedPnlUsdt: -0.02, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: -0.02, marginUsdt: 1, agent: 'K' });
     const lossDop = lastReward().dopamineDelta;
     // Loss should produce measurable negative dopamine — NOT crushed to
     // near-zero by the outlier-inflated normalizer.
@@ -200,16 +200,16 @@ describe('pushReward observer-derive — outlier robustness (MAD)', () => {
   it('MAD normalization keeps chemistry response stable across outlier injection', () => {
     // Build a baseline: 6 small wins of 1% pnlFrac.
     for (let i = 0; i < 6; i++) {
-      k.pushReward({ source: 'pre', realizedPnlUsdt: 0.01, marginUsdt: 1, agent: 'K' });
+      k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: 0.01, marginUsdt: 1, agent: 'K' });
     }
     // Record dopamine for a typical 1% win pre-outlier.
-    k.pushReward({ source: 'typical-pre', realizedPnlUsdt: 0.01, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: 0.01, marginUsdt: 1, agent: 'K' });
     const dopPre = lastReward().dopamineDelta;
     // Inject outlier.
-    k.pushReward({ source: 'outlier', realizedPnlUsdt: 1.0, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: 1.0, marginUsdt: 1, agent: 'K' });
     // Same typical 1% win post-outlier — dopamine should be similar
     // (MAD didn't move; under stddev it would be much smaller).
-    k.pushReward({ source: 'typical-post', realizedPnlUsdt: 0.01, marginUsdt: 1, agent: 'K' });
+    k.pushReward({ source: 'polo_authoritative_close', realizedPnlUsdt: 0.01, marginUsdt: 1, agent: 'K' });
     const dopPost = lastReward().dopamineDelta;
     // Ratio should be close to 1 — outlier didn't suppress response.
     // (Under stddev the ratio would be ~5-10×.)
@@ -234,7 +234,7 @@ describe('pushReward observer-derive — kappaProxim from rolling kappa stddev',
     // non-degenerate.
     for (let i = 0; i < 6; i++) {
       k.pushReward({
-        source: 'seed',
+        source: 'polo_authoritative_close',
         realizedPnlUsdt: 0.05,
         marginUsdt: 1,
         kappaAtExit: 63 + (i % 2),  // alternating 63/64
@@ -243,7 +243,7 @@ describe('pushReward observer-derive — kappaProxim from rolling kappa stddev',
     }
     // Now a win exactly at κ*.
     k.pushReward({
-      source: 'peak',
+      source: 'polo_authoritative_close',
       realizedPnlUsdt: 0.05,
       marginUsdt: 1,
       kappaAtExit: 64,
@@ -257,7 +257,7 @@ describe('pushReward observer-derive — kappaProxim from rolling kappa stddev',
     // Seed history
     for (let i = 0; i < 6; i++) {
       k.pushReward({
-        source: 'seed',
+        source: 'polo_authoritative_close',
         realizedPnlUsdt: 0.05,
         marginUsdt: 1,
         kappaAtExit: 60 + (i % 3),
@@ -266,7 +266,7 @@ describe('pushReward observer-derive — kappaProxim from rolling kappa stddev',
     }
     // κ at κ*
     k.pushReward({
-      source: 'at-star',
+      source: 'polo_authoritative_close',
       realizedPnlUsdt: 0.05,
       marginUsdt: 1,
       kappaAtExit: 64,
@@ -275,7 +275,7 @@ describe('pushReward observer-derive — kappaProxim from rolling kappa stddev',
     const at = lastReward();
     // κ far from κ*
     k.pushReward({
-      source: 'far',
+      source: 'polo_authoritative_close',
       realizedPnlUsdt: 0.05,
       marginUsdt: 1,
       kappaAtExit: 80,
@@ -287,7 +287,7 @@ describe('pushReward observer-derive — kappaProxim from rolling kappa stddev',
 
   it('kappaAtExit missing → kappaProxim falls to 0.5 (legacy fallback preserved)', () => {
     k.pushReward({
-      source: 'no-kappa',
+      source: 'polo_authoritative_close',
       realizedPnlUsdt: 0.05,
       marginUsdt: 1,
       // kappaAtExit omitted

--- a/apps/api/src/services/monkey/__tests__/safePnlSql.test.ts
+++ b/apps/api/src/services/monkey/__tests__/safePnlSql.test.ts
@@ -136,40 +136,43 @@ import { observerFibCoefficient } from '../ocean_reward.js';
 import { computeNetPnlForReward } from '../safePnlSql.js';
 
 describe('net-of-fees reward signal (P1/P5/P25 — chemistry must see lived economic reality)', () => {
-  it('15:30:45 case: gross +0.148 but net ≈ −0.02 after fees → oceanCoeff must be 0, no positive tier reward', () => {
-    // User's exact production report: hold was 8.5 min (not 56.9), gross +0.148,
-    // Polo fees made it net-negative (~ −0.02). The observer reward gate must
-    // NOT fire positive chemistry on this structurally losing trade.
+  it('synthetic close path returns 0 — no fabricated fee estimate (operator "no knobs" doctrine 2026-05-27)', () => {
+    // The previous implementation used 9 bp + 0.18 floor as a fee estimate,
+    // which were knobs the operator explicitly rejected. The canonical
+    // reward path is now `applyPoloRealizedPnlAfterClose` which fetches
+    // Polo's real realizedPnl and pushes a separate `polo_authoritative_close`
+    // event. The synthetic immediate-close path returns 0 so no chemistry
+    // fires on estimated data; the authoritative event supersedes within
+    // seconds.
     const grossPnl = 0.148;
-    // Realistic margin for the trade that produced ~$0.17 fee hit at 9 bp + floor
-    const margin = 1.2; // notional ~19.2 USDT
+    const margin = 1.2;
     const notional = margin * 16;
 
     const netPnl = computeNetPnlForReward(grossPnl, notional);
-    // Must reproduce the user's measured outcome: net negative
-    expect(netPnl).toBeLessThan(0);
+    // No fabricated fee — synthetic path returns 0 by design.
+    expect(netPnl).toBe(0);
 
-    // Simulate the history the kernel would have seen (small positive median)
+    // Downstream observer behavior unchanged: 0 pnlFrac → coeff 0.
     const history = [0.0005, 0.0012, -0.0008, 0.0003, 0.0009];
-
-    // The pnlFrac passed to the observer must be the *net* version
     const netPnlFrac = netPnl / margin;
     const coeff = observerFibCoefficient(netPnlFrac, history);
-
-    // Gross would have produced positive z and tier ≥1.
-    // Net must produce z ≤ 0 → coeff = 0 (no positive chemistry).
     expect(coeff).toBe(0);
   });
 
-  it('computeNetPnlForReward is conservative (never over-rewards marginal gross-positive trades)', () => {
-    const gross = 0.05;
-    const notional = 10;
-    const net = computeNetPnlForReward(gross, notional);
-    expect(net).toBeLessThan(gross);
-    // On very small gross the net can easily go negative
-    const tinyGross = 0.005;
-    const tinyNet = computeNetPnlForReward(tinyGross, notional);
-    expect(tinyNet).toBeLessThan(0);
+  it('cold-start / test fixture path (notional ≤ 0) falls open to gross', () => {
+    // Test harnesses that don't thread a notional (legacy / cold-start)
+    // keep working. Production paths always thread notional > 0 and
+    // therefore hit the zero-fallback above.
+    expect(computeNetPnlForReward(0.5, 0)).toBe(0.5);
+    expect(computeNetPnlForReward(-0.5, 0)).toBe(-0.5);
+    expect(computeNetPnlForReward(1.0, -5)).toBe(1.0);
+    expect(computeNetPnlForReward(1.0, NaN)).toBe(1.0);
+  });
+
+  it('non-finite gross input returns 0 (defensive)', () => {
+    expect(computeNetPnlForReward(NaN, 10)).toBe(0);
+    expect(computeNetPnlForReward(Infinity, 10)).toBe(0);
+    expect(computeNetPnlForReward(-Infinity, 10)).toBe(0);
   });
 });
 

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -8629,6 +8629,7 @@ export class MonkeyKernel extends EventEmitter {
     symbol: string,
     markPrice: number,
     totals: Record<AgentLabel, { pnl: number; qty: number }>,
+    tradeId?: string,   // preparation for canonical Polo surface (authoritative reward)
   ): void {
     const symState = this.symbolStates.get(symbol);
     try {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -8826,21 +8826,20 @@ export class MonkeyKernel extends EventEmitter {
       }
     }
 
-    const netPnlUsdtForReward = computeNetPnlForReward(grossPnlUsdt, marginUsdt * 16);
+    // "Reward based on actual profit" doctrine (operator 2026-05-27 / 28):
+    //   polo_authoritative_close: realizedPnlUsdt IS the Polo net (fees +
+    //     funding already subtracted by the exchange). Use it directly.
+    //   any other source (synthetic immediate-close): chemistry waits.
+    //     The follow-up applyPoloRealizedPnlAfterClose call will push a
+    //     polo_authoritative_close event within ~1 tick.
+    // Replaces the prior `computeNetPnlForReward` fee-estimator (9 bp +
+    // 0.18 floor) which the operator explicitly rejected as a knob.
+    const netPnlUsdtForReward = input.source === 'polo_authoritative_close'
+      ? grossPnlUsdt
+      : computeNetPnlForReward(grossPnlUsdt, marginUsdt * 16);
     const pnlFrac = marginUsdt > 0
       ? netPnlUsdtForReward / marginUsdt
       : 0;
-
-    // Hard assert (LIVED ONLY 5): if the net is materially worse than gross
-    // on a positive-gross trade, we must not let gross leak into chemistry.
-    if (grossPnlUsdt > 0 && netPnlUsdtForReward <= 0 && Math.abs(netPnlUsdtForReward - grossPnlUsdt) > 0.01) {
-      logger.warn('[LIVED ONLY 5][REWARD] gross-positive trade is net-negative after fees — chemistry correctly receives net', {
-        gross: grossPnlUsdt,
-        netForReward: netPnlUsdtForReward,
-        source: input.source,
-        symbol: input.symbol,
-      });
-    }
 
     // 2026-05-25 (observer-derive PR) — replaces magic input scales
     // (1.5×, 0.5×, 2×, /10) with observer-derived normalization against

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -6749,7 +6749,8 @@ export class MonkeyKernel extends EventEmitter {
             `UPDATE autonomous_trades
                 SET status = 'closed', exit_price = $1, exit_time = NOW(),
                     exit_reason = $2, exit_order_id = $3, exit_gate = 'agent_l_force_harvest',
-                    ${SAFE_PNL_FROM_ROW}
+                    ${SAFE_PNL_FROM_ROW},
+                    gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_FROM_ROW})
               WHERE id = $4
               RETURNING pnl`,
             [lastPrice, 'agent_l_force_harvest', orderId, row.id],
@@ -7010,7 +7011,8 @@ export class MonkeyKernel extends EventEmitter {
       await pool.query(
         `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
                 exit_reason='race_lost_to_sibling', exit_gate='race_lost_to_sibling',
-                ${SAFE_PNL_FROM_ROW} WHERE id=$2`,
+                ${SAFE_PNL_FROM_ROW},
+                gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_FROM_ROW}) WHERE id=$2`,
         [markPrice, tradeId],
       ).catch(() => { /* non-fatal */ });
       const reason = acquired.reason === 'recently_closed'
@@ -7434,7 +7436,8 @@ export class MonkeyKernel extends EventEmitter {
               `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
                       exit_reason='exchange_position_vanished',
                       exit_gate='exchange_position_vanished',
-                      ${SAFE_PNL_FROM_ROW} WHERE id=$2`,
+                      ${SAFE_PNL_FROM_ROW},
+                      gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_FROM_ROW}) WHERE id=$2`,
               [markPrice, tradeId],
             ).catch(() => { /* non-fatal */ });
             return {

--- a/apps/api/src/services/monkey/safePnlSql.ts
+++ b/apps/api/src/services/monkey/safePnlSql.ts
@@ -95,19 +95,32 @@ export function computeNetPnlForReward(
   grossPnlUsdt: number,
   notionalUsdt: number,
 ): number {
-  if (!Number.isFinite(grossPnlUsdt) || !Number.isFinite(notionalUsdt) || notionalUsdt <= 0) {
-    return grossPnlUsdt; // fall-open only for cold-start / test fixtures
+  // "Reward based on actual profit" doctrine (operator 2026-05-27):
+  //   "dont suggest knobs jsut increase the telemetry and reward based on
+  //    actual profit."
+  //
+  // The previous 9bp + 0.18 floor were knobs — fee estimates the operator
+  // explicitly rejected. The canonical reward path is
+  // applyPoloRealizedPnlAfterClose, which fetches Polo's real realizedPnl
+  // (net of fees + funding) and pushes a `polo_authoritative_close` event
+  // carrying the actual lived economic outcome. That path is the only one
+  // that produces chemistry from now on.
+  //
+  // This function (called for the immediate synthetic-close path) now
+  // returns 0 when an authoritative Polo notional context exists — the
+  // chemistry waits for the Polo-authoritative event rather than
+  // fabricating a fee estimate. The pre-Polo synthetic push therefore
+  // produces no chemistry delta; it's a placeholder that the
+  // authoritative event will replace within seconds.
+  //
+  // Cold-start / test fixtures (no notional → notionalUsdt ≤ 0) fall
+  // open to gross so harness code that doesn't thread a notional keeps
+  // working. Production paths always thread notional > 0.
+  if (!Number.isFinite(grossPnlUsdt)) return 0;
+  if (!Number.isFinite(notionalUsdt) || notionalUsdt <= 0) {
+    return grossPnlUsdt;
   }
-  // Conservative round-trip taker + funding buffer (Polo USDT-M typical)
-  // plus a small absolute floor so micro-edge trades that are gross-positive
-  // but fee-negative (the exact 15:30:45 case) correctly produce net ≤ 0
-  // for the reward observer.
-  const roundTripFeePct = 0.0009; // 9 bp conservative
-  const feeHit = Math.max(
-    notionalUsdt * roundTripFeePct,
-    0.18, // absolute floor — reproduces the ~$0.17 fee hit the user measured on the +0.148 gross trade (conservative)
-  );
-  return grossPnlUsdt - feeHit;
+  return 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

Per operator directive 2026-05-27: *"dont suggest knobs jsut increase the telemetry and reward based on actual profit."*

Grok's PR 18625977 wired the canonical Polo-authoritative reward path (`applyPoloRealizedPnlAfterClose` → `pushReward` with `source='polo_authoritative_close'`). Correct architecture. But the intermediate `computeNetPnlForReward` fee-estimator (**9 bp + 0.18 floor**) was left as the fallback for the synthetic immediate-close path — and those constants are exactly the knobs the operator rejected.

## Doctrine made explicit

- `polo_authoritative_close` source: `realizedPnlUsdt` IS the Polo net (fees + funding already subtracted by the exchange). Use directly.
- Any other source (synthetic immediate-close): chemistry waits. The follow-up `applyPoloRealizedPnlAfterClose` call will push a `polo_authoritative_close` event within ~1 tick.
- `computeNetPnlForReward(gross, notional > 0)` → **0** (no fabricated estimate). Cold-start / test-fixture path (notional ≤ 0) still falls open to gross for legacy harnesses.

If the Polo history fetch fails intermittently, the kernel learns **nothing** from that close — preferable to learning from a fabricated fee estimate. *"Reward based on actual profit"* → if we don't know the actual profit, don't reward.

## Files

- `safePnlSql.ts:computeNetPnlForReward` — function body simplified; constants deleted.
- `loop.ts:pushReward` — explicit `source === 'polo_authoritative_close'` branch uses `grossPnlUsdt` directly; synthetic branch goes through the (now zero-returning) helper.
- `safePnlSql.test.ts` — pins new doctrine (synthetic returns 0, cold-start fall-open, non-finite defensive).
- `pushRewardObserverDerive.test.ts` + `perAgentNC.test.ts` — source labels updated from descriptive (`'test'`/`'seed'`/`'huge'`) to `'polo_authoritative_close'` so tests exercise the canonical reward path. Reward-shape semantics (z-score, kappa-prox, observer Fibonacci) unchanged — just live on the authoritative path now.

## Verification

- `yarn tsc --noEmit`: clean
- `yarn vitest run`: **1979 passed**, 12 skipped (was 1963 + 16 failed before the test source-label rewrite)
- User's 15:30:45 case (gross +0.148, Polo net ≈ −0.02): still produces `oceanCoeff=0` — now because the synthetic path emits no chemistry at all, and the `polo_authoritative_close` event (when it fires) carries the real −0.02 which is below median.

## Test plan

- [x] TS typecheck + vitest sweep
- [ ] CI green
- [ ] Post-deploy: confirm `polo_authoritative_close` reward log lines fire on each close
- [ ] Post-deploy: confirm no `oceanCoeff > 0` fires when Polo realized is ≤ 0 (the 15:30:45 class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align reward computation with exchange-reported realized PnL by removing synthetic fee-estimator knobs and making chemistry trigger only from Polo-authoritative close events.

Bug Fixes:
- Stop fabricating net PnL from gross using a fixed fee estimate so rewards no longer learn from inaccurate synthetic profit signals.

Enhancements:
- Treat `polo_authoritative_close` rewards as authoritative by using realized PnL directly and deferring chemistry for synthetic closes until the exchange event arrives.
- Propagate `gross_pnl` into closed trade records when missing to preserve the canonical PnL surface for later authoritative updates.
- Relax `computeNetPnlForReward` to pass through gross PnL only for cold-start or test-fixture cases without notional and return zero otherwise, avoiding synthetic fee assumptions.
- Extend the reward plumbing with an optional trade identifier parameter in preparation for a canonical Polo reward surface.

Tests:
- Update reward observer and per-agent neurochemistry tests to exercise the canonical `polo_authoritative_close` reward path while preserving existing reward-shape semantics.
- Add and adjust PnL safety tests to pin the new net-PnL-for-reward doctrine, including cold-start behavior and non-finite input handling.