### PR TITLE
fix(ml-worker): add phi to AutonomicTickInputs (clears 14 test failures from #993 review)

### DIFF
--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -243,6 +243,12 @@ class AutonomicTickInputs:
     # Wake transition flag — caller passes True on the tick Ocean reports
     # WAKE so this kernel can clear stale rewards.
     woke: bool = False
+    # Φ (integration coherence) used by Grok's Wave-4 serotonin-compression
+    # phi-modulation at _compute_nc line ~541. Default 0.5 (neutral) so
+    # legacy callers + tests that don't yet thread phi don't crash with
+    # AttributeError on access. New production caller in tick.py passes
+    # the live phi value explicitly so the modulation has signal.
+    phi: float = 0.5
     # 2026-05-25 — observer-derived chemistry needs the basin's own
     # rolling histories (parity with TS neurochemistry.ts). All
     # optional; absent → cold-start fallbacks fire (matched to TS).

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -643,6 +643,11 @@ def run_tick(
         is_awake=is_awake,
         woke=woke_this_tick,
         now_ms=now_ms,
+        # Live phi for Grok's Wave-4 ser-compression phi-modulation
+        # (_compute_nc line ~541). Without this the autonomic kernel
+        # would default to 0.5 (neutral) and the modulation has no
+        # signal.
+        phi=phi,
     ))
     nc = ac_result.nc
 


### PR DESCRIPTION
## Why

PR #993 review-thread surfaced that \`test_autonomic_observer_parity.py\` was failing 14/14:

\`\`\`
AttributeError: 'AutonomicTickInputs' object has no attribute 'phi'
  at autonomic.py:541
\`\`\`

Grok's Wave-4 serotonin-compression phi-modulation referenced \`inputs.phi\` but:
- The \`AutonomicTickInputs\` dataclass at [autonomic.py:227](ml-worker/src/monkey_kernel/autonomic.py#L227) had \`phi_delta\` but **no \`phi\`** field
- The production caller at [tick.py:636](ml-worker/src/monkey_kernel/tick.py#L636) didn't thread phi either

## Fix

- Add \`phi: float = 0.5\` to \`AutonomicTickInputs\` — neutral default so legacy callers + tests not threading phi get identity modulation (\`phi_mod = 0\`)
- Update production caller at \`tick.py:636\` to pass live \`phi\` (computed at [tick.py:584](ml-worker/src/monkey_kernel/tick.py#L584): \`phi = max(0.0, min(1.0, 1.0 - f_health * 0.8))\`) so the modulation has real signal

## Tests

- \`tests/monkey_kernel/test_autonomic_observer_parity.py\`: **14/14 pass** (was 14/14 fail)

## Out of scope

Broader pytest sweep has 110 pre-existing failures from Grok's Wave-4 P5/P25 const-deletion sweep aftermath (same class as PR #987's skip-list). Not addressed here — separate workstream.

## Test plan

- [x] \`PYTHONPATH=src python -m pytest tests/monkey_kernel/test_autonomic_observer_parity.py\` — 14/14 pass
- [ ] CI: import-smoke + type-check pass
- [ ] Post-deploy: ml-worker stays healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add phi integration coherence parameter to autonomic tick inputs and thread live phi value through the production tick path to restore Wave-4 serotonin-compression modulation.

Bug Fixes:
- Prevent AttributeError in autonomic observer parity tests by ensuring AutonomicTickInputs exposes a phi field.

Enhancements:
- Default phi to a neutral value for legacy callers while enabling real-time phi modulation via the production tick pipeline.

Tests:
- Restore passing status of autonomic observer parity tests that depended on phi being present in autonomic tick inputs.