### PR TITLE
feat(monkey): hold-time floor from lane decision-period (cure wins-cut-short)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
+++ b/apps/api/src/services/monkey/__tests__/heldPositionRejustification.test.ts
@@ -769,3 +769,138 @@ describe('held-position rejustification — conviction post-Layer-2B-port', () =
     expect(out.fired).toBe('conviction_failed');
   });
 });
+
+// ─── Hold-time floor (2026-05-28 CC1 operator-selected fix) ────────
+
+describe('hold-time floor suppresses internal-coherence exits', () => {
+  const FLOOR = 600; // seconds — mirrors LANE_DECISION_PERIOD_MS.trend / 1000
+
+  it('regime_change is suppressed when held < floor', () => {
+    const basinA: Basin = uniformBasin(BASIN_DIM);
+    const basinB: Basin = Array.from({ length: BASIN_DIM }, (_, i) =>
+      i === 0 ? 1.0 : 0.0,
+    );
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.20,
+      emotions: NEUTRAL_EMO,
+      regimeConfidence: 0.99,
+      regimeChangeStreak: 10,
+      regimeStabilityTicksRequired: 3,
+      basinAtOpen: basinA,
+      basinNow: basinB,
+      heldDurationS: 30,        // held 30s, floor 600s
+      holdTimeFloorS: FLOOR,
+    });
+    expect(out.fired).not.toBe('regime_change');
+  });
+
+  it('regime_change fires once held >= floor (same scenario, different time)', () => {
+    const basinA: Basin = uniformBasin(BASIN_DIM);
+    const basinB: Basin = Array.from({ length: BASIN_DIM }, (_, i) =>
+      i === 0 ? 1.0 : 0.0,
+    );
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.DRIFT,
+      phiNow: 0.20,
+      emotions: NEUTRAL_EMO,
+      regimeConfidence: 0.99,
+      regimeChangeStreak: 10,
+      regimeStabilityTicksRequired: 3,
+      basinAtOpen: basinA,
+      basinNow: basinB,
+      heldDurationS: 700,       // held 700s > 600s floor
+      holdTimeFloorS: FLOOR,
+    });
+    expect(out.fired).toBe('regime_change');
+  });
+
+  it('phi_collapse is suppressed when held < floor', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.10,             // well below floor 0.27 / φ ≈ 0.167
+      emotions: NEUTRAL_EMO,
+      heldDurationS: 30,
+      holdTimeFloorS: FLOOR,
+    });
+    expect(out.fired).not.toBe('phi_collapse');
+  });
+
+  it('phi_collapse fires once held >= floor', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.10,
+      emotions: NEUTRAL_EMO,
+      heldDurationS: 700,
+      holdTimeFloorS: FLOOR,
+    });
+    expect(out.fired).toBe('phi_collapse');
+  });
+
+  it('conviction_failed is suppressed when held < floor', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: { confidence: 0.05, anxiety: 0.15, confusion: 0.10 },
+      convictionFailedStreak: 5,
+      convictionFailedTicksRequired: 2,
+      heldDurationS: 30,
+      holdTimeFloorS: FLOOR,
+    });
+    expect(out.fired).not.toBe('conviction_failed');
+  });
+
+  it('conviction_failed fires once held >= floor', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: { confidence: 0.05, anxiety: 0.15, confusion: 0.10 },
+      convictionFailedStreak: 5,
+      convictionFailedTicksRequired: 2,
+      heldDurationS: 700,
+      holdTimeFloorS: FLOOR,
+    });
+    expect(out.fired).toBe('conviction_failed');
+  });
+
+  it('stale_bleed is NOT gated by the floor (safety exit must fire regardless of time)', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.25,
+      emotions: NEUTRAL_EMO,
+      heldDurationS: STALE_BLEED_MIN_DURATION_S + 1,  // 30min+ held
+      currentRoi: STALE_BLEED_ROI_THRESHOLD - 0.005,  // worse than -1%
+      holdTimeFloorS: FLOOR,
+    });
+    // stale_bleed's own duration gate (30min) is strictly larger than
+    // any lane floor, so it will always have aged into the floor first.
+    expect(out.fired).toBe('stale_bleed');
+  });
+
+  it('floor=0 (undefined) preserves legacy behavior — coherence exits fire promptly', () => {
+    const out = evaluateRejustification({
+      regimeAtOpen: MonkeyMode.INVESTIGATION,
+      phiAtOpen: 0.27,
+      regimeNow: MonkeyMode.INVESTIGATION,
+      phiNow: 0.10,
+      emotions: NEUTRAL_EMO,
+      heldDurationS: 5,
+      // holdTimeFloorS undefined → no floor → phi_collapse fires
+    });
+    expect(out.fired).toBe('phi_collapse');
+  });
+});

