### PR TITLE
feat(api): exemplar-observation channel ingress (#1033 PR1, dark/write-only)

### DIFF
--- a/apps/api/database/migrations/065_monkey_exemplar_decisions.sql
+++ b/apps/api/database/migrations/065_monkey_exemplar_decisions.sql
@@ -1,0 +1,51 @@
+-- 065_monkey_exemplar_decisions.sql
+--
+-- CC→kernel exemplar-observation channel (poloniex-trading-platform#1033).
+--
+-- Records the CC exemplar trader's per-cycle DECISION — including deliberate
+-- ABSTENTIONS (flat-by-choice in chop) — so the kernel can later OBSERVE
+-- "what good looks like" and, crucially, distinguish a deliberate stand-aside
+-- from mere absence. A trade-only channel can't teach restraint; a decision
+-- STREAM can (operator 2026-05-29: "how does the kernel learn you're holding
+-- flat and not just absent?").
+--
+-- STAGED ROLLOUT / safety (mirrors the 062 expectation-decision doctrine):
+--   * PR1 (this migration + ingress endpoint): WRITE-ONLY. No kernel reads it
+--     yet. Zero live-behaviour change.
+--   * PR2 (separate, FLAG-GATED): kernel consumes these rows as a witnessed-
+--     peer signal (raise entry bar where the exemplar abstained; reinforce
+--     where it won). That PR alters live decisions and rolls out behind a flag.
+--   * Writes are BEST-EFFORT: failure to record a decision MUST NEVER affect
+--     trading or safety. All non-key columns nullable.
+--
+-- References: #1033 (coupled exemplar⇄kernel loop), #1032 (rotation/expectancy),
+-- #1028 (authoritative reward), 062 (expectation-decision audit template).
+
+CREATE TABLE IF NOT EXISTS monkey_exemplar_decisions (
+  id            BIGSERIAL PRIMARY KEY,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Who produced the exemplar decision (bootstrap=Claude; future=gemma/ollama).
+  source        TEXT NOT NULL DEFAULT 'cc_bootstrap',
+  symbol        TEXT,
+  -- enter | hold | exit | abstain  (abstain = deliberate flat — first-class)
+  action        TEXT NOT NULL,
+  is_abstain    BOOLEAN NOT NULL DEFAULT FALSE,
+  side          TEXT,                 -- short | long | null (null on abstain)
+  conviction    FLOAT8,               -- 0..1 self-rated conviction
+  -- The exemplar's regime read (its own classification of the tape).
+  regime        TEXT,                 -- trend_up | trend_down | chop | ...
+  -- Kernel signals the exemplar OBSERVED this cycle (basinDir, tape, cell, ...).
+  kernel_signals JSONB,
+  price         FLOAT8,               -- mark price at decision time
+  reasoning     TEXT,                 -- why this decision (the teaching label)
+  -- Outcome, backfilled when the position the decision opened later closes.
+  outcome_pnl   FLOAT8,
+  outcome_r     FLOAT8,               -- realized R multiple (pnl / 1R risk)
+  CHECK (action IN ('enter', 'hold', 'exit', 'abstain'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_monkey_exemplar_decisions_symbol_time
+  ON monkey_exemplar_decisions (symbol, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_monkey_exemplar_decisions_recent
+  ON monkey_exemplar_decisions (created_at DESC);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,6 +23,7 @@ import governanceRoutes from './routes/governance.js';
 import marketsRoutes from './routes/markets.js';
 import mlRoutes from './routes/ml.js';
 import monitoringRoutes from './routes/monitoring.js';
+import monkeyExemplarRoutes from './routes/monkey-exemplar.js';
 import paperTradingRoutes from './routes/paper-trading.js';
 import proxyRoutes from './routes/proxy.js';
 import publicAdminRoutes from './routes/public-admin.js';
@@ -179,6 +180,7 @@ app.use('/api/agent', agentRoutes); // Autonomous trading agent routes
 app.use('/api/autonomous', autonomousTraderRoutes); // trade-history read (FAT control stripped 2026-05-21)
 app.use('/api/reconciliation', reconciliationRoutes); // State reconciliation service
 app.use('/api/monitoring', monitoringRoutes); // Monitoring and error tracking routes
+app.use('/api/monkey-exemplar', monkeyExemplarRoutes); // CC→kernel exemplar-observation ingress (#1033, dark/write-only)
 app.use('/api/governance', governanceRoutes); // Operator-facing kernel observability (sleep-state, parity logs)
 app.use('/api/admin', adminRoutes); // Admin routes for migrations
 app.use('/api/dashboard', dashboardRoutes); // Unified dashboard data endpoint

--- a/apps/api/src/routes/__tests__/monkey-exemplar.test.ts
+++ b/apps/api/src/routes/__tests__/monkey-exemplar.test.ts
@@ -1,0 +1,52 @@
+/**
+ * monkey-exemplar.test.ts — semantics of the exemplar decision normalizer
+ * (#1033 PR1). Pins the key teaching rule: ABSTAIN is a first-class, deliberate
+ * flat (side=null, is_abstain=true) — distinguishable from absence — and bad
+ * input is rejected.
+ */
+import { describe, expect, it } from 'vitest';
+import { normalizeExemplarDecision } from '../monkey-exemplar.js';
+
+describe('normalizeExemplarDecision', () => {
+  it('treats abstain as a first-class deliberate flat (side null, is_abstain true)', () => {
+    const r = normalizeExemplarDecision({ action: 'abstain', symbol: 'BTC_USDT_PERP', side: 'short', regime: 'chop', reasoning: 'low-vol grind, no 8R' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.action).toBe('abstain');
+    expect(r.value.isAbstain).toBe(true);
+    expect(r.value.side).toBeNull(); // abstain forces side null even if one was sent
+    expect(r.value.regime).toBe('chop');
+  });
+
+  it('keeps side on a directional entry and flags is_abstain false', () => {
+    const r = normalizeExemplarDecision({ action: 'enter', side: 'SHORT', conviction: 0.7, price: '73276.77' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.action).toBe('enter');
+    expect(r.value.isAbstain).toBe(false);
+    expect(r.value.side).toBe('short');
+    expect(r.value.conviction).toBe(0.7);
+    expect(r.value.price).toBeCloseTo(73276.77, 2);
+  });
+
+  it('rejects an invalid action', () => {
+    const r = normalizeExemplarDecision({ action: 'yolo' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('coerces non-finite numerics to null and defaults source', () => {
+    const r = normalizeExemplarDecision({ action: 'hold', conviction: 'NaN', price: undefined });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.conviction).toBeNull();
+    expect(r.value.price).toBeNull();
+    expect(r.value.source).toBe('cc_bootstrap');
+  });
+
+  it('coerces an unknown side to null on non-abstain', () => {
+    const r = normalizeExemplarDecision({ action: 'enter', side: 'sideways' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.side).toBeNull();
+  });
+});

--- a/apps/api/src/routes/monkey-exemplar.ts
+++ b/apps/api/src/routes/monkey-exemplar.ts
@@ -1,0 +1,147 @@
+/**
+ * monkey-exemplar.ts — ingress for the CC→kernel exemplar-observation channel
+ * (poloniex-trading-platform#1033, PR1: WRITE-ONLY / dark).
+ *
+ * The CC exemplar trader (bootstrap: Claude; future: Gemma/Ollama) POSTs its
+ * per-cycle DECISION here — including deliberate ABSTENTIONS — so the kernel
+ * can later observe "what good looks like" and tell a chosen stand-aside from
+ * absence. No kernel consumption yet; PR2 wires that behind a flag.
+ *
+ * Auth: shared secret `CC_EXEMPLAR_SECRET` via `x-exemplar-secret` header
+ * (constant-time compare), so the external exemplar can write without a user
+ * JWT. Writes are BEST-EFFORT and must never affect trading/safety.
+ */
+import express, { type Request, type Response } from 'express';
+import crypto from 'crypto';
+import { pool } from '../db/connection.js';
+import { logger } from '../utils/logger.js';
+
+const router = express.Router();
+
+const VALID_ACTIONS = ['enter', 'hold', 'exit', 'abstain'] as const;
+type ExemplarAction = (typeof VALID_ACTIONS)[number];
+
+export interface NormalizedExemplarDecision {
+  source: string;
+  symbol: string | null;
+  action: ExemplarAction;
+  isAbstain: boolean;
+  side: 'short' | 'long' | null;
+  conviction: number | null;
+  regime: string | null;
+  kernelSignals: unknown;
+  price: number | null;
+  reasoning: string | null;
+  outcomePnl: number | null;
+  outcomeR: number | null;
+}
+
+/**
+ * Pure validation/normalization of an exemplar decision payload. Kept pure so
+ * the decision SEMANTICS are unit-testable without a DB:
+ *   - action must be one of enter|hold|exit|abstain.
+ *   - abstain ALWAYS implies side=null and isAbstain=true (a deliberate flat,
+ *     not a directional bet) — this is what lets the kernel distinguish a
+ *     chosen stand-aside from absence.
+ *   - non-abstain MAY carry a side; side is coerced to short|long|null.
+ */
+export function normalizeExemplarDecision(
+  body: Record<string, unknown>,
+): { ok: true; value: NormalizedExemplarDecision } | { ok: false; error: string } {
+  const action = String(body.action ?? '').toLowerCase();
+  if (!VALID_ACTIONS.includes(action as ExemplarAction)) {
+    return { ok: false, error: `action must be one of ${VALID_ACTIONS.join('|')}` };
+  }
+  const isAbstain = action === 'abstain';
+  const rawSide = String(body.side ?? '').toLowerCase();
+  const side: 'short' | 'long' | null = isAbstain
+    ? null
+    : rawSide === 'short' || rawSide === 'long'
+      ? rawSide
+      : null;
+  const num = (v: unknown): number | null => {
+    if (v === undefined || v === null || v === '') return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  };
+  return {
+    ok: true,
+    value: {
+      source: typeof body.source === 'string' && body.source.length > 0 ? body.source : 'cc_bootstrap',
+      symbol: typeof body.symbol === 'string' && body.symbol.length > 0 ? body.symbol : null,
+      action: action as ExemplarAction,
+      isAbstain,
+      side,
+      conviction: num(body.conviction),
+      regime: typeof body.regime === 'string' ? body.regime : null,
+      kernelSignals: body.kernelSignals ?? null,
+      price: num(body.price),
+      reasoning: typeof body.reasoning === 'string' ? body.reasoning : null,
+      outcomePnl: num(body.outcomePnl),
+      outcomeR: num(body.outcomeR),
+    },
+  };
+}
+
+function validSecret(provided: string | undefined): boolean {
+  const expected = process.env.CC_EXEMPLAR_SECRET?.trim();
+  if (!expected || expected === 'CHANGE_ME') return false;
+  if (!provided) return false;
+  const a = Buffer.from(provided, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+router.post('/observe', async (req: Request, res: Response) => {
+  if (!validSecret(req.header('x-exemplar-secret'))) {
+    return res.status(401).json({ ok: false, error: 'unauthorized' });
+  }
+  const norm = normalizeExemplarDecision((req.body ?? {}) as Record<string, unknown>);
+  if (norm.ok === false) return res.status(400).json({ ok: false, error: norm.error });
+  const d = norm.value;
+  try {
+    const result = await pool.query<{ id: string }>(
+      `INSERT INTO monkey_exemplar_decisions
+         (source, symbol, action, is_abstain, side, conviction, regime,
+          kernel_signals, price, reasoning, outcome_pnl, outcome_r)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+       RETURNING id`,
+      [
+        d.source, d.symbol, d.action, d.isAbstain, d.side, d.conviction, d.regime,
+        d.kernelSignals === null ? null : JSON.stringify(d.kernelSignals),
+        d.price, d.reasoning, d.outcomePnl, d.outcomeR,
+      ],
+    );
+    return res.json({ ok: true, id: result.rows[0]?.id ?? null });
+  } catch (err) {
+    // Best-effort: never block the exemplar's loop on a write failure.
+    logger.warn('[exemplar] observe insert failed (non-fatal)', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return res.status(200).json({ ok: false, error: 'write_failed_noop' });
+  }
+});
+
+router.get('/recent', async (req: Request, res: Response) => {
+  if (!validSecret(req.header('x-exemplar-secret'))) {
+    return res.status(401).json({ ok: false, error: 'unauthorized' });
+  }
+  const symbol = typeof req.query.symbol === 'string' ? req.query.symbol : null;
+  const limit = Math.min(Number(req.query.limit) || 20, 200);
+  try {
+    const result = symbol
+      ? await pool.query(
+          `SELECT * FROM monkey_exemplar_decisions WHERE symbol = $1 ORDER BY created_at DESC LIMIT $2`,
+          [symbol, limit],
+        )
+      : await pool.query(
+          `SELECT * FROM monkey_exemplar_decisions ORDER BY created_at DESC LIMIT $1`,
+          [limit],
+        );
+    return res.json({ ok: true, rows: result.rows });
+  } catch (err) {
+    return res.status(200).json({ ok: false, error: 'read_failed', rows: [] });
+  }
+});
+
+export default router;


### PR DESCRIPTION
Part of #1033 (coupled CC⇄kernel feedback loop). **PR1 = the write-only foundation; zero live-behaviour change.**

## Why
For the kernel to learn "what good looks like" from the CC exemplar trader, it must OBSERVE the exemplar's *decisions* — including deliberate **ABSTENTIONS** (flat-by-choice in chop). A trade-only signal can't teach restraint; the kernel can't tell a chosen stand-aside from absence. So this is a **decision stream**, abstain is first-class.

## What
- **migration 065** — `monkey_exemplar_decisions`: per-cycle decisions (`enter|hold|exit|abstain`) + regime, observed `kernel_signals` (basinDir/tape/cell), conviction, reasoning, backfillable `outcome_pnl/outcome_r`. Best-effort/nullable (never blocks trading) per the 062 template. Auto-applies on deploy.
- **routes/monkey-exemplar.ts** — `POST /api/monkey-exemplar/observe` (shared-secret `CC_EXEMPLAR_SECRET`, constant-time) + `GET /recent`. Insert best-effort (write failure → 200 noop, never throws into the exemplar's loop).
- **normalizeExemplarDecision()** — pure validator: abstain forces `side=null`/`is_abstain=true`, invalid actions rejected, numerics coerced. 5 semantic unit tests.

## Not in this PR (staged)
PR2 (FLAG-GATED) wires the kernel to **consume** these rows as a witnessed-peer signal — raise the entry bar where the exemplar abstained, reinforce where it won. That's the part that alters live trading; it rolls out behind a flag with the loop's damping (1:8 rotation #1032, Ocean regulation). Built/validated separately, ideally with operator watching first ticks.

tsc clean; 5/5 normalizer tests green. Relates #1032, #1028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)