### PR TITLE
fix(api): reward ledger reads authoritative realized PnL + funding from /v3/account/bills (#1028)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/polo_bills_reward.test.ts
+++ b/apps/api/src/services/monkey/__tests__/polo_bills_reward.test.ts
@@ -1,0 +1,119 @@
+/**
+ * polo_bills_reward.test.ts — money-path tests for composePoloBillsReward
+ * (poloniex-trading-platform#1028).
+ *
+ * Fixtures are the EXACT `/v3/account/bills` rows captured from the live
+ * polytrade-be account on 2026-05-29 for the two closes the Grok review
+ * flagged. The prior synthetic gross under-counted (ETH reported −3.5568);
+ * these PNL rows reconcile to the exchange-exported closed PnL of −4.2499
+ * (ETH) and −2.24352466 (BTC). Pinning that reconciliation here.
+ */
+import { describe, expect, it } from 'vitest';
+import { composePoloBillsReward, type PoloBillRow } from '../polo_reward_ledger.js';
+
+const ETH_CLOSE_MS = 1780045824884;
+const BTC_CLOSE_MS = 1780045854898;
+
+// 8 ETH PNL bills (sz) at the close cTime → Σ = −4.2499 (exchange truth).
+const ETH_PNL_SZ = [-0.7709, -0.4067, -0.222, -0.4887, -1.2648, -0.6312, -0.3654, -0.1002];
+// 4 BTC PNL bills → Σ = −2.24352466…
+const BTC_PNL_SZ = [
+  -0.320870666666666666, -1.283082666666666666, -0.480976, -0.158595333333333333,
+];
+
+function pnlRows(symbol: string, szs: number[], cTimeMs: number): PoloBillRow[] {
+  return szs.map((sz) => ({ type: 'PNL', sz, symbol, cTimeMs }));
+}
+
+describe('composePoloBillsReward', () => {
+  it('reconciles ETH realized PnL to the exchange export (−4.2499)', () => {
+    const rows = pnlRows('ETH_USDT_PERP', ETH_PNL_SZ, ETH_CLOSE_MS);
+    const out = composePoloBillsReward(rows, {
+      symbol: 'ETH_USDT_PERP',
+      closeStartMs: ETH_CLOSE_MS - 2000,
+      closeEndMs: ETH_CLOSE_MS + 2000,
+      holdStartMs: ETH_CLOSE_MS - 3_600_000,
+      holdEndMs: ETH_CLOSE_MS + 2000,
+    });
+    expect(out.pnlRowCount).toBe(8);
+    expect(out.realizedPnl).toBeCloseTo(-4.2499, 6);
+    expect(out.fundingSigned).toBe(0);
+  });
+
+  it('reconciles BTC realized PnL to the exchange export (−2.24352466)', () => {
+    const rows = pnlRows('BTC_USDT_PERP', BTC_PNL_SZ, BTC_CLOSE_MS);
+    const out = composePoloBillsReward(rows, {
+      symbol: 'BTC_USDT_PERP',
+      closeStartMs: BTC_CLOSE_MS - 2000,
+      closeEndMs: BTC_CLOSE_MS + 2000,
+      holdStartMs: BTC_CLOSE_MS - 3_600_000,
+      holdEndMs: BTC_CLOSE_MS + 2000,
+    });
+    expect(out.pnlRowCount).toBe(4);
+    expect(out.realizedPnl).toBeCloseTo(-2.24352466, 6);
+  });
+
+  it('sums FUNDING_FEE signed flow in the hold window (+ received, − paid)', () => {
+    const rows: PoloBillRow[] = [
+      ...pnlRows('ETH_USDT_PERP', ETH_PNL_SZ, ETH_CLOSE_MS),
+      { type: 'FUNDING_FEE', sz: 0.12641643, symbol: 'ETH_USDT_PERP', cTimeMs: ETH_CLOSE_MS - 1_000_000 },
+      { type: 'FUNDING_FEE', sz: -0.05173194, symbol: 'ETH_USDT_PERP', cTimeMs: ETH_CLOSE_MS - 2_000_000 },
+    ];
+    const out = composePoloBillsReward(rows, {
+      symbol: 'ETH_USDT_PERP',
+      closeStartMs: ETH_CLOSE_MS - 2000,
+      closeEndMs: ETH_CLOSE_MS + 2000,
+      holdStartMs: ETH_CLOSE_MS - 3_600_000,
+      holdEndMs: ETH_CLOSE_MS + 2000,
+    });
+    expect(out.realizedPnl).toBeCloseTo(-4.2499, 6);
+    expect(out.fundingRowCount).toBe(2);
+    expect(out.fundingSigned).toBeCloseTo(0.12641643 - 0.05173194, 8);
+  });
+
+  it('excludes PNL rows outside the close window', () => {
+    const rows: PoloBillRow[] = [
+      ...pnlRows('ETH_USDT_PERP', ETH_PNL_SZ, ETH_CLOSE_MS),
+      // a different close of the same symbol an hour later — must NOT be counted
+      { type: 'PNL', sz: -99, symbol: 'ETH_USDT_PERP', cTimeMs: ETH_CLOSE_MS + 3_600_000 },
+    ];
+    const out = composePoloBillsReward(rows, {
+      symbol: 'ETH_USDT_PERP',
+      closeStartMs: ETH_CLOSE_MS - 2000,
+      closeEndMs: ETH_CLOSE_MS + 2000,
+      holdStartMs: ETH_CLOSE_MS - 3_600_000,
+      holdEndMs: ETH_CLOSE_MS + 2000,
+    });
+    expect(out.pnlRowCount).toBe(8);
+    expect(out.realizedPnl).toBeCloseTo(-4.2499, 6);
+  });
+
+  it('excludes other symbols and TRANSFER rows', () => {
+    const rows: PoloBillRow[] = [
+      ...pnlRows('ETH_USDT_PERP', ETH_PNL_SZ, ETH_CLOSE_MS),
+      { type: 'PNL', sz: -50, symbol: 'BTC_USDT_PERP', cTimeMs: ETH_CLOSE_MS },
+      { type: 'TRANSFER', sz: 1000, symbol: 'ETH_USDT_PERP', cTimeMs: ETH_CLOSE_MS },
+    ];
+    const out = composePoloBillsReward(rows, {
+      symbol: 'ETH_USDT_PERP',
+      closeStartMs: ETH_CLOSE_MS - 2000,
+      closeEndMs: ETH_CLOSE_MS + 2000,
+      holdStartMs: ETH_CLOSE_MS - 3_600_000,
+      holdEndMs: ETH_CLOSE_MS + 2000,
+    });
+    expect(out.pnlRowCount).toBe(8);
+    expect(out.realizedPnl).toBeCloseTo(-4.2499, 6);
+  });
+
+  it('returns pnlRowCount=0 when no PNL rows match (caller must fall back)', () => {
+    const out = composePoloBillsReward([], {
+      symbol: 'ETH_USDT_PERP',
+      closeStartMs: ETH_CLOSE_MS - 2000,
+      closeEndMs: ETH_CLOSE_MS + 2000,
+      holdStartMs: ETH_CLOSE_MS - 3_600_000,
+      holdEndMs: ETH_CLOSE_MS + 2000,
+    });
+    expect(out.pnlRowCount).toBe(0);
+    expect(out.realizedPnl).toBe(0);
+  });
+});

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -45,8 +45,9 @@ import { composeCooldown, formatCooldownTelemetry } from './cooldown_composer.js
 import { noteClose as noteHeartClose } from './heart_arbitrator.js';
 import { evaluatePostCloseCooldownGate } from './postclose_cooldown_gate.js';
 import {
+  composePoloBillsReward,
   computePoloAuthoritativeReward,
-  detectFundingSignDiscrepancies,
+  type PoloBillRow,
 } from './polo_reward_ledger.js';
 import {
   recordLaneDecision,
@@ -9312,12 +9313,14 @@ export class MonkeyKernel extends EventEmitter {
       const RETRY_DELAY_MS = 200;
       let totalCloseFees = 0;
       let fillCount = 0;
+      let closeFillCTimes: number[] = [];
       let nonUsdtFees: Array<{ ordId: string; feeCcy: string; feeAmt: number }> = [];
       type FeeSummary = {
         totalFees: number;
         fillsSeen: number;
         filledOrderIds: Set<string>;
         skippedNonUsdt: Array<{ ordId: string; feeCcy: string; feeAmt: number }>;
+        cTimesMs: number[];
       };
       const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
       const rowsFromResponse = (resp: unknown): Array<Record<string, unknown>> => {
@@ -9332,6 +9335,7 @@ export class MonkeyKernel extends EventEmitter {
         let fillsSeen = 0;
         const filledOrderIds = new Set<string>();
         const skippedNonUsdt: Array<{ ordId: string; feeCcy: string; feeAmt: number }> = [];
+        const cTimesMs: number[] = [];
         await Promise.all(orderIds.map(async (ordId) => {
           try {
             const resp = await poloniexFuturesService.getExecutionDetails(credentials, {
@@ -9352,6 +9356,11 @@ export class MonkeyKernel extends EventEmitter {
               totalFees += Math.abs(feeAmt);
               fillsSeen += 1;
               filledOrderIds.add(ordId);
+              // Capture fill cTime so the authoritative bills PNL rows
+              // (which share the close fill's cTime) can be matched by a
+              // tight window — bills carry no ordId (#1028).
+              const ct = Number(f.cTime);
+              if (Number.isFinite(ct)) cTimesMs.push(ct);
             }
           } catch (fetchErr) {
             logger.warn('[Monkey] /trade/order/trades fetch failed for fee subtraction', {
@@ -9360,13 +9369,14 @@ export class MonkeyKernel extends EventEmitter {
             });
           }
         }));
-        return { totalFees, fillsSeen, filledOrderIds, skippedNonUsdt };
+        return { totalFees, fillsSeen, filledOrderIds, skippedNonUsdt, cTimesMs };
       };
 
       for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
         const summary = await fetchFeeSummary(closeOrderIds, 'close');
         totalCloseFees = summary.totalFees;
         fillCount = summary.fillsSeen;
+        closeFillCTimes = summary.cTimesMs;
         nonUsdtFees = summary.skippedNonUsdt;
         if (summary.filledOrderIds.size >= closeOrderIds.length || attempt === MAX_ATTEMPTS) break;
         apiCache.invalidatePrefix('GET:/trade/order/trades');
@@ -9421,64 +9431,88 @@ export class MonkeyKernel extends EventEmitter {
         });
       }
 
-      let totalFundingFlows = 0;
-      let fundingRows = 0;
-      let fundingComplete = false;
+      // ── Authoritative realized PnL + funding from /v3/account/bills (#1028) ──
+      // Poloniex account bills are literal USDT cash movements: `type=PNL`
+      // rows are the per-fill realized PnL (verified 2026-05-29 to
+      // reconcile EXACTLY to the exchange-exported closed PnL — ETH
+      // −4.2499, BTC −2.243525), and `type=FUNDING_FEE` rows are signed
+      // funding cash. This replaces (a) the synthetic per-row gross, which
+      // under-counted the realized loss (ETH reported −3.5568), and (b)
+      // `/v3/trade/funding`, which does not exist (404 — confirmed live).
+      // Bills carry no ordId, so PNL rows are matched by symbol + a tight
+      // window around the close fills' cTime (PNL bill cTime == close fill
+      // cTime), and funding by the position hold window [entry, close].
       const entryTimes = tradeRowsRes.rows
         .map((row) => row.entry_time ? new Date(row.entry_time).getTime() : NaN)
         .filter((ms) => Number.isFinite(ms));
       const fundingStartMs = entryTimes.length > 0 ? Math.min(...entryTimes) : NaN;
-      if (Number.isFinite(fundingStartMs)) {
-        try {
-          const resp = await poloniexFuturesService.getFundingHistory(credentials, {
-            symbol,
-            posSide: side === 'long' ? 'LONG' : 'SHORT',
-            sTime: Math.max(0, fundingStartMs - 1_000),
-            eTime: closeTimeMs + 1_000,
-            limit: 100,
-          });
-          const rows = rowsFromResponse(resp);
-          // #1024 follow-up: also collect the per-row funding rate so we
-          // can sanity-check the sign of `fundingFee` against the
-          // expected direction implied by (position side, rate sign).
-          // The kernel's own pre-entry funding gate documents the
-          // convention; if Polo's history field deviates we want to
-          // know in production logs, not silently mis-attribute.
-          const fundingRowsForCheck: Array<{ fundingFee: number; rate: number }> = [];
-          for (const row of rows) {
-            const raw = row.fundingFee ?? row.fundingAmt ?? row.feeAmt ?? row.amount ?? row.amt ?? '0';
-            const amount = parseFloat(String(raw));
-            if (!Number.isFinite(amount)) continue;
-            totalFundingFlows += amount;
-            fundingRows += 1;
-            const rateRaw = row.fundingRate ?? row.fR ?? row.rate;
-            const rate = rateRaw === undefined ? NaN : parseFloat(String(rateRaw));
-            if (Number.isFinite(rate)) {
-              fundingRowsForCheck.push({ fundingFee: amount, rate });
-            }
-          }
-          fundingComplete = true;
-          // Surface API convention drift without breaking the reward
-          // channel. If discrepancies show up in production, the
-          // ADD-signed semantics in computePoloAuthoritativeReward
-          // needs revisiting.
-          const discrepancies = detectFundingSignDiscrepancies(side, fundingRowsForCheck);
-          if (discrepancies.length > 0) {
-            logger.warn('[Monkey] Polo funding sign discrepancy detected', {
-              symbol, side,
-              count: discrepancies.length,
-              sample: discrepancies.slice(0, 3),
+      const holdStartMs = Number.isFinite(fundingStartMs)
+        ? fundingStartMs
+        : closeTimeMs - 24 * 60 * 60 * 1000; // 24h lookback when entry_time missing
+      const closeCTimes = closeFillCTimes.length > 0 ? closeFillCTimes : [closeTimeMs];
+      const closeStartMs = Math.min(...closeCTimes) - 5_000;
+      const closeEndMs = Math.max(...closeCTimes) + 5_000;
+      const normSymbol = poloniexFuturesService.normalizeSymbol(symbol);
+
+      const billRows: PoloBillRow[] = [];
+      let billsComplete = false;
+      try {
+        let cursor: string | null = null;
+        for (let page = 0; page < 8; page += 1) {
+          const billsResp = await poloniexFuturesService.getAccountBills(
+            credentials,
+            { limit: 100, ...(cursor ? { from: cursor } : {}) },
+          );
+          const rows = rowsFromResponse(billsResp);
+          if (rows.length === 0) break;
+          for (const r of rows) {
+            billRows.push({
+              type: String((r as { type?: unknown }).type ?? ''),
+              sz: parseFloat(String((r as { sz?: unknown }).sz ?? 'NaN')),
+              symbol: String((r as { symbol?: unknown }).symbol ?? ''),
+              cTimeMs: Number((r as { cTime?: unknown }).cTime),
             });
           }
-        } catch (fundingErr) {
-          logger.warn('[Monkey] /trade/funding fetch failed for full-net pnl', {
-            symbol, side,
-            err: fundingErr instanceof Error ? fundingErr.message : String(fundingErr),
-          });
+          cursor = String((rows[rows.length - 1] as { id?: unknown }).id ?? '') || null;
+          // Stop once the whole page predates the hold window.
+          if (rows.every((r) => Number((r as { cTime?: unknown }).cTime) < holdStartMs)) break;
+          if (!cursor) break;
         }
-      } else {
-        logger.warn('[Monkey] Polo full-net unavailable — missing entry_time for funding window', {
-          symbol, side, tradeIdsCount: tradeIds.length,
+        billsComplete = true;
+      } catch (billsErr) {
+        logger.warn('[Monkey] /account/bills fetch failed for authoritative reward pnl', {
+          symbol, side,
+          err: billsErr instanceof Error ? billsErr.message : String(billsErr),
+        });
+      }
+
+      const billsComp = composePoloBillsReward(billRows, {
+        symbol: normSymbol,
+        closeStartMs,
+        closeEndMs,
+        holdStartMs,
+        holdEndMs: closeTimeMs + 5_000,
+      });
+      const totalFundingFlows = billsComp.fundingSigned;
+      const fundingRows = billsComp.fundingRowCount;
+      const fundingComplete = billsComplete;
+
+      // Authoritative realized PnL is the bills PNL sum when rows matched;
+      // otherwise fall back to the synthetic per-row gross (e.g. bills not
+      // indexed yet) so a window miss never writes a spurious 0.
+      const useBillsRealized = billsComplete && billsComp.pnlRowCount > 0;
+      const authoritativeGross = useBillsRealized ? billsComp.realizedPnl : grossSum;
+      if (useBillsRealized && Math.abs(billsComp.realizedPnl - grossSum) > 0.01) {
+        logger.info('[Monkey] Polo-authoritative realized-from-bills vs synthetic gross', {
+          symbol, side,
+          billsRealized: billsComp.realizedPnl.toFixed(6),
+          syntheticGross: grossSum.toFixed(6),
+          delta: (billsComp.realizedPnl - grossSum).toFixed(6),
+          pnlRows: billsComp.pnlRowCount,
+        });
+      } else if (billsComplete && billsComp.pnlRowCount === 0) {
+        logger.warn('[Monkey] Polo-authoritative: no bills PNL rows matched close window; using synthetic gross', {
+          symbol, side, closeStartMs, closeEndMs, billRowCount: billRows.length,
         });
       }
 
@@ -9488,14 +9522,12 @@ export class MonkeyKernel extends EventEmitter {
         });
       }
 
-      // #1024 follow-up: pure-helper composition (testable in isolation).
-      // `totalFundingFlows` is the SIGNED sum of fundingFee per the
-      // canonical Polo convention (positive = received, negative = paid).
-      // The helper ADDS this signed value to compute pnl_net_full —
-      // correcting the prior `- totalFundingFlows` which inverted the
-      // direction (paid funding would have INCREASED net pnl).
+      // Pure-helper composition (testable in isolation). `grossSum` now
+      // carries the authoritative bills realized PnL; `fundingFlowsSigned`
+      // is the signed FUNDING_FEE sum (positive = received, negative =
+      // paid) — the helper ADDS it to compute pnl_net_full.
       const reward = computePoloAuthoritativeReward({
-        grossSum,
+        grossSum: authoritativeGross,
         totalCloseFees,
         totalOpenFees,
         openFeesComplete,
@@ -9508,6 +9540,9 @@ export class MonkeyKernel extends EventEmitter {
       logger.info('[Monkey] Polo-authoritative: reward-ledger pnl computed', {
         symbol, side,
         grossSum: grossSum.toFixed(4),
+        authoritativeGross: authoritativeGross.toFixed(4),
+        realizedSource: useBillsRealized ? 'bills_pnl' : 'synthetic_gross',
+        billsPnlRows: billsComp.pnlRowCount,
         totalCloseFees: totalCloseFees.toFixed(4),
         totalOpenFees: totalOpenFees.toFixed(4),
         totalFundingFlows: totalFundingFlows.toFixed(4),

--- a/apps/api/src/services/monkey/polo_reward_ledger.ts
+++ b/apps/api/src/services/monkey/polo_reward_ledger.ts
@@ -163,3 +163,80 @@ export function detectFundingSignDiscrepancies(
   }
   return out;
 }
+
+/**
+ * Authoritative realized-PnL + funding composition from `/v3/account/bills`
+ * (poloniex-trading-platform#1028).
+ *
+ * Poloniex account bills are literal USDT cash movements per row:
+ *   type 'PNL'         — realized price PnL of a close fill (signed `sz`)
+ *   type 'FUNDING_FEE' — funding cash flow (signed `sz`: + received, − paid)
+ *   type 'TRANSFER'    — deposits/withdrawals (NOT a trade outcome; excluded)
+ *
+ * Verified 2026-05-29 against the live polytrade-be account: summing the
+ * `type=PNL` rows over the close-fill window reconciles EXACTLY to the
+ * exchange-exported closed PnL (ETH −4.2499 from 8 rows; BTC −2.243525 from
+ * 4 rows). The prior path self-computed a synthetic per-row gross that
+ * under-counted (ETH reported −3.5568), and pulled funding from
+ * `/v3/trade/funding` — which does not exist (404). Funding lives in
+ * FUNDING_FEE bills.
+ *
+ * Bills carry no `ordId`, so PNL rows are matched by symbol + a tight cTime
+ * window around the close fills (PNL bill cTime == close fill cTime), and
+ * funding rows by the position hold window [entry, close].
+ */
+export interface PoloBillRow {
+  /** Bill type: 'PNL' | 'FUNDING_FEE' | 'TRANSFER' | ... */
+  type: string;
+  /** Signed USDT cash movement for this bill row. */
+  sz: number;
+  /** Normalized symbol, e.g. ETH_USDT_PERP. */
+  symbol: string;
+  /** Bill creation time in epoch ms. */
+  cTimeMs: number;
+}
+
+export interface PoloBillsComposition {
+  /** Σ of `type=PNL` `sz` within the close window — authoritative realized PnL. */
+  realizedPnl: number;
+  /** Σ of `type=FUNDING_FEE` `sz` within the hold window (+ received, − paid). */
+  fundingSigned: number;
+  /** Count of PNL rows matched (0 → caller must NOT trust realizedPnl; fall back). */
+  pnlRowCount: number;
+  /** Count of FUNDING_FEE rows matched. */
+  fundingRowCount: number;
+}
+
+export function composePoloBillsReward(
+  rows: PoloBillRow[],
+  opts: {
+    symbol: string;
+    /** Tight window around the close fills (inclusive, epoch ms). */
+    closeStartMs: number;
+    closeEndMs: number;
+    /** Position hold window for funding attribution (inclusive, epoch ms). */
+    holdStartMs: number;
+    holdEndMs: number;
+  },
+): PoloBillsComposition {
+  let realizedPnl = 0;
+  let fundingSigned = 0;
+  let pnlRowCount = 0;
+  let fundingRowCount = 0;
+  for (const r of rows) {
+    if (r.symbol !== opts.symbol) continue;
+    if (!Number.isFinite(r.sz) || !Number.isFinite(r.cTimeMs)) continue;
+    if (r.type === 'PNL' && r.cTimeMs >= opts.closeStartMs && r.cTimeMs <= opts.closeEndMs) {
+      realizedPnl += r.sz;
+      pnlRowCount += 1;
+    } else if (
+      r.type === 'FUNDING_FEE' &&
+      r.cTimeMs >= opts.holdStartMs &&
+      r.cTimeMs <= opts.holdEndMs
+    ) {
+      fundingSigned += r.sz;
+      fundingRowCount += 1;
+    }
+  }
+  return { realizedPnl, fundingSigned, pnlRowCount, fundingRowCount };
+}

--- a/apps/api/src/services/poloniexFuturesService.js
+++ b/apps/api/src/services/poloniexFuturesService.js
@@ -849,13 +849,11 @@ class PoloniexFuturesService {
     return this.getExecutionDetails(credentials, params);
   }
 
-  /**
-   * Get account funding history.
-   * Endpoint: GET /v3/trade/funding
-   */
-  async getFundingHistory(credentials, params = {}) {
-    return this.makeRequest(credentials, 'GET', '/trade/funding', null, params);
-  }
+  // NOTE: getFundingHistory was removed (#1028). It targeted
+  // `GET /v3/trade/funding`, which does not exist on Poloniex v3 (404 —
+  // confirmed live 2026-05-29). Funding cash flow is read from
+  // `GET /v3/account/bills` (type=FUNDING_FEE rows) via getAccountBills;
+  // realized PnL likewise comes from bills (type=PNL rows).
 
   /**
    * Close a position at market price.


### PR DESCRIPTION
Closes #1028.

## Problem
The Polo-authoritative reward path under-counted realized losses and could never reach full-net:
1. **Realized PnL was a synthetic per-row gross** (entry/exit/qty diff). On the 2026-05-29 ETH close it reported **−3.5568** vs the exchange's **−4.2499**.
2. **Funding came from `GET /v3/trade/funding`, which doesn't exist (404)** → `hasFullNet` was never true → permanent fallback to `polo_gross_minus_close_fees`.

## Verification (read-only, live `polytrade-be`)
Poloniex **account bills** are the authoritative cash ledger:
- `type=PNL` rows = per-fill realized PnL. Summed over the close window they reconcile **EXACTLY** to the exchange export: **ETH −4.249900 (8 rows), BTC −2.243525 (4 rows)**.
- `type=FUNDING_FEE` rows = signed funding cash (+ received / − paid).
- `type=TRANSFER` = deposits/withdrawals (excluded).

## Changes
- **polo_reward_ledger.ts** — new pure `composePoloBillsReward(rows, window)`: sums `PNL` in a tight window around the close fills' `cTime` (bills carry no `ordId`) and `FUNDING_FEE` over the hold window. Unit-tested with the exact reconciled fixtures.
- **loop.ts** (`applyPoloRealizedPnlAfterClose`) — fetch `/v3/account/bills` (paginated to the hold window), feed bills realized PnL as the authoritative `grossSum` and bills funding as `fundingFlowsSigned` (`fundingComplete` now achievable → **full-net reachable**). Falls back to synthetic gross only when **no** PNL rows match (e.g. not yet indexed) so a window miss never writes a spurious 0. Captures close-fill `cTime`s from the existing fee pass; adds a realized-from-bills vs synthetic-gross cross-check log + `realizedSource` telemetry.
- **poloniexFuturesService.js** — remove dead `getFundingHistory` (`/trade/funding` 404).

`computePoloAuthoritativeReward` is unchanged — its inputs are now authoritative.

## Tests
- New `polo_bills_reward.test.ts` (6) pins the exact reconciliation (−4.2499 / −2.24352466), funding sign, window/symbol/TRANSFER exclusion, and the `pnlRowCount=0` fallback contract.
- Existing `polo_reward_ledger_hardening.test.ts` (18) still green. tsc clean.

## Behavioural note
Losses will now register at their true (larger) magnitude in chemistry + `autonomous_trades.pnl` — this is the intended correctness fix (accurate exchange-authoritative reward), not a tuning change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)