--- a/apps/api/src/services/monkey/held_position_rejustification.ts
+++ b/apps/api/src/services/monkey/held_position_rejustification.ts
@@ -149,6 +149,30 @@ export interface RejustificationInput {
    * back-compat with callers that don't yet thread origin.
    */
   origin?: 'own' | 'adopted';
+  /**
+   * Hold-time floor 2026-05-28 (CC1, operator-selected fix):
+   * Internal-coherence exits (regime_change, phi_collapse,
+   * conviction_failed) are suppressed until the position has been held
+   * at least `holdTimeFloorS` seconds. Derived from the lane's
+   * `LANE_DECISION_PERIOD_MS` (scalp 60s, swing 180s, trend 600s) —
+   * NOT an operator knob. The lane *defines* its decision period;
+   * exiting before that period elapses means the kernel hasn't given
+   * its own thesis room to develop.
+   *
+   * The 2026-05-27 audit showed avg hold 8min on trend trades whose
+   * lane decision-period is 600s (10 min). Wins capture 0.08% of
+   * notional, losses 0.18%, loss/win ratio 2× — the textbook
+   * wins-cut-short-losses-let-run pattern. This floor is the
+   * structural cure.
+   *
+   * IMPORTANT: TP, hard SL, directional_disagreement (basinDir flip),
+   * and stale_bleed are NEVER gated by this floor — they're safety
+   * exits that must fire promptly regardless of time. Only the
+   * internal-coherence checks are gated.
+   *
+   * Undefined disables the floor (legacy callers; back-compat).
+   */
+  holdTimeFloorS?: number;
 }
 
 export type RejustificationFire =
@@ -232,6 +256,19 @@ export function evaluateRejustification(
   }
   const phiFloor = phiAtOpen / PHI_GOLDEN_FLOOR_RATIO;
 
+  // Hold-time floor 2026-05-28 (CC1, operator-selected fix):
+  // The 2026-05-27 audit showed avg hold 8 min on positions whose lane
+  // decision period is 60-600s — wins get harvested before edges develop.
+  // When the floor is supplied AND the position hasn't aged into it yet,
+  // internal-coherence exits (regime/phi/conviction) are SUPPRESSED.
+  // directional_disagreement is exempt (safety: basinDir flipped against
+  // held side is decisive regardless of time).
+  // stale_bleed runs at L350+ with its own 30min duration gate which is
+  // strictly larger than any lane period, so the floor doesn't conflict.
+  const heldS = input.heldDurationS ?? Infinity;  // Infinity = floor passes by default
+  const floorS = input.holdTimeFloorS ?? 0;
+  const beforeHoldTimeFloor = heldS < floorS;
+
   // Commit 3 (Cascade brief 2026-05-27): adopted positions skip the
   // regime / phi / conviction / stale_bleed checks. Those gates assume
   // the kernel's own basin context at entry — adopted positions never
