### PR TITLE
hotfix(monkey): polo-authoritative marginUsdt query — qty → quantity column

### DIFF
--- a/apps/api/src/services/monkey/__tests__/polo_authoritative_margin_query.test.ts
+++ b/apps/api/src/services/monkey/__tests__/polo_authoritative_margin_query.test.ts
@@ -1,0 +1,60 @@
+/**
+ * polo_authoritative_margin_query.test.ts — regression guard for the
+ * column-name bug fixed in PR #1001 (qty → quantity).
+ *
+ * 2026-05-28 incident: applyPoloRealizedPnlAfterClose computed the
+ * per-close-group margin via:
+ *   SELECT SUM(COALESCE(entry_price, 0) * COALESCE(qty, 0) / ...) AS margin_usdt
+ *     FROM autonomous_trades WHERE id = ANY($1)
+ *
+ * The autonomous_trades table has no `qty` column (the column is
+ * `quantity`, per migrations 048 + 060). Postgres raised an
+ * undefined-column error, the surrounding `.catch` non-fatal block
+ * swallowed it silently at LOG_LEVEL=info, marginUsdt stayed at the
+ * fallback `1`, and the polo_authoritative_close reward push fired
+ * with pnlFrac inflated 30–500× (visible in the b8139a81 deploy log
+ * as values like `pnlFrac=-343.79%`).
+ *
+ * Existing tests stub marginUsdt directly via pushReward and never
+ * exercise the SQL query, so the bug had no test coverage. This file
+ * is the regression guard: it asserts the live source file uses the
+ * correct column name (`quantity`) and not the buggy one (`qty`).
+ * Catches the specific drift without needing a live DB.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LOOP_TS_PATH = join(__dirname, '..', 'loop.ts');
+
+function extractMarginQueryBlock(): string {
+  const src = readFileSync(LOOP_TS_PATH, 'utf8');
+  // Pull the line containing the margin SUM query.
+  const match = src.match(/SELECT SUM\(COALESCE\(entry_price[\s\S]*?AS margin_usdt[\s\S]*?FROM autonomous_trades[\s\S]*?ANY\(\$1\)/);
+  if (!match) {
+    throw new Error('Could not locate the polo-authoritative margin SUM query in loop.ts');
+  }
+  return match[0];
+}
+
+describe('polo-authoritative margin query (regression guard for PR #1001)', () => {
+  it('uses the `quantity` column from autonomous_trades', () => {
+    const sql = extractMarginQueryBlock();
+    expect(sql).toMatch(/COALESCE\(quantity,\s*0\)/);
+  });
+
+  it('does NOT reference the non-existent `qty` column', () => {
+    const sql = extractMarginQueryBlock();
+    // Word-boundary check so 'quantity' doesn't accidentally match 'qty'.
+    expect(sql).not.toMatch(/\bqty\b/);
+  });
+
+  it('continues to reference entry_price + leverage (other valid columns)', () => {
+    const sql = extractMarginQueryBlock();
+    expect(sql).toMatch(/COALESCE\(entry_price,\s*0\)/);
+    expect(sql).toMatch(/COALESCE\(leverage,\s*16\)/);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -9101,13 +9101,14 @@ export class MonkeyKernel extends EventEmitter {
       try {
         // 2026-05-28 hotfix: column is `quantity` (per migration
         // 060_backfill_quantity_base_asset.sql + 048 schema), not `qty`.
-        // The previous query referenced a non-existent column, so SUM
-        // returned NULL, marginUsdt stayed at the fallback 1, and the
-        // polo_authoritative_close reward push fired with
-        // pnlFrac = pnl / 1 — visible in the b8139a81 deploy log as
-        // values like -343.79% (= -$3.44 / $1) instead of the real
-        // ~-3% ROE. The Postgres `catch` silently swallowed the
-        // undefined-column error so the bug was invisible at LOG_LEVEL=info.
+        // The previous query referenced a non-existent column, which
+        // raised a Postgres `undefined column` error at execution. The
+        // surrounding `.catch { /* non-fatal */ }` swallowed that error
+        // silently at LOG_LEVEL=info, so marginUsdt stayed at the
+        // fallback 1, and the polo_authoritative_close reward push fired
+        // with pnlFrac = pnl / 1 — visible in the b8139a81 deploy log as
+        // values like -343.79% (= -$3.44 / $1) instead of the real ~-3% ROE.
+        // PR #1001 fixes the column name and surfaces the catch via warn.
         const mres = await pool.query(
           `SELECT SUM(COALESCE(entry_price, 0) * COALESCE(quantity, 0) / GREATEST(COALESCE(leverage, 16), 1)) AS margin_usdt
              FROM autonomous_trades
