### PR TITLE
feat(monkey): contracts-cap=0 diagnostic telemetry (operator visibility)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -8161,13 +8161,39 @@ export class MonkeyKernel extends EventEmitter {
         newContracts, currentContracts, cap,
       );
       if (clampedNewContracts === 0) {
+        // Diagnostic telemetry (2026-05-28 CC1): include the inputs the
+        // operator needs to immediately distinguish "kernel correctly
+        // refusing entry due to insufficient free equity" from "input
+        // threading bug somewhere upstream". Most operators looking at
+        // this log line want to know IMMEDIATELY whether they should
+        // top up the account or whether the kernel is mis-computing.
+        const dop = req.dopamine ?? 0.5;
+        const gaba = req.gaba ?? 0.5;
+        const riskFraction = Math.max(0.1, dop * req.phi * (1 - gaba));
+        const denom = req.entryPrice * symbolLotSize;
+        const equityHeadroom = Math.max(0, req.availableEquityUsdt ?? 0);
+        const expectedCap = denom > 0
+          ? Math.floor((equityHeadroom * riskFraction * req.leverage) / denom)
+          : 0;
+        const reason = !req.availableEquityUsdt || req.availableEquityUsdt <= 0
+          ? 'no_equity_threaded_from_caller'
+          : equityHeadroom * riskFraction * req.leverage < denom
+            ? `insufficient_free_equity (need ≥ ${(denom / Math.max(1, req.leverage * riskFraction)).toFixed(2)} USDT free, have ${equityHeadroom.toFixed(2)})`
+            : 'unknown';
         logger.info('[Monkey] entry suppressed by contracts cap', {
           symbol, agent: effectiveAgent, side, lane: effectiveLane,
           currentContracts, attemptedNew: newContracts, cap,
+          availableEquity: req.availableEquityUsdt?.toFixed(2),
+          leverage: req.leverage,
+          riskFraction: riskFraction.toFixed(3),
+          dopamine: dop.toFixed(3), phi: req.phi.toFixed(3), gaba: gaba.toFixed(3),
+          contractNotional: denom.toFixed(2),
+          expectedCap,
+          rootCause: reason,
         });
         return {
           executed: false, orderId: null,
-          reason: `at_position_contracts_cap: open=${currentContracts} desired=${newContracts} cap=${cap}`,
+          reason: `at_position_contracts_cap: open=${currentContracts} desired=${newContracts} cap=${cap} | ${reason}`,
         };
       }
       if (clampedNewContracts < newContracts) {


### PR DESCRIPTION
## Why

When `kernelDerivedContractCap` returns 0, the prior log line was:
\`\`\`
reason: at_position_contracts_cap: open=0 desired=1 cap=0
\`\`\`

Tells the operator the kernel won't enter but not WHY. Two distinct root causes share the signature:
- `availableEquityUsdt` isn't being threaded from the caller (bug)
- `availableEquityUsdt` is genuinely too small for even 1 contract (kernel doing the right thing — free margin exhausted)

Observed 2026-05-27 16:40+ UTC: ~30 `cap=0` events in 30 min on ETH; operator couldn't tell from logs whether to top up the account or investigate a threading bug.

## What

Augment the cap=0 log + return-reason with:
- `availableEquity` (the threaded value)
- `leverage`
- `riskFraction = max(0.1, dop × phi × (1-gaba))`
- `dopamine / phi / gaba`
- `contractNotional = markPrice × contractSize`
- `expectedCap` (the formula's `floor()` math)
- `rootCause` ∈ `{no_equity_threaded_from_caller, insufficient_free_equity (need ≥ X have Y), unknown}`

The `reason` string returned to callers also carries `rootCause` so `monkey_decisions` analysis can bucket the suppression class without re-deriving from logs.

**No behavior change** in the cap formula itself — pure diagnostic addition.

## Test plan

- [x] `yarn tsc --noEmit`: clean
- [x] `yarn vitest run`: 1979 passed, 12 skipped (no regressions)
- [ ] Post-deploy: confirm `rootCause` field appears in `[Monkey] entry suppressed by contracts cap` log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhance monkey kernel contracts-cap=0 handling with richer diagnostic telemetry and root-cause reporting for suppressed entries.

Enhancements:
- Augment contracts-cap=0 suppression logging with equity, leverage, risk parameters, contract notional, expected contract cap, and a classified root-cause field.
- Include a root-cause descriptor in the returned reason string so downstream analysis can distinguish input-threading issues from genuine insufficient-equity conditions without re-deriving from logs.