### PR TITLE
hotfix(ml-worker): add missing _registry alias in autonomic.py (NameError at runtime)

### DIFF
--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -47,6 +47,20 @@ from .state import NeurochemicalState
 
 logger = logging.getLogger("monkey_kernel.autonomic")
 
+# Module-level registry alias — Grok's Wave 4 P5/P25 sweep added
+# `_registry.get(...)` calls inside the new `get_*` observer functions
+# (lines 156/166/173/180/187/514) but did NOT add the corresponding
+# module-level `_registry = get_registry()` alias that working_memory.py
+# and other Wave 4 modules use. Production NameError at 02:22:14 UTC:
+#   "NameError: name '_registry' is not defined. Did you mean: 'get_registry'?"
+# (firing at function-call time on `get_pnl_frac_history_max()`, which
+# the kernel evaluates on each close to size pnlFracHistory).
+#
+# The import-smoke gate from PR #985 catches IMPORT-time breaks but not
+# function-evaluation-time NameErrors — follow-up gate would need to
+# invoke each `get_*` observer once. Filed in session memory.
+_registry = get_registry()
+
 
 # ═══════════════════════════════════════════════════════════════
 #  UCP v6.6 §29 frozen facts (mirror vex config/frozen_facts)


### PR DESCRIPTION
## Why

Production NameError firing on every close, 2026-05-28 02:22:14 UTC and onward:

\`\`\`
NameError: name '_registry' is not defined. Did you mean: 'get_registry'?
File "/app/src/monkey_kernel/autonomic.py", line 166, in get_pnl_frac_history_max
  base = int(_registry.get("autonomic.pnl_frac_history_max", default=200))
\`\`\`

Grok's Wave 4 P5/P25 sweep added 6 \`_registry.get(...)\` calls inside the new \`get_*\` observer functions but did **not** add the module-level \`_registry = get_registry()\` alias that working_memory.py and other Wave 4 modules use as the pattern.

The PR #985 import-smoke gate catches **import-time** breaks (which is why ml-worker's container survived startup — function defs parse fine, only bodies fail at call time). It does not yet invoke each observer function. Filed as a follow-up in the commit message.

## Fix

One line: \`_registry = get_registry()\` immediately after the import.

Verified locally that all 5 affected observer functions evaluate cleanly: \`get_reward_half_life_ms\`, \`get_pnl_frac_history_max\`, \`get_reward_dop_scale\`, \`get_reward_ser_scale\`, \`get_reward_loss_dop_scale\`.

## Production impact

Every close was failing the chemistry sizing path. \`pnl_frac_history_max\` wasn't being read — the rolling-ring bound fell through to whatever default the caller used. Live trades continued (the error didn't kill the close path; one chemistry-derivation branch silently dropped). Resolves the corresponding \`/monkey/autonomic/reward\` 500 Internal Server Error stream.

## Test plan

- [x] Local Python smoke — all 5 get_* observer functions evaluate
- [ ] CI: import-smoke + type-check
- [ ] Post-deploy: \`/monkey/autonomic/reward\` returns 200, no NameError in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix NameError in autonomic reward observer functions by ensuring the module uses a shared registry instance for configuration lookups.