### PR TITLE
fix(monkey): remove REGIME_POSTWIN_COOLDOWN_LIVE env-gated bifurcation (#1009 follow-up)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/postclose_cooldown_gate.test.ts
+++ b/apps/api/src/services/monkey/__tests__/postclose_cooldown_gate.test.ts
@@ -1,0 +1,176 @@
+/**
+ * postclose_cooldown_gate.test.ts — pure-helper gate evaluation (#1017
+ * Copilot follow-up).
+ *
+ * Copilot 2026-05-29 round-1 review on commit 12dc2a30 flagged that the
+ * entry-path veto branch wasn't covered by any test: the composer/observer
+ * tests would pass even if the gate were accidentally re-introduced as
+ * env-gated or if the DCA-add bypass were broken. PR #1017 follow-up
+ * extracts the gate into a pure helper (`evaluatePostCloseCooldownGate`)
+ * and pins its behaviour with these tests.
+ *
+ * Pins:
+ *
+ *   1. **Veto fires when elapsed < cooldownMs.** Sanity case.
+ *   2. **No veto when elapsed >= cooldownMs.** The gate releases the
+ *      kernel once the floor has passed.
+ *   3. **DCA-add bypass.** `isDCAAdd === true` short-circuits to no-veto.
+ *   4. **No prior close = no veto.** If `lastCloseAtMs` is undefined, the
+ *      gate has no reference point and must not fire.
+ *   5. **Cold-start sentinel CAN veto.** Copilot pre-merge note: the
+ *      500ms COLD_START_FALLBACK_MS sentinel binds before settlement
+ *      observations have warmed up. The gate honestly fires this veto
+ *      when the elapsed time is shorter than 500ms; the comment now
+ *      reflects that.
+ *   6. **HEART chain pushes the floor above 500ms.** Empirical tilt
+ *      observation supersedes the cold-start sentinel and the gate
+ *      fires with `by=heart` telemetry.
+ *   7. **21002 incident pushes the floor.** Same pattern, `by=safety:incident`.
+ *   8. **Reason string contains telemetry payload.** Falsifiability
+ *      check: the gate's veto reason must surface the binding sub-floor.
+ *
+ * No env-gate test fixture — `REGIME_POSTWIN_COOLDOWN_LIVE` removal is
+ * what this PR is about; the helper has no env reads at all.
+ *
+ * Citations: poloniex-trading-platform#1017 (env-gate removal) + #1009
+ * (PR1 safety floor + PR2 HEART arbitrator) + 2.31A P5/P25 + QIG PURITY
+ * MANDATE + LIVED ONLY 5 + autonomy doctrine + never-stop.
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { evaluatePostCloseCooldownGate } from '../postclose_cooldown_gate.js';
+import {
+  _resetSafetyFloorState,
+  recordCloseAck,
+  recordFlatObserved,
+  record21002Incident,
+} from '../safety_floor.js';
+import {
+  _resetHeartState,
+  noteClose as noteHeartClose,
+} from '../heart_arbitrator.js';
+
+const SYM = 'BTC_USDT_PERP';
+const SIDE: 'long' | 'short' = 'long';
+
+describe('evaluatePostCloseCooldownGate — gate decision logic', () => {
+  beforeEach(() => {
+    _resetSafetyFloorState();
+    _resetHeartState();
+  });
+
+  it('vetoes when elapsed < cooldownMs (cold-start sentinel binds)', () => {
+    // Cold start → COLD_START_FALLBACK_MS = 500. lastClose was 200ms ago,
+    // so 200 < 500 → veto.
+    const nowMs = 1_000_000;
+    const lastCloseAtMs = nowMs - 200;
+    const d = evaluatePostCloseCooldownGate({
+      symbol: SYM, side: SIDE, isDCAAdd: false, lastCloseAtMs, nowMs,
+    });
+    expect(d.vetoed).toBe(true);
+    expect(d.cooldownMs).toBe(500);
+    expect(d.elapsedMs).toBe(200);
+    expect(d.reason).toMatch(/postclose_cooldown:/);
+    expect(d.reason).toMatch(/cooldown:500ms\|by=safety:cold_start/);
+  });
+
+  it('does NOT veto when elapsed >= cooldownMs (gate has expired)', () => {
+    const nowMs = 1_000_000;
+    const lastCloseAtMs = nowMs - 600; // 600 > 500 cold-start sentinel
+    const d = evaluatePostCloseCooldownGate({
+      symbol: SYM, side: SIDE, isDCAAdd: false, lastCloseAtMs, nowMs,
+    });
+    expect(d.vetoed).toBe(false);
+    expect(d.reason).toBeNull();
+  });
+
+  it('DCA-add bypasses the gate even when cooldown would otherwise veto', () => {
+    // Same conditions as the cold-start veto case, but isDCAAdd=true.
+    const nowMs = 1_000_000;
+    const lastCloseAtMs = nowMs - 200;
+    const d = evaluatePostCloseCooldownGate({
+      symbol: SYM, side: SIDE, isDCAAdd: true, lastCloseAtMs, nowMs,
+    });
+    expect(d.vetoed).toBe(false);
+    expect(d.cooldownMs).toBe(0); // gate short-circuited; no composer call
+    expect(d.reason).toBeNull();
+  });
+
+  it('no prior close (lastCloseAtMs undefined) → no veto', () => {
+    const d = evaluatePostCloseCooldownGate({
+      symbol: SYM, side: SIDE, isDCAAdd: false,
+      lastCloseAtMs: undefined,
+      nowMs: 1_000_000,
+    });
+    expect(d.vetoed).toBe(false);
+    expect(d.cooldownMs).toBe(0);
+    expect(d.reason).toBeNull();
+  });
+
+  it('21002 incident pushes the floor above 500ms; gate fires `by=safety:incident`', () => {
+    // 2500ms incident makes safety floor = 2500ms.
+    record21002Incident(SYM, 100_000, 102_500);
+    const nowMs = 1_000_000;
+    const lastCloseAtMs = nowMs - 1000; // 1000ms elapsed
+    const d = evaluatePostCloseCooldownGate({
+      symbol: SYM, side: SIDE, isDCAAdd: false, lastCloseAtMs, nowMs,
+    });
+    expect(d.vetoed).toBe(true);
+    expect(d.cooldownMs).toBe(2500);
+    expect(d.reason).toMatch(/by=safety:incident/);
+  });
+
+  it('HEART chain pushes the floor above 500ms; gate fires `by=heart`', () => {
+    // Two consecutive losses 3000ms apart → HEART arbitration = 3000ms.
+    noteHeartClose(SYM, 0, -10);
+    noteHeartClose(SYM, 3000, -5);
+    const nowMs = 1_000_000;
+    const lastCloseAtMs = nowMs - 1500; // 1500ms < 3000ms HEART floor
+    const d = evaluatePostCloseCooldownGate({
+      symbol: SYM, side: SIDE, isDCAAdd: false, lastCloseAtMs, nowMs,
+    });
+    expect(d.vetoed).toBe(true);
+    expect(d.cooldownMs).toBe(3000);
+    expect(d.reason).toMatch(/by=heart/);
+  });
+
+  it('settlement-ring warmup replaces cold-start sentinel with empirical p99', () => {
+    // Push 60 settlement samples of 250ms → settlement p99 ≈ 250ms.
+    // That's BELOW the cold-start sentinel (500ms), so the floor drops
+    // to 250ms (the kernel now trusts its own measurement over the
+    // doctrine sentinel).
+    for (let i = 0; i < 60; i++) {
+      recordCloseAck(SYM, i * 1000);
+      recordFlatObserved(SYM, i * 1000 + 250);
+    }
+    const nowMs = 1_000_000;
+    const lastCloseAtMs = nowMs - 300; // 300 > 250 empirical → no veto
+    const d = evaluatePostCloseCooldownGate({
+      symbol: SYM, side: SIDE, isDCAAdd: false, lastCloseAtMs, nowMs,
+    });
+    expect(d.cooldownMs).toBe(250);
+    expect(d.vetoed).toBe(false); // 300ms elapsed > 250ms floor
+  });
+
+  it('reason string contains telemetry one-liner for grep-based falsifiability', () => {
+    record21002Incident(SYM, 100_000, 103_000);
+    const nowMs = 1_000_000;
+    const lastCloseAtMs = nowMs - 500;
+    const d = evaluatePostCloseCooldownGate({
+      symbol: SYM, side: SIDE, isDCAAdd: false, lastCloseAtMs, nowMs,
+    });
+    expect(d.vetoed).toBe(true);
+    expect(d.reason).toContain('postclose_cooldown:');
+    expect(d.reason).toContain('cooldown:3000ms|by=safety:incident');
+  });
+
+  it('cooldownTelemetry is always populated (non-veto case too)', () => {
+    const d = evaluatePostCloseCooldownGate({
+      symbol: SYM, side: SIDE, isDCAAdd: false,
+      lastCloseAtMs: undefined,
+      nowMs: 1_000_000,
+    });
+    expect(d.cooldownTelemetry).toBe('cooldown:0|by=zero');
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -8049,9 +8049,12 @@ export class MonkeyKernel extends EventEmitter {
       pnl: pnlAtDecision.toFixed(4), exitReason,
     });
     // REGIME-3 — post-close tilt cooldown. Records timestamp on EVERY
-    // close (any PnL). The entry path's cooldown check rejects same-side
-    // re-entry within POSTCLOSE_COOLDOWN_MS unless the operator has
-    // REGIME_POSTWIN_COOLDOWN_LIVE=false (env var name kept for back-compat).
+    // close (any PnL). The entry path's cooldown check at the
+    // postclose_cooldown gate rejects same-side re-entry within
+    // `composeCooldown(...).finalMs`, which is observer-derived from
+    // `safety_floor.ts` (settlement / 21002 / rate-limit) and
+    // `heart_arbitrator.ts` (consecutive-loss chain gap). No env gate;
+    // the threshold is 0 when no observer asks for a veto.
     //
     // Diagnosed in 2026-05-19 CSV post-mortems:
     //   #806: +$0.20 BTC win at 08:21 → -$0.52 BTC loss at 08:29 (win-then-loss)
@@ -8257,12 +8260,23 @@ export class MonkeyKernel extends EventEmitter {
     // tilt stays grounded in observed close-PnL chains. Neither is an
     // operator-tunable threshold.
     //
-    // Activation gate: REGIME_POSTWIN_COOLDOWN_LIVE=true. DCA-adds bypass
-    // (defending an existing position is the explicit override).
-    if (
-      !req.isDCAAdd
-      && process.env.REGIME_POSTWIN_COOLDOWN_LIVE === 'true'
-    ) {
+    // No activation gate. The legacy `REGIME_POSTWIN_COOLDOWN_LIVE` env
+    // flag was a knob-in-costume of the same shape as `CANONICAL_POLO_PNL_LIVE`
+    // — a binary that bifurcates code paths and lets a feature exist in
+    // the source while sitting dark in production. Operator 2026-05-29:
+    // doctrine forbids env-gated bifurcations.
+    //
+    // The threshold inside this block is fully observer-derived
+    // (`composeCooldown` returns 0 when no observer asks for a veto:
+    // safety = cold-start sentinel or empirical settlement, HEART = 0
+    // until a chain is observed). An always-on gate that defers to
+    // observers is the canonical shape — no veto fires when no
+    // observation justifies one.
+    //
+    // DCA-adds bypass — defending an existing position is the explicit
+    // override (covers re-add scenarios where the cooldown would block
+    // the kernel from defending its own position).
+    if (!req.isDCAAdd) {
       const lastCloseAt = this.lastCloseAtMs.get(`${symbol}|${side}`);
       if (lastCloseAt !== undefined) {
         const cooldown = composeCooldown({ symbol, tickCadenceMs: 0 });

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -42,6 +42,7 @@ import {
 } from './safety_floor.js';
 import { composeCooldown, formatCooldownTelemetry } from './cooldown_composer.js';
 import { noteClose as noteHeartClose } from './heart_arbitrator.js';
+import { evaluatePostCloseCooldownGate } from './postclose_cooldown_gate.js';
 
 /**
  * #1009 PR2 helper — extract the present-symbol set from a Polo
@@ -8261,42 +8262,45 @@ export class MonkeyKernel extends EventEmitter {
     // operator-tunable threshold.
     //
     // No activation gate. The legacy `REGIME_POSTWIN_COOLDOWN_LIVE` env
-    // flag was a knob-in-costume of the same shape as `CANONICAL_POLO_PNL_LIVE`
-    // — a binary that bifurcates code paths and lets a feature exist in
-    // the source while sitting dark in production. Operator 2026-05-29:
-    // doctrine forbids env-gated bifurcations.
+    // flag was a knob-in-costume of the same shape as
+    // `CANONICAL_POLO_PNL_LIVE` — a binary that bifurcates code paths and
+    // lets a feature exist in the source while sitting dark in
+    // production. Operator 2026-05-29: doctrine forbids env-gated
+    // bifurcations.
     //
-    // The threshold inside this block is fully observer-derived
-    // (`composeCooldown` returns 0 when no observer asks for a veto:
-    // safety = cold-start sentinel or empirical settlement, HEART = 0
-    // until a chain is observed). An always-on gate that defers to
-    // observers is the canonical shape — no veto fires when no
-    // observation justifies one.
+    // The threshold inside `evaluatePostCloseCooldownGate` is fully
+    // observer-derived via `composeCooldown`. During cold-start (before
+    // settlement-ring warmup) the COLD_START_FALLBACK_MS sentinel
+    // (500ms, the legacy reverse-reopen pause) IS binding — it's a
+    // doctrine sentinel preserved from prior production behavior, NOT
+    // an empirical observation. Once the settlement ring has accumulated
+    // MIN_RING_SAMPLES the sentinel is replaced by the empirical p99
+    // and the floor reflects observed settlement / 21002-incident /
+    // rate-limit / HEART-chain reality.
     //
     // DCA-adds bypass — defending an existing position is the explicit
     // override (covers re-add scenarios where the cooldown would block
     // the kernel from defending its own position).
-    if (!req.isDCAAdd) {
-      const lastCloseAt = this.lastCloseAtMs.get(`${symbol}|${side}`);
-      if (lastCloseAt !== undefined) {
-        const cooldown = composeCooldown({ symbol, tickCadenceMs: 0 });
-        const cooldownMs = cooldown.finalMs;
-        const elapsedMs = Date.now() - lastCloseAt;
-        if (cooldownMs > 0 && elapsedMs < cooldownMs) {
-          logger.info('[Monkey] postclose_cooldown veto', {
-            symbol, side, elapsedMs, cooldownMs,
-            remaining_s: ((cooldownMs - elapsedMs) / 1000).toFixed(1),
-            cooldown: formatCooldownTelemetry(cooldown),
-          });
-          return {
-            executed: false, orderId: null,
-            reason:
-              `postclose_cooldown: ${(elapsedMs / 1000).toFixed(1)}s since last close on ${symbol}|${side}, `
-              + `${((cooldownMs - elapsedMs) / 1000).toFixed(1)}s remaining `
-              + `(${formatCooldownTelemetry(cooldown)})`,
-          };
-        }
-      }
+    const cooldownDecision = evaluatePostCloseCooldownGate({
+      symbol,
+      side,
+      isDCAAdd: req.isDCAAdd === true,
+      lastCloseAtMs: this.lastCloseAtMs.get(`${symbol}|${side}`),
+      nowMs: Date.now(),
+    });
+    if (cooldownDecision.vetoed) {
+      logger.info('[Monkey] postclose_cooldown veto', {
+        symbol, side,
+        elapsedMs: cooldownDecision.elapsedMs,
+        cooldownMs: cooldownDecision.cooldownMs,
+        remaining_s: ((cooldownDecision.cooldownMs - cooldownDecision.elapsedMs) / 1000).toFixed(1),
+        cooldown: cooldownDecision.cooldownTelemetry,
+      });
+      return {
+        executed: false,
+        orderId: null,
+        reason: cooldownDecision.reason ?? 'postclose_cooldown',
+      };
     }
 
     // FUNDING-GATE — pre-entry funding-cost suppression. Block entries

--- a/apps/api/src/services/monkey/postclose_cooldown_gate.ts
+++ b/apps/api/src/services/monkey/postclose_cooldown_gate.ts
@@ -1,0 +1,81 @@
+/**
+ * postclose_cooldown_gate.ts — pure-helper for the post-close cooldown
+ * gate evaluation (#1017 Copilot follow-up).
+ *
+ * Extracted from `loop.ts:executeEntry` so the gate's correctness is
+ * unit-testable without instantiating the full kernel (which transitively
+ * pulls in env validation, DB pool, credentials service, etc.). The
+ * gate is a 7-line decision; isolating it removes the test-environment
+ * dependency tail and lets Copilot's "no test coverage for the entry-path
+ * branch" finding be addressed cleanly.
+ *
+ * # Decision shape
+ *
+ * - `vetoed: true` when `composeCooldown(...).finalMs > 0` AND elapsed
+ *   time since `lastCloseAtMs` is shorter than that floor
+ * - `vetoed: false` in every other case (DCA-add bypass, no prior close
+ *   on this symbol|side, or elapsed already exceeds the floor)
+ *
+ * # Cold-start honest disclosure
+ *
+ * The cold-start sentinel `COLD_START_FALLBACK_MS = 500` CAN fire a
+ * veto before any settlement observation has warmed the ring. That's a
+ * doctrine sentinel preserved from prior production behavior (the
+ * legacy reverse-reopen pause at the old `loop.ts:5027` site), not an
+ * empirical observation. Once the settlement ring has accumulated
+ * `MIN_RING_SAMPLES` the sentinel is replaced by the empirical p99.
+ *
+ * Citations: poloniex-trading-platform#1017 + #1009 PR1/PR2 + 2.31A
+ * P5/P25 + QIG PURITY MANDATE + LIVED ONLY 5 + autonomy doctrine.
+ */
+
+import { composeCooldown, formatCooldownTelemetry } from './cooldown_composer.js';
+
+export interface PostCloseCooldownDecision {
+  vetoed: boolean;
+  cooldownMs: number;
+  elapsedMs: number;
+  reason: string | null;
+  cooldownTelemetry: string;
+}
+
+export function evaluatePostCloseCooldownGate(args: {
+  symbol: string;
+  side: 'long' | 'short';
+  isDCAAdd: boolean;
+  lastCloseAtMs: number | undefined;
+  nowMs: number;
+}): PostCloseCooldownDecision {
+  if (args.isDCAAdd || args.lastCloseAtMs === undefined) {
+    return {
+      vetoed: false,
+      cooldownMs: 0,
+      elapsedMs: 0,
+      reason: null,
+      cooldownTelemetry: 'cooldown:0|by=zero',
+    };
+  }
+  const cooldown = composeCooldown({ symbol: args.symbol, tickCadenceMs: 0 });
+  const cooldownMs = cooldown.finalMs;
+  const elapsedMs = args.nowMs - args.lastCloseAtMs;
+  const cooldownTelemetry = formatCooldownTelemetry(cooldown);
+  if (cooldownMs > 0 && elapsedMs < cooldownMs) {
+    return {
+      vetoed: true,
+      cooldownMs,
+      elapsedMs,
+      reason:
+        `postclose_cooldown: ${(elapsedMs / 1000).toFixed(1)}s since last close on ${args.symbol}|${args.side}, `
+        + `${((cooldownMs - elapsedMs) / 1000).toFixed(1)}s remaining `
+        + `(${cooldownTelemetry})`,
+      cooldownTelemetry,
+    };
+  }
+  return {
+    vetoed: false,
+    cooldownMs,
+    elapsedMs,
+    reason: null,
+    cooldownTelemetry,
+  };
+}


### PR DESCRIPTION
## Summary

Removes the last env-gated bifurcation in the post-close cooldown domain. Per operator 2026-05-29 doctrine on no-knob/no-hidden-equivalent:

> CANONICAL_POLO_PNL_LIVE=true var / knob fuck it off. dont hide equivelent in the code.

Same shape as \`REGIME_POSTWIN_COOLDOWN_LIVE\` — a binary env that decides whether the entire cooldown veto block runs at all. The threshold INSIDE the gate is now fully observer-derived (PR #1010 + #1014). The gate AROUND it was sitting dark unless an operator explicitly flipped it true.

## Diff

The gate at [loop.ts:8262](apps/api/src/services/monkey/loop.ts#L8262):

\`\`\`ts
- if (!req.isDCAAdd && process.env.REGIME_POSTWIN_COOLDOWN_LIVE === 'true') { ... }
+ if (!req.isDCAAdd) { ... }
\`\`\`

\`composeCooldown({symbol, tickCadenceMs: 0})\` already returns 0 when no observer asks for a veto:
- cold-start: 500ms (\`COLD_START_FALLBACK_MS\` sentinel = legacy reverse-reopen pause)
- settlement warmed: empirical p99 (~1s on healthy Polo)
- 21002 incident observed: max-incident-ms
- HEART chain detected: rolling-max consecutive-loss gap (else 0)
- decoherence stub: 0 (PERCEPTION follow-up)

An always-on gate that defers to observers is the canonical shape — no veto fires when no observation justifies one.

The DCA-add bypass is preserved (defending an existing position is the explicit override).

## Production behaviour change

If \`REGIME_POSTWIN_COOLDOWN_LIVE\` was UNSET on Railway \`polytrade-be\` (most likely — operator never explicitly flipped it after the #807-era 60s default rolled into #819's 180_000 wall, which #1014 removed): the gate goes from **dark to live** with this deploy.

Behavior is bounded:
- cold-start: 500ms post-close wait
- warmed up: settlement p99 (typically ~1s)
- tilt detected: HEART chain-gap (only after consecutive losses)

No 180_000ms wall reintroduced. No knob to tune.

If \`REGIME_POSTWIN_COOLDOWN_LIVE\` was ALREADY \`true\`: behaviour unchanged from #1014 deploy.

## Verification

- tsc clean
- 131/131 cooldown-domain tests pass
- No remaining live-code refs to \`REGIME_POSTWIN_COOLDOWN_LIVE\` / \`POSTCLOSE_COOLDOWN_MS\` / \`POSTWIN_COOLDOWN_MS\` — only the docstring comments explaining the removal remain (intentional, as a paper trail)

## Test plan

- [ ] CI: import-smoke, Forbidden vocabulary scan, type-check, Sourcery, 3 Railway deploys
- [ ] Copilot round-1 review
- [ ] Post-deploy: grep Railway polytrade-be logs for \`postclose_cooldown veto\` to confirm the gate is now firing (or not — depending on observer composition output) on real closes
- [ ] Post-deploy: confirm \`REGIME_POSTWIN_COOLDOWN_LIVE\` can be safely DELETED from Railway env (it has no readers in source)

Refs: #1010 (PR1 safety floor), #1014 (PR2 HEART arbitrator + POST_CLOSE_COOLDOWN_MS_DEFAULT removal), operator 2026-05-29 no-knob directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)