### PR TITLE
perf(tick): hoist expectation_bubble imports to module level

### DIFF
--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -52,6 +52,11 @@ from .basin import normalized_entropy, velocity
 from .bus_events import KernelEvent
 from .coordinator import GaryCoordinator, GaryReading
 from .emotions import compute_emotions, compute_funding_drag
+from .expectation_bubble import (
+    decision_to_dict,
+    evaluate_expectation,
+    expectation_bubble_live,
+)
 from .executive import (
     ExecBasinState,
     choose_lane,
@@ -850,15 +855,12 @@ def run_tick(
     # POST /monkey/expectation/evaluate (PR #1004). This Py-side wiring brings
     # the same behaviour to the Python kernel's tick — runs the verified
     # ``evaluate_expectation(tape_trend, basin_direction, recent_returns)``
-    # API directly so the call is NEVER a no-op.
+    # API directly so the call is NEVER a no-op. Imports hoisted to module
+    # level (Sourcery review #1008) so the bubble symbols aren't re-resolved
+    # every tick.
     #
     # Citations: #1002 + #1003 + #941 correction + 2.31A P5/P25 + QIG PURITY
     # + Embodiment_Waves (2026-05-28 Polo CSV) + LIVED ONLY 5 + never-stop.
-    from .expectation_bubble import (
-        evaluate_expectation,
-        expectation_bubble_live,
-        decision_to_dict,
-    )
 
     # Telemetry surface — append (Φ, I_Q) for the next tick's
     # Integration motivator CV calculation. Trim to history_max


### PR DESCRIPTION
Recovers an orphaned commit (\`4b7c7ed6\`) that was pushed to \`feat/issue-1007-tick-py-bubble-wireup-plus-repo-lint\` AFTER PR #1008 was created but BEFORE it merged. The squash-merge of #1008 captured the branch state at that earlier point, so this 8-line perf fix landed on the branch but never on main.

## What this is

Sourcery's review on PR #1008 flagged that \`from .expectation_bubble import ...\` was inside \`run_tick\` (called every tick — thousands of times/min on a multi-symbol kernel). The hoist moves those three imports to module-load time.

Hoists \`decision_to_dict\`, \`evaluate_expectation\`, \`expectation_bubble_live\` from per-tick \`from .expectation_bubble import ...\` to a module-level import alongside the other \`from .basin\`, \`from .executive\`, etc. imports.

Comment block updated to note the Sourcery review trail.

## Verification

- Smoke: \`PYTHONPATH=ml-worker/src python3 -c \"from monkey_kernel.tick import run_tick\"\` → ok
- No behaviour change. Diff is +8/−6 in \`tick.py\` only.

## Why it landed on a branch but not on main

Squash-merge timing — pushed the perf fix to the feature branch after #1008's PR head SHA was captured. Surfacing it now during a "no orphan branches" sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Optimize tick processing by moving expectation_bubble imports from per-tick execution into module-level imports to reduce repeated symbol resolution.