@@ -284,7 +321,7 @@ export function evaluateRejustification(
   // rejects single-tick noise; the FR filter rejects label changes
   // where the basin's geometry has barely moved (the kernel's
   // perception is still consonant with what justified entry).
-  if (regimeNow !== regimeAtOpen) {
+  if (regimeNow !== regimeAtOpen && !beforeHoldTimeFloor) {
     const confidenceLoadBearing = regimeConfidence > PI_STRUCT_BOUNDARY_R_SQUARED;
     const streakSatisfied = regimeChangeStreak >= regimeStabilityTicksRequired;
     // FR-distance gate. When anchors are missing (basin not plumbed),
@@ -309,7 +346,7 @@ export function evaluateRejustification(
       };
     }
   }
-  if (phiNow < phiFloor) {
+  if (phiNow < phiFloor && !beforeHoldTimeFloor) {
     return {
       checked: true,
       fired: 'phi_collapse',
@@ -332,6 +369,7 @@ export function evaluateRejustification(
   if (
     emotions.confidence < emotions.anxiety + emotions.confusion
     && convictionFailedStreak >= convictionFailedTicksRequired
+    && !beforeHoldTimeFloor
   ) {
     return {
       checked: true,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -3426,6 +3426,14 @@ export class MonkeyKernel extends EventEmitter {
               heldDurationS,
               currentRoi,
               origin: heldOrigin,
+              // Hold-time floor (2026-05-28, CC1 operator-selected fix):
+              // Derived from the lane's canonical decision period (60s
+              // scalp / 180s swing / 600s trend). Suppresses regime/phi/
+              // conviction exits before the position has been held long
+              // enough for the kernel's own thesis to develop. TP, SL,
+              // directional_disagreement, stale_bleed remain unaffected.
+              // See held_position_rejustification.ts:holdTimeFloorS docs.
+              holdTimeFloorS: LANE_DECISION_PERIOD_MS[heldLane] / 1000,
             })
           : {
               checked: false, fired: null, reason: '', phiFloor: null,


### PR DESCRIPTION
## Why

Operator-selected fix after 6h audit of post-PR-#984 (Polo-authoritative reward) behavior:

| metric | value |
|---|---|
| 182 closes / 6h | |
| WR | **66.5%** (the "88%" headline was sample noise) |
| net | **+\$4.15** |
| avg win | **\$0.120** |
| avg loss | **−\$0.242** |
| **loss/win ratio** | **2.01×** |
| avg hold | 8.3 min |
| avg notional | \$146 |
| avg win ROI on notional | 0.083% |
| avg loss ROI on notional | −0.180% |

The Polo-authoritative net reward (PR #984) is working correctly, but it reveals that wins barely beat fees because positions exit on internal-coherence noise long before the kernel's own thesis develops. The kernel enters a trend trade with a 600s lane decision period — and exits in 8 minutes on regime/phi/conviction flicker.

## What

Suppress the three internal-coherence exits (`regime_change`, `phi_collapse`, `conviction_failed`) until the position has been held at least `holdTimeFloorS` seconds. Floor is derived from the lane's canonical `LANE_DECISION_PERIOD_MS` — **NOT** an operator knob, the lane *defines* its decision period:

| lane | floor |
|---|---|
| scalp | 60s |
| swing | 180s |
| trend | 600s |

## Safety exits never gated

- **TP** (take-profit price reached) — fires immediately
- **SL** (stop-loss price reached) — fires immediately
- **directional_disagreement** (basinDir flipped vs held side) — decisive geometric information regardless of time
- **stale_bleed** (30min+ at < −1% ROI) — the 30min duration gate is strictly larger than any lane floor, so the floor doesn't affect when stale_bleed fires
- **adopted positions** (per #983 Commit 3) — already skip all three coherence checks entirely

## Tests

8 new cases pin the floor semantics:
- regime / phi / conviction each tested at `held=30s` (floor=600s, **suppressed**) and `held=700s` (passes, **fires**)
- `stale_bleed` verified to fire regardless of floor
- `holdTimeFloorS` undefined preserves legacy behavior

Full TS sweep: **1987 passed**, 12 skipped.

## Test plan

- [x] TS typecheck + vitest sweep
- [ ] CI green
- [ ] Post-deploy 1h window: avg hold time on closed trades should increase substantially (target: trend lane median hold ≥ 600s)
- [ ] Post-deploy 1h window: loss/win ratio should fall toward 1.0 as winners get room to develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a lane-derived hold-time floor for internal-coherence exits in the monkey kernel to reduce premature position closures while keeping safety exits unaffected.

Enhancements:
- Add a configurable hold-time floor parameter, derived from each lane’s decision period, that gates regime_change, phi_collapse, and conviction_failed exits until positions have been held long enough.
- Wire the lane decision-period-based hold-time floor through the monkey loop into held-position rejustification while preserving legacy behavior when the floor is undefined.

Tests:
- Add unit tests verifying that regime_change, phi_collapse, and conviction_failed are suppressed before the hold-time floor and fire after it, that stale_bleed remains ungated, and that undefined floor preserves legacy behavior.