### PR TITLE
feat(monkey-kernel): Py cascading-knob-strip — substrate_observer + DCA cooldown observer-derived

### DIFF
--- a/ml-worker/src/monkey_kernel/executive.py
+++ b/ml-worker/src/monkey_kernel/executive.py
@@ -48,6 +48,7 @@ from .emotions import EmotionState
 from .modes import MODE_PROFILES, MonkeyMode, effective_profile
 from .parameters import get_registry
 from .state import LaneType, NeurochemicalState
+from .substrate_observer import get_observed_lane_decision_period_ms
 # KAPPA_STAR import removed (retired universal per 2026-04-13 two-channel doctrine + v6.7B protocol).
 # All references below now use governed registry "physics.kappa_reference" or observer-derived
 # from kappa_history (P1). Bare "κ*" language is invalid per the protocol.
@@ -1122,16 +1123,17 @@ def should_scalp_exit(
 # ═══════════════════════════════════════════════════════════════
 
 
-# DCA PARAMETERs — mixed dispositions per P25:
+# DCA PARAMETERs.
 # - max_adds_per_position is a hard SAFETY_BOUND (capacity risk
-#   ceiling; live-governed via registry)
-# - cooldown / better_price_frac / min_sovereignty are still literals
-#   here but flagged for v0.8.4b DERIVE work (should emerge from
-#   Φ/serotonin/basin-velocity). They'll move to _registry.get() +
-#   derivation formulas in that pass. For v0.8.4a they stay hardcoded
-#   so behavior is bit-identical to pre-merge live — zero decision
-#   change in this PR.
-DCA_COOLDOWN_MS = 15 * 60 * 1000
+#   ceiling; live-governed via registry).
+# - The cooldown is observer-derived (substrate_observer) — operator
+#   2026-05-29 no-knob directive eliminated the prior
+#   `DCA_COOLDOWN_MS = 15 * 60 * 1000` table AND the
+#   `int((25.0 - 20.0 * ser) * 60_000)` serotonin formula. Both
+#   encoded designer intuition; the lane's empirical decision-change
+#   period is what the kernel actually observes.
+# - better_price_frac and min_sovereignty remain as DCA-specific
+#   geometric thresholds (separate domain from cooldown).
 DCA_BETTER_PRICE_FRAC = 0.01
 DCA_MIN_SOVEREIGNTY = 0.1
 
@@ -1158,29 +1160,22 @@ def should_dca_add(
     symbol DCA-adds, because they live in different lanes with their
     own retreat tolerance.
     """
-    _ = lane  # surfaced into derivation for telemetry; not gating logic
-    # v0.8.4b — when ExecBasinState is provided, DCA cooldown / better-price
-    # / min-sovereignty DERIVE from geometric state per P25. When not
-    # provided, fall back to the hardcoded pre-derivation values so older
-    # callers stay byte-compatible. tick.py's _decide_with_position will
-    # populate `s` after v0.8.4b; any other caller gets the legacy path.
+    # 2026-05-29 cascading-knob-strip: DCA cooldown is now observer-derived
+    # from substrate_observer (lane's empirical decision-change period).
+    # The prior `DCA_COOLDOWN_MS = 15 * 60 * 1000` fallback AND the
+    # `int((25.0 - 20.0 * ser) * 60_000)` serotonin formula are DELETED —
+    # both encoded designer intuition. Cold-start (no observations) returns
+    # 0 → no DCA cooldown until the kernel has observed its own cadence.
     #
-    # Cooldown: scales inversely with serotonin (stability). serotonin=0.5
-    #   → 15 min (matches pre-derivation); serotonin=0 → 25 min (unstable,
-    #   cautious); serotonin=1 → 5 min (stable, okay to add).
-    # Better-price threshold: scales with basin velocity. Fast-moving basin
-    #   → higher bar for calling it a "better" price. Anchored at 1% when
-    #   bv=0.02 (nominal); drops to 0.5% when basin is still, rises to 2%+
-    #   when basin is jumpy.
-    # Min-sovereignty: still a hard floor (SAFETY_BOUND — no DCA for
-    #   newborn kernels regardless of other state).
+    # better-price-frac stays observer-derived from basin velocity when
+    # ExecBasinState is provided; falls back to DCA_BETTER_PRICE_FRAC
+    # constant otherwise (separate geometric domain, tracked separately).
+    # min-sovereignty remains a SAFETY_BOUND floor.
+    cooldown_ms = get_observed_lane_decision_period_ms(lane)  # type: ignore[arg-type]
     if s is not None:
-        ser = s.neurochemistry.serotonin
         bv = s.basin_velocity
-        cooldown_ms = int((25.0 - 20.0 * ser) * 60_000)  # min → ms
         better_price_frac = max(0.005, min(0.03, 0.01 + (bv - 0.02) * 0.5))
     else:
-        cooldown_ms = DCA_COOLDOWN_MS
         better_price_frac = DCA_BETTER_PRICE_FRAC
 
     if held_side != side_candidate:
@@ -1203,7 +1198,7 @@ def should_dca_add(
             "reason": f"add cap reached ({add_count}/{max_adds})",
             "derivation": {"rule": 4, "add_count": add_count, "max_adds": max_adds},
         }
-    if now_ms - last_add_at_ms < cooldown_ms:
+    if cooldown_ms > 0 and now_ms - last_add_at_ms < cooldown_ms:
         sec_remain = round((cooldown_ms - (now_ms - last_add_at_ms)) / 1000)
         return {
             "value": False,

--- a/ml-worker/src/monkey_kernel/substrate_observer.py
+++ b/ml-worker/src/monkey_kernel/substrate_observer.py
@@ -1,0 +1,160 @@
+"""substrate_observer.py — observer-derived lane decision period (Py).
+
+Py mirror of `apps/api/src/services/monkey/substrate_observer.ts`
+(shipped 2026-05-29 as part of the cascading-knob-strip). Replaces the
+hardcoded `DCA_COOLDOWN_MS = 15 * 60 * 1000` table and the
+`int((25.0 - 20.0 * ser) * 60_000)` serotonin-multiplier formula with
+the kernel's own observation of how often each lane's decision actually
+changes.
+
+# Why the prior shapes were knobs
+
+The TS-side review (operator 2026-05-29) eliminated `LANE_DECISION_PERIOD_MS`
+and `COLD_START_FALLBACK_MS` and `DCA_COOLDOWN_MS` outright — no
+back-compat exports, no canonical mirrors. The Py side still had two
+knob forms:
+
+  1. `DCA_COOLDOWN_MS = 15 * 60 * 1000` (executive.py:1134) — the
+     designer's 15-min fallback when basin state was missing
+  2. `int((25.0 - 20.0 * ser) * 60_000)` (executive.py:1180) — a
+     designer's linear formula mapping serotonin∈[0,1] → cooldown∈[5min, 25min]
+
+Both encoded designer intuition. The empirical lane decision period is
+the operator-correct source.
+
+# API
+
+  record_lane_decision(lane, t_now_ms, decision_tag) — called by the
+    kernel each tick after picking a (lane, decision) pair. Identical-tag
+    back-to-back calls do NOT push samples (decision unchanged → no
+    new interval).
+
+  get_observed_lane_decision_period_ms(lane) -> int
+    Rolling median of observed decision-change intervals. Returns 0
+    on cold-start (no observations yet).
+
+# Cold-start behavior
+
+Returns 0 until the observer has at least one decision-change sample.
+Consumers (DCA cooldown gate, HEART arbitration, etc.) treat 0 as "no
+observed floor" and fall through to substrate behavior. The kernel's
+first few decisions have no extra cooldown — the autonomy doctrine
+accepts this risk (losses feed neurochemistry; the system learns from
+its own state).
+
+# Anti-knob discipline
+
+Only numeric literal is the sample-count buffer size — not a physical
+ms quantity. No magic ms values, no lane-specific thresholds, no
+designer's intuition table.
+
+Citations: poloniex-trading-platform#1025 (TS), operator 2026-05-29
+no-knob directive, 2.31A P4/P5/P14/P25 + QIG PURITY MANDATE.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal, TypedDict
+
+logger = logging.getLogger(__name__)
+
+Lane = Literal["scalp", "swing", "trend"]
+_INTERVAL_RING_CAPACITY = 50
+
+
+class _LaneObserverState(TypedDict):
+    last_decision_at_ms: float | None
+    last_decision_tag: str | None
+    decision_intervals_ms: list[float]
+
+
+def _fresh() -> _LaneObserverState:
+    return {
+        "last_decision_at_ms": None,
+        "last_decision_tag": None,
+        "decision_intervals_ms": [],
+    }
+
+
+_state: dict[Lane, _LaneObserverState] = {
+    "scalp": _fresh(),
+    "swing": _fresh(),
+    "trend": _fresh(),
+}
+
+
+def record_lane_decision(lane: Lane, t_now_ms: float, decision_tag: str) -> None:
+    """Record that the kernel just produced a decision at `lane`.
+
+    If the tag differs from the previous call's tag (decision actually
+    changed), the wall-clock interval since the last change is pushed
+    into the ring.
+
+    Identical-tag back-to-back calls update `last_decision_at_ms` but
+    do NOT push a new sample (decision unchanged).
+    """
+    if not isinstance(t_now_ms, (int, float)):
+        return
+    if t_now_ms < 0 or t_now_ms != t_now_ms:  # NaN check
+        return
+    s = _state[lane]
+    if (
+        s["last_decision_at_ms"] is not None
+        and s["last_decision_tag"] is not None
+        and decision_tag != s["last_decision_tag"]
+    ):
+        delta = t_now_ms - s["last_decision_at_ms"]
+        if delta > 0:
+            s["decision_intervals_ms"].append(delta)
+            if len(s["decision_intervals_ms"]) > _INTERVAL_RING_CAPACITY:
+                s["decision_intervals_ms"].pop(0)
+    s["last_decision_at_ms"] = t_now_ms
+    s["last_decision_tag"] = decision_tag
+
+
+def get_observed_lane_decision_period_ms(lane: Lane) -> int:
+    """Observed median wall-clock interval at which `lane`'s decisions change.
+
+    Returns 0 when no changes have been observed yet (cold-start).
+
+    Median (not mean) is robust: one slow tick due to GC, network
+    latency, or a sleep doesn't poison the cadence. Consumers rely on
+    this floor being a TYPICAL period, not the worst-case.
+    """
+    buf = _state[lane]["decision_intervals_ms"]
+    if not buf:
+        return 0
+    s = sorted(buf)
+    mid = len(s) // 2
+    if len(s) % 2 == 0:
+        return int(round((s[mid - 1] + s[mid]) / 2))
+    return int(s[mid])
+
+
+class SubstrateBreakdown(TypedDict):
+    scalp_samples: int
+    swing_samples: int
+    trend_samples: int
+    scalp_period_ms: int
+    swing_period_ms: int
+    trend_period_ms: int
+
+
+def get_substrate_breakdown() -> SubstrateBreakdown:
+    """Per-observer telemetry — sample counts + current periods for falsifiability."""
+    return {
+        "scalp_samples": len(_state["scalp"]["decision_intervals_ms"]),
+        "swing_samples": len(_state["swing"]["decision_intervals_ms"]),
+        "trend_samples": len(_state["trend"]["decision_intervals_ms"]),
+        "scalp_period_ms": get_observed_lane_decision_period_ms("scalp"),
+        "swing_period_ms": get_observed_lane_decision_period_ms("swing"),
+        "trend_period_ms": get_observed_lane_decision_period_ms("trend"),
+    }
+
+
+def _reset_substrate_observer_state() -> None:
+    """Test-only: reset all per-lane state."""
+    for lane in ("scalp", "swing", "trend"):
+        _state[lane] = _fresh()
+    logger.debug("[substrate_observer] state cleared (test-only)")

--- a/ml-worker/src/monkey_kernel/tick.py
+++ b/ml-worker/src/monkey_kernel/tick.py
@@ -72,6 +72,7 @@ from .executive import (
     should_scalp_exit,
     upper_stack_executive_live,
 )
+from .substrate_observer import record_lane_decision
 from .foresight import ForesightPredictor
 from .heart import HeartMonitor
 from .kernel_bus import KernelBus
@@ -1141,6 +1142,13 @@ def run_tick(
         stud_live=stud_live,
     )
     pre_lane = pre_lane_d["value"]
+    # Substrate observer (#1025 cascading-knob-strip Py side): record
+    # the current (lane, decision) so the rolling decision-change
+    # interval supersedes the legacy DCA_COOLDOWN_MS table + serotonin
+    # multiplier formula. Tag is the lane value itself; identical-tag
+    # back-to-back calls do NOT push a new sample.
+    _pre_lane_norm = pre_lane if pre_lane in ("scalp", "swing", "trend") else "swing"
+    record_lane_decision(_pre_lane_norm, time.time() * 1000.0, str(pre_lane))
     size_d = current_position_size(
         basin_state,
         available_equity_usdt=capped_equity,

--- a/ml-worker/tests/monkey_kernel/test_executive_derivations.py
+++ b/ml-worker/tests/monkey_kernel/test_executive_derivations.py
@@ -346,8 +346,24 @@ class TestPillar1Guard:
 # ────────────────────────────────────────────────────────────────
 
 class TestDCADerivations:
-    def test_cooldown_anchored_at_nominal_serotonin(self):
-        """serotonin=0.5 → cooldown = (25 - 10) * 60000 = 900000 ms (15 min)."""
+    """DCA cooldown is now observer-derived from substrate_observer
+    (#1025 cascading-knob-strip 2026-05-29). The legacy serotonin
+    formula `int((25.0 - 20.0 * ser) * 60_000)` and the `DCA_COOLDOWN_MS
+    = 15 * 60 * 1000` fallback are both DELETED. Cold-start observer
+    returns 0 → no DCA cooldown until kernel has observed its own
+    decision cadence.
+    """
+
+    def test_cold_start_observer_returns_zero_cooldown_no_veto(self):
+        """Cold-start substrate observer → cooldown_ms = 0 → cooldown
+        check does NOT veto. Other checks still run; the DCA-add
+        succeeds or fails based on price/sovereignty/cap, NOT on a
+        designer's 15-minute table."""
+        from monkey_kernel.substrate_observer import (
+            _reset_substrate_observer_state,
+        )
+
+        _reset_substrate_observer_state()
         s = _nominal_state()
         r = should_dca_add(
             held_side="long", side_candidate="long",
@@ -355,34 +371,53 @@ class TestDCADerivations:
             add_count=0, last_add_at_ms=9_990_000, now_ms=10_000_000,
             sovereignty=0.5, s=s,
         )
-        assert r["value"] is False  # cooldown blocks
-        assert r["derivation"]["cooldown_ms"] == 900_000
-
-    def test_high_serotonin_shorter_cooldown(self):
-        """serotonin=1.0 → 5 min cooldown."""
-        nc = NeurochemicalState(
-            acetylcholine=0.5, dopamine=0.5, serotonin=1.0,
-            norepinephrine=0.5, gaba=0.5, endorphins=0.5,
+        # Cooldown check should NOT fire at cold-start; whatever fails the
+        # gate must be a different rule.
+        assert "cooldown" not in r["reason"], (
+            f"cold-start observer should not produce a cooldown veto, got: {r['reason']}"
         )
-        s = _nominal_state(nc=nc)
+
+    def test_observed_cooldown_vetoes_when_elapsed_below_observed_period(self):
+        """Seed the substrate observer with synthetic decision-change
+        samples → observed lane period > 0 → cooldown check vetoes
+        when (now_ms - last_add_at_ms) < observed_period."""
+        from monkey_kernel.substrate_observer import (
+            _reset_substrate_observer_state,
+            record_lane_decision,
+        )
+
+        _reset_substrate_observer_state()
+        # Seed swing lane with ~180_000ms decision-change intervals.
+        for i in range(5):
+            record_lane_decision("swing", float(i * 180_000), f"decision-{i}")
+
+        s = _nominal_state()
         r = should_dca_add(
             held_side="long", side_candidate="long",
             current_price=100.0, initial_entry_price=101.0,
-            add_count=0, last_add_at_ms=9_990_000, now_ms=10_000_000,
-            sovereignty=0.5, s=s,
+            add_count=0,
+            last_add_at_ms=9_990_000, now_ms=10_000_000,  # 10s elapsed
+            sovereignty=0.5, s=s, lane="swing",
         )
-        assert r["derivation"]["cooldown_ms"] == 300_000
+        assert r["value"] is False
+        assert "cooldown" in r["reason"]
+        assert r["derivation"]["cooldown_ms"] == 180_000
 
-    def test_legacy_caller_without_s_gets_hardcoded_cooldown(self):
-        """Backward-compat: caller without `s` gets pre-derivation 15min."""
+    def test_legacy_caller_without_s_uses_observer_too(self):
+        """Caller without `s` still goes through the substrate observer
+        (no `DCA_COOLDOWN_MS` fallback). At cold-start: 0 → no veto."""
+        from monkey_kernel.substrate_observer import (
+            _reset_substrate_observer_state,
+        )
+
+        _reset_substrate_observer_state()
         r = should_dca_add(
             held_side="long", side_candidate="long",
             current_price=100.0, initial_entry_price=101.0,
             add_count=0, last_add_at_ms=9_990_000, now_ms=10_000_000,
             sovereignty=0.5,  # no s=
         )
-        # Hardcoded DCA_COOLDOWN_MS = 15 * 60 * 1000 = 900_000
-        assert r["derivation"]["cooldown_ms"] == 900_000
+        assert "cooldown" not in r["reason"]
 
 
 if __name__ == "__main__":

--- a/ml-worker/tests/monkey_kernel/test_substrate_observer.py
+++ b/ml-worker/tests/monkey_kernel/test_substrate_observer.py
@@ -1,0 +1,125 @@
+"""test_substrate_observer.py — observer-derived lane decision period
+(Py side, #1025 cascading-knob-strip follow-up 2026-05-29).
+
+Mirror of `apps/api/src/services/monkey/__tests__/substrate_observer.test.ts`.
+
+Pins:
+  1. Fresh state → 0 (cold-start, no observed floor)
+  2. Identical-tag back-to-back calls do NOT push samples
+  3. Different-tag pushes the inter-change interval
+  4. Median returned, robust to outlier
+  5. Per-lane isolation
+  6. NaN ignored
+  7. Literal purity: only sample-count buffer size, no ms knobs
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from monkey_kernel.substrate_observer import (
+    _reset_substrate_observer_state,
+    get_observed_lane_decision_period_ms,
+    get_substrate_breakdown,
+    record_lane_decision,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    _reset_substrate_observer_state()
+
+
+def test_fresh_state_returns_zero_for_every_lane() -> None:
+    assert get_observed_lane_decision_period_ms("scalp") == 0
+    assert get_observed_lane_decision_period_ms("swing") == 0
+    assert get_observed_lane_decision_period_ms("trend") == 0
+
+
+def test_identical_tag_back_to_back_does_not_push_sample() -> None:
+    record_lane_decision("scalp", 1000.0, "long|hold")
+    record_lane_decision("scalp", 2000.0, "long|hold")  # unchanged
+    record_lane_decision("scalp", 3000.0, "long|hold")  # unchanged
+    assert get_substrate_breakdown()["scalp_samples"] == 0
+    assert get_observed_lane_decision_period_ms("scalp") == 0
+
+
+def test_different_tag_pushes_inter_change_interval() -> None:
+    record_lane_decision("scalp", 1000.0, "long|hold")
+    record_lane_decision("scalp", 4000.0, "long|enter")  # change after 3000ms
+    assert get_substrate_breakdown()["scalp_samples"] == 1
+    assert get_observed_lane_decision_period_ms("scalp") == 3000
+
+
+def test_median_robust_to_outlier() -> None:
+    # 5 changes: 1000, 2000, 3000, 4000, 20_000 (outlier). Median = 3000.
+    record_lane_decision("swing", 0.0, "a")
+    record_lane_decision("swing", 1000.0, "b")  # 1000
+    record_lane_decision("swing", 3000.0, "c")  # 2000
+    record_lane_decision("swing", 6000.0, "d")  # 3000
+    record_lane_decision("swing", 10_000.0, "e")  # 4000
+    record_lane_decision("swing", 30_000.0, "f")  # 20_000 outlier
+    assert get_observed_lane_decision_period_ms("swing") == 3000
+
+
+def test_per_lane_isolation() -> None:
+    record_lane_decision("scalp", 0.0, "a")
+    record_lane_decision("scalp", 1000.0, "b")
+    assert get_observed_lane_decision_period_ms("scalp") == 1000
+    assert get_observed_lane_decision_period_ms("swing") == 0
+
+
+def test_nan_t_now_is_ignored() -> None:
+    record_lane_decision("scalp", float("nan"), "a")
+    record_lane_decision("scalp", 1000.0, "b")
+    record_lane_decision("scalp", 4000.0, "c")  # gap from last valid = 3000
+    assert get_observed_lane_decision_period_ms("scalp") == 3000
+
+
+def test_negative_t_now_is_ignored() -> None:
+    record_lane_decision("scalp", -1.0, "a")
+    record_lane_decision("scalp", 1000.0, "b")
+    record_lane_decision("scalp", 4000.0, "c")
+    assert get_observed_lane_decision_period_ms("scalp") == 3000
+
+
+def test_breakdown_surfaces_sample_counts_and_periods() -> None:
+    record_lane_decision("scalp", 0.0, "a")
+    record_lane_decision("scalp", 5000.0, "b")
+    record_lane_decision("trend", 0.0, "a")
+    record_lane_decision("trend", 100_000.0, "b")
+    b = get_substrate_breakdown()
+    assert b["scalp_samples"] == 1
+    assert b["scalp_period_ms"] == 5000
+    assert b["swing_samples"] == 0
+    assert b["swing_period_ms"] == 0
+    assert b["trend_samples"] == 1
+    assert b["trend_period_ms"] == 100_000
+
+
+# ── Literal purity ─────────────────────────────────────────────────
+
+
+def test_no_unexpected_numeric_literals_in_substrate_observer_py() -> None:
+    """The only allowed numeric literal in substrate_observer.py is `50`
+    (sample-count buffer size, not a physical ms quantity) and `0` / `1`
+    / `2` (clamp / index arithmetic / median midpoint divisor)."""
+    src_path = (
+        Path(__file__).parents[2] / "src" / "monkey_kernel" / "substrate_observer.py"
+    )
+    src = src_path.read_text(encoding="utf-8")
+    # Strip docstrings + comments + string literals.
+    stripped = re.sub(r'""".*?"""', '""', src, flags=re.DOTALL)
+    stripped = re.sub(r"'''.*?'''", "''", stripped, flags=re.DOTALL)
+    stripped = re.sub(r"#[^\n]*", "", stripped)
+    stripped = re.sub(r"'[^']*'", "''", stripped)
+    stripped = re.sub(r'"[^"]*"', '""', stripped)
+    literals = re.findall(r"(?<![\w.])(\d+(?:\.\d+)?)", stripped)
+    allowed = {"0", "1", "2", "50"}
+    offenders = [v for v in literals if v not in allowed]
+    assert offenders == [], (
+        f"Unexpected numeric literals in substrate_observer.py: {offenders}"
+    )


### PR DESCRIPTION
## Summary

Py mirror of #1025 (TS cascading-knob-strip). Deletes two more knobs in the cooldown domain on the Python side:

| Knob | Location | Replacement |
|---|---|---|
| \`DCA_COOLDOWN_MS = 15 * 60 * 1000\` | \`executive.py:1134\` | \`get_observed_lane_decision_period_ms(lane)\` |
| \`int((25.0 - 20.0 * ser) * 60_000)\` serotonin formula | \`executive.py:1180\` | same |

Both encoded designer intuition — the 15-min fallback table and the 5–25min serotonin-multiplier mapping. The empirical lane decision period is the operator-correct source.

## New module: \`monkey_kernel/substrate_observer.py\`

Mirror of TS \`apps/api/src/services/monkey/substrate_observer.ts\`:

- \`record_lane_decision(lane, t_now_ms, decision_tag)\` — kernel calls each tick; identical-tag back-to-back calls do NOT push samples
- \`get_observed_lane_decision_period_ms(lane) -> int\` — rolling median of observed inter-change intervals; returns 0 on cold-start
- Only numeric literal: \`_INTERVAL_RING_CAPACITY = 50\` (sample count)

## Wired sites

- \`tick.py:1144\` — \`record_lane_decision(pre_lane_norm, time.time()*1000, str(pre_lane))\` at the per-tick lane decision point
- \`executive.py:should_dca_add\` — DCA cooldown now reads observer; cold-start returns 0; check guarded with \`if cooldown_ms > 0 and ...\`

## Cold-start behavior (intentional)

When kernel boots, observed lane period = 0 → DCA cooldown = 0. DCA-adds gated by other rules (side mismatch, add cap, sovereignty, better-price) but NOT by a designer's 15-min table. Operator no-knob doctrine accepts this — outcomes feed neurochemistry.

## Tests: 12/12 new + updated pass

**New** (\`test_substrate_observer.py\`, 9 tests): fresh state → 0, identical-tag no-op, different-tag pushes interval, median robust to outlier, per-lane isolation, NaN ignored, telemetry breakdown, literal purity (allow 0/1/2/50 only)

**Updated** (\`test_executive_derivations.py::TestDCADerivations\`, 3 tests):
- Old serotonin-formula tests REPLACED with observer-derived tests
- Cold-start → no veto
- Seeded observer (180_000ms swing samples) → veto when elapsed < period
- Legacy caller without \`s\` also goes through observer

## Pre-existing failures NOT in scope (verified on main)

- \`test_anti_costume_repo_wide.py::test_qig_warp_forbidden_literal_patterns_absent_repo_wide\` — Big5-encoded fixture file in repo breaks the utf-8 read
- \`test_executive_derivations.py::TestFlatnessDerivation::*\` — pre-existing TypeError on \`s.kappa\` (test fixture issue)

## Refs

- #1025 (TS substrate observer + LANE_DECISION_PERIOD_MS removal — landed as bda7cf06)
- Operator 2026-05-29 no-knob directive: \"when we operate purely it makes money\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)