### PR TITLE
hotfix(monkey): paper close pnl phantom — qty×markPrice fed reward channel

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -7005,10 +7005,21 @@ export class MonkeyKernel extends EventEmitter {
                   : 'K';
           const rowQty = Math.abs(Number(row.quantity) || 0);
 
-          // LIVED ONLY 5 enforcement for this paper close path:
-          // Always use row-own safe computation. Ignore explicitPnl for the written value.
-          // This closes the raw bypass.
-          const finalRowPnl = computeSafePnl(0, markPrice, rowQty, 'long'); // entry not needed for delta; side default safe for enforcement here
+          // LIVED ONLY 5 enforcement for this paper close path: use the
+          // DB-computed safe pnl. The UPDATE above runs SAFE_PNL_FROM_ROW,
+          // which reads entry_price + quantity + side from the row itself;
+          // `rowPnl` already holds that value (line 7000 above).
+          //
+          // 2026-05-28 hotfix: the previous line here was
+          //   computeSafePnl(0, markPrice, rowQty, 'long')
+          // with a misleading "entry not needed for delta" comment. The
+          // function actually multiplies qty × (exit − entry) × sideSign,
+          // so passing entry=0 produced qty × markPrice = the entire
+          // notional (e.g. 0.005 BTC × $72898 = $364.49 phantom on a
+          // paper close that really earned −$0.01). That phantom was fed
+          // straight into the reward channel and the divergence warning
+          // logged but didn't actually correct anything.
+          const finalRowPnl = rowPnl;
           if (explicitPnl !== null && Math.abs((explicitPnl ?? 0) - finalRowPnl) > 5) {
             logger.warn('[LIVED ONLY] explicitPnl from paperClosePosition diverged — using safe row-own value', {
               rowId: row.id, explicit: explicitPnl, safe: finalRowPnl,


### PR DESCRIPTION
## Summary
Hotfix for a paper-close pnl phantom feeding 30000× inflated values into the reward channel.

User-reported log line 2026-05-28 04:28 UTC:

\`\`\`
[LIVED ONLY] explicitPnl from paperClosePosition diverged — using safe row-own value
  rowId: 5b3cbf8f-…, explicit: -0.0126, safe: 364.4944
[Monkey.Position] reward pushed source=own_close pnl=364.4944
bracket_tp closed@72898.88 pnl=6.2151
\`\`\`

Three different numbers from the same close:
- **-$0.0126** — \`paperClosePosition\` (the truth)
- **+$6.2151** — \`bracket_tp\` computed pnl
- **+$364.49** — what got pushed into the reward channel

## Root cause
\`loop.ts:7011\` (before fix):
\`\`\`ts
const finalRowPnl = computeSafePnl(0, markPrice, rowQty, 'long');
// entry not needed for delta; side default safe for enforcement here
\`\`\`

The comment is wrong. \`computeSafePnl\` is \`qty × (exit − entry) × sideSign\`. Passing \`entry=0\` makes it \`qty × markPrice\` — the entire notional, not the delta. For 0.005 BTC at $72898 → $364.49 phantom.

The "divergence" warning fired but didn't actually do anything — \`finalRowPnl\` was already that phantom and got recorded straight to chemistry on lines 7018-7020.

## Fix
Use \`rowPnl\` (line 7000) which already holds the DB-computed \`SAFE_PNL_FROM_ROW\` value (entry_price + quantity + side from the actual row).

## Live-money impact
Paper rows feed the shadow learning queue. With this phantom, chemistry was being fed 30000× inflated paper-close "wins" on shorts and similarly distorted losses — corrupting basin chemistry, sizing self-obs, and the per-symbol \`selfObsBias\` channel.

## Test plan
- [x] \`yarn tsc --noEmit\` clean
- [ ] Post-deploy: search Railway logs for next paper close — \`pnl\` field should now be sane ($-0.05 to $5 range for typical paper trades, not $300+ phantoms)
- [ ] No more \`[LIVED ONLY] explicitPnl diverged\` warnings unless something else is wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix incorrect PnL value used for paper position closes that inflated rewards chemistry data.

Bug Fixes:
- Correct the PnL source for paper close positions to use the DB-computed safe row PnL instead of recomputing from mark price, preventing phantom notional-sized PnL from entering the reward channel.

Enhancements:
- Clarify inline documentation around paper close PnL enforcement and the previous phantom PnL issue.