### PR TITLE
fix(ml-worker): Py reward no longer 500s on losing closes (loss_dop_scale UnboundLocalError)

### DIFF
--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -365,10 +365,14 @@ class AutonomicKernel:
             # Honest model coefficients for the reward→chemistry transform.
             dop_scale = get_reward_dop_scale()
             ser_scale = get_reward_ser_scale()
-            loss_dop_scale = get_reward_loss_dop_scale()
             dop = float(np.tanh(pnl_frac * dop_scale) * 0.5 * ocean_coeff)
             ser = float(np.tanh(pnl_frac) * ser_scale * ocean_coeff)
         else:
+            # Loss-side coefficient is consumed only here; bind it on this
+            # branch (72895fcb regression bound it under `pnl_frac > 0`,
+            # so every losing close raised UnboundLocalError and the
+            # autonomic /reward endpoint 500'd before chemistry updated).
+            loss_dop_scale = get_reward_loss_dop_scale()
             dop = float(-np.tanh(-pnl_frac * loss_dop_scale) * 0.1)
             ser = 0.0
 

--- a/ml-worker/tests/monkey_kernel/test_autonomic_observer_parity.py
+++ b/ml-worker/tests/monkey_kernel/test_autonomic_observer_parity.py
@@ -249,3 +249,41 @@ def test_endo_at_kappa_star_saturates_envelope():
         external_coupling=0.5,
     ))
     assert nc.endorphins == pytest.approx(0.5, abs=0.05)
+
+
+def test_push_reward_on_loss_does_not_raise():
+    """Regression: loss-path reward (pnl_frac <= 0) must not crash.
+
+    Bug introduced by 72895fcb: loss_dop_scale was bound only in the
+    ``pnl_frac > 0`` branch but consumed in the ``else`` branch, so every
+    authoritative *losing* close raised UnboundLocalError and the Python
+    autonomic /reward endpoint 500'd — non-zero loss PnL never reached
+    chemistry. See [[polytrade_session_20260528_overnight_polo_chemistry_restored]].
+    """
+    k = AutonomicKernel(label="test")
+    reward = k.push_reward(
+        source="polo_authoritative_close",
+        realized_pnl_usdt=-3.5568,
+        margin_usdt=78.2,
+        symbol="ETH",
+    )
+    # Loss → negative, finite dopamine mood-dip; no serotonin/endorphin.
+    assert reward.dopamine_delta < 0.0
+    import math
+    assert math.isfinite(reward.dopamine_delta)
+    assert reward.serotonin_delta == 0.0
+    assert reward.endorphin_delta == 0.0
+    assert reward.pnl_fraction < 0.0
+
+
+def test_push_reward_on_win_still_binds_scales():
+    """Win-path must remain intact after the loss-path fix."""
+    k = AutonomicKernel(label="test")
+    reward = k.push_reward(
+        source="polo_authoritative_close",
+        realized_pnl_usdt=2.0,
+        margin_usdt=50.0,
+        symbol="BTC",
+    )
+    assert reward.dopamine_delta > 0.0
+    assert reward.serotonin_delta > 0.0


### PR DESCRIPTION
## P0 — live-money chemistry blocker

Found in the Grok review log: every authoritative **losing** close crashed the Python autonomic reward ingress.

\`\`\`
UnboundLocalError: cannot access local variable 'loss_dop_scale'
ml-worker/src/monkey_kernel/autonomic.py:372
[autonomic_client] reward push failed {"status":500,"body":"Internal Server Error"}
\`\`\`

### Root cause
\`push_reward\` bound \`loss_dop_scale\` only inside the \`pnl_frac > 0\` branch (regression from \`72895fcb\`, which extracted the hardcoded \`0.5\` into \`get_reward_loss_dop_scale()\`) but consumed it in the \`else\` branch. On a loss the \`if\` body is skipped, so the name is never bound → \`UnboundLocalError\`. Sibling vars \`dop_scale\`/\`ser_scale\` were unaffected because they're consumed in the same branch they're defined in.

Effect: TS computed and wrote the reward ledger correctly (\`pnlSource=polo_gross_minus_close_fees\`), but the Python \`/monkey/autonomic/reward\` endpoint 500'd, so **non-zero loss PnL never reached chemistry**. Wins were fine, masking the bug.

### Fix
Move the coefficient lookup into the \`else\` branch that uses it (mirrors how \`dop_scale\`/\`ser_scale\` are scoped to the win branch). Win path unchanged.

### Tests
- \`test_push_reward_on_loss_does_not_raise\` — reproduces the exact crash; asserts negative finite dopamine, zero serotonin/endorphin.
- \`test_push_reward_on_win_still_binds_scales\` — guards the win path.

Full \`test_autonomic_observer_parity.py\` suite: 19/19 green.

### Out of scope (follow-ups, separately tracked)
- Reward-ledger **source-of-truth** divergence vs exchange export (app \`poloRealized\` undercounts loss; ETH -3.5568 vs CSV -4.2499) — TS reconstruction issue.
- Invalid \`/v3/trade/funding\` endpoint (404) → should be \`/v3/account/bills\` per polo-futures skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)