### PR TITLE
hotfix(api): kill nested-SAFE_PNL_FROM_ROW COALESCE boolean bug

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -159,7 +159,7 @@ import {
   clampMarginToNotionalHeadroom,
 } from './agentEquityBound.js';
 import { planCloseChunks } from './closeChunker.js';
-import { SAFE_PNL_FROM_ROW, verifyPnl, computeSafePnl, checkNotionalConsistency, computeNetPnlForReward } from './safePnlSql.js';
+import { SAFE_PNL_FROM_ROW, SAFE_PNL_EXPR, verifyPnl, computeSafePnl, checkNotionalConsistency, computeNetPnlForReward } from './safePnlSql.js';
 import {
   getOutcomeRingStats,
   computeBreakEvenNotionalFloor,
@@ -6780,7 +6780,7 @@ export class MonkeyKernel extends EventEmitter {
                 SET status = 'closed', exit_price = $1, exit_time = NOW(),
                     exit_reason = $2, exit_order_id = $3, exit_gate = 'agent_l_force_harvest',
                     ${SAFE_PNL_FROM_ROW},
-                    gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_FROM_ROW})
+                    gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_EXPR})
               WHERE id = $4
               RETURNING pnl`,
             [lastPrice, 'agent_l_force_harvest', orderId, row.id],
@@ -6971,7 +6971,7 @@ export class MonkeyKernel extends EventEmitter {
               : `UPDATE autonomous_trades
                     SET status = 'closed', exit_price = $1, exit_time = NOW(),
                         exit_reason = $2, exit_order_id = $3, exit_gate = $5, ${SAFE_PNL_FROM_ROW},
-                        gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_FROM_ROW})
+                        gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_EXPR})
                   WHERE id = $4
                   RETURNING pnl`,
             explicitPnl !== null
@@ -7042,7 +7042,7 @@ export class MonkeyKernel extends EventEmitter {
         `UPDATE autonomous_trades SET status='closed', exit_price=$1, exit_time=NOW(),
                 exit_reason='race_lost_to_sibling', exit_gate='race_lost_to_sibling',
                 ${SAFE_PNL_FROM_ROW},
-                gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_FROM_ROW}) WHERE id=$2`,
+                gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_EXPR}) WHERE id=$2`,
         [markPrice, tradeId],
       ).catch(() => { /* non-fatal */ });
       const reason = acquired.reason === 'recently_closed'
@@ -7467,7 +7467,7 @@ export class MonkeyKernel extends EventEmitter {
                       exit_reason='exchange_position_vanished',
                       exit_gate='exchange_position_vanished',
                       ${SAFE_PNL_FROM_ROW},
-                      gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_FROM_ROW}) WHERE id=$2`,
+                      gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_EXPR}) WHERE id=$2`,
               [markPrice, tradeId],
             ).catch(() => { /* non-fatal */ });
             return {

--- a/apps/api/src/services/monkey/safePnlSql.ts
+++ b/apps/api/src/services/monkey/safePnlSql.ts
@@ -46,9 +46,25 @@
  * `side` column stores 'buy' or 'long' for long-side and 'sell' or
  * 'short' for short-side. Both legacy spellings are handled.
  */
-export const SAFE_PNL_FROM_ROW =
-  `pnl = quantity * ($1::numeric - entry_price) * `
+/**
+ * The pnl value expression alone (no `pnl =` prefix). Use INSIDE other
+ * SQL expressions where you need the computed value, not a SET clause.
+ *
+ * The 2026-05-28 production bug that motivated this: callers were
+ * embedding SAFE_PNL_FROM_ROW inside COALESCE like
+ *   `gross_pnl = COALESCE(gross_pnl, ${SAFE_PNL_FROM_ROW})`
+ * which expands to `COALESCE(numeric, pnl = quantity * ...)` — the
+ * inner part is an equality test returning BOOLEAN, so Postgres
+ * rejects with "COALESCE types numeric and boolean cannot be matched".
+ *
+ * Use SAFE_PNL_EXPR when nesting; use SAFE_PNL_FROM_ROW only as the
+ * last SET clause.
+ */
+export const SAFE_PNL_EXPR =
+  `quantity * ($1::numeric - entry_price) * `
   + `CASE WHEN side IN ('buy', 'long') THEN 1::numeric ELSE -1::numeric END`;
+
+export const SAFE_PNL_FROM_ROW = `pnl = ${SAFE_PNL_EXPR}`;
 
 /**
  * Compute the same pnl in TypeScript for callers that need the value


### PR DESCRIPTION
## Why

Production Postgres error 2026-05-28 02:21:08 UTC firing on multiple close paths:

\`\`\`
ERROR:  COALESCE types numeric and boolean cannot be matched
        at character 348
\`\`\`

## Root cause

\`SAFE_PNL_FROM_ROW\` is a **full SET clause** —
\`pnl = quantity * (\$1::numeric - entry_price) * CASE … END\`.

Recent code nested it inside COALESCE in 4 sites (loop.ts:6783, 6974, 7045, 7470):

\`\`\`ts
\`gross_pnl = COALESCE(gross_pnl, \${SAFE_PNL_FROM_ROW})\`
\`\`\`

Expanding to:

\`\`\`sql
COALESCE(gross_pnl, pnl = quantity * ...)
                    ^^^^^^^^^^^^^^^^^^^^^ EQUALITY TEST → boolean
\`\`\`

Postgres rejects the mixed numeric/boolean COALESCE.

## Fix

Add a sibling constant \`SAFE_PNL_EXPR\` — the value expression alone, no \`pnl =\` prefix. \`SAFE_PNL_FROM_ROW\` reuses \`SAFE_PNL_EXPR\` so the two stay in lockstep. Update the 4 COALESCE sites to use \`SAFE_PNL_EXPR\`.

\`\`\`ts
export const SAFE_PNL_EXPR =
  \`quantity * (\$1::numeric - entry_price) * \`
  + \`CASE WHEN side IN ('buy', 'long') THEN 1::numeric ELSE -1::numeric END\`;
export const SAFE_PNL_FROM_ROW = \`pnl = \${SAFE_PNL_EXPR}\`;
\`\`\`

## Impact in production

All 4 affected sites are post-close \`gross_pnl\` backfill paths (force-harvest, race-lost, exchange-vanished, reconciler ghost recovery). Each was raising the Postgres error inside its catch block. Combined with the autonomic.py \`_registry\` NameError on a parallel hotfix PR (#990), both database-side and chemistry-side error streams are addressed.

## Verification

- \`yarn tsc --noEmit\`: clean
- \`yarn vitest run\`: **2023 passed**, 12 skipped (no regressions)
- \`SAFE_PNL_FROM_ROW\` string output unchanged (test pinned it; still \`pnl = quantity * …\`)

## Test plan

- [x] TS typecheck + vitest sweep
- [ ] CI green
- [ ] Post-deploy: no \`COALESCE types numeric and boolean\` errors in Postgres logs
- [ ] Post-deploy: \`gross_pnl\` column gets populated on closes (verify via DB query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent Postgres COALESCE type errors in pnl backfill paths by separating the pnl value expression from the SET-clause helper and updating nested usages accordingly.

Enhancements:
- Introduce a SAFE_PNL_EXPR constant for the pnl value expression and redefine SAFE_PNL_FROM_ROW in terms of it to keep SQL helpers consistent.
- Update gross_pnl backfill UPDATE statements to use SAFE_PNL_EXPR inside COALESCE while retaining SAFE_PNL_FROM_ROW for SET clauses only.