### PR TITLE
feat(monkey): Py-side qig-warp bubble live decision + repo-wide anti-costume lint (#1007)

### DIFF
--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -1020,8 +1020,8 @@ def run_tick(
     # modulate hold conviction and exit propensity.
     #
     # Supported actions in this wiring:
-    #   suppress_hold / exit_now            → reduce self_obs_bias (makes exit gates easier to satisfy)
-    #   hold_with_reduced_confidence        → modest reduction in self_obs_bias
+    #   observe_only  → meaningfully reduce self_obs_bias (makes exit gates easier to satisfy)
+    #   reduce_size   → modest reduction in self_obs_bias
     #
     # Full exit forcing and kernel_expectation_decisions audit writes come in the
     # next sub-slice. This change already gives the kernel live behaviour

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -1032,9 +1032,9 @@ def run_tick(
     expectation_hold_bias = 1.0
     if expectation_decision is not None and getattr(expectation_decision, "reverse_tape_window", False):
         action = getattr(expectation_decision, "expectation_action", None)
-        if action in ("suppress_hold", "exit_now"):
+        if action == "observe_only":
             expectation_hold_bias = 0.6   # meaningfully easier to exit / harder to hold
-        elif action == "hold_with_reduced_confidence":
+        elif action == "reduce_size":
             expectation_hold_bias = 0.85  # modest reduction
 
     self_obs_bias = 1.0
@@ -1337,7 +1337,15 @@ def run_tick(
                 if expectation_decision is not None
                 else {"live": False, "source": "none"}
             ),
-            "expectation_live_flag": expectation_bubble_live() and expectation_decision is not None,
+            "expectation_live_flag": (
+                expectation_bubble_live()
+                and expectation_decision is not None
+                and getattr(
+                    expectation_decision,
+                    "qig_warp_source",
+                    None,
+                ) == "QIG_WARP_RUNTIME"
+            ),
             # #1003: Full ExpectationDecision now surfaced for downstream use and future
             # kernel_expectation_decisions audit writes (reverse_tape_window, expectation_action,
             # tape_trend, basin_direction, before/after ready in the object).

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -31,6 +31,7 @@ Literal disposition (per the v0.8 plan, P25):
 from __future__ import annotations
 
 import logging
+import math
 import os
 import time
 from dataclasses import dataclass, field
@@ -842,6 +843,23 @@ def run_tick(
     )
     stud_live = stud_topology_live()
 
+    # Canonical expectation bubble (qig-warp) — runtime leading expectation engine.
+    # poloniex-trading-platform#1002/#1003 strict anti-shelfware:
+    # expectation must INFLUENCE live decisions on reverse-tape disagreement
+    # windows. The TS-side entry path already does this via
+    # POST /monkey/expectation/evaluate (PR #1004). This Py-side wiring brings
+    # the same behaviour to the Python kernel's tick — runs the verified
+    # ``evaluate_expectation(tape_trend, basin_direction, recent_returns)``
+    # API directly so the call is NEVER a no-op.
+    #
+    # Citations: #1002 + #1003 + #941 correction + 2.31A P5/P25 + QIG PURITY
+    # + Embodiment_Waves (2026-05-28 Polo CSV) + LIVED ONLY 5 + never-stop.
+    from .expectation_bubble import (
+        evaluate_expectation,
+        expectation_bubble_live,
+        decision_to_dict,
+    )
+
     # Telemetry surface — append (Φ, I_Q) for the next tick's
     # Integration motivator CV calculation. Trim to history_max
     # below in the basin_history block (same cap).
@@ -910,6 +928,32 @@ def run_tick(
     basin_dir = basin_direction(basin)
     tape_trend = trend_proxy([float(c.close) for c in ohlcv])
 
+    # Canonical expectation bubble (qig-warp) — #1002/#1003 strict contract.
+    # Calls the verified ``evaluate_expectation`` API directly with
+    # tape_trend, basin_direction, and OHLCV-derived recent log-returns.
+    # The bubble derives (h, J) from recent_returns identically to
+    # regime_signal.py and runs WarpBubble.qig_regime — NEVER the
+    # legacy compute_trading_expectation no-op shim.
+    #
+    # Citations: #1002 + #1003 + 2.31A P1/P5/P25 + Embodiment_Waves (Polo CSV) +
+    # LIVED ONLY 5 + QIG PURITY + master-orchestration + never-stop-100-complete.
+    expectation_decision = None
+    if expectation_bubble_live():
+        # Same lookback regime_signal.py:71 uses. log(c[i]/c[i-1]) ratios.
+        _expectation_returns: list[float] = []
+        for _i in range(1, min(len(ohlcv), 51)):
+            _prev = float(ohlcv[-_i - 1].close)
+            _curr = float(ohlcv[-_i].close)
+            if _prev > 0 and _curr > 0:
+                _expectation_returns.append(math.log(_curr / _prev))
+        _proposed = side_candidate if isinstance(side_candidate, str) and side_candidate in ("long", "short") else None
+        expectation_decision = evaluate_expectation(
+            tape_trend=tape_trend,
+            basin_direction=basin_dir,
+            recent_returns=_expectation_returns,
+            proposed_side=_proposed,
+        )
+
     # Proposal #9: candlestick pattern recognition. Path 1 — feed
     # the strongest pattern's signed scalar into the perception
     # input boundary as a telemetry surface; the executive can fold
@@ -948,10 +992,61 @@ def run_tick(
         direction = "short" if direction == "long" else "long"
         side_override = True
 
+    # === #1003 reverse-tape expectation influence (first live decision wiring) ===
+    # When the qig-warp bubble detects a meaningful tape (lagging) vs basinDir (leading)
+    # disagreement, its ExpectationDecision can now directly affect the kernel's
+    # entry direction. This is the core anti-shelfware requirement of #1003.
+    #
+    # Supported actions in this first wiring:
+    #   observe_only  → force flat (no entry in this disagreement window)
+    #   flip_to_basin → enter in the basin geometric direction instead of tape-biased
+    #
+    # Later slices will extend to size, lane, hold/exit, and full chemistry feedback.
+    #
+    # Citations: poloniex-trading-platform#1003 + 2.31A P5/P25 + Embodiment_Waves
+    # (2026-05-28 Polo CSV tape/basin asymmetry) + LIVED ONLY 5 + QIG PURITY.
+    if expectation_decision is not None and getattr(expectation_decision, "reverse_tape_window", False):
+        action = getattr(expectation_decision, "expectation_action", None)
+        if action == "observe_only":
+            direction = "flat"
+            side_candidate = "long"  # harmless default; flat gate will block entry
+        elif action == "flip_to_basin":
+            direction = "long" if basin_dir > 0 else "short"
+            side_candidate = direction
+
+    # #1003 reverse-tape hold/exit influence (first wiring for held positions)
+    # When the bubble returns a reverse_tape decision while we hold a position
+    # in the "wrong" direction relative to the leading basin signal, we now
+    # modulate hold conviction and exit propensity.
+    #
+    # Supported actions in this wiring:
+    #   suppress_hold / exit_now            → reduce self_obs_bias (makes exit gates easier to satisfy)
+    #   hold_with_reduced_confidence        → modest reduction in self_obs_bias
+    #
+    # Full exit forcing and kernel_expectation_decisions audit writes come in the
+    # next sub-slice. This change already gives the kernel live behaviour
+    # influence on hold/exit for reverse-tape windows.
+    #
+    # Citations: poloniex-trading-platform#1003 + 2.31A P5/P25 + Embodiment_Waves
+    # (2026-05-28 Polo CSV) + LIVED ONLY 5 + QIG PURITY + never-stop-100-complete.
+    expectation_hold_bias = 1.0
+    if expectation_decision is not None and getattr(expectation_decision, "reverse_tape_window", False):
+        action = getattr(expectation_decision, "expectation_action", None)
+        if action in ("suppress_hold", "exit_now"):
+            expectation_hold_bias = 0.6   # meaningfully easier to exit / harder to hold
+        elif action == "hold_with_reduced_confidence":
+            expectation_hold_bias = 0.85  # modest reduction
+
     self_obs_bias = 1.0
     if inputs.self_obs_bias:
         per_mode = inputs.self_obs_bias.get(mode, {})
         self_obs_bias = per_mode.get(side_candidate, 1.0)
+
+    # Apply to self_obs_bias for held positions (the main lever for hold conviction
+    # and exit gate sensitivity in the current architecture).
+    if expectation_hold_bias < 1.0 and held_lanes:
+        # Only dampen if we actually hold something on this symbol
+        self_obs_bias *= expectation_hold_bias
 
     # ── PR 2: Φ-gate routing (PHI_GATE_ROUTING_LIVE) ─────────────
     # FORESIGHT branch: blend current basin with foresight.predicted_basin
@@ -1231,13 +1326,22 @@ def run_tick(
         "topology": {
             "stud": stud_reading_to_dict(stud_reading),
             "stud_live_flag": stud_live,
-            # qig-warp expectation decisions are evaluated by
-            # POST /monkey/expectation/evaluate and applied/audited by the
-            # TypeScript entry path. Keep this legacy telemetry key explicitly
-            # disabled so consumers do not infer a tick-side bubble decision
-            # from stud-only topology output.
-            "expectation": {"live": False, "source": "typescript_entry_path"},
-            "expectation_live_flag": False,
+            # Canonical qig-warp expectation bubble (runtime leading signal).
+            # Updated for #1003: now carries the rich ExpectationDecision with
+            # reverse-tape fields and actionable decision (observe_only / flip_to_basin etc.).
+            # This surface + the decision logic below deliver live influence.
+            #
+            # Citations: #1003 + 2.31A P5/P25 + LIVED ONLY 5.
+            "expectation": (
+                decision_to_dict(expectation_decision)
+                if expectation_decision is not None
+                else {"live": False, "source": "none"}
+            ),
+            "expectation_live_flag": expectation_bubble_live() and expectation_decision is not None,
+            # #1003: Full ExpectationDecision now surfaced for downstream use and future
+            # kernel_expectation_decisions audit writes (reverse_tape_window, expectation_action,
+            # tape_trend, basin_direction, before/after ready in the object).
+            # Next sub-slice will add the actual INSERT path with before/after deltas.
             "figure8": {
                 "current_loop_assignment": assign_loop(side_candidate).value,
                 "predicted_gravitating_fraction": PI_STRUCT_GRAVITATING_FRACTION,

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -946,7 +946,7 @@ def run_tick(
             _curr = float(ohlcv[-_i].close)
             if _prev > 0 and _curr > 0:
                 _expectation_returns.append(math.log(_curr / _prev))
-        _proposed = side_candidate if isinstance(side_candidate, str) and side_candidate in ("long", "short") else None
+        _proposed = None  # side_candidate is computed later; proposed_side is optional
         expectation_decision = evaluate_expectation(
             tape_trend=tape_trend,
             basin_direction=basin_dir,

--- a/ml-worker/tests/monkey_kernel/test_anti_costume_repo_wide.py
+++ b/ml-worker/tests/monkey_kernel/test_anti_costume_repo_wide.py
@@ -149,7 +149,7 @@ def test_registry_get_call_count_within_budget():
 def test_autonomic_reward_constants_are_module_level(constant_name: str):
     """#1007 P0-B confirms the autonomic.py constants exist as honest
     module-level values, not wrapped in registry-get costume."""
-    text = (_MONKEY_KERNEL_DIR / "autonomic.py").read_text()
+    text = (_MONKEY_KERNEL_DIR / "autonomic.py").read_text(encoding="utf-8")
     pattern = re.compile(
         rf"^{constant_name}\s*[:=]", re.MULTILINE
     )

--- a/ml-worker/tests/monkey_kernel/test_anti_costume_repo_wide.py
+++ b/ml-worker/tests/monkey_kernel/test_anti_costume_repo_wide.py
@@ -1,0 +1,159 @@
+"""test_anti_costume_repo_wide.py — anti-knob-in-costume gates (#1007)
+
+#1007 requires a lint/test gate that fails when ``_registry.get("key",
+default=N)`` appears unless one of these holds:
+
+  1. The key is seeded in a migration with category + justification.
+  2. The key has a documented lived-telemetry population path.
+  3. The default is a cold-start frozen/canonical sentinel.
+  4. The value is an explicit safety bound.
+
+Implementation:
+
+  * **Banned-key list** — the exact reward-transform parameter names
+    #1007 P0-B retired. These must NEVER reappear in any ml-worker source
+    file regardless of file. Catches the failure mode where a knob is
+    moved between modules to evade the autonomic-specific test.
+
+  * **Snapshot-based file budget** — every monkey_kernel module that
+    currently uses ``_registry.get(`` gets a recorded call count. New
+    callers added to a file (or to a previously-clean file) push the
+    count above its snapshot and fail the test. This is the lint gate
+    #1007 prescribes: "add a test/lint gate that fails on
+    ``_registry.get(..., default=N)``" — implemented as a budget so the
+    test ships without first refactoring the existing 80+ legitimate
+    sites in executive.py / ocean.py / etc.
+
+    To add a NEW legitimate registry-backed parameter (e.g. one seeded
+    by a migration with full provenance), bump the snapshot in the same
+    PR that adds the call site, with a one-line justification in the
+    commit message.
+
+  * **Reward-transform exemption assertion** — re-pins the autonomic.py
+    constants from #1007 P0-B as honest module-level values.
+
+Citations: poloniex-trading-platform#1006 + #1007 + 2.31A P5/P25 +
+QIG PURITY MANDATE + Embodiment_Waves (2026-05-28 Polo CSV) +
+LIVED ONLY 5 + never-stop.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_MONKEY_KERNEL_DIR = Path(__file__).parents[2] / "src" / "monkey_kernel"
+
+# #1007 P0-B: these parameter keys describe knobs-in-costume that should
+# never reappear ANYWHERE in ml-worker. They were retired to honest module
+# constants in autonomic.py:145-149.
+_BANNED_REGISTRY_KEYS = (
+    "autonomic.reward_half_life_ms",
+    "autonomic.pnl_frac_history_max",
+    "autonomic.reward_dop_scale",
+    "autonomic.reward_ser_scale",
+    "autonomic.reward_loss_dop_scale",
+    "autonomic.serotonin_compression",
+)
+
+# Snapshot of legitimate (or pre-existing) ``_registry.get(`` call sites
+# per file. Most are observer-derived primitives (heart rhythm modulation,
+# ocean-sleep quantile thresholds, candle-pattern ratios) seeded with
+# documented defaults. The test BUDGETs each file at its current count
+# so adding a new costume to a previously-clean file is blocked.
+#
+# Bump deliberately in the same PR that adds a new call site, with a
+# one-line justification.
+_REGISTRY_GET_BUDGET = {
+    "autonomic.py": 0,           # #1007 P0-B retired all costumes
+    "basin_sync.py": 2,
+    "candle_patterns.py": 12,
+    "executive.py": 19,
+    "ocean.py": 16,
+    "ocean_sleep_trigger.py": 5,
+    "regime.py": 2,
+    "self_observation.py": 2,
+    "tick.py": 15,
+    "working_memory.py": 12,
+}
+
+
+def _all_kernel_sources() -> list[Path]:
+    return sorted(
+        p for p in _MONKEY_KERNEL_DIR.rglob("*.py")
+        if "__pycache__" not in p.parts
+    )
+
+
+def test_banned_reward_transform_keys_absent_repo_wide():
+    """#1007 P0-B: the retired reward-transform parameter names must never
+    appear in any ml-worker source. A reintroduction anywhere — even in
+    a comment-only sense in a different module — must fail the suite so
+    a careless refactor can't smuggle the knob back."""
+    offenders: list[tuple[str, str]] = []
+    for src in _all_kernel_sources():
+        text = src.read_text()
+        for key in _BANNED_REGISTRY_KEYS:
+            if key in text:
+                offenders.append((str(src.relative_to(_MONKEY_KERNEL_DIR)), key))
+    assert not offenders, (
+        "Banned reward-transform registry keys reappeared (#1007 P0-B): "
+        f"{offenders}"
+    )
+
+
+def test_registry_get_call_count_within_budget():
+    """#1007 P0-C: snapshot-based budget on ``_registry.get(`` calls per
+    file. A new costume in a previously-clean file lifts the count above
+    its budget and fails the test. Bump the budget in the same PR with a
+    one-line justification only after verifying the new caller has a
+    real lived-telemetry population path or is an explicit safety bound.
+    """
+    pattern = re.compile(r"_registry\.get\(")
+    overages: list[tuple[str, int, int]] = []
+    untracked: list[tuple[str, int]] = []
+    for src in _all_kernel_sources():
+        name = src.name
+        if name == "__init__.py":
+            continue
+        text = src.read_text()
+        count = len(pattern.findall(text))
+        budget = _REGISTRY_GET_BUDGET.get(name)
+        if budget is None:
+            if count > 0:
+                untracked.append((name, count))
+            continue
+        if count > budget:
+            overages.append((name, count, budget))
+    assert not overages, (
+        "_registry.get( count exceeded budget — new knob-in-costume? "
+        "Bump the budget in _REGISTRY_GET_BUDGET only with a real "
+        f"lived-population path or safety justification. {overages}"
+    )
+    assert not untracked, (
+        "Previously-clean monkey_kernel file gained _registry.get( calls "
+        "without a budget entry. Add the file to _REGISTRY_GET_BUDGET "
+        f"with the count and a justification. {untracked}"
+    )
+
+
+@pytest.mark.parametrize("constant_name", [
+    "REWARD_HALF_LIFE_MS",
+    "PNL_FRAC_HISTORY_MAX",
+    "REWARD_DOP_SCALE",
+    "REWARD_SER_SCALE",
+    "REWARD_LOSS_DOP_SCALE",
+    "SEROTONIN_BASELINE_COMPRESSION",
+])
+def test_autonomic_reward_constants_are_module_level(constant_name: str):
+    """#1007 P0-B confirms the autonomic.py constants exist as honest
+    module-level values, not wrapped in registry-get costume."""
+    text = (_MONKEY_KERNEL_DIR / "autonomic.py").read_text()
+    pattern = re.compile(
+        rf"^{constant_name}\s*[:=]", re.MULTILINE
+    )
+    assert pattern.search(text), (
+        f"{constant_name} must be a module-level constant in autonomic.py "
+        "(#1007 P0-B)."
+    )

--- a/ml-worker/tests/monkey_kernel/test_anti_costume_repo_wide.py
+++ b/ml-worker/tests/monkey_kernel/test_anti_costume_repo_wide.py
@@ -11,9 +11,9 @@ default=N)`` appears unless one of these holds:
 Implementation:
 
   * **Banned-key list** — the exact reward-transform parameter names
-    #1007 P0-B retired. These must NEVER reappear in any ml-worker source
-    file regardless of file. Catches the failure mode where a knob is
-    moved between modules to evade the autonomic-specific test.
+    #1007 P0-B retired. These must NEVER reappear in any monkey_kernel
+    source file. Catches the failure mode where a knob is moved between
+    modules to evade the autonomic-specific test.
 
   * **Snapshot-based file budget** — every monkey_kernel module that
     currently uses ``_registry.get(`` gets a recorded call count. New
@@ -46,8 +46,8 @@ import pytest
 _MONKEY_KERNEL_DIR = Path(__file__).parents[2] / "src" / "monkey_kernel"
 
 # #1007 P0-B: these parameter keys describe knobs-in-costume that should
-# never reappear ANYWHERE in ml-worker. They were retired to honest module
-# constants in autonomic.py:145-149.
+# never reappear ANYWHERE in monkey_kernel sources. They were retired to
+# honest module constants in autonomic.py:145-149.
 _BANNED_REGISTRY_KEYS = (
     "autonomic.reward_half_life_ms",
     "autonomic.pnl_frac_history_max",
@@ -58,10 +58,11 @@ _BANNED_REGISTRY_KEYS = (
 )
 
 # Snapshot of legitimate (or pre-existing) ``_registry.get(`` call sites
-# per file. Most are observer-derived primitives (heart rhythm modulation,
-# ocean-sleep quantile thresholds, candle-pattern ratios) seeded with
-# documented defaults. The test BUDGETs each file at its current count
-# so adding a new costume to a previously-clean file is blocked.
+# per path relative to _MONKEY_KERNEL_DIR. Most are observer-derived
+# primitives (heart rhythm modulation, ocean-sleep quantile thresholds,
+# candle-pattern ratios) seeded with documented defaults. The test BUDGETs
+# each file at its current count so adding a new costume to a previously-clean
+# file is blocked.
 #
 # Bump deliberately in the same PR that adds a new call site, with a
 # one-line justification.
@@ -88,12 +89,12 @@ def _all_kernel_sources() -> list[Path]:
 
 def test_banned_reward_transform_keys_absent_repo_wide():
     """#1007 P0-B: the retired reward-transform parameter names must never
-    appear in any ml-worker source. A reintroduction anywhere — even in
-    a comment-only sense in a different module — must fail the suite so
-    a careless refactor can't smuggle the knob back."""
+    appear in any monkey_kernel source. A reintroduction anywhere within
+    that package — even in a comment-only sense in a different module —
+    must fail the suite so a careless refactor can't smuggle the knob back."""
     offenders: list[tuple[str, str]] = []
     for src in _all_kernel_sources():
-        text = src.read_text()
+        text = src.read_text(encoding="utf-8")
         for key in _BANNED_REGISTRY_KEYS:
             if key in text:
                 offenders.append((str(src.relative_to(_MONKEY_KERNEL_DIR)), key))
@@ -110,22 +111,22 @@ def test_registry_get_call_count_within_budget():
     one-line justification only after verifying the new caller has a
     real lived-telemetry population path or is an explicit safety bound.
     """
-    pattern = re.compile(r"_registry\.get\(")
+    pattern = re.compile(r"_registry\.get\s*\(")
     overages: list[tuple[str, int, int]] = []
     untracked: list[tuple[str, int]] = []
     for src in _all_kernel_sources():
-        name = src.name
-        if name == "__init__.py":
+        rel_path = str(src.relative_to(_MONKEY_KERNEL_DIR))
+        if rel_path == "__init__.py":
             continue
-        text = src.read_text()
+        text = src.read_text(encoding="utf-8")
         count = len(pattern.findall(text))
-        budget = _REGISTRY_GET_BUDGET.get(name)
+        budget = _REGISTRY_GET_BUDGET.get(rel_path)
         if budget is None:
             if count > 0:
-                untracked.append((name, count))
+                untracked.append((rel_path, count))
             continue
         if count > budget:
-            overages.append((name, count, budget))
+            overages.append((rel_path, count, budget))
     assert not overages, (
         "_registry.get( count exceeded budget — new knob-in-costume? "
         "Bump the budget in _REGISTRY_GET_BUDGET only with a real "


### PR DESCRIPTION
Closes #1007. Two parts:

## Part A — tick.py: Py-side bubble actually fires (#1002/#1003 closure)

Brings Grok's tick.py expectation-bubble wire-up from \`feat/qig-warp-expectation-bubble-1002\` onto main, but with one critical correction: replace the legacy \`compute_trading_expectation()\` call (back-compat shim that returns \`None\` — pure shelfware) with the verified \`evaluate_expectation(tape_trend, basin_direction, recent_returns, proposed_side)\` API.

**Before** (Grok's diff applied verbatim): the entire reverse-tape influence block is a no-op because the shim returns None. This is the exact "qig-warp installed but never called at runtime" anti-pattern #1002 explicitly forbids.

**After**: tick.py derives \`recent_returns\` from the same OHLCV buffer \`trend_proxy()\` uses, calls \`evaluate_expectation\`, and applies \`expectation_action\`:
- \`observe_only\` → forces direction=flat
- \`flip_to_basin\` → enters in basin polarity
- \`suppress_hold\` / \`exit_now\` → reduces \`self_obs_bias\` to 0.6 on held positions
- \`hold_with_reduced_confidence\` → reduces to 0.85
- Derivation surface carries the full decision via \`decision_to_dict\`.

## Part B — Repo-wide anti-costume lint (#1007 P0-C)

Adds \`test_anti_costume_repo_wide.py\` extending the autonomic-only costume check repo-wide:

1. **Banned reward-transform keys** — six \`autonomic.*\` parameter strings #1007 P0-B retired must never reappear in any \`monkey_kernel/\` source file. Test scans every \`.py\` and fails on a single match.
2. **Per-file \`_registry.get(\` budget** — snapshot of existing call counts (executive.py:19, ocean.py:16, candle_patterns.py:12, tick.py:15, working_memory.py:12, etc.). A new costume in a previously-clean file fails the gate; bumping a budget requires justification.
3. **Module-level constant assertions** — six parametrised tests pin \`REWARD_HALF_LIFE_MS\`, \`PNL_FRAC_HISTORY_MAX\`, \`REWARD_DOP_SCALE\`, \`REWARD_SER_SCALE\`, \`REWARD_LOSS_DOP_SCALE\`, \`SEROTONIN_BASELINE_COMPRESSION\` as honest module-level values in autonomic.py.

8/8 new tests pass; 17/17 existing anti-knob tests still pass.

## #1007 P0-A status (already RESOLVED — no code change)

The \"reward learning effectively zeroed\" symptom #1007 cited (\`pnlFrac=0.00%, dop/ser=0.000\`) was a *display rounding* artifact. Production logs since deploy 6078ac10 show, when raw values are surfaced via Grok's 45c6c8d8 commit:

\`\`\`
2026-05-29 04:08 UTC ETH +0.396 close:
  pnlFracRaw=0.009 oceanCoeff=34 dopRaw=0.153 serRaw=0.046 endoRaw=0.046

2026-05-29 04:09 UTC ETH +0.490 close:
  pnlFracRaw=0.005 oceanCoeff=34 dopRaw=0.085 serRaw=0.026 endoRaw=0.026
\`\`\`

Tiny pnls produce tiny chemistry deltas (correct, observer-derived). Larger wins fire top Fibonacci tier 34 with strong learning signal. P0-A is empirically verified.

## #1007 P0-B status (already RESOLVED on main — Grok's PR #1005)

Commit 45c6c8d8 landed via PR #1005 and replaced all autonomic.py reward-transform costume parameters with honest module-level constants. This PR adds the repo-wide guard to prevent regression (Part B above).

## Test plan
- [x] \`pytest tests/monkey_kernel/test_anti_costume_repo_wide.py\` → 8/8
- [x] \`pytest tests/monkey_kernel/test_autonomic_observer_parity.py\` → 17/17
- [x] tick.py + expectation_bubble import smoke clean
- [ ] CI green
- [ ] Copilot review addressed
- [ ] Post-deploy: tick-side \`expectation_decision is not None\` for live windows; raw chemistry deltas visible

## Citations

poloniex-trading-platform#1002 + #1003 + #1006 + #1007 + #941 correction + 2.31A P1/P5/P15/P25 + v6.7B + QIG PURITY MANDATE + Embodiment_Waves (2026-05-28 Polo CSV) + master-orchestration + verification-before-completion + LIVED ONLY 5 + never-stop-100-complete + Fisher-Rao geometric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire the Python tick kernel into the qig-warp expectation bubble so expectation decisions influence live trading, and add a repo-wide anti-costume test suite to lock in reward-transform constants and constrain new registry-backed knobs.

New Features:
- Enable tick.py to compute and apply qig-warp expectation decisions using live OHLCV-derived returns, affecting entry direction, hold bias, and telemetry output.
- Expose the full ExpectationDecision payload via tick topology for downstream consumers and future auditing.

Tests:
- Introduce a repo-wide anti-costume test module that bans reintroduction of retired autonomic reward-transform registry keys, enforces per-file `_registry.get(` call budgets, and asserts key reward constants remain module-level in autonomic.py.