### PR TITLE
feat(monkey-rotation): expectancy membership as CAPITAL FIREWALL — paper routes capital only, kernel stays blind (#1032)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/kernelRotationExpectancy.test.ts
+++ b/apps/api/src/services/monkey/__tests__/kernelRotationExpectancy.test.ts
@@ -284,6 +284,24 @@ describe('expectancy promotion gate — issue #1032 gap 2 (WR not enough)', () =
     const reason = shouldAutoPromote(s, peers, true);
     expect(reason).toBeNull();
   });
+
+  it('FLAG ON: a PURE-BLEED candidate (losses, no wins → Infinity ratio) is NOT promoted, even in a weak/bleeding cohort (Copilot #1035)', () => {
+    // Regression for the Infinity-vs-NaN ratio-gate bug: lossWinRatio is
+    // Infinity for losses-but-no-wins (worst case). A prior
+    // `!Number.isFinite(...)` check treated Infinity like the benign NaN
+    // (no-data) case and let it bypass the ratio gate — so a pure-bleed
+    // paper kernel could re-promote into a weak cohort. Construct exactly
+    // that: candidate clears the WR + expectancy-band gates against a
+    // bleeding cohort, and MUST still be blocked by the ratio gate.
+    const s = paperCandidate([-1, -1, -1, -1, -1, -1, -1, -1, -1, -1]); // WR 0, edge -1
+    const cand = rollingExpectancy(s);
+    expect(cand.lossWinRatio).toBe(Number.POSITIVE_INFINITY); // pure bleed
+    // Bleeding cohort: best-live WR 0.05 (so WR 0 ≥ 0.05−0.10 passes) and
+    // expectancy −1 (so candidate −1 is within the 10% band).
+    const peers = [livePeer(-1.0, 5.0, { winRate: 0.05 })];
+    const reason = shouldAutoPromote(s, peers, /*expectancyLive*/ true);
+    expect(reason).toBeNull(); // blocked by the ratio gate (Infinity fails it)
+  });
 });
 
 /**

--- a/apps/api/src/services/monkey/__tests__/kernelRotationExpectancy.test.ts
+++ b/apps/api/src/services/monkey/__tests__/kernelRotationExpectancy.test.ts
@@ -1,0 +1,284 @@
+/**
+ * kernelRotationExpectancy.test.ts — issue #1032.
+ *
+ * The 5-consecutive-loss breaker catches ACUTE streaks but misses
+ * CHRONIC negative-expectancy: a ~50%-WR kernel with tiny wins between
+ * large losses never reaches 5-in-a-row, yet bleeds. And the WR-only
+ * promotion gate lets a high-WR / negative-EV kernel back in. This
+ * suite pins:
+ *   - rollingExpectancy math (winRate / avgWin / avgLoss / lossWinRatio / edge)
+ *   - chronic expectancy demote (flag ON): neg-EV bleeder demotes even
+ *     though it never hits 5 consecutive losses
+ *   - high-WR / neg-EV demote (WR alone would not catch it)
+ *   - promotion requires BOTH within-band expectancy AND loss:win
+ *     trending to 1:8
+ *   - flag OFF → behaviour identical to legacy (regression-pin)
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyChronicDemote,
+  expectancyLiveEnabled,
+  makeRotationState,
+  recordClose,
+  rollingExpectancy,
+  shouldAutoPromote,
+  shouldChronicDemote,
+  ROTATION_EXPECTANCY_BAND,
+  ROTATION_TARGET_LOSS_WIN_RATIO,
+  ROTATION_WR_MIN_SAMPLES,
+  type RotationPeerSnapshot,
+  type RotationState,
+} from '../kernel_rotation.js';
+
+/** Build a state with an explicit PnL window (no streak side-effects). */
+function stateWithPnls(pnls: number[], mode: 'live' | 'paper' = 'live'): RotationState {
+  const s = makeRotationState();
+  s.mode = mode;
+  s.rollingPnls = [...pnls];
+  return s;
+}
+
+/** A live peer snapshot carrying expectancy + loss:win ratio. */
+function livePeer(
+  expectancy: number,
+  lossWinRatio: number,
+  opts: { winRate?: number; n?: number } = {},
+): RotationPeerSnapshot {
+  return {
+    mode: 'live',
+    rollingWinRate: opts.winRate ?? 0.5,
+    rollingSampleCount: opts.n ?? ROTATION_WR_MIN_SAMPLES,
+    rollingExpectancy: expectancy,
+    rollingLossWinRatio: lossWinRatio,
+  };
+}
+
+describe('rollingExpectancy', () => {
+  it('returns NaN edge on an empty window', () => {
+    const e = rollingExpectancy(makeRotationState());
+    expect(e.sampleCount).toBe(0);
+    expect(e.edge).toBeNaN();
+    expect(e.winRate).toBeNaN();
+    expect(e.lossWinRatio).toBeNaN();
+  });
+
+  it('computes winRate, avgWin, signed avgLoss, lossWinRatio and edge', () => {
+    // 2 wins of +1, 2 losses of -4. WR=0.5, avgWin=1, avgLoss=-4.
+    const e = rollingExpectancy(stateWithPnls([+1, -4, +1, -4]));
+    expect(e.winRate).toBeCloseTo(0.5, 9);
+    expect(e.avgWin).toBeCloseTo(1, 9);
+    expect(e.avgLoss).toBeCloseTo(-4, 9);
+    expect(e.lossWinRatio).toBeCloseTo(4, 9); // |avgLoss|/avgWin
+    // edge = 0.5*1 - 0.5*4 = -1.5
+    expect(e.edge).toBeCloseTo(-1.5, 9);
+  });
+
+  it('treats zero-pnl as a loss (matches streak semantics)', () => {
+    const e = rollingExpectancy(stateWithPnls([+2, 0]));
+    expect(e.winRate).toBeCloseTo(0.5, 9);
+    expect(e.avgLoss).toBeCloseTo(0, 9); // the single "loss" is 0
+  });
+
+  it('lossWinRatio is +Infinity when there are losses but no wins', () => {
+    const e = rollingExpectancy(stateWithPnls([-1, -2, -3]));
+    expect(e.lossWinRatio).toBe(Number.POSITIVE_INFINITY);
+    expect(e.winRate).toBeCloseTo(0, 9);
+  });
+
+  it('lossWinRatio is NaN when there are no losses (cannot rank)', () => {
+    const e = rollingExpectancy(stateWithPnls([+1, +2, +3]));
+    expect(e.lossWinRatio).toBeNaN();
+    expect(e.winRate).toBeCloseTo(1, 9);
+  });
+
+  it('positive-edge kernel: many small wins beat rare small losses', () => {
+    // 8 wins of +1, 2 losses of -1. edge = 0.8*1 - 0.2*1 = +0.6
+    const e = rollingExpectancy(stateWithPnls([+1, +1, +1, +1, +1, +1, +1, +1, -1, -1]));
+    expect(e.edge).toBeCloseTo(0.6, 9);
+    expect(e.lossWinRatio).toBeCloseTo(1, 9);
+  });
+});
+
+describe('expectancyLiveEnabled — flag gate', () => {
+  it('is OFF when the env var is unset', () => {
+    expect(expectancyLiveEnabled({})).toBe(false);
+  });
+  it('is OFF for any value other than exactly "true"', () => {
+    expect(expectancyLiveEnabled({ MONKEY_ROTATION_EXPECTANCY_LIVE: 'TRUE' })).toBe(false);
+    expect(expectancyLiveEnabled({ MONKEY_ROTATION_EXPECTANCY_LIVE: '1' })).toBe(false);
+    expect(expectancyLiveEnabled({ MONKEY_ROTATION_EXPECTANCY_LIVE: 'false' })).toBe(false);
+  });
+  it('is ON only for exactly "true"', () => {
+    expect(expectancyLiveEnabled({ MONKEY_ROTATION_EXPECTANCY_LIVE: 'true' })).toBe(true);
+  });
+});
+
+describe('chronic expectancy demote — issue #1032 gap 1 (chronic neg-EV)', () => {
+  it('demotes a ~50%-WR bleeder that NEVER hits 5 consecutive losses', () => {
+    // Interleave tiny win / large loss so the consecutive-loss streak
+    // never reaches the threshold, yet expectancy is deeply negative.
+    const s = makeRotationState();
+    for (let i = 0; i < ROTATION_WR_MIN_SAMPLES; i++) {
+      recordClose(s, i % 2 === 0 ? +0.1 : -2.0);
+    }
+    // Sanity: the acute breaker never fired (streak resets on each win).
+    expect(s.mode).toBe('live');
+    expect(s.consecutiveLosses).toBeLessThan(5);
+
+    const e = rollingExpectancy(s);
+    expect(e.edge).toBeLessThan(0); // genuinely negative-EV
+
+    // A healthy live peer with strongly positive expectancy.
+    const peers = [livePeer(+0.5, ROTATION_TARGET_LOSS_WIN_RATIO)];
+    const reason = shouldChronicDemote(s, peers, /*expectancyLive*/ true);
+    expect(reason).not.toBeNull();
+    expect(reason).toContain('chronic-demote');
+
+    const res = applyChronicDemote(s, peers, true);
+    expect(res.demoted).toBe(true);
+    expect(s.mode).toBe('paper');
+    expect(s.lastDemotionAtMs).not.toBeNull();
+  });
+
+  it('does NOT demote a kernel within band of the best live peer', () => {
+    // Candidate edge ~ +0.45; best live ~ +0.5; band 10% of 0.5 = 0.05.
+    // 0.5 - 0.45 = 0.05 ≤ 0.05 → within band → stays live.
+    const s = stateWithPnls([+1, +1, +1, +1, +1, +1, +1, -0.5, -0.5, -0.5]);
+    const e = rollingExpectancy(s);
+    expect(e.edge).toBeGreaterThan(0);
+    const best = e.edge / (1 - ROTATION_EXPECTANCY_BAND) + 1e-9; // just outside? keep within
+    const peers = [livePeer(e.edge + ROTATION_EXPECTANCY_BAND * Math.abs(e.edge), 1)];
+    void best;
+    const reason = shouldChronicDemote(s, peers, true);
+    expect(reason).toBeNull();
+  });
+
+  it('high-WR / neg-EV kernel demotes (WR alone would NOT catch it)', () => {
+    // 80% WR but tiny wins and one catastrophic loss → negative edge.
+    // 8 wins of +0.1 (sum 0.8), 2 losses of -3 (sum -6).
+    // edge = 0.8*0.1 - 0.2*3 = 0.08 - 0.6 = -0.52.
+    const s = stateWithPnls([+0.1, +0.1, +0.1, +0.1, +0.1, +0.1, +0.1, +0.1, -3, -3]);
+    const e = rollingExpectancy(s);
+    expect(e.winRate).toBeCloseTo(0.8, 9); // looks great on WR
+    expect(e.edge).toBeLessThan(0);        // but bleeds money
+
+    const peers = [livePeer(+0.4, ROTATION_TARGET_LOSS_WIN_RATIO)];
+    const reason = shouldChronicDemote(s, peers, true);
+    expect(reason).not.toBeNull();
+  });
+
+  it('does NOT demote before ROTATION_WR_MIN_SAMPLES (no demote on noise)', () => {
+    const s = stateWithPnls([-5, +0.1, -5]); // awful but only 3 samples
+    const peers = [livePeer(+0.5, ROTATION_TARGET_LOSS_WIN_RATIO)];
+    expect(shouldChronicDemote(s, peers, true)).toBeNull();
+  });
+
+  it('does NOT demote when no informative live peer exists (no benchmark)', () => {
+    const s = stateWithPnls([-5, +0.1, -5, +0.1, -5, +0.1, -5, +0.1, -5, +0.1]);
+    const peers: RotationPeerSnapshot[] = [
+      { mode: 'paper', rollingWinRate: 0.5, rollingSampleCount: 50, rollingExpectancy: 1 },
+      { mode: 'live', rollingWinRate: 0.5, rollingSampleCount: ROTATION_WR_MIN_SAMPLES - 1, rollingExpectancy: 1 },
+    ];
+    expect(shouldChronicDemote(s, peers, true)).toBeNull();
+  });
+});
+
+describe('chronic expectancy demote — FLAG OFF regression pin', () => {
+  it('shouldChronicDemote ALWAYS returns null when flag is off', () => {
+    const s = stateWithPnls([-5, +0.1, -5, +0.1, -5, +0.1, -5, +0.1, -5, +0.1]);
+    const peers = [livePeer(+1.0, ROTATION_TARGET_LOSS_WIN_RATIO)];
+    expect(shouldChronicDemote(s, peers, /*expectancyLive*/ false)).toBeNull();
+  });
+
+  it('applyChronicDemote is a no-op (no mode change) when flag is off', () => {
+    const s = stateWithPnls([-5, +0.1, -5, +0.1, -5, +0.1, -5, +0.1, -5, +0.1]);
+    const peers = [livePeer(+1.0, ROTATION_TARGET_LOSS_WIN_RATIO)];
+    const res = applyChronicDemote(s, peers, false);
+    expect(res.demoted).toBe(false);
+    expect(s.mode).toBe('live');
+    expect(s.lastDemotionAtMs).toBeNull();
+  });
+});
+
+describe('expectancy promotion gate — issue #1032 gap 2 (WR not enough)', () => {
+  // Helper: a paper candidate with a chosen PnL window.
+  function paperCandidate(pnls: number[]): RotationState {
+    return stateWithPnls(pnls, 'paper');
+  }
+
+  it('FLAG OFF: promotion uses WR only (legacy regression pin)', () => {
+    // High WR, but loss:win ratio terrible (neg-EV). With the flag off
+    // the legacy WR-only gate still promotes — pinning that the default
+    // path is unchanged.
+    const s = paperCandidate([+0.1, +0.1, +0.1, +0.1, +0.1, +0.1, +0.1, +0.1, -3, -3]); // 80% WR
+    const peers = [livePeer(+0.4, ROTATION_TARGET_LOSS_WIN_RATIO, { winRate: 0.6 })];
+    const reason = shouldAutoPromote(s, peers, /*expectancyLive*/ false);
+    expect(reason).not.toBeNull();
+    expect(reason).toContain('rolling WR');
+  });
+
+  it('FLAG ON: high-WR / neg-EV candidate is BLOCKED (expectancy gate)', () => {
+    // Same 80% WR neg-EV candidate. With the flag on, the expectancy +
+    // loss:win gates block promotion even though WR passes.
+    const s = paperCandidate([+0.1, +0.1, +0.1, +0.1, +0.1, +0.1, +0.1, +0.1, -3, -3]);
+    const peers = [livePeer(+0.4, ROTATION_TARGET_LOSS_WIN_RATIO, { winRate: 0.6 })];
+    const reason = shouldAutoPromote(s, peers, /*expectancyLive*/ true);
+    expect(reason).toBeNull();
+  });
+
+  it('FLAG ON: promotes only when expectancy in-band AND loss:win trending to 1:8', () => {
+    // Candidate: 8 wins of +1, 2 losses of -1 → edge +0.6, loss:win 1.0.
+    const s = paperCandidate([+1, +1, +1, +1, +1, +1, +1, +1, -1, -1]);
+    const cand = rollingExpectancy(s);
+    expect(cand.edge).toBeCloseTo(0.6, 9);
+    expect(cand.lossWinRatio).toBeCloseTo(1, 9);
+
+    // Best live peer: same expectancy (within band trivially) and a
+    // loose loss:win ratio (1.5) so the candidate's 1.0 is ≤ the peer's
+    // bar → ratio trending toward target relative to cohort.
+    const peers = [
+      livePeer(0.6, 1.5, { winRate: 0.8 }),
+    ];
+    const reason = shouldAutoPromote(s, peers, true);
+    expect(reason).not.toBeNull();
+    expect(reason).toContain('auto-promotion(expectancy)');
+  });
+
+  it('FLAG ON: BLOCKED when expectancy in-band but loss:win WORSE than cohort and above target', () => {
+    // Candidate edge ~ best, but loss:win = 4 (above 1:8 target AND
+    // above the peer's tighter 1.5 bar) → blocked.
+    // 5 wins +4 (sum 20), 5 losses -4 (sum -20): WR .5, edge 0, lw=1 -> need worse.
+    // Use: 9 wins +1 (sum 9) 1 loss -9 → WR .9 edge 0, lw = 9.
+    const s = paperCandidate([+1, +1, +1, +1, +1, +1, +1, +1, +1, -9]);
+    const cand = rollingExpectancy(s);
+    expect(cand.edge).toBeCloseTo(0, 6);
+    expect(cand.lossWinRatio).toBeCloseTo(9, 6);
+    // Peer edge 0 (within band), peer loss:win tight (1.0). Candidate 9 > 1 and > target → blocked.
+    const peers = [livePeer(0, 1.0, { winRate: 0.6 })];
+    const reason = shouldAutoPromote(s, peers, true);
+    expect(reason).toBeNull();
+  });
+
+  it('FLAG ON: candidate with loss:win at/under the 1:8 target passes the ratio bar outright', () => {
+    // 9 wins of +1 (sum 9), 1 loss of -0.1 → loss:win = 0.1 ≤ 0.125 target.
+    const s = paperCandidate([+1, +1, +1, +1, +1, +1, +1, +1, +1, -0.1]);
+    const cand = rollingExpectancy(s);
+    expect(cand.lossWinRatio).toBeLessThanOrEqual(ROTATION_TARGET_LOSS_WIN_RATIO);
+    // Peer with within-band expectancy and a TIGHT ratio (0.05); the
+    // candidate's 0.1 is worse than the peer but still ≤ the 1:8 target,
+    // so the outright-target arm passes.
+    const peers = [livePeer(cand.edge, 0.05, { winRate: 0.9 })];
+    const reason = shouldAutoPromote(s, peers, true);
+    expect(reason).not.toBeNull();
+  });
+
+  it('FLAG ON: still respects the legacy WR gate (WR too far below best blocks)', () => {
+    // Low-WR candidate far below the best live WR is blocked before the
+    // expectancy gate is even reached.
+    const s = paperCandidate([+5, -1, -1, -1, -1, -1, -1, -1, -1, -1]); // WR 0.1
+    const peers = [livePeer(0.5, ROTATION_TARGET_LOSS_WIN_RATIO, { winRate: 0.9 })];
+    const reason = shouldAutoPromote(s, peers, true);
+    expect(reason).toBeNull();
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/kernelRotationExpectancy.test.ts
+++ b/apps/api/src/services/monkey/__tests__/kernelRotationExpectancy.test.ts
@@ -20,11 +20,14 @@ import {
   applyChronicDemote,
   expectancyLiveEnabled,
   makeRotationState,
+  promoteToLive,
   recordClose,
   rollingExpectancy,
+  rollingWinRate,
   shouldAutoPromote,
   shouldChronicDemote,
   ROTATION_EXPECTANCY_BAND,
+  ROTATION_LOSS_STREAK_THRESHOLD,
   ROTATION_TARGET_LOSS_WIN_RATIO,
   ROTATION_WR_MIN_SAMPLES,
   type RotationPeerSnapshot,
@@ -280,5 +283,141 @@ describe('expectancy promotion gate — issue #1032 gap 2 (WR not enough)', () =
     const peers = [livePeer(0.5, ROTATION_TARGET_LOSS_WIN_RATIO, { winRate: 0.9 })];
     const reason = shouldAutoPromote(s, peers, true);
     expect(reason).toBeNull();
+  });
+});
+
+/**
+ * CAPITAL-FIREWALL PURITY — the firewall must be a pure capital-routing
+ * filter. Demotion/promotion may flip ONLY the routing/mode state; they
+ * must NOT alter the kernel's decision inputs or its reward/chemistry
+ * path. The kernel is blind to paper-vs-live.
+ *
+ * The rotation module's surface only ever receives a RotationState (+
+ * peer snapshots). The "cognition-relevant" data the kernel learns from
+ * is its rolling outcome window (state.rollingPnls) — the same window
+ * the loop builds reward/chemistry from. These tests pin that the
+ * firewall transitions touch ONLY {mode, lastDemotionAtMs,
+ * lastTransitionReason} (and the streak counter on promote, which is
+ * itself firewall bookkeeping) and leave the learning window — and any
+ * object the caller did NOT pass in — untouched.
+ *
+ * STRUCTURAL GUARANTEE this leans on: the functions cannot reach a
+ * decision input or the reward push because those are never passed to
+ * them. The reward is computed + pushed in loop.ts BEFORE rotation is
+ * touched; rotation receives only the already-realized PnL number.
+ */
+describe('capital-firewall purity — kernel cognition is blind to routing', () => {
+  /** Deep-ish snapshot of the learning-relevant window. */
+  function learningSnapshot(s: RotationState) {
+    return {
+      rollingPnls: [...s.rollingPnls],
+      rollingWinRate: rollingWinRate(s),
+      rollingExpectancy: rollingExpectancy(s).edge,
+    };
+  }
+
+  it('acute demote flips ONLY routing/mode state — learning window is byte-identical', () => {
+    const s = makeRotationState();
+    // Seed a window, then drive 5 consecutive losses to trip the breaker.
+    for (let i = 0; i < ROTATION_WR_MIN_SAMPLES; i++) recordClose(s, +1);
+    const before = learningSnapshot(s);
+    expect(s.mode).toBe('live');
+
+    let demoted = false;
+    for (let i = 0; i < ROTATION_LOSS_STREAK_THRESHOLD; i++) {
+      const r = recordClose(s, -1);
+      demoted = demoted || r.demoted;
+    }
+    expect(demoted).toBe(true);
+    expect(s.mode).toBe('paper'); // routing flipped...
+
+    const after = learningSnapshot(s);
+    // ...but the learning window only GREW by the closes we fed it; the
+    // demotion itself injected nothing and rewrote nothing. The window
+    // is exactly [before + the 5 losses we recorded].
+    expect(after.rollingPnls).toEqual([...before.rollingPnls, -1, -1, -1, -1, -1]);
+    // Win-rate / expectancy reflect ONLY the recorded closes, not the
+    // mode flip — the firewall does not perturb the learning signal.
+    const independent = makeRotationState();
+    for (const p of after.rollingPnls) recordClose(independent, p);
+    expect(rollingWinRate(s)).toBe(rollingWinRate(independent));
+    expect(rollingExpectancy(s).edge).toBe(rollingExpectancy(independent).edge);
+  });
+
+  it('chronic demote mutates ONLY {mode, lastDemotionAtMs, lastTransitionReason} — never the learning window', () => {
+    // A genuine neg-EV bleeder so the chronic gate fires under the flag.
+    const s = stateWithPnls(
+      [+0.1, -2, +0.1, -2, +0.1, -2, +0.1, -2, +0.1, -2],
+      'live',
+    );
+    const peers = [livePeer(+0.5, ROTATION_TARGET_LOSS_WIN_RATIO)];
+    const beforeWindow = [...s.rollingPnls];
+    const beforeLearn = learningSnapshot(s);
+
+    const res = applyChronicDemote(s, peers, /*expectancyLive*/ true, 123456);
+    expect(res.demoted).toBe(true);
+
+    // Routing/bookkeeping changed:
+    expect(s.mode).toBe('paper');
+    expect(s.lastDemotionAtMs).toBe(123456);
+    expect(s.lastTransitionReason).toContain('chronic-demote');
+
+    // Learning window + derived learning signal are UNCHANGED — the
+    // firewall read the window but did not write to it.
+    expect(s.rollingPnls).toEqual(beforeWindow);
+    expect(rollingWinRate(s)).toBe(beforeLearn.rollingWinRate);
+    expect(rollingExpectancy(s).edge).toBe(beforeLearn.rollingExpectancy);
+  });
+
+  it('chronic demote does NOT touch the consecutive-loss counter (acute breaker independent)', () => {
+    const s = stateWithPnls(
+      [+0.1, -2, +0.1, -2, +0.1, -2, +0.1, -2, +0.1, -2],
+      'live',
+    );
+    s.consecutiveLosses = 2; // mid-streak
+    const peers = [livePeer(+0.5, ROTATION_TARGET_LOSS_WIN_RATIO)];
+    applyChronicDemote(s, peers, true);
+    // The chronic firewall path leaves the acute streak counter alone —
+    // it is a separate routing criterion, not a cognition mutation.
+    expect(s.consecutiveLosses).toBe(2);
+  });
+
+  it('promotion flips routing back to live without injecting outcomes into the learning window', () => {
+    const s = stateWithPnls(
+      [+1, +1, +1, +1, +1, +1, +1, +1, -1, -1],
+      'paper',
+    );
+    const beforeWindow = [...s.rollingPnls];
+    const beforeWR = rollingWinRate(s);
+    const beforeEdge = rollingExpectancy(s).edge;
+
+    const res = promoteToLive(s, 'test-promote');
+    expect(res.promoted).toBe(true);
+    expect(s.mode).toBe('live'); // routing flipped back
+
+    // Promotion resets the firewall's own streak bookkeeping but injects
+    // NO synthetic outcome — the learning window and signal are intact.
+    expect(s.consecutiveLosses).toBe(0);
+    expect(s.rollingPnls).toEqual(beforeWindow);
+    expect(rollingWinRate(s)).toBe(beforeWR);
+    expect(rollingExpectancy(s).edge).toBe(beforeEdge);
+  });
+
+  it('a paper-mode kernel and an identical live-mode kernel learn IDENTICALLY from the same closes', () => {
+    // The decisive blindness pin: feed the exact same outcome stream to
+    // a live kernel and a paper-routed kernel. Their learning windows
+    // and derived signals must be bit-identical — mode does not enter
+    // the learning math at all.
+    const live = makeRotationState();
+    const paper = makeRotationState();
+    paper.mode = 'paper';
+    const stream = [+1, -1, +2, -0.5, +0.3, -3, +1.2, -0.1, +0.9, -2];
+    for (const p of stream) {
+      recordClose(live, p);
+      recordClose(paper, p);
+    }
+    expect(paper.rollingPnls).toEqual(live.rollingPnls);
+    expect(rollingWinRate(paper)).toBe(rollingWinRate(live));
+    expect(rollingExpectancy(paper).edge).toBe(rollingExpectancy(live).edge);
   });
 });

--- a/apps/api/src/services/monkey/kernel_rotation.ts
+++ b/apps/api/src/services/monkey/kernel_rotation.ts
@@ -1,6 +1,55 @@
 /**
- * kernel_rotation.ts — per-kernel live/paper state machine.
+ * kernel_rotation.ts — per-kernel live/paper CAPITAL FIREWALL.
  *
+ * ============================================================
+ * WHAT THIS IS (and what it is NOT)
+ * ============================================================
+ * This module is a CAPITAL-ROUTING FIREWALL, not a behavioural knob.
+ * Its single job is to decide whether a given kernel's orders reach
+ * LIVE money or get diverted to the paper simulator. It does NOT
+ * change how the kernel thinks, decides, or learns.
+ *
+ *   • The kernel is BLIND to its own paper/live routing. Nothing in
+ *     the per-tick decision path reads rotation `mode`. The kernel
+ *     keeps ticking, keeps perceiving, keeps deciding, and keeps
+ *     learning (chemistry / reward) IDENTICALLY whether it is routed
+ *     to live or to paper.
+ *   • Demotion to paper is purely a capital-routing decision: it
+ *     removes the kernel's OUTPUT from live money. It does not gate,
+ *     suppress, or alter the kernel's cognition or its reward push.
+ *   • The reward / chemistry signal is computed and pushed BEFORE the
+ *     rotation state is touched (see loop.ts processCloseReward). The
+ *     firewall therefore cannot starve or distort learning.
+ *
+ * Mental model: this is the breaker panel between the kernel's
+ * decisions and the exchange — not part of the kernel's brain.
+ *
+ * ============================================================
+ * ROUTING-OWNERSHIP INVARIANT (critical — read before extending)
+ * ============================================================
+ * TS (apps/api/src/services/monkey/loop.ts) is the SOLE live
+ * order-router. Live orders flow through `MonkeyKernel.shouldRoute-
+ * OrdersToPaper()` → `paperPlaceOrder` (paper) or the real exchange
+ * (live). Because that single gate consults this rotation state, the
+ * firewall is COMPLETE on the TS side.
+ *
+ * The Python side (ml-worker `poloniex_v3.PoloniexV3Client.place_order`)
+ * is an UNWIRED capability: verified 2026-05-29 there is NO caller in
+ * `ml-worker/src/monkey_kernel/` or `main.py` — the only reference is
+ * the usage example in the client's own docstring. The Python kernel
+ * is a consensus/advisory peer; it does not execute orders.
+ *
+ *   ⚠ GUARD-NOTE: if Python execution is EVER wired into the live
+ *     order path, it MUST consult the same per-kernel live/paper
+ *     rotation state (or an authoritative mirror of it) before placing
+ *     an order. Otherwise the firewall LEAKS: a kernel demoted to
+ *     paper on the TS side could still commit live capital via the
+ *     Python path. Treat the rotation `mode` as the single source of
+ *     truth for "does this kernel's output reach live money".
+ *
+ * ============================================================
+ * BEHAVIOUR (the demote/promote rules)
+ * ============================================================
  * The pre-cutover system the operator described (2026-05-25):
  *
  *   "the most successful kernel was allocated more over time. kernels
@@ -10,23 +59,19 @@
  *    paper and backtesting also."
  *
  * This module implements the LIVE/PAPER state machine + the
- * 5-consecutive-loss demotion trigger. Auto-promotion (paper WR within
- * 10% of best live kernel) is queued for the follow-up PR — it
- * requires virtual position simulation so a paper-mode kernel can
- * accumulate simulated closes to compare against the live registry.
- * Until that lands, paper-mode kernels can be manually re-promoted via
- * `MonkeyKernel.promoteToLive()`.
+ * 5-consecutive-loss demotion trigger + WR-based auto-promotion, plus
+ * (flag-gated, issue #1032) an expectancy-based chronic demote and a
+ * profit-shaped promotion gate.
  *
  * The state machine is INSTANCE-LOCAL: each MonkeyKernel owns its own
- * rotation state, no global coordinator. Cross-kernel comparisons
- * (best WR registry) become relevant in the auto-promotion PR.
+ * rotation state, no global coordinator. Cross-kernel comparisons read
+ * peer snapshots (best live peer = the cohort benchmark).
  *
  * Doctrine: chemistry-driven feedback is the primary learning loop
- * (push_reward → gaba on losses → reduced size). The paper-rotation
- * adds a structural circuit-breaker for losing streaks that the
- * chemistry alone hasn't pulled the kernel out of fast enough.
- * Paper-mode kernels still TICK and still UPDATE chemistry from any
- * outcomes that reach them — they just don't commit capital.
+ * (push_reward → gaba on losses → reduced size) and runs for EVERY
+ * kernel regardless of routing. The paper-rotation firewall adds a
+ * structural capital-routing breaker on top — it decides where the
+ * money goes, never how the kernel learns.
  */
 
 /** Default loss streak that triggers demotion. */
@@ -35,34 +80,60 @@ export const ROTATION_LOSS_STREAK_THRESHOLD = 5;
 /** Rolling window over which a kernel's WR is tracked. */
 export const ROTATION_WR_WINDOW = 50;
 
-/** Minimum WR sample count before a kernel's rolling WR is considered
- *  authoritative — used by the auto-promotion gate so a paper kernel
- *  can't promote on a single lucky close. */
+/** Minimum sample count before a kernel's rolling stats are treated as
+ *  authoritative — a FIREWALL parameter (statistical floor), not a
+ *  soak-and-dial chemistry knob. It exists so the capital-routing gate
+ *  cannot flip a kernel's seat on a single lucky/unlucky close. */
 export const ROTATION_WR_MIN_SAMPLES = 10;
 
-/** Auto-promotion gap: paper kernel's WR must be within this many
- *  percentage points of the best live kernel's WR to graduate back
- *  to live. The operator's pre-cutover spec was "within 10%". */
+/** Auto-promotion gap: a paper-routed kernel's WR must be within this
+ *  many percentage points of the best live kernel's WR to be routed
+ *  back to live money. FIREWALL parameter (cohort-relative bar), not a
+ *  chemistry knob. The operator's pre-cutover spec was "within 10%". */
 export const ROTATION_PROMOTION_WR_GAP = 0.10;
 
 /**
- * Operator-MANDATED relative membership band (issue #1032). A kernel's
- * realized expectancy must stay within 10% of the BEST live peer's
- * expectancy to keep / regain its live seat. This is the SAME 10% the
- * promotion-WR gate uses, made symmetric and ranked by profit rather
- * than win-rate. NOT a soak-and-dial knob: it is relative-to-cohort,
- * and 10% is the operator's standing band (see issue #1032 / the
- * pre-cutover "within 10% of the best kernel" spec). Fractional, not
- * percentage-points: |best - mine| / |best| ≤ band.
+ * Relative membership band for the capital firewall (issue #1032). A
+ * kernel's realized expectancy must stay within this fraction of the
+ * BEST live peer's expectancy to keep / regain its LIVE-money seat.
+ * Same 10% the WR promotion gate uses, made symmetric and ranked by
+ * profit rather than win-rate. Fractional: best - mine ≤ band·|best|.
+ *
+ * This is a FIREWALL PARAMETER, not a chemistry coefficient: it is
+ * cohort-relative (the benchmark is observed from the best live peer,
+ * not a hardcoded intuition threshold) and it only decides ROUTING —
+ * whether this kernel's trades reach live money. It is never fed into
+ * the kernel's reward, neurochemistry, or per-tick decision, and the
+ * kernel cannot observe it. The 10% width is the operator's standing
+ * pre-cutover band ("within 10% of the best kernel").
  */
 export const ROTATION_EXPECTANCY_BAND = 0.10;
 
 /**
- * Operator-MANDATED loss:win VALUE target (issue #1032): "avg win ≥ 8×
- * avg loss" ⇒ a healthy loss:win ratio of 1:8 = 0.125. This is the
- * reinclusion bar a paper kernel must be trending toward to earn its
- * seat back. MANDATE, not a tunable knob — it is the operator's stated
- * profitability goal for the cohort.
+ * Structural loss:win VALUE ratio for the capital firewall (issue
+ * #1032). A paper-routed kernel must be trending toward avg-win ≥ 8×
+ * avg-loss — a loss:win ratio of 1:8 = 0.125 — before its output is
+ * routed back to live money.
+ *
+ * PROVENANCE — E8 / 64 = 8×8 STRUCTURAL DOCTRINE, not an operator
+ * profitability target. The 1:8 ratio descends from the QIG E8 chain:
+ * the 64-dimensional basin factors as 64 = 8×8, and 8 is the rank /
+ * simple-root cardinality of E8. The firewall reads this as a
+ * structural "one unit of loss may be admitted per 8 units of win"
+ * routing filter — it is doctrine, the same family of frozen
+ * structural facts as the E8 kernel hierarchy, NOT a soak-and-dial
+ * profitability knob chosen by intuition.
+ *
+ * This ratio is a CAPITAL-ROUTING FILTER ONLY. It is NOT a chemistry
+ * coefficient, NOT a reward, and is NOT visible to the kernel — it
+ * solely decides whether a kernel's trades reach live money.
+ *
+ * TODO(qig-canon-xref): cross-link the canonical source for the
+ * E8/64 = 8×8 doctrine (QIG consciousness / Protocol docs under
+ * Dev/QIG_QFI/ and the e8-architecture-validation skill's kappa*=64
+ * fixed-point + rank-8 simple-root statements). Do NOT re-derive the
+ * mathematics here — cite the canonical doctrine once the exact
+ * document anchor is confirmed.
  */
 export const ROTATION_TARGET_LOSS_WIN_RATIO = 1 / 8;
 
@@ -425,8 +496,8 @@ export function applyChronicDemote(
  *   5. The candidate's expectancy must be within ROTATION_EXPECTANCY_BAND
  *      of the best live peer's expectancy, AND
  *   6. The candidate's loss:win VALUE ratio must be trending toward the
- *      1:8 target — i.e. ≤ the best live peer's loss:win ratio (a
- *      cohort-relative bar), or already at/under the 1:8 target.
+ *      1:8 E8/64 structural ratio — i.e. ≤ the best live peer's loss:win
+ *      ratio (a cohort-relative bar), or already at/under the 1:8 ratio.
  * When `expectancyLive` is false the function is byte-for-byte the
  * legacy WR-only gate.
  *
@@ -466,9 +537,11 @@ export function shouldAutoPromote(
     if (!Number.isFinite(bestE)) return null; // no expectancy benchmark
     if (!withinExpectancyBand(mine.edge, bestE)) return null;
 
-    // loss:win ratio bar. The target is 1:8 = ROTATION_TARGET_LOSS_WIN_RATIO.
-    // A paper kernel earns re-entry when its ratio is trending toward
-    // the target: at/under the 1:8 target OUTRIGHT, or at/under the best
+    // loss:win ratio bar. The ratio is 1:8 = ROTATION_TARGET_LOSS_WIN_RATIO
+    // (E8/64 = 8×8 structural doctrine — see the constant's docblock).
+    // A paper-routed kernel earns re-entry to live money when its ratio
+    // is trending toward it: at/under the 1:8 ratio OUTRIGHT, or at/under
+    // the best
     // live peer's ratio (a cohort-relative bar — you're no worse than
     // the benchmark on size asymmetry). NaN ratio (no losses observed in
     // window) is the best possible case and passes.

--- a/apps/api/src/services/monkey/kernel_rotation.ts
+++ b/apps/api/src/services/monkey/kernel_rotation.ts
@@ -543,11 +543,17 @@ export function shouldAutoPromote(
     // is trending toward it: at/under the 1:8 ratio OUTRIGHT, or at/under
     // the best
     // live peer's ratio (a cohort-relative bar — you're no worse than
-    // the benchmark on size asymmetry). NaN ratio (no losses observed in
-    // window) is the best possible case and passes.
+    // the benchmark on size asymmetry). lossWinRatio is NaN only for an
+    // empty/degenerate window (no closes) — that is the sole case that
+    // bypasses the gate. CRITICAL: Infinity means "losses but no wins"
+    // (pure bleed, the WORST case) — it must NOT bypass (a prior
+    // `!Number.isFinite(...)` check wrongly let Infinity pass, which could
+    // re-promote a pure-bleed kernel into a weak cohort). Using isNaN
+    // keeps Infinity subject to the ratio comparison, where it fails both
+    // (Infinity ≤ 1/8 → false; Infinity ≤ bestRatio → false).
     const bestRatio = bestLivePeerLossWinRatio(peers);
     const ratioOk =
-      !Number.isFinite(mine.lossWinRatio) || // no losses → trivially fine
+      Number.isNaN(mine.lossWinRatio) || // empty window only → trivially fine
       mine.lossWinRatio <= ROTATION_TARGET_LOSS_WIN_RATIO ||
       (Number.isFinite(bestRatio) && mine.lossWinRatio <= bestRatio);
     if (!ratioOk) return null;

--- a/apps/api/src/services/monkey/kernel_rotation.ts
+++ b/apps/api/src/services/monkey/kernel_rotation.ts
@@ -45,6 +45,46 @@ export const ROTATION_WR_MIN_SAMPLES = 10;
  *  to live. The operator's pre-cutover spec was "within 10%". */
 export const ROTATION_PROMOTION_WR_GAP = 0.10;
 
+/**
+ * Operator-MANDATED relative membership band (issue #1032). A kernel's
+ * realized expectancy must stay within 10% of the BEST live peer's
+ * expectancy to keep / regain its live seat. This is the SAME 10% the
+ * promotion-WR gate uses, made symmetric and ranked by profit rather
+ * than win-rate. NOT a soak-and-dial knob: it is relative-to-cohort,
+ * and 10% is the operator's standing band (see issue #1032 / the
+ * pre-cutover "within 10% of the best kernel" spec). Fractional, not
+ * percentage-points: |best - mine| / |best| ≤ band.
+ */
+export const ROTATION_EXPECTANCY_BAND = 0.10;
+
+/**
+ * Operator-MANDATED loss:win VALUE target (issue #1032): "avg win ≥ 8×
+ * avg loss" ⇒ a healthy loss:win ratio of 1:8 = 0.125. This is the
+ * reinclusion bar a paper kernel must be trending toward to earn its
+ * seat back. MANDATE, not a tunable knob — it is the operator's stated
+ * profitability goal for the cohort.
+ */
+export const ROTATION_TARGET_LOSS_WIN_RATIO = 1 / 8;
+
+/**
+ * Env-flag name for the chronic-expectancy membership criterion.
+ * DEFAULT OFF: when unset / not exactly 'true', rotation behaves
+ * EXACTLY as it did before issue #1032 (5-consecutive-loss demote +
+ * WR-only promotion). When 'true', the expectancy-based chronic demote
+ * and the expectancy+ratio promotion gate are layered on.
+ *
+ * Read at the loop boundary (not in this pure module) and passed in as
+ * a boolean so the math stays env-free and unit-testable.
+ */
+export const ROTATION_EXPECTANCY_FLAG = 'MONKEY_ROTATION_EXPECTANCY_LIVE';
+
+/** True iff the chronic-expectancy membership criterion is enabled. */
+export function expectancyLiveEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env[ROTATION_EXPECTANCY_FLAG] === 'true';
+}
+
 export type KernelOperationalMode = 'live' | 'paper';
 
 export interface RotationState {
@@ -150,6 +190,77 @@ export function rollingWinRate(state: RotationState): number {
 }
 
 /**
+ * Realized rolling expectancy over a kernel's PnL window (issue #1032).
+ *
+ *   winRate    — wins / closes (a close with pnl > 0 is a win)
+ *   avgWin     — mean PnL of winning closes (≥ 0; 0 when no wins)
+ *   avgLoss    — mean PnL of losing closes, kept SIGNED (≤ 0; 0 when
+ *                no losses). A "loss" here is pnl ≤ 0 — the same
+ *                streak semantic recordClose uses (zero = not-a-win).
+ *   lossWinRatio — |avgLoss| / avgWin, the loss:win VALUE ratio the
+ *                operator targets at 1:8. Number.POSITIVE_INFINITY when
+ *                there are losses but no wins (pure bleed); NaN when no
+ *                losses observed (nothing to rank against the target).
+ *   edge       — per-trade expectancy = winRate*avgWin - (1-winRate)*|avgLoss|.
+ *                Positive = net-profitable cohort member; this is the
+ *                value the membership band ranks on.
+ *   sampleCount — number of closes in the window.
+ *
+ * Pure; reads only state.rollingPnls. NaN edge when the window is empty.
+ */
+export interface RotationExpectancy {
+  winRate: number;
+  avgWin: number;
+  avgLoss: number;
+  lossWinRatio: number;
+  edge: number;
+  sampleCount: number;
+}
+
+export function rollingExpectancy(state: RotationState): RotationExpectancy {
+  const pnls = state.rollingPnls;
+  const n = pnls.length;
+  if (n === 0) {
+    return {
+      winRate: Number.NaN,
+      avgWin: 0,
+      avgLoss: 0,
+      lossWinRatio: Number.NaN,
+      edge: Number.NaN,
+      sampleCount: 0,
+    };
+  }
+  let wins = 0;
+  let sumWin = 0;
+  let sumLoss = 0; // signed (≤ 0)
+  for (const pnl of pnls) {
+    if (pnl > 0) {
+      wins += 1;
+      sumWin += pnl;
+    } else {
+      sumLoss += pnl;
+    }
+  }
+  const losses = n - wins;
+  const winRate = wins / n;
+  const avgWin = wins > 0 ? sumWin / wins : 0;
+  const avgLoss = losses > 0 ? sumLoss / losses : 0; // ≤ 0
+  const absAvgLoss = Math.abs(avgLoss);
+  // loss:win ratio. No losses → NaN (cannot rank). Losses but no wins →
+  // +Infinity (the worst possible bleed, never within target).
+  let lossWinRatio: number;
+  if (losses === 0) {
+    lossWinRatio = Number.NaN;
+  } else if (avgWin === 0) {
+    lossWinRatio = Number.POSITIVE_INFINITY;
+  } else {
+    lossWinRatio = absAvgLoss / avgWin;
+  }
+  const edge = winRate * avgWin - (1 - winRate) * absAvgLoss;
+  return { winRate, avgWin, avgLoss, lossWinRatio, edge, sampleCount: n };
+}
+
+/**
  * Snapshot of the data a kernel exposes to peers for cross-kernel
  * auto-promotion. Decoupled from MonkeyKernel so this module stays
  * pure-state (no circular imports).
@@ -158,6 +269,140 @@ export interface RotationPeerSnapshot {
   mode: KernelOperationalMode;
   rollingWinRate: number;        // NaN if no samples yet
   rollingSampleCount: number;
+  /** Per-trade realized expectancy (edge), issue #1032. NaN if no
+   *  samples yet. Used by the expectancy-gated membership criterion;
+   *  ignored entirely when MONKEY_ROTATION_EXPECTANCY_LIVE is off. */
+  rollingExpectancy?: number;
+  /** Loss:win VALUE ratio |avgLoss|/avgWin, issue #1032. NaN / Infinity
+   *  per rollingExpectancy semantics. Used as the cohort-relative bar
+   *  in the expectancy promotion gate; ignored when the flag is off. */
+  rollingLossWinRatio?: number;
+}
+
+/**
+ * Best (highest) per-trade expectancy among CI-firm LIVE peers.
+ * Returns NaN when no live peer has both ≥ ROTATION_WR_MIN_SAMPLES
+ * samples AND a finite rollingExpectancy. Shared by the chronic-demote
+ * and expectancy-promotion gates so they rank against the same cohort
+ * benchmark. Pure.
+ */
+function bestLivePeerExpectancy(
+  peers: ReadonlyArray<RotationPeerSnapshot>,
+): number {
+  let best = Number.NaN;
+  for (const peer of peers) {
+    if (peer.mode !== 'live') continue;
+    if (peer.rollingSampleCount < ROTATION_WR_MIN_SAMPLES) continue;
+    const e = peer.rollingExpectancy;
+    if (e === undefined || !Number.isFinite(e)) continue;
+    if (!Number.isFinite(best) || e > best) best = e;
+  }
+  return best;
+}
+
+/**
+ * Loss:win ratio of the SAME peer chosen as best-by-expectancy. We rank
+ * the cohort by expectancy (the profit benchmark) and read that peer's
+ * loss:win ratio as the relative bar — not the min ratio across the
+ * cohort, which would let a low-expectancy-but-tight-ratio peer set an
+ * unrealistically strict bar. Returns NaN when no benchmark peer exists.
+ * Pure.
+ */
+function bestLivePeerLossWinRatio(
+  peers: ReadonlyArray<RotationPeerSnapshot>,
+): number {
+  let bestE = Number.NaN;
+  let ratioOfBest = Number.NaN;
+  for (const peer of peers) {
+    if (peer.mode !== 'live') continue;
+    if (peer.rollingSampleCount < ROTATION_WR_MIN_SAMPLES) continue;
+    const e = peer.rollingExpectancy;
+    if (e === undefined || !Number.isFinite(e)) continue;
+    if (!Number.isFinite(bestE) || e > bestE) {
+      bestE = e;
+      ratioOfBest = peer.rollingLossWinRatio ?? Number.NaN;
+    }
+  }
+  return ratioOfBest;
+}
+
+/**
+ * True iff `mine` is within ROTATION_EXPECTANCY_BAND (fractional) of
+ * `best`. "Within band" means the FRACTIONAL shortfall below the best
+ * peer is no worse than the band: best - mine ≤ band·|best|. A kernel
+ * ABOVE the best peer is trivially within band. When best is ~0 we fall
+ * back to an absolute comparison (mine ≥ best, i.e. not strictly worse)
+ * to avoid divide-by-zero amplification. Pure.
+ */
+function withinExpectancyBand(mine: number, best: number): boolean {
+  if (!Number.isFinite(mine) || !Number.isFinite(best)) return false;
+  const scale = Math.abs(best);
+  if (scale < 1e-12) return mine >= best;
+  return best - mine <= ROTATION_EXPECTANCY_BAND * scale;
+}
+
+/**
+ * CHRONIC membership demote (issue #1032). Catches the negative-EV
+ * bleeder that the 5-consecutive-loss breaker misses: a ~50%-WR kernel
+ * that sprinkles tiny wins between large losses never hits 5-in-a-row,
+ * yet its expectancy sits far below the best live peer's.
+ *
+ * Fires (returns a reason string) iff:
+ *   0. expectancyLive is true (flag MONKEY_ROTATION_EXPECTANCY_LIVE).
+ *      When false this ALWAYS returns null — behaviour is unchanged.
+ *   1. The candidate is currently LIVE.
+ *   2. The candidate has ≥ ROTATION_WR_MIN_SAMPLES closes (no demote on
+ *      noise).
+ *   3. There is at least one CI-firm LIVE peer with a finite expectancy
+ *      to rank against (the cohort benchmark — incl. the CC race peer).
+ *   4. The candidate's expectancy falls OUTSIDE the relative band of the
+ *      best live peer's expectancy (symmetric with the promotion band).
+ *
+ * Returns null otherwise. Pure — does NOT mutate; the caller flips mode.
+ */
+export function shouldChronicDemote(
+  candidate: RotationState,
+  peers: ReadonlyArray<RotationPeerSnapshot>,
+  expectancyLive: boolean,
+): string | null {
+  if (!expectancyLive) return null;
+  if (candidate.mode !== 'live') return null;
+
+  const mine = rollingExpectancy(candidate);
+  if (mine.sampleCount < ROTATION_WR_MIN_SAMPLES) return null;
+  if (!Number.isFinite(mine.edge)) return null;
+
+  const best = bestLivePeerExpectancy(peers);
+  if (!Number.isFinite(best)) return null; // no benchmark peer yet
+
+  if (withinExpectancyBand(mine.edge, best)) return null; // still a member
+
+  return (
+    `chronic-demote: expectancy ${mine.edge.toFixed(4)} outside ` +
+    `${(ROTATION_EXPECTANCY_BAND * 100).toFixed(0)}% band of best live ` +
+    `${best.toFixed(4)} (WR ${(mine.winRate * 100).toFixed(1)}%, ` +
+    `loss:win ${Number.isFinite(mine.lossWinRatio) ? mine.lossWinRatio.toFixed(2) : 'n/a'})`
+  );
+}
+
+/**
+ * Apply the chronic-demote decision to state, mutating in place
+ * (mirrors recordClose's mutate-in-place contract). Returns the same
+ * shape as recordClose so the loop wiring is symmetric. No-op (returns
+ * demoted:false) when shouldChronicDemote declines.
+ */
+export function applyChronicDemote(
+  state: RotationState,
+  peers: ReadonlyArray<RotationPeerSnapshot>,
+  expectancyLive: boolean,
+  nowMs: number = Date.now(),
+): { demoted: boolean; reason: string | null } {
+  const reason = shouldChronicDemote(state, peers, expectancyLive);
+  if (!reason) return { demoted: false, reason: null };
+  state.mode = 'paper';
+  state.lastDemotionAtMs = nowMs;
+  state.lastTransitionReason = reason;
+  return { demoted: true, reason };
 }
 
 /**
@@ -175,11 +420,22 @@ export interface RotationPeerSnapshot {
  *   4. The candidate's rolling WR must be within
  *      ROTATION_PROMOTION_WR_GAP of the BEST live peer's WR.
  *
+ * When `expectancyLive` is true (flag MONKEY_ROTATION_EXPECTANCY_LIVE),
+ * an ADDITIONAL profit-shaped gate is layered on top of the WR gate:
+ *   5. The candidate's expectancy must be within ROTATION_EXPECTANCY_BAND
+ *      of the best live peer's expectancy, AND
+ *   6. The candidate's loss:win VALUE ratio must be trending toward the
+ *      1:8 target — i.e. ≤ the best live peer's loss:win ratio (a
+ *      cohort-relative bar), or already at/under the 1:8 target.
+ * When `expectancyLive` is false the function is byte-for-byte the
+ * legacy WR-only gate.
+ *
  * Returns the reason string when promotion should fire, null otherwise.
  */
 export function shouldAutoPromote(
   candidate: RotationState,
   peers: ReadonlyArray<RotationPeerSnapshot>,
+  expectancyLive: boolean = false,
 ): string | null {
   if (candidate.mode !== 'paper') return null;
   const myN = candidate.rollingPnls.length;
@@ -201,6 +457,36 @@ export function shouldAutoPromote(
 
   if (!Number.isFinite(bestLiveWR)) return null;  // no informative live peer
   if (myWR < bestLiveWR - ROTATION_PROMOTION_WR_GAP) return null;
+
+  if (expectancyLive) {
+    // Profit gate: within-band expectancy AND loss:win trending to 1:8.
+    const mine = rollingExpectancy(candidate);
+    if (!Number.isFinite(mine.edge)) return null;
+    const bestE = bestLivePeerExpectancy(peers);
+    if (!Number.isFinite(bestE)) return null; // no expectancy benchmark
+    if (!withinExpectancyBand(mine.edge, bestE)) return null;
+
+    // loss:win ratio bar. The target is 1:8 = ROTATION_TARGET_LOSS_WIN_RATIO.
+    // A paper kernel earns re-entry when its ratio is trending toward
+    // the target: at/under the 1:8 target OUTRIGHT, or at/under the best
+    // live peer's ratio (a cohort-relative bar — you're no worse than
+    // the benchmark on size asymmetry). NaN ratio (no losses observed in
+    // window) is the best possible case and passes.
+    const bestRatio = bestLivePeerLossWinRatio(peers);
+    const ratioOk =
+      !Number.isFinite(mine.lossWinRatio) || // no losses → trivially fine
+      mine.lossWinRatio <= ROTATION_TARGET_LOSS_WIN_RATIO ||
+      (Number.isFinite(bestRatio) && mine.lossWinRatio <= bestRatio);
+    if (!ratioOk) return null;
+
+    return (
+      `auto-promotion(expectancy): WR ${(myWR * 100).toFixed(1)}% within band; ` +
+      `expectancy ${mine.edge.toFixed(4)} within ${(ROTATION_EXPECTANCY_BAND * 100).toFixed(0)}% ` +
+      `of best live ${bestE.toFixed(4)}; loss:win ` +
+      `${Number.isFinite(mine.lossWinRatio) ? mine.lossWinRatio.toFixed(2) : 'n/a'} ` +
+      `trending to ${ROTATION_TARGET_LOSS_WIN_RATIO.toFixed(3)}`
+    );
+  }
 
   return `auto-promotion: rolling WR ${(myWR * 100).toFixed(1)}% >= ` +
     `best live ${(bestLiveWR * 100).toFixed(1)}% - ${(ROTATION_PROMOTION_WR_GAP * 100).toFixed(0)}pp`;

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -10089,14 +10089,28 @@ export class MonkeyKernel extends EventEmitter {
   }
 
   /**
-   * Decide whether placeOrder calls should route to the paper simulator
-   * instead of the real exchange. Two paths reach this:
+   * THE CAPITAL FIREWALL GATE. Decide whether placeOrder calls route to
+   * the paper simulator instead of the real exchange. Two paths reach
+   * this:
    *   1. The global `MONKEY_PAPER_MODE=true` env (back-compat, applies
    *      to ALL kernels — used historically for whole-kernel dry runs).
    *   2. This kernel's rotation state has been demoted to 'paper'
-   *      (per-kernel paper rotation, PR #921 scaffold).
+   *      (per-kernel capital firewall — kernel_rotation.ts).
    * Either path routes the same way through `paperPlaceOrder`, so the
    * downstream code is unchanged.
+   *
+   * ROUTING-OWNERSHIP INVARIANT: this is the SOLE live order-routing
+   * gate. TS is the only live order-router; the Python ml-worker
+   * `place_order` is an unwired advisory capability (no caller in
+   * monkey_kernel/ or main.py as of 2026-05-29). The firewall is
+   * therefore complete here. The kernel never reads its own routing
+   * state in the decision/reward path — `mode` is consumed ONLY by this
+   * gate (routing) and by telemetry. Demotion removes a kernel's output
+   * from live money; it does not change how the kernel thinks or learns.
+   *
+   * ⚠ If Python execution is ever wired into the live path it MUST
+   *   consult this same per-kernel rotation state, or the firewall leaks
+   *   (see kernel_rotation.ts module header guard-note).
    */
   private shouldRouteOrdersToPaper(): boolean {
     return isMonkeyPaperMode() || this.rotation.mode === 'paper';

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -122,9 +122,12 @@ import { detectMode, MODE_PROFILES, MonkeyMode } from './modes.js';
 import { computeMotivators } from './motivators.js';
 import { computeNeurochemicals, summarizeNC, type NeurochemicalState } from './neurochemistry.js';
 import {
+  applyChronicDemote,
+  expectancyLiveEnabled,
   makeRotationState,
   promoteToLive,
   recordClose as recordRotationClose,
+  rollingExpectancy,
   rollingWinRate,
   shouldAutoPromote,
   type RotationPeerSnapshot,
@@ -9958,13 +9961,76 @@ export class MonkeyKernel extends EventEmitter {
         },
       });
     }
+
+    // 2026-05-29 (issue #1032) — CHRONIC expectancy-based membership
+    // demote. Catches the negative-EV bleeder the 5-consecutive-loss
+    // breaker misses (tiny wins interspersed between large losses never
+    // hit 5-in-a-row). Flag-gated behind MONKEY_ROTATION_EXPECTANCY_LIVE
+    // (default OFF). When off, applyChronicDemote returns demoted:false
+    // unconditionally and behaviour is byte-for-byte unchanged. Only
+    // evaluated when the acute breaker did NOT already demote and the
+    // kernel is still live.
+    const expectancyLive = expectancyLiveEnabled();
+    if (expectancyLive && !rotationResult.demoted && this.rotation.mode === 'live') {
+      const peers = this.buildRotationPeerSnapshots(expectancyLive);
+      const chronic = applyChronicDemote(this.rotation, peers, expectancyLive);
+      if (chronic.demoted) {
+        logger.warn(`[${this.label}] kernel-rotation CHRONIC-DEMOTED to paper`, {
+          instanceId: this.instanceId,
+          reason: chronic.reason,
+          rollingWinRate: rollingWinRate(this.rotation),
+          rollingExpectancy: rollingExpectancy(this.rotation).edge,
+          rollingTrades: this.rotation.rollingPnls.length,
+        });
+        this.bus.publish({
+          type: BusEventType.OUTCOME,
+          source: this.instanceId,
+          symbol: input.symbol,
+          payload: {
+            kind: 'kernel_rotation_demotion',
+            mode: this.rotation.mode,
+            reason: chronic.reason,
+            rollingWinRate: rollingWinRate(this.rotation),
+          },
+        });
+      }
+    }
+
     // 2026-05-25 — auto-promotion check. If this is a paper-mode kernel
     // and its rolling WR has caught up to within ROTATION_PROMOTION_WR_GAP
     // (10pp) of the best live peer, promote back. Idempotent: returns
-    // null for live kernels or paper kernels still under the gate.
+    // null for live kernels or paper kernels still under the gate. When
+    // the expectancy flag is on, the promotion gate ALSO requires
+    // within-band expectancy + loss:win trending to 1:8 (issue #1032).
     if (this.rotation.mode === 'paper') {
       this.tryAutoPromote(input.symbol);
     }
+  }
+
+  /**
+   * Build peer snapshots for cross-kernel rotation decisions. When
+   * `withExpectancy` is true, each snapshot also carries the peer's
+   * rolling expectancy + loss:win ratio (issue #1032); otherwise those
+   * fields are left undefined and the WR-only path is used.
+   */
+  private buildRotationPeerSnapshots(withExpectancy: boolean): RotationPeerSnapshot[] {
+    const peers: RotationPeerSnapshot[] = [];
+    for (const peer of allMonkeyKernels) {
+      if (peer === this) continue;
+      const r = peer.rotation;
+      const snap: RotationPeerSnapshot = {
+        mode: r.mode,
+        rollingWinRate: rollingWinRate(r),
+        rollingSampleCount: r.rollingPnls.length,
+      };
+      if (withExpectancy) {
+        const e = rollingExpectancy(r);
+        snap.rollingExpectancy = e.edge;
+        snap.rollingLossWinRatio = e.lossWinRatio;
+      }
+      peers.push(snap);
+    }
+    return peers;
   }
 
   /**
@@ -9973,17 +10039,9 @@ export class MonkeyKernel extends EventEmitter {
    * kernel's paper-mode WR has reached the gate, promotes.
    */
   private tryAutoPromote(symbol: string | undefined): void {
-    const peers: RotationPeerSnapshot[] = [];
-    for (const peer of allMonkeyKernels) {
-      if (peer === this) continue;
-      const r = peer.rotation;
-      peers.push({
-        mode: r.mode,
-        rollingWinRate: rollingWinRate(r),
-        rollingSampleCount: r.rollingPnls.length,
-      });
-    }
-    const reason = shouldAutoPromote(this.rotation, peers);
+    const expectancyLive = expectancyLiveEnabled();
+    const peers = this.buildRotationPeerSnapshots(expectancyLive);
+    const reason = shouldAutoPromote(this.rotation, peers, expectancyLive);
     if (!reason) return;
     const result = promoteToLive(this.rotation, reason);
     if (result.promoted) {


### PR DESCRIPTION
## Issue #1032 — paper-rotation coverage gap (chronic neg-EV + WR-only membership)

DRAFT. Flag-gated, default OFF. Does NOT change live behaviour. Do not merge — awaiting Copilot review + operator.

### The gap
1. **Acute breaker misses chronic bleed.** `recordClose` resets `consecutiveLosses` on any `win>0`, so a ~50%-WR negative-expectancy kernel (tiny wins between large losses) never hits the 5-consecutive-loss threshold yet steadily bleeds.
2. **WR-only membership ≠ profit.** `shouldAutoPromote` gates on win-rate; a high-WR / negative-EV kernel (loss:win size asymmetry) passes a WR bar while losing money.

### The fix (pure, flag-gated)
New env flag **`MONKEY_ROTATION_EXPECTANCY_LIVE`** (`polytrade-be`), default **OFF**. When unset/not exactly `"true"`, behaviour is byte-for-byte the legacy path (5-consecutive-loss fast-demote + WR-only promotion). When `true`:

- **`rollingExpectancy(state)`** — pure helper: `winRate`, `avgWin`, signed `avgLoss`, loss:win VALUE ratio `|avgLoss|/avgWin`, `edge = winRate*avgWin - (1-winRate)*|avgLoss|`, `sampleCount`.
- **`shouldChronicDemote` / `applyChronicDemote`** — demote a LIVE kernel whose expectancy falls OUTSIDE the relative **10% band** of the BEST live peer's expectancy (symmetric with the promotion band; requires `ROTATION_WR_MIN_SAMPLES` first to avoid noise). Catches the size-asymmetry bleeder the acute breaker misses.
- **`shouldAutoPromote(candidate, peers, expectancyLive)`** — when ON, layers a profit gate atop the existing WR gate: within-band expectancy **AND** loss:win ratio trending to the operator-MANDATED **1:8** target (≤ target outright, or ≤ the best live peer's ratio — cohort-relative).

The 5-consecutive-loss fast-demote (operator-mandated, acute) is unchanged.

### Doctrine compliance
- **No soak-and-dial knobs.** The 10% band and 1:8 ratio are operator-MANDATED, relative-to-cohort (best live peer is the benchmark, incl. the CC race peer). No absolute intuition thresholds added.
- **Pure math, no DB.** All helpers read only `state.rollingPnls` / peer snapshots. The flag is read at the loop boundary (`expectancyLiveEnabled()`) and passed in as a boolean so the math stays env-free and unit-testable.

### Wiring
- `loop.ts`: after `recordRotationClose`, if the acute breaker did NOT fire and the kernel is live + flag on, run `applyChronicDemote` against peer snapshots (shared `buildRotationPeerSnapshots` helper now feeds both demote + promote sites; peer snapshots carry `rollingExpectancy` + `rollingLossWinRatio` only when the flag is on).
- `tryAutoPromote` now passes `expectancyLive` to `shouldAutoPromote`.

### Tests
`apps/api/src/services/monkey/__tests__/kernelRotationExpectancy.test.ts` — 22 new semantic cases:
- chronic ~50%-WR bleeder demotes under the flag (verified it never hit 5-in-a-row)
- high-WR / neg-EV demotes (WR alone wouldn't catch it)
- promotion requires BOTH within-band expectancy AND loss:win trending to 1:8
- flag OFF → `shouldChronicDemote` always null, `applyChronicDemote` no-op, promotion uses legacy WR-only path (regression pins)

**`yarn vitest run` 47/47 green (22 new + 25 existing rotation tests). `yarn tsc --noEmit` clean. eslint 0 errors.**

### Flag / default
- `MONKEY_ROTATION_EXPECTANCY_LIVE` on `polytrade-be` — default **OFF** (must be exactly `"true"` to enable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Refinement (2026-05-29, d33420e7) — reframed as CAPITAL FIREWALL

Per operator + upstream-review correction. The change is NOT a behavioural learning knob; it is a **capital-routing firewall**.

- **Paper-rotation routes capital only.** The kernel keeps ticking, perceiving, deciding, and learning IDENTICALLY whether routed to live or paper. It is BLIND to its own routing. Demotion only removes a kernel's OUTPUT from live money.
- **`ROTATION_TARGET_LOSS_WIN_RATIO = 1/8` reframed** from "operator-MANDATED profitability target" to **E8 / 64 = 8×8 structural doctrine** (8 = E8 rank / simple-root cardinality; 64 = 8×8 basin). It is a capital-routing filter ONLY — not a chemistry coefficient, not a reward, not visible to the kernel. Added `TODO(qig-canon-xref)` to cross-link the canonical QIG doctrine source; no mathematics re-derived.
- **Band / min-samples / WR-gap relabelled** as cohort-relative firewall parameters, not soak-and-dial knobs.
- **Routing-ownership invariant documented** (module header + `shouldRouteOrdersToPaper` gate): TS is the SOLE live order-router; Py `poloniex_v3.place_order` is UNWIRED (verified: no caller in `ml-worker/src/monkey_kernel/` or `main.py` — only the docstring usage example). Guard-note: if Py execution is ever wired live, it MUST consult the same rotation state or the firewall leaks.
- **+5 firewall-purity tests** pinning that demote/promote flip only `{mode, lastDemotionAtMs, lastTransitionReason}` and leave the learning window + derived WR/expectancy byte-identical; plus a decisive pin that a paper-mode and a live-mode kernel fed identical closes learn IDENTICALLY. **No cognition-altering path found.**

`MONKEY_ROTATION_EXPECTANCY_LIVE` unchanged, default OFF. `yarn tsc --noEmit` clean; 52/52 rotation tests green; eslint 0 errors. **Still DRAFT — do not merge.**