@@ -9119,11 +9120,13 @@ export class MonkeyKernel extends EventEmitter {
       } catch (err) {
         // Promoted from silent catch 2026-05-28: same lesson as the row
         // UPDATE catch below — silent swallows mask real bugs (this very
-        // bug went undetected because it was silent). Visible warn so
-        // we see exactly what's happening if the query ever truly fails.
+        // bug went undetected because it was silent). Log the full error
+        // object (including stack + Postgres `code`/`detail` if present)
+        // so any future query failure is diagnosable without re-shipping.
         logger.warn('[Monkey] Polo-authoritative marginUsdt query failed; falling back to 1', {
           symbol, tradeIdsCount: tradeIds.length,
-          err: err instanceof Error ? err.message : String(err),
+          err,
+          errMessage: err instanceof Error ? err.message : String(err),
         });
       }
 

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -9099,15 +9099,33 @@ export class MonkeyKernel extends EventEmitter {
       // No new knob. Full provenance + LIVED ONLY 5.
       let marginUsdt = 1;
       try {
+        // 2026-05-28 hotfix: column is `quantity` (per migration
+        // 060_backfill_quantity_base_asset.sql + 048 schema), not `qty`.
+        // The previous query referenced a non-existent column, so SUM
+        // returned NULL, marginUsdt stayed at the fallback 1, and the
+        // polo_authoritative_close reward push fired with
+        // pnlFrac = pnl / 1 — visible in the b8139a81 deploy log as
+        // values like -343.79% (= -$3.44 / $1) instead of the real
+        // ~-3% ROE. The Postgres `catch` silently swallowed the
+        // undefined-column error so the bug was invisible at LOG_LEVEL=info.
         const mres = await pool.query(
-          `SELECT SUM(COALESCE(entry_price, 0) * COALESCE(qty, 0) / GREATEST(COALESCE(leverage, 16), 1)) AS margin_usdt
+          `SELECT SUM(COALESCE(entry_price, 0) * COALESCE(quantity, 0) / GREATEST(COALESCE(leverage, 16), 1)) AS margin_usdt
              FROM autonomous_trades
             WHERE id = ANY($1)`,
           [tradeIds]
         );
         const m = mres.rows[0]?.margin_usdt ? parseFloat(mres.rows[0].margin_usdt) : NaN;
         if (Number.isFinite(m) && m > 0.1) marginUsdt = m;
-      } catch { /* non-fatal; fallback keeps prior behaviour */ }
+      } catch (err) {
+        // Promoted from silent catch 2026-05-28: same lesson as the row
+        // UPDATE catch below — silent swallows mask real bugs (this very
+        // bug went undetected because it was silent). Visible warn so
+        // we see exactly what's happening if the query ever truly fails.
+        logger.warn('[Monkey] Polo-authoritative marginUsdt query failed; falling back to 1', {
+          symbol, tradeIdsCount: tradeIds.length,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
 
       // Directly fulfill the canonical surface (user 2026-05-28 / #992):
       // Push an authoritative reward event using the real Polo realized value.


### PR DESCRIPTION
## Summary
PR #1000 verification on deploy b8139a81 showed \`polo_authoritative_close\` events firing correctly (the wiring works!) but with inflated pnlFrac because the margin query was reading a non-existent column.

\`\`\`
[Monkey.Swing] reward pushed source=polo_authoritative_close
  symbol=BTC_USDT_PERP pnl=-3.4379 pnlFrac=-343.79% oceanCoeff=0
[Monkey] Py autonomic reward push (doctrine source verification)
  source=polo_authoritative_close marginUsdt=1 ...
\`\`\`

\`marginUsdt=1\` is the fallback. The query was \`SUM(... COALESCE(qty, 0) ...)\` — but the actual column is \`quantity\` per migrations 048 + 060.

The undefined-column error was swallowed by \`.catch { /* non-fatal */ }\`, so the bug was invisible at LOG_LEVEL=info — exact same silent-dark class that #998 + #994 + #1000 were systematically eliminating. **The catch pattern was the bug-detection escape hatch.**

## Changes
1. \`qty\` → \`quantity\` in the margin query at \`loop.ts:9103\`
2. Promoted the catch from silent to \`logger.warn\` (matches the row UPDATE pattern from PR #1000 round-1)

## Impact
pnlFrac was inflated roughly 30–500× on typical positions, driving dopamine/serotonin deltas wildly out of band. With this fix, pnlFrac on a -\\$3.44 close lands around -3% ROE-equivalent (assuming ~\\$110 margin), the observer fib coefficient operates in band, and chemistry returns to designed scale.

## Test plan
- [x] \`yarn tsc --noEmit\` clean
- [ ] Copilot review requested
- [ ] Post-deploy: next \`[Monkey.Position] reward pushed source=polo_authoritative_close\` log line should show sane pnlFrac (\\< 10% in magnitude for typical closes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix margin USDT calculation and improve error visibility for polo authoritative close rewards.

Bug Fixes:
- Correct the marginUsdt query to use the existing quantity column so pnlFrac is computed from real margin instead of a fallback value.

Enhancements:
- Log a warning when the polo-authoritative marginUsdt query fails instead of silently swallowing errors, improving observability of future issues.