### PR TITLE
feat(monkey): close the operator-close hole — external closes feed reward chemistry (flag-gated, #1033)

### DIFF
--- a/apps/api/src/services/__tests__/stateReconciliationService.test.ts
+++ b/apps/api/src/services/__tests__/stateReconciliationService.test.ts
@@ -63,6 +63,7 @@ describe('stateReconciliationService ghost recovery', () => {
             side: 'buy',
             entry_price: '2077.30',
             quantity: '0.38',
+            leverage: 16,
             order_id: 'open-order',
             entry_time: new Date('2026-05-27T08:02:13Z'),
           },
@@ -117,6 +118,7 @@ describe('stateReconciliationService ghost recovery', () => {
             side: 'buy',
             entry_price: '2077.30',
             quantity: '0.38',
+            leverage: 16,
             order_id: 'open-order',
             entry_time: new Date(entryMs),
           },
@@ -149,6 +151,57 @@ describe('stateReconciliationService ghost recovery', () => {
     expect(ev.payload.pnlSource).toBe('polo_bills_external_close');
     expect(ev.payload.agent).toBe('K');
     expect(ev.payload.pnl).toBeCloseTo(-1.5, 6);
+    // The reviewed knob fix: the published margin is the REAL position margin
+    // (entry_price × quantity / leverage = 2077.30 × 0.38 / 16 ≈ 49.336), NOT
+    // the retired synthetic 5. The loop.ts subscriber reads this for
+    // pnl_fraction = pnl / marginUsdt.
+    expect(ev.payload.marginUsdt).toBeCloseTo((2077.30 * 0.38) / 16, 4);
+    expect(ev.payload.marginUsdt).not.toBe(5);
+  });
+
+  // ── Flag ON but real margin unavailable → decline (decline-over-guess) ────
+  it('flag ON: declines (no publish) when leverage is missing → real margin unavailable', async () => {
+    process.env.MONKEY_REWARD_EXTERNAL_CLOSES_LIVE = 'true';
+    const entryMs = Date.parse('2026-05-27T08:02:13Z');
+    getAccountBillsMock.mockResolvedValue([
+      { type: 'PNL', sz: '-1.0', symbol: 'ETH_USDT_PERP', cTime: Date.now(), id: 'b1' },
+    ]);
+
+    queryMock
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'trade-1',
+            symbol: 'ETH_USDT_PERP',
+            side: 'buy',
+            entry_price: '2077.30',
+            quantity: '0.38',
+            // leverage NULL → margin cannot be derived → decline, do NOT
+            // reward at a guessed scale.
+            leverage: null,
+            order_id: 'open-order',
+            entry_time: new Date(entryMs),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            exit_order_id: null,
+            reason: 'monkey|kernel=monkey-swing|agent=K|lane=scalp|src=v0.10',
+            agent: 'K',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const { stateReconciliationService } = await import('../stateReconciliationService.js');
+    await stateReconciliationService.reconcile('user-1');
+
+    // The row still closes (bookkeeping) but NO reward is published because the
+    // real margin (the chemistry scale) is unavailable.
+    expect(publishMock).not.toHaveBeenCalled();
   });
 
   // ── Flag ON: a kernel-own late close is NOT double-rewarded ───────────────
@@ -168,6 +221,7 @@ describe('stateReconciliationService ghost recovery', () => {
             side: 'buy',
             entry_price: '2077.30',
             quantity: '0.38',
+            leverage: 16,
             order_id: 'open-order',
             entry_time: new Date(entryMs),
           },

--- a/apps/api/src/services/__tests__/stateReconciliationService.test.ts
+++ b/apps/api/src/services/__tests__/stateReconciliationService.test.ts
@@ -15,6 +15,7 @@ vi.mock('../apiCredentialsService.js', () => ({
   },
 }));
 
+const getAccountBillsMock = vi.fn().mockResolvedValue([]);
 vi.mock('../poloniexFuturesService.js', () => ({
   default: {
     getAccountBalance: vi.fn().mockResolvedValue({ eq: '100' }),
@@ -26,6 +27,8 @@ vi.mock('../poloniexFuturesService.js', () => ({
         realizedPnl: '-1.0382',
       },
     ]),
+    getAccountBills: (...args: unknown[]) => getAccountBillsMock(...args),
+    normalizeSymbol: (s: string) => s,
   },
 }));
 
@@ -44,6 +47,9 @@ describe('stateReconciliationService ghost recovery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     queryMock.mockReset();
+    getAccountBillsMock.mockReset();
+    getAccountBillsMock.mockResolvedValue([]);
+    delete process.env.MONKEY_REWARD_EXTERNAL_CLOSES_LIVE;
   });
 
   it('closes a ghost row even when aggregate recovered PnL is conservatively ignored', async () => {
@@ -88,6 +94,104 @@ describe('stateReconciliationService ghost recovery', () => {
     );
     expect(updateCall).toBeTruthy();
     expect(updateCall?.[1]).toEqual(['manual_close_user', 'trade-1', null]);
+    expect(publishMock).not.toHaveBeenCalled();
+    expect(getAccountBillsMock).not.toHaveBeenCalled();
+  });
+
+  // ── Flag ON: external close fires exactly one bills-authoritative reward ───
+  it('flag ON: publishes exactly one external-close reward with the bills magnitude', async () => {
+    process.env.MONKEY_REWARD_EXTERNAL_CLOSES_LIVE = 'true';
+    const entryMs = Date.parse('2026-05-27T08:02:13Z');
+    // Two PNL bill rows in the close window → Σ = −1.5 (authoritative).
+    getAccountBillsMock.mockResolvedValue([
+      { type: 'PNL', sz: '-1.0', symbol: 'ETH_USDT_PERP', cTime: Date.now(), id: 'b1' },
+      { type: 'PNL', sz: '-0.5', symbol: 'ETH_USDT_PERP', cTime: Date.now(), id: 'b2' },
+    ]);
+
+    queryMock
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'trade-1',
+            symbol: 'ETH_USDT_PERP',
+            side: 'buy',
+            entry_price: '2077.30',
+            quantity: '0.38',
+            order_id: 'open-order',
+            entry_time: new Date(entryMs),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // performance row
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            exit_order_id: null,
+            reason: 'monkey|kernel=monkey-swing|agent=K|lane=scalp|src=v0.10',
+            agent: 'K',
+          },
+        ],
+      })
+      // Close ghost row UPDATE — transitions open→closed (rowCount 1).
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const { stateReconciliationService } = await import('../stateReconciliationService.js');
+    const result = await stateReconciliationService.reconcile('user-1');
+
+    expect(result.ghosts).toHaveLength(1);
+    expect(getAccountBillsMock).toHaveBeenCalled();
+    // Exactly one OUTCOME publish, carrying the bills-authoritative magnitude
+    // (single row → 100% qty share → −1.5) and the external-close provenance.
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const ev = publishMock.mock.calls[0][0];
+    expect(ev.type).toBe('outcome');
+    expect(ev.payload.source).toBe('reconciler_recovered:manual_close_user');
+    expect(ev.payload.pnlSource).toBe('polo_bills_external_close');
+    expect(ev.payload.agent).toBe('K');
+    expect(ev.payload.pnl).toBeCloseTo(-1.5, 6);
+  });
+
+  // ── Flag ON: a kernel-own late close is NOT double-rewarded ───────────────
+  it('flag ON: does NOT reward a kernel-own late-landing close (post_close_race)', async () => {
+    process.env.MONKEY_REWARD_EXTERNAL_CLOSES_LIVE = 'true';
+    const entryMs = Date.parse('2026-05-27T08:02:13Z');
+    getAccountBillsMock.mockResolvedValue([
+      { type: 'PNL', sz: '-1.0', symbol: 'ETH_USDT_PERP', cTime: Date.now(), id: 'b1' },
+    ]);
+
+    queryMock
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'trade-1',
+            symbol: 'ETH_USDT_PERP',
+            side: 'buy',
+            entry_price: '2077.30',
+            quantity: '0.38',
+            order_id: 'open-order',
+            entry_time: new Date(entryMs),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      // Ghost ctx: exit_order_id present → kernel's own close landed late →
+      // ghostReason = 'reconciled_post_close_race' → reward already fired on
+      // the kernel's own path; must NOT be re-rewarded here.
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            exit_order_id: 'kernel-close-order',
+            reason: 'monkey|kernel=monkey-swing|agent=K|lane=scalp|src=v0.10',
+            agent: 'K',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const { stateReconciliationService } = await import('../stateReconciliationService.js');
+    await stateReconciliationService.reconcile('user-1');
+
+    // No external-close reward publish for a kernel-own close.
     expect(publishMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/monkey/__tests__/external_close_reward.test.ts
+++ b/apps/api/src/services/monkey/__tests__/external_close_reward.test.ts
@@ -1,0 +1,150 @@
+/**
+ * external_close_reward.test.ts — money-path policy tests for the
+ * "operator-close hole" reward decision (#1033).
+ *
+ * The reconciler does the DB/Polo I/O + bus publish; the testable policy
+ * lives in `decideExternalCloseReward`. These tests pin the four required
+ * behaviours from the spec:
+ *
+ *   1. Flag ON + external close + agent + authoritative bills magnitude
+ *      → fires exactly one reward with the correct (bills) magnitude.
+ *   2. A kernel-own close (ghostReason='reconciled_post_close_race') is NOT
+ *      double-rewarded — it is declined regardless of flag/magnitude.
+ *   3. Flag OFF → declined (`flag_off`) → byte-identical to today
+ *      (bookkeeping-only; no reward).
+ *   4. Authoritative-only magnitude: no PNL bill rows → declined
+ *      (`no_bills_pnl`) rather than rewarding a guessed value.
+ *
+ * The reward magnitude fed downstream is the bills-authoritative realized
+ * PnL (the SAME `/v3/account/bills` type=PNL surface the kernel's own close
+ * path consumes), NOT the lossy ±90s position-history match.
+ */
+import { describe, expect, it } from 'vitest';
+import { decideExternalCloseReward } from '../polo_reward_ledger.js';
+
+describe('decideExternalCloseReward (operator-close hole #1033)', () => {
+  // ── Guard 3: flag OFF → byte-identical to today (regression pin) ──────────
+  it('declines when the flag is OFF (flag_off) regardless of inputs', () => {
+    const out = decideExternalCloseReward({
+      enabled: false,
+      ghostReason: 'manual_close_user',
+      agent: 'K',
+      billsRealizedPnl: -4.2499,
+      pnlBillRowCount: 8,
+    });
+    expect(out.eligible).toBe(false);
+    if (!out.eligible) expect(out.reason).toBe('flag_off');
+  });
+
+  // ── Happy path: flag ON + external close + agent + authoritative magnitude ─
+  it('fires exactly one reward with the bills-authoritative magnitude', () => {
+    const out = decideExternalCloseReward({
+      enabled: true,
+      ghostReason: 'manual_close_user',
+      agent: 'K',
+      billsRealizedPnl: -4.2499,
+      pnlBillRowCount: 8,
+    });
+    expect(out.eligible).toBe(true);
+    if (out.eligible) {
+      // The magnitude is the bills realized PnL, not a synthetic/history value.
+      expect(out.realizedPnl).toBeCloseTo(-4.2499, 6);
+      expect(out.pnlSource).toBe('polo_bills_external_close');
+    }
+  });
+
+  it('fires for a positive (winning) external/CC exemplar close', () => {
+    const out = decideExternalCloseReward({
+      enabled: true,
+      ghostReason: 'manual_close_user',
+      agent: 'M',
+      billsRealizedPnl: 3.14,
+      pnlBillRowCount: 2,
+    });
+    expect(out.eligible).toBe(true);
+    if (out.eligible) expect(out.realizedPnl).toBeCloseTo(3.14, 6);
+  });
+
+  // ── Guard 1: NO double-count vs the kernel's own close path ───────────────
+  it('declines a kernel-own late-landing close (reconciled_post_close_race)', () => {
+    const out = decideExternalCloseReward({
+      enabled: true,
+      ghostReason: 'reconciled_post_close_race',
+      agent: 'K',
+      billsRealizedPnl: -4.2499,
+      pnlBillRowCount: 8,
+    });
+    expect(out.eligible).toBe(false);
+    if (!out.eligible) expect(out.reason).toBe('not_external_close');
+  });
+
+  it('declines any non-external ghost reason', () => {
+    for (const reason of ['reconciled', 'kernel_adopted', 'unknown', '']) {
+      const out = decideExternalCloseReward({
+        enabled: true,
+        ghostReason: reason,
+        agent: 'T',
+        billsRealizedPnl: -1.0,
+        pnlBillRowCount: 3,
+      });
+      expect(out.eligible).toBe(false);
+      if (!out.eligible) expect(out.reason).toBe('not_external_close');
+    }
+  });
+
+  // ── Guard 4: must attribute to an agent's chemistry ───────────────────────
+  it('declines an unattributed (null-agent) external close', () => {
+    const out = decideExternalCloseReward({
+      enabled: true,
+      ghostReason: 'manual_close_user',
+      agent: null,
+      billsRealizedPnl: -2.0,
+      pnlBillRowCount: 4,
+    });
+    expect(out.eligible).toBe(false);
+    if (!out.eligible) expect(out.reason).toBe('no_agent');
+  });
+
+  // ── Guard 3: authoritative-only magnitude ─────────────────────────────────
+  it('declines when no PNL bill rows matched (no_bills_pnl) — never guesses', () => {
+    const out = decideExternalCloseReward({
+      enabled: true,
+      ghostReason: 'manual_close_user',
+      agent: 'K',
+      billsRealizedPnl: 0,
+      pnlBillRowCount: 0,
+    });
+    expect(out.eligible).toBe(false);
+    if (!out.eligible) expect(out.reason).toBe('no_bills_pnl');
+  });
+
+  it('declines a non-finite magnitude (defensive)', () => {
+    const out = decideExternalCloseReward({
+      enabled: true,
+      ghostReason: 'manual_close_user',
+      agent: 'L',
+      billsRealizedPnl: Number.NaN,
+      pnlBillRowCount: 2,
+    });
+    expect(out.eligible).toBe(false);
+    if (!out.eligible) expect(out.reason).toBe('non_finite_pnl');
+  });
+
+  // ── Dedup intent: the decision is a pure function of its inputs, so a
+  // second identical call yields the same eligibility. The reconciler's
+  // status='open' UPDATE guard ensures the PUBLISH happens at most once per
+  // row; this pins that the policy itself is deterministic (no hidden state
+  // that could let a second tick re-reward).
+  it('is a pure deterministic decision (same inputs → same output)', () => {
+    const input = {
+      enabled: true,
+      ghostReason: 'manual_close_user',
+      agent: 'K' as const,
+      billsRealizedPnl: -4.2499,
+      pnlBillRowCount: 8,
+    };
+    const a = decideExternalCloseReward(input);
+    const b = decideExternalCloseReward(input);
+    expect(a).toEqual(b);
+  });
+});

--- a/apps/api/src/services/monkey/__tests__/external_close_reward.test.ts
+++ b/apps/api/src/services/monkey/__tests__/external_close_reward.test.ts
@@ -31,24 +31,28 @@ describe('decideExternalCloseReward (operator-close hole #1033)', () => {
       agent: 'K',
       billsRealizedPnl: -4.2499,
       pnlBillRowCount: 8,
+      marginUsdt: 12.5,
     });
     expect(out.eligible).toBe(false);
     if (!out.eligible) expect(out.reason).toBe('flag_off');
   });
 
   // ── Happy path: flag ON + external close + agent + authoritative magnitude ─
-  it('fires exactly one reward with the bills-authoritative magnitude', () => {
+  it('fires exactly one reward with the bills-authoritative magnitude + real margin', () => {
     const out = decideExternalCloseReward({
       enabled: true,
       ghostReason: 'manual_close_user',
       agent: 'K',
       billsRealizedPnl: -4.2499,
       pnlBillRowCount: 8,
+      marginUsdt: 12.5,
     });
     expect(out.eligible).toBe(true);
     if (out.eligible) {
       // The magnitude is the bills realized PnL, not a synthetic/history value.
       expect(out.realizedPnl).toBeCloseTo(-4.2499, 6);
+      // The scale is the REAL position margin, not the retired synthetic 5.
+      expect(out.marginUsdt).toBeCloseTo(12.5, 6);
       expect(out.pnlSource).toBe('polo_bills_external_close');
     }
   });
@@ -60,10 +64,61 @@ describe('decideExternalCloseReward (operator-close hole #1033)', () => {
       agent: 'M',
       billsRealizedPnl: 3.14,
       pnlBillRowCount: 2,
+      marginUsdt: 8.0,
     });
     expect(out.eligible).toBe(true);
     if (out.eligible) expect(out.realizedPnl).toBeCloseTo(3.14, 6);
   });
+
+  // ── Guard 5 (the reviewed knob fix): REAL margin scaling, not /5 ──────────
+  it('carries the REAL position margin so pnl_fraction = pnl / actual_margin (not /5)', () => {
+    // A small position: $0.50 margin (e.g. $8 notional at 16×). The retired
+    // knob would have scaled this loss by /5 (pnl_fraction = -0.50/5 = -0.10),
+    // hugely understating the lesson. With the real margin the fraction is
+    // -0.50/0.50 = -1.0 — the position lost a full margin's worth.
+    const realizedPnl = -0.50;
+    const realMargin = 0.50;
+    const out = decideExternalCloseReward({
+      enabled: true,
+      ghostReason: 'manual_close_user',
+      agent: 'K',
+      billsRealizedPnl: realizedPnl,
+      pnlBillRowCount: 4,
+      marginUsdt: realMargin,
+    });
+    expect(out.eligible).toBe(true);
+    if (out.eligible) {
+      const realFraction = out.realizedPnl / out.marginUsdt;
+      const syntheticFraction = out.realizedPnl / 5;
+      expect(realFraction).toBeCloseTo(-1.0, 6);
+      expect(syntheticFraction).toBeCloseTo(-0.10, 6);
+      // The real lesson is 10× the magnitude the synthetic /5 knob taught.
+      expect(Math.abs(realFraction)).toBeGreaterThan(Math.abs(syntheticFraction));
+    }
+  });
+
+  // ── Guard 5: decline when the real margin is unavailable (decline-over-guess) ─
+  it.each([
+    ['null margin', null],
+    ['zero margin', 0],
+    ['negative margin', -3.2],
+    ['NaN margin', Number.NaN],
+    ['Infinity margin', Number.POSITIVE_INFINITY],
+  ] as Array<[string, number | null]>)(
+    'declines (no_real_margin) when margin is unavailable: %s',
+    (_label, margin) => {
+      const out = decideExternalCloseReward({
+        enabled: true,
+        ghostReason: 'manual_close_user',
+        agent: 'K',
+        billsRealizedPnl: -4.2499,
+        pnlBillRowCount: 8,
+        marginUsdt: margin,
+      });
+      expect(out.eligible).toBe(false);
+      if (!out.eligible) expect(out.reason).toBe('no_real_margin');
+    },
+  );
 
   // ── Guard 1: NO double-count vs the kernel's own close path ───────────────
   it('declines a kernel-own late-landing close (reconciled_post_close_race)', () => {
@@ -73,6 +128,7 @@ describe('decideExternalCloseReward (operator-close hole #1033)', () => {
       agent: 'K',
       billsRealizedPnl: -4.2499,
       pnlBillRowCount: 8,
+      marginUsdt: 12.5,
     });
     expect(out.eligible).toBe(false);
     if (!out.eligible) expect(out.reason).toBe('not_external_close');
@@ -86,6 +142,7 @@ describe('decideExternalCloseReward (operator-close hole #1033)', () => {
         agent: 'T',
         billsRealizedPnl: -1.0,
         pnlBillRowCount: 3,
+        marginUsdt: 5.0,
       });
       expect(out.eligible).toBe(false);
       if (!out.eligible) expect(out.reason).toBe('not_external_close');
@@ -100,6 +157,7 @@ describe('decideExternalCloseReward (operator-close hole #1033)', () => {
       agent: null,
       billsRealizedPnl: -2.0,
       pnlBillRowCount: 4,
+      marginUsdt: 5.0,
     });
     expect(out.eligible).toBe(false);
     if (!out.eligible) expect(out.reason).toBe('no_agent');
@@ -113,6 +171,7 @@ describe('decideExternalCloseReward (operator-close hole #1033)', () => {
       agent: 'K',
       billsRealizedPnl: 0,
       pnlBillRowCount: 0,
+      marginUsdt: 5.0,
     });
     expect(out.eligible).toBe(false);
     if (!out.eligible) expect(out.reason).toBe('no_bills_pnl');
@@ -125,6 +184,22 @@ describe('decideExternalCloseReward (operator-close hole #1033)', () => {
       agent: 'L',
       billsRealizedPnl: Number.NaN,
       pnlBillRowCount: 2,
+      marginUsdt: 5.0,
+    });
+    expect(out.eligible).toBe(false);
+    if (!out.eligible) expect(out.reason).toBe('non_finite_pnl');
+  });
+
+  // Guard ordering: pnl is checked before margin, so a non-finite pnl AND a
+  // bad margin reports the pnl reason (the lesson is undefined either way).
+  it('reports non_finite_pnl before no_real_margin when both are bad', () => {
+    const out = decideExternalCloseReward({
+      enabled: true,
+      ghostReason: 'manual_close_user',
+      agent: 'K',
+      billsRealizedPnl: Number.NaN,
+      pnlBillRowCount: 2,
+      marginUsdt: null,
     });
     expect(out.eligible).toBe(false);
     if (!out.eligible) expect(out.reason).toBe('non_finite_pnl');
@@ -142,6 +217,7 @@ describe('decideExternalCloseReward (operator-close hole #1033)', () => {
       agent: 'K' as const,
       billsRealizedPnl: -4.2499,
       pnlBillRowCount: 8,
+      marginUsdt: 12.5,
     };
     const a = decideExternalCloseReward(input);
     const b = decideExternalCloseReward(input);

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1435,25 +1435,35 @@ export class MonkeyKernel extends EventEmitter {
           src.startsWith('reconciler_recovered');
         if (!isRecovered) return;
         if (!recoveredOutcomeMatchesInstance(payload, this.instanceId)) return;
-        // Reconciler-recovered events use marginUsdt=5 to match the
-        // global pushReward path's constant for ghost-close recoveries
-        // (see lines below this subscriber, marginUsdt: 5).
-        this.applyOutcomeToAgent(event.symbol, agent, side as 'long' | 'short', pnl, 5);
+        // Margin scale for `pnl_fraction = pnl / marginUsdt`.
+        //
+        // #1033 refine: external-close reward events (the reconciler's
+        // `manual_close_user` path) now carry the position's REAL margin in
+        // `payload.marginUsdt` (= entry_price × quantity / leverage) so the
+        // chemistry learns at the TRUE scale of the lesson. The hardcoded
+        // `marginUsdt = 5` was a synthetic scale knob (P1 violation): it set
+        // pnl_fraction = pnl / 5 regardless of the actual position size.
+        //
+        // Legacy ghost-recovery events (other ghostReasons: exchange-side
+        // liquidation, partial-fill cleanup) still lack qty/leverage and emit
+        // no `payload.marginUsdt`, so they fall through to the nominal 5 —
+        // UNCHANGED, byte-identical behaviour. Only the external-close path,
+        // which now emits a real `payload.marginUsdt`, uses the real scale.
+        const payloadMargin = Number(payload.marginUsdt ?? NaN);
+        const rewardMargin =
+          Number.isFinite(payloadMargin) && payloadMargin > 0 ? payloadMargin : 5;
+        this.applyOutcomeToAgent(event.symbol, agent, side as 'long' | 'short', pnl, rewardMargin);
         // 2026-05-16 per-agent NC: also feed reconciler-recovered
         // ghost-closes into the agent's chemistry queue. Without this,
         // M/T/L closes that the close-path missed (exchange-side
         // liquidation, manual UI close, partial-fill cleanup) would
         // update emotion state but NOT the agent's dopamine window.
-        // Margin estimation: ghost-recovered events lack qty + mark
-        // price; reuse the witnessExit pattern of a fixed nominal
-        // margin (5 USDT) so pnlFraction = pnl / 5 stays bounded and
-        // doesn't blow out the dop/ser/endo deltas on a one-off ghost.
         try {
           this.pushReward({
             source: `reconciler_recovered:${String(payload.ghostReason ?? 'unknown')}`,
             symbol: event.symbol,
             realizedPnlUsdt: pnl,
-            marginUsdt: 5,
+            marginUsdt: rewardMargin,
             agent,
           });
         } catch { /* non-fatal */ }
@@ -1465,7 +1475,7 @@ export class MonkeyKernel extends EventEmitter {
           source: `reconciler_recovered:${String(payload.ghostReason ?? 'unknown')}`,
           symbol: event.symbol,
           realizedPnlUsdt: pnl,
-          marginUsdt: 5,
+          marginUsdt: rewardMargin,
         });
         const ghostReason = String(payload.ghostReason ?? 'unknown');
         logger.info(

--- a/apps/api/src/services/monkey/polo_reward_ledger.ts
+++ b/apps/api/src/services/monkey/polo_reward_ledger.ts
@@ -276,12 +276,32 @@ export function composePoloBillsReward(
  *    one).
  * 4. AGENT-OWNED. Only K/M/T/L-attributed rows feed an agent's chemistry.
  *    A null/unknown agent → not eligible (nothing to attribute to).
+ * 5. REAL MARGIN (no synthetic scale knob). The reward chemistry derives its
+ *    dopamine/serotonin magnitude from `pnl_fraction = pnl / marginUsdt`, so
+ *    `marginUsdt` IS the scale of the lesson. A hardcoded constant
+ *    (`marginUsdt = 5`) was a P1 knob that synthetically scaled the chemistry
+ *    independent of the position's real size. The reconciler computes the
+ *    actual position margin from the autonomous_trades row(s) —
+ *    `Σ(entry_price × quantity) / leverage` (quantity is base-asset post
+ *    migration 060, so entry_price × quantity is the USDT notional directly;
+ *    no contract-size multiplier is needed) — the SAME formula the kernel's
+ *    own close path uses (#992, loop.ts). If the real margin is unavailable
+ *    (missing/zero leverage, qty, or entry price → non-finite or ≤0), we
+ *    DECLINE rather than feed a guessed/synthetic-margin reward (decline over
+ *    guess: better to miss a lesson than teach it at the wrong scale).
  */
 export type ExternalCloseRewardEligibility =
   | {
       eligible: true;
       /** Bills-authoritative realized PnL to feed the reward chemistry. */
       realizedPnl: number;
+      /**
+       * Real position margin (USDT) computed from the autonomous_trades
+       * row(s) — `Σ(entry_price × quantity) / leverage`. Drives
+       * `pnl_fraction = pnl / marginUsdt` in the reward chemistry. NEVER a
+       * hardcoded constant (the retired `marginUsdt = 5` P1 knob).
+       */
+      marginUsdt: number;
       /** Provenance tag for the OUTCOME publish + telemetry. */
       pnlSource: 'polo_bills_external_close';
     }
@@ -293,7 +313,8 @@ export type ExternalCloseRewardEligibility =
         | 'not_external_close'
         | 'no_agent'
         | 'no_bills_pnl'
-        | 'non_finite_pnl';
+        | 'non_finite_pnl'
+        | 'no_real_margin';
     };
 
 export function decideExternalCloseReward(input: {
@@ -307,6 +328,13 @@ export function decideExternalCloseReward(input: {
   billsRealizedPnl: number;
   /** Count of PNL bill rows matched (0 → no authoritative magnitude). */
   pnlBillRowCount: number;
+  /**
+   * Real position margin (USDT) for the group, computed by the reconciler as
+   * `Σ(entry_price × quantity) / leverage` over the ghost rows. `null` (or a
+   * non-finite/≤0 value) means the real margin could not be derived (missing
+   * leverage/qty/entry) → decline over guess. NEVER a hardcoded fallback.
+   */
+  marginUsdt: number | null;
 }): ExternalCloseRewardEligibility {
   if (!input.enabled) return { eligible: false, reason: 'flag_off' };
   // Guard 1: ONLY operator/CC external closes. `reconciled_post_close_race`
@@ -322,9 +350,18 @@ export function decideExternalCloseReward(input: {
   if (!Number.isFinite(input.billsRealizedPnl)) {
     return { eligible: false, reason: 'non_finite_pnl' };
   }
+  // Guard 5: REAL margin only — decline over guess. The retired `marginUsdt=5`
+  // knob synthetically scaled the chemistry; here the scale must be the
+  // position's real margin or we decline.
+  if (input.marginUsdt === null
+      || !Number.isFinite(input.marginUsdt)
+      || input.marginUsdt <= 0) {
+    return { eligible: false, reason: 'no_real_margin' };
+  }
   return {
     eligible: true,
     realizedPnl: input.billsRealizedPnl,
+    marginUsdt: input.marginUsdt,
     pnlSource: 'polo_bills_external_close',
   };
 }

--- a/apps/api/src/services/monkey/polo_reward_ledger.ts
+++ b/apps/api/src/services/monkey/polo_reward_ledger.ts
@@ -240,3 +240,91 @@ export function composePoloBillsReward(
   }
   return { realizedPnl, fundingSigned, pnlRowCount, fundingRowCount };
 }
+
+/**
+ * External-close reward decision (the "operator-close hole" — #1033).
+ *
+ * Externally/operator-closed positions (closed in the exchange UI, or by a
+ * CC/operator exemplar trade — NOT by a kernel-issued close order) currently
+ * feed realized PnL into bookkeeping (`autonomous_trades.pnl` via the
+ * reconciler) but DO NOT feed the kernel's reward chemistry. The kernel's own
+ * close path (`applyPoloRealizedPnlAfterClose`, keyed on the kernel's own
+ * `closeOrderIds`) is the only thing that fires `pushReward` /
+ * `callAutonomicReward` today. So operator/CC exemplar trades teach nothing.
+ *
+ * This pure helper decides — for a SINGLE ghost-closed row the reconciler is
+ * about to finalize — whether to ALSO route its realized PnL into the reward
+ * chemistry, and with what magnitude. The reconciler does the DB/Polo I/O and
+ * the bus publish; this function holds the (testable) policy so the decision
+ * is unit-pinnable without the DB/Polo/env machinery.
+ *
+ * # Guards encoded here (mirrors the task spec)
+ *
+ * 1. NO DOUBLE-COUNT vs the kernel's own close path. A kernel-issued close
+ *    that lands late is tagged `reconciled_post_close_race` by the reconciler
+ *    (it carries an `exit_order_id`); its reward already fired on the kernel's
+ *    own path. ONLY `manual_close_user` (operator/CC external close) is
+ *    eligible here. Any other ghostReason → not eligible.
+ * 2. FLAG-GATED. `enabled=false` (flag OFF) → never eligible → byte-identical
+ *    to today's bookkeeping-only behaviour.
+ * 3. AUTHORITATIVE MAGNITUDE. The reward magnitude is the bills-authoritative
+ *    realized PnL (`/v3/account/bills` `type=PNL` sum, #1028) — the SAME
+ *    surface the kernel's own close path consumes. The lossy ±90s
+ *    position-history match is NOT used for reward. If no PNL bill rows
+ *    matched (`pnlBillRowCount <= 0`), we decline rather than reward a
+ *    synthetic/guessed magnitude (better to miss a lesson than teach a wrong
+ *    one).
+ * 4. AGENT-OWNED. Only K/M/T/L-attributed rows feed an agent's chemistry.
+ *    A null/unknown agent → not eligible (nothing to attribute to).
+ */
+export type ExternalCloseRewardEligibility =
+  | {
+      eligible: true;
+      /** Bills-authoritative realized PnL to feed the reward chemistry. */
+      realizedPnl: number;
+      /** Provenance tag for the OUTCOME publish + telemetry. */
+      pnlSource: 'polo_bills_external_close';
+    }
+  | {
+      eligible: false;
+      /** Why the reward was declined (telemetry/debugging only). */
+      reason:
+        | 'flag_off'
+        | 'not_external_close'
+        | 'no_agent'
+        | 'no_bills_pnl'
+        | 'non_finite_pnl';
+    };
+
+export function decideExternalCloseReward(input: {
+  /** `MONKEY_REWARD_EXTERNAL_CLOSES_LIVE === 'true'`. */
+  enabled: boolean;
+  /** The reconciler's ghost reason for this row. */
+  ghostReason: string;
+  /** The owning agent, or null if unattributed. */
+  agent: 'K' | 'M' | 'T' | 'L' | null;
+  /** Σ of `type=PNL` bill `sz` over the close window. */
+  billsRealizedPnl: number;
+  /** Count of PNL bill rows matched (0 → no authoritative magnitude). */
+  pnlBillRowCount: number;
+}): ExternalCloseRewardEligibility {
+  if (!input.enabled) return { eligible: false, reason: 'flag_off' };
+  // Guard 1: ONLY operator/CC external closes. `reconciled_post_close_race`
+  // (kernel's own late-landing close) and any other reason are excluded so a
+  // kernel-own close can never be double-rewarded here.
+  if (input.ghostReason !== 'manual_close_user') {
+    return { eligible: false, reason: 'not_external_close' };
+  }
+  // Guard 4: must attribute to an agent's chemistry.
+  if (input.agent === null) return { eligible: false, reason: 'no_agent' };
+  // Guard 3: authoritative magnitude only.
+  if (input.pnlBillRowCount <= 0) return { eligible: false, reason: 'no_bills_pnl' };
+  if (!Number.isFinite(input.billsRealizedPnl)) {
+    return { eligible: false, reason: 'non_finite_pnl' };
+  }
+  return {
+    eligible: true,
+    realizedPnl: input.billsRealizedPnl,
+    pnlSource: 'polo_bills_external_close',
+  };
+}

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -15,6 +15,11 @@ import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
 import { BusEventType, getKernelBus } from './monkey/kernel_bus.js';
 import { extractKernelInstanceIdFromReason } from './monkey/recovered_outcome_routing.js';
+import {
+  composePoloBillsReward,
+  decideExternalCloseReward,
+  type PoloBillRow,
+} from './monkey/polo_reward_ledger.js';
 import { inferLaneFromLeverage, kernelAdoptLive } from './laneFromLeverage.js';
 import { getPrecisions } from './marketCatalog.js';
 
@@ -545,6 +550,112 @@ class StateReconciliationService {
           );
         }
 
+        // ── External-close reward: bills-authoritative realized PnL ──────────
+        //
+        // The "operator-close hole" (#1033): externally/operator-closed
+        // positions (closed in the exchange UI, or by a CC/operator exemplar
+        // trade — NOT by a kernel-issued close) feed realized PnL into
+        // bookkeeping above but DO NOT feed the kernel's reward chemistry. The
+        // existing loop.ts subscriber for `reconciler_recovered:*` OUTCOME
+        // events is starved because the conservative LIVED ONLY guard nulls
+        // `pnlForLedger` and gates the publish on it being non-null.
+        //
+        // Behind MONKEY_REWARD_EXTERNAL_CLOSES_LIVE (default OFF), for external
+        // (`manual_close_user`) closes we recover the authoritative realized
+        // PnL from /v3/account/bills (type=PNL sum, #1028 — the SAME surface
+        // the kernel's own close path consumes) and publish the OUTCOME event
+        // so the kernel learns from these exemplar closes. The lossy ±90s
+        // position-history match above is NOT used for the reward magnitude.
+        //
+        // Best-effort: any failure here is swallowed and never blocks
+        // reconciliation. Flag OFF → this block is inert and behaviour is
+        // byte-identical to today (bookkeeping-only).
+        const externalRewardEnabled =
+          process.env.MONKEY_REWARD_EXTERNAL_CLOSES_LIVE === 'true';
+        const groupHasExternalGhost = groupGhosts.some(
+          (g) => g.ghostReason === 'manual_close_user' && g.agent !== null,
+        );
+        let externalBillsRealizedPnl = 0;
+        let externalBillsPnlRowCount = 0;
+        if (externalRewardEnabled && groupHasExternalGhost && credentials && symbol) {
+          try {
+            // Tight close window around the time the reconciler is finalizing
+            // these ghosts (NOW); funding hold window back to the oldest
+            // ghost's entry_time. Bills carry no ordId — PNL rows are matched
+            // by symbol + this window (PNL bill cTime == close fill cTime).
+            const nowMs = Date.now();
+            const oldestEntryMs = Math.min(
+              ...groupGhosts.map(
+                (g) => new Date(g.dbTrade.entry_time).getTime() || nowMs,
+              ),
+            );
+            const holdStartMs = Number.isFinite(oldestEntryMs)
+              ? oldestEntryMs
+              : nowMs - 24 * 60 * 60 * 1000;
+            const normSymbol = poloniexFuturesService.normalizeSymbol(symbol);
+            const billRows: PoloBillRow[] = [];
+            const seenBillIds = new Set<string>();
+            let cursor: string | null = null;
+            for (let page = 0; page < 8; page += 1) {
+              const billsResp = await poloniexFuturesService.getAccountBills(
+                credentials,
+                { limit: 100, ...(cursor ? { from: cursor } : {}) },
+              );
+              const rows: any[] = Array.isArray(billsResp)
+                ? billsResp
+                : (billsResp?.data ?? []);
+              if (rows.length === 0) break;
+              for (const r of rows) {
+                // Dedup by bill id so a non-advancing cursor (or a repeated
+                // page) can never double-count a PNL row into the reward
+                // magnitude. Bills without an id fall back to a composite key.
+                const billId = String(
+                  r?.id ?? `${r?.type ?? ''}|${r?.cTime ?? ''}|${r?.sz ?? ''}`,
+                );
+                if (seenBillIds.has(billId)) continue;
+                seenBillIds.add(billId);
+                billRows.push({
+                  type: String(r?.type ?? ''),
+                  sz: parseFloat(String(r?.sz ?? 'NaN')),
+                  symbol: String(r?.symbol ?? ''),
+                  cTimeMs: Number(r?.cTime),
+                });
+              }
+              const nextCursor = String(rows[rows.length - 1]?.id ?? '') || null;
+              if (rows.every((r) => Number(r?.cTime) < holdStartMs)) break;
+              // Stop if the cursor did not advance (defensive against an API
+              // that echoes the same page — otherwise we'd spin the 8 pages).
+              if (!nextCursor || nextCursor === cursor) break;
+              cursor = nextCursor;
+            }
+            // Close window: the reconciler discovers the close AFTER the fact,
+            // so the exchange-side close cTime is somewhere between the oldest
+            // entry and now. Use a generous [holdStart, now+5s] window for PNL
+            // matching — these are external closes the kernel never timed, so
+            // a tight cTime window (used on kernel-own closes) is unavailable.
+            const billsComp = composePoloBillsReward(billRows, {
+              symbol: normSymbol,
+              closeStartMs: holdStartMs,
+              closeEndMs: nowMs + 5_000,
+              holdStartMs,
+              holdEndMs: nowMs + 5_000,
+            });
+            externalBillsRealizedPnl = billsComp.realizedPnl;
+            externalBillsPnlRowCount = billsComp.pnlRowCount;
+            logger.info('[RECONCILE] External-close bills realized recovered', {
+              symbol: normSymbol,
+              realizedPnl: billsComp.realizedPnl.toFixed(4),
+              pnlRows: billsComp.pnlRowCount,
+              fundingRows: billsComp.fundingRowCount,
+            });
+          } catch (billsErr) {
+            logger.warn('[RECONCILE] External-close bills fetch failed (non-fatal)', {
+              symbol,
+              err: billsErr instanceof Error ? billsErr.message : String(billsErr),
+            });
+          }
+        }
+
         // Write each ghost row with pro-rata PnL share.
         for (const g of groupGhosts) {
           const rowQty = Math.abs(parseFloat(g.dbTrade.quantity)) || 0;
@@ -573,41 +684,86 @@ class StateReconciliationService {
               pnlForLedger = null;
             }
 
-            await pool.query(
+            // Dedup: gate the close transition on status='open' so the reward
+            // publish below fires AT MOST ONCE per row (the row is only
+            // transitioned to 'closed' by exactly one reconciler tick). This
+            // prevents a re-reward if a later tick re-examines an
+            // already-closed row.
+            const closeRes = await pool.query(
               `UPDATE autonomous_trades
                SET status = 'closed',
                    exit_reason = $1,
                    exit_time = NOW(),
                    pnl = COALESCE($3, pnl)
-               WHERE id = $2`,
+               WHERE id = $2 AND status = 'open'`,
               [g.ghostReason, g.dbTrade.id, pnlForLedger],
             );
+            const transitioned = (closeRes.rowCount ?? 0) === 1;
             logger.info(
               `[RECONCILE] Closed ghost DB record ${g.dbTrade.id} for user ${userId}: ${g.dbTrade.symbol} ${g.dbTrade.side} (reason=${g.ghostReason}${
                 pnlForLedger !== null ? `, share=${(rowShare * 100).toFixed(1)}%, recovered_pnl=${pnlForLedger.toFixed(4)}` : ''
               })`,
             );
-            if (pnlForLedger !== null && g.agent !== null) {
-              try {
-                const bus = getKernelBus();
-                bus.publish({
-                  type: BusEventType.OUTCOME,
-                  source: 'reconciler',
-                  symbol: g.dbTrade.symbol,
-                  payload: {
-                    agent: g.agent,
-                    instanceId: g.instanceId,
-                    side: normalizeDbSide(g.dbTrade.side),
-                    pnl: pnlForLedger,
-                    source: `reconciler_recovered:${g.ghostReason}`,
-                    ghostReason: g.ghostReason,
+
+            // ── External-close reward publish (#1033, flag-gated) ─────────────
+            //
+            // The pure helper encodes every guard: flag ON, ghostReason ===
+            // 'manual_close_user' (excludes the kernel's own late-landing
+            // 'reconciled_post_close_race' close so it can NEVER be
+            // double-rewarded), agent attributed, and a bills-authoritative
+            // magnitude (declines on no PNL rows rather than guess). When the
+            // flag is OFF the decision is `flag_off` → no publish → behaviour
+            // is byte-identical to the bookkeeping-only path above.
+            //
+            // We only publish when THIS tick transitioned the row (dedup) so
+            // the chemistry sees each external close exactly once.
+            const rewardDecision = decideExternalCloseReward({
+              enabled: externalRewardEnabled,
+              ghostReason: g.ghostReason,
+              agent: g.agent,
+              billsRealizedPnl: externalBillsRealizedPnl,
+              pnlBillRowCount: externalBillsPnlRowCount,
+            });
+            if (rewardDecision.eligible && transitioned) {
+              // Pro-rata the group's authoritative realized PnL by this row's
+              // qty share so a DCA-stacked external close attributes each row
+              // its proportional slice (mirrors the bookkeeping rowShare).
+              const rowRewardPnl = rewardDecision.realizedPnl * rowShare;
+              if (Number.isFinite(rowRewardPnl)) {
+                try {
+                  const bus = getKernelBus();
+                  bus.publish({
+                    type: BusEventType.OUTCOME,
+                    source: 'reconciler',
+                    symbol: g.dbTrade.symbol,
+                    payload: {
+                      agent: g.agent,
+                      instanceId: g.instanceId,
+                      side: normalizeDbSide(g.dbTrade.side),
+                      pnl: rowRewardPnl,
+                      // The loop.ts subscriber keys on
+                      // `source.startsWith('reconciler_recovered')` →
+                      // applyOutcomeToAgent + pushReward + callAutonomicReward.
+                      source: `reconciler_recovered:${g.ghostReason}`,
+                      ghostReason: g.ghostReason,
+                      tradeId: g.dbTrade.id,
+                      pnlSource: rewardDecision.pnlSource,
+                    },
+                  });
+                  logger.info('[RECONCILE] External-close reward published to chemistry', {
                     tradeId: g.dbTrade.id,
-                  },
-                });
-              } catch (busErr) {
-                logger.debug('[RECONCILE] OUTCOME publish failed', {
-                  err: busErr instanceof Error ? busErr.message : String(busErr),
-                });
+                    symbol: g.dbTrade.symbol,
+                    agent: g.agent,
+                    rowRewardPnl: rowRewardPnl.toFixed(4),
+                    pnlSource: rewardDecision.pnlSource,
+                  });
+                } catch (busErr) {
+                  // Best-effort: a reward-firing failure NEVER blocks
+                  // reconciliation or trading.
+                  logger.debug('[RECONCILE] External-close OUTCOME publish failed (non-fatal)', {
+                    err: busErr instanceof Error ? busErr.message : String(busErr),
+                  });
+                }
               }
             }
           } catch (updateErr) {

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -115,7 +115,13 @@ class StateReconciliationService {
 
       // ── 4. Fetch DB-recorded open trades ────────────────────────────────────
       const dbResult = await pool.query(
-        `SELECT id, symbol, side, entry_price, quantity, order_id, entry_time
+        // `leverage` (nullable INTEGER, migration 048) is needed to compute the
+        // real position margin for the external-close reward (#1033 refine):
+        // margin = entry_price × quantity / leverage. Without it the chemistry
+        // scale would fall back to a synthetic constant (the retired
+        // marginUsdt=5 knob). quantity is base-asset (migration 060) so
+        // entry_price × quantity is the USDT notional directly.
+        `SELECT id, symbol, side, entry_price, quantity, leverage, order_id, entry_time
          FROM autonomous_trades
          WHERE user_id = $1 AND status = 'open'`,
         [userId]
@@ -126,6 +132,7 @@ class StateReconciliationService {
         side: string;
         entry_price: string;
         quantity: string;
+        leverage: number | string | null;
         order_id: string | null;
         entry_time: Date | string;
       }[] = dbResult.rows;
@@ -633,6 +640,23 @@ class StateReconciliationService {
             // entry and now. Use a generous [holdStart, now+5s] window for PNL
             // matching — these are external closes the kernel never timed, so
             // a tight cTime window (used on kernel-own closes) is unavailable.
+            //
+            // KNOWN LIMITATION (#1033 refine): bills carry no ordId/side, so
+            // the PNL sum is matched by symbol + this time window only. If two
+            // DISTINCT close events of the SAME symbol+side land inside one
+            // reconciler interval, their PNL bills aggregate. For the
+            // external-close group this is actually CORRECT — every K-owned row
+            // in the group is attributed the aggregate, pro-rated by qty. The
+            // residual unhandled case is a same-symbol+side PNL bill from a
+            // DIFFERENT lifecycle (e.g. a kernel-own close that landed in the
+            // same window) being folded into the external reward magnitude.
+            // Tightening this reliably needs an ordId-tagged or per-fill bills
+            // surface (tracked as the polo per-row-vs-per-position follow-up);
+            // a time-only heuristic would mis-split legitimately-aggregated
+            // closes, so we keep the symbol+window match and accept the rare
+            // cross-lifecycle overlap rather than ship a fragile narrower
+            // window. The flag default-OFF keeps this inert until the surface
+            // improves.
             const billsComp = composePoloBillsReward(billRows, {
               symbol: normSymbol,
               closeStartMs: holdStartMs,
@@ -654,6 +678,46 @@ class StateReconciliationService {
               err: billsErr instanceof Error ? billsErr.message : String(billsErr),
             });
           }
+        }
+
+        // ── Real position margin for the external-close reward (#1033 refine) ──
+        //
+        // The reward chemistry scales by `pnl_fraction = pnl / marginUsdt`, so
+        // marginUsdt IS the lesson's scale. The original PR passed a hardcoded
+        // `marginUsdt = 5` into the loop.ts reward subscriber — a synthetic
+        // scale knob (P1 violation). Replace it with the position's REAL margin
+        // derived from the autonomous_trades row(s):
+        //   margin = entry_price × quantity / leverage
+        // (quantity is base-asset post migration 060, so entry_price × quantity
+        // is the USDT notional directly — no contract-size multiplier; this is
+        // the SAME formula the kernel's own close path uses, #992 loop.ts).
+        //
+        // Computed per-row (leverage can differ across DCA-stacked rows) so each
+        // pro-rata reward carries its OWN real scale, and summed for the
+        // group-level eligibility decision. A row whose entry/qty/leverage is
+        // missing or non-positive contributes null → decline over guess.
+        const rowMarginUsdt = (t: typeof groupGhosts[number]['dbTrade']): number | null => {
+          const entry = parseFloat(t.entry_price);
+          const qty = Math.abs(parseFloat(t.quantity));
+          const levRaw = t.leverage === null || t.leverage === undefined
+            ? NaN
+            : Number(t.leverage);
+          const lev = Number.isFinite(levRaw) ? levRaw : NaN;
+          if (!Number.isFinite(entry) || entry <= 0) return null;
+          if (!Number.isFinite(qty) || qty <= 0) return null;
+          if (!Number.isFinite(lev) || lev <= 0) return null;
+          const margin = (entry * qty) / lev;
+          return Number.isFinite(margin) && margin > 0 ? margin : null;
+        };
+        // Group margin: present only if EVERY external ghost row has a real
+        // margin. Any null → the group's real scale is incomplete → decline
+        // (rather than reward part of the group at a guessed scale).
+        let groupExternalMargin: number | null = 0;
+        for (const g of groupGhosts) {
+          if (g.ghostReason !== 'manual_close_user' || g.agent === null) continue;
+          const m = rowMarginUsdt(g.dbTrade);
+          if (m === null) { groupExternalMargin = null; break; }
+          groupExternalMargin = (groupExternalMargin ?? 0) + m;
         }
 
         // Write each ghost row with pro-rata PnL share.
@@ -717,14 +781,23 @@ class StateReconciliationService {
             //
             // We only publish when THIS tick transitioned the row (dedup) so
             // the chemistry sees each external close exactly once.
+            // Per-row REAL margin (entry_price × quantity / leverage). This is
+            // THIS row's own scale — passed in the OUTCOME payload so the
+            // loop.ts subscriber feeds `pnl_fraction = pnl / marginUsdt` with
+            // the real position margin, NOT the retired synthetic `5`.
+            const rowMargin = rowMarginUsdt(g.dbTrade);
             const rewardDecision = decideExternalCloseReward({
               enabled: externalRewardEnabled,
               ghostReason: g.ghostReason,
               agent: g.agent,
               billsRealizedPnl: externalBillsRealizedPnl,
               pnlBillRowCount: externalBillsPnlRowCount,
+              // Group-level real margin gates eligibility (decline if any row
+              // in the group lacks a real margin); the per-row margin below
+              // sets the published scale.
+              marginUsdt: groupExternalMargin,
             });
-            if (rewardDecision.eligible && transitioned) {
+            if (rewardDecision.eligible && transitioned && rowMargin !== null) {
               // Pro-rata the group's authoritative realized PnL by this row's
               // qty share so a DCA-stacked external close attributes each row
               // its proportional slice (mirrors the bookkeeping rowShare).
@@ -741,6 +814,9 @@ class StateReconciliationService {
                       instanceId: g.instanceId,
                       side: normalizeDbSide(g.dbTrade.side),
                       pnl: rowRewardPnl,
+                      // REAL per-row margin → the loop.ts subscriber uses this
+                      // for pnl_fraction instead of the synthetic marginUsdt=5.
+                      marginUsdt: rowMargin,
                       // The loop.ts subscriber keys on
                       // `source.startsWith('reconciler_recovered')` →
                       // applyOutcomeToAgent + pushReward + callAutonomicReward.
@@ -755,6 +831,7 @@ class StateReconciliationService {
                     symbol: g.dbTrade.symbol,
                     agent: g.agent,
                     rowRewardPnl: rowRewardPnl.toFixed(4),
+                    rowMarginUsdt: rowMargin.toFixed(4),
                     pnlSource: rewardDecision.pnlSource,
                   });
                 } catch (busErr) {


### PR DESCRIPTION
## What

Closes the **operator-close hole**: externally/operator-closed positions (closed via the exchange UI, or by a CC/operator exemplar trade — **not** by a kernel-issued close order) currently feed realized PnL into bookkeeping (`autonomous_trades.pnl` via the reconciler) but **do not** feed the kernel's reward chemistry. Operator/CC exemplar trades therefore teach the kernel nothing.

Behind a new flag **`MONKEY_REWARD_EXTERNAL_CLOSES_LIVE` (default OFF)**, external (`manual_close_user`) ghost closes now also route their **bills-authoritative** realized PnL into the reward chemistry (`pushReward` / `callAutonomicReward`), via the existing `reconciler_recovered:*` OUTCOME subscriber in `loop.ts`.

## Root cause (why the hole exists)

The reconciler's ghost-recovery block (`stateReconciliationService.ts` ~L562) nulls the recovered PnL under the conservative LIVED ONLY guard (`pnlForLedger = null`) and gates the OUTCOME bus publish on it being non-null. The downstream reward subscriber (`loop.ts` ~L1437 → `applyOutcomeToAgent` + `pushReward` + `callAutonomicReward`) already exists — it is simply **starved** because the publish never fires.

## The fix

When the flag is ON and a ghost is an external (`manual_close_user`) close of an agent-owned (K/M/T/L) row, the reconciler:
1. Recovers the authoritative realized PnL from `/v3/account/bills` (`type=PNL` sum) via the existing `composePoloBillsReward` — the **same #1028 surface** the kernel's own close path consumes.
2. Publishes the OUTCOME event (`source: reconciler_recovered:manual_close_user`, `pnlSource: polo_bills_external_close`) with that magnitude, pro-rata across DCA-stacked rows.

## Guards (all mandatory, all present)

| Guard | Mechanism |
|---|---|
| **No double-count vs kernel-own close** | Only `manual_close_user` is eligible. The kernel's own late-landing close is tagged `reconciled_post_close_race` (carries `exit_order_id`) — its reward already fired on the kernel-own path — and is **excluded**. |
| **At-most-once per row** | The close UPDATE is gated on `WHERE id=$ AND status='open'`; the publish only fires when that UPDATE transitioned the row (`rowCount === 1`). A later tick re-examining a closed row cannot re-reward. |
| **Authoritative magnitude only** | The lossy ±90s position-history match is **not** used for the reward. If no PNL bill rows match, the reward is **declined** (better to miss a lesson than teach a wrong magnitude). |
| **Pagination safety** | Bills are deduped by `id` and the page loop breaks on a non-advancing cursor — a repeated page can never inflate the magnitude. |
| **Best-effort isolation** | Every failure (bills fetch, publish) is swallowed; it never blocks reconciliation or trading. |
| **Flag OFF = byte-identical** | Default OFF → `decideExternalCloseReward` returns `flag_off` → no bills fetch, no publish. Regression-pinned. |

## Design note

The decision policy is extracted into a **pure helper** `decideExternalCloseReward` in `polo_reward_ledger.ts` (the reconciler pulls in DB + Polo service which kills the unit-test env; this mirrors the existing `composePoloAuthoritativeReward` extraction pattern). The reconciler does the I/O + publish; the helper holds the testable guards.

## PnL source: bills-authoritative (not reconciler ±90s match) — and why

The reconciler's existing recovered PnL comes from the `getPositionHistory` ±90s match, which #1028 replaced for kernel-own closes because it is lossy (only records on full position close; misses DCA partials; under-counted live). This PR feeds the reward channel from `/v3/account/bills` `type=PNL` rows instead — the canonical surface verified 2026-05-29 to reconcile exactly to the exchange export. Bookkeeping (`autonomous_trades.pnl`) is left exactly as today (still nulled under the LIVED ONLY guard); only the **reward magnitude** uses bills.

## Tests

- `external_close_reward.test.ts` (9) — pure-helper guards: flag OFF declines (`flag_off`); flag ON + external + agent + bills → fires with correct magnitude; kernel-own race close declined (`not_external_close`); null-agent declined; no-bills declined (`no_bills_pnl`); non-finite declined; determinism.
- `stateReconciliationService.test.ts` (+2) — reconciler integration: flag ON publishes **exactly one** OUTCOME with bills magnitude (−1.5 from two PNL rows) and `polo_bills_external_close` provenance; kernel-own `reconciled_post_close_race` close → **no** publish. Existing flag-OFF test unchanged (regression pin: no publish, `pnl` nulled).

`yarn tsc --noEmit` clean. `yarn vitest run` → 18/18 green (9 + 3 reconciler + 6 existing bills).

## Rollout

- Env var on **polytrade-be** (the apps/api service that runs the reconciler): `MONKEY_REWARD_EXTERNAL_CLOSES_LIVE`. Default/absent = OFF = today's behaviour. Flip to `true` to enable.

## Uncertainties / follow-ups

- **Close window for bills matching**: kernel-own closes use a tight ±5s window around the close-fill `cTime`. External closes are discovered after the fact, so this PR uses a generous `[oldestEntry, now+5s]` window. If a symbol had two external closes inside one reconciler interval, their PNL bills would aggregate — acceptable (the chemistry sees the net), but worth noting.
- **Margin scale**: the downstream `loop.ts` subscriber uses the existing fixed `marginUsdt=5` nominal for `reconciler_recovered:*` events (unchanged by this PR). That is the established convention for recovered closes; tuning it is out of scope here.

DRAFT — do not merge. Relates to #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)