### PR TITLE
feat(monkey): HINDSIGHT — legibility-gated counterfactual prediction error (flag-OFF, DRAFT)

### DIFF
--- a/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
+++ b/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
@@ -23,6 +23,7 @@ import {
   resolveHindsight,
   isContinuationLegible,
   isEligibleForRegret,
+  legibilityStrength,
   deriveMagnitude,
   gabaTargetKey,
   medianAndMad,
@@ -96,6 +97,16 @@ describe('legibility gate (PURITY KEYSTONE)', () => {
     expect(isEligibleForRegret(legibleShortBundle({ kernelOwnedClose: false }), true).reason).toBe('not_owned');
     expect(isEligibleForRegret(legibleShortBundle({ warpExpectationSign: 1 }), true).reason).toBe('not_legible');
     expect(isEligibleForRegret(legibleShortBundle(), false).reason).toBe('regime_changed');
+  });
+  it('weak legibility scales regret instead of opening a full-strength gate', () => {
+    const strong = legibilityStrength(legibleShortBundle());
+    const weak = legibilityStrength(legibleShortBundle({
+      warpExpectationConfidence: 0.001,
+      basinDirAtClose: -0.000001,
+      coherenceStreak: 1,
+    }));
+    expect(weak).toBeGreaterThan(0);
+    expect(weak).toBeLessThan(strong);
   });
 });
 
@@ -261,17 +272,18 @@ describe('gabaTargetKey', () => {
 
 describe('TS↔Py fixture-level parity (exact magnitudes)', () => {
   // These exact values are mirrored in test_hindsight_regret.py
-  // (test_parity_*). salience = tanh(|frac| / MAD), MAD = 0.01.
+  // (test_parity_*). regret = tanh(|frac| / MAD) × legibility, MAD = 0.01.
   const margin = 100;
   const salience = (frac: number, mad: number): number => Math.tanh(Math.abs(frac) / mad);
+  const legibility = legibilityStrength(legibleShortBundle());
 
-  it('regret: dop = -tanh(0.30/0.01); ACh = NE = +salience', () => {
+  it('regret: dop = -tanh(0.30/0.01) × legibility; ACh = NE = +scaled salience', () => {
     const res = resolveHindsight(
       legibleShortBundle(),
       { realizedPnlUsdt: 0, horizonEndPnlUsdt: 30, marginUsdt: margin, regimePersisted: true },
       PNL_FRAC_HISTORY,
     );
-    const s = salience(0.30, 0.01);
+    const s = salience(0.30, 0.01) * legibility;
     expect(res.nt.dopamineDelta).toBeCloseTo(-s, 9);
     expect(res.nt.acetylcholineDelta).toBeCloseTo(s, 9);
     expect(res.nt.norepinephrineDelta).toBeCloseTo(s, 9);
@@ -293,6 +305,6 @@ describe('TS↔Py fixture-level parity (exact magnitudes)', () => {
       PNL_FRAC_HISTORY,
     );
     expect(res.predictionErrorZ).toBeCloseTo(1.0, 9);
-    expect(res.nt.dopamineDelta).toBeCloseTo(-salience(0.01, 0.01), 9);
+    expect(res.nt.dopamineDelta).toBeCloseTo(-salience(0.01, 0.01) * legibility, 9);
   });
 });

--- a/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
+++ b/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
@@ -1,206 +1,298 @@
 /**
- * hindsightRegret.test.ts — counterfactual-regret reward signal.
+ * hindsightRegret.test.ts — legibility-gated counterfactual prediction error.
  *
- * Semantic cases (operator spec 2026-05-29):
- *   - held-would-have-won  → aversive regret scaled by foregone gain
- *   - held-would-have-lost → no regret / mild positive (good close)
- *   - regret bounded        → huge foregone gain doesn't blow up chemistry
- *   - flag OFF              → isHindsightRegretLive() false by default
+ * Semantic cases (operator doctrine 2026-05-29, redesign of PR #1038):
+ *   - legible premature close   → full regret vector, correct signs, observer-scaled
+ *   - NON-legible continuation  → NO regret (surprise/noise), zero vector
+ *   - operator / non-owned close → no self-regret
+ *   - regime changed after close → no/zero regret
+ *   - good close / avoided loss  → relief vector (no aversion)
+ *   - targeted GABA              → bound to (regime,side) pattern, never global
+ *   - observer scale             → magnitude tracks the kernel's own MAD
+ *   - fail-closed                → invalid price/margin → zero vector
+ *   - flag OFF                   → isHindsightRegretLive() false by default
  *
- * The asymmetry (regret ONLY when holding would have won) is the property
- * that stops the signal from making the kernel scared to ever close.
+ * The FIXTURES block is shared verbatim with the Python parity test
+ * (test_hindsight_regret.py) so TS↔Py outputs are asserted equal within
+ * tolerance at the fixture level.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
 import {
   counterfactualPnlUsdt,
-  advanceWatch,
-  resolveRegret,
-  medianAbsoluteDeviation,
+  resolveHindsight,
+  isContinuationLegible,
+  isEligibleForRegret,
+  deriveMagnitude,
+  gabaTargetKey,
+  medianAndMad,
   isHindsightRegretLive,
-  REGRET_DOP_CAP,
-  GOOD_CLOSE_DOP,
-  type HindsightWatch,
+  type CloseSenseBundle,
+  type CounterfactualOutcome,
 } from '../hindsightRegret.js';
 
-function watch(overrides: Partial<HindsightWatch> = {}): HindsightWatch {
+// ── Shared fixtures (kept byte-for-byte in sync with the Py parity test) ──
+// A stable observer-scale history (MAD = 0.01) so magnitudes are deterministic.
+const PNL_FRAC_HISTORY = [0.0, 0.01, -0.01, 0.02, -0.02, 0.0, 0.01, -0.01];
+
+function legibleShortBundle(overrides: Partial<CloseSenseBundle> = {}): CloseSenseBundle {
+  // Operator's case: a SHORT cut into a continuing downtrend. Legible =
+  // warp expectation short-favoured, basinDir still negative, coherent hold.
   return {
-    symbol: 'BTC_USDT_PERP',
-    sideSign: -1, // closed short (the operator's −$36 short into a downtrend)
-    qty: 1,
-    exitPrice: 100,
-    realizedPnlUsdt: -36,
-    marginUsdt: 100,
-    closedAtMs: 0,
-    expiresAtMs: 30 * 60 * 1000,
-    bestCounterfactualPnlUsdt: -36, // seeded to realized
+    kernelOwnedClose: true,
+    sideSign: -1,
+    warpExpectationSign: -1,
+    warpExpectationConfidence: 0.7,
+    regimeAtClose: 'aligned',
+    basinDirAtClose: -0.25,
+    tapeTrendAtClose: -0.3,
+    coherenceStreak: 4,
     ...overrides,
   };
 }
 
 describe('counterfactualPnlUsdt', () => {
-  it('closed short gains when price falls after exit', () => {
-    // short qty=1 exit=100, price drops to 90 → marginal = (90-100)*-1*1 = +10
-    // total = realized(-36) + 10 = -26
+  it('short gains as price falls below exit', () => {
+    // closed short at 100, qty 2, realized +5; price drops to 90 → held would
+    // have added (100-90)*2 = +20 → total 25.
     const cf = counterfactualPnlUsdt(
-      { sideSign: -1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 },
+      { sideSign: -1, qty: 2, exitPrice: 100, realizedPnlUsdt: 5 },
       90,
     );
-    expect(cf).toBeCloseTo(-26, 9);
+    expect(cf).toBeCloseTo(25, 6);
   });
-
-  it('closed short loses when price rises after exit', () => {
-    // price rises to 110 → marginal = (110-100)*-1*1 = -10 → total = -46
+  it('long gains as price rises above exit', () => {
     const cf = counterfactualPnlUsdt(
-      { sideSign: -1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 },
+      { sideSign: 1, qty: 2, exitPrice: 100, realizedPnlUsdt: 5 },
       110,
     );
-    expect(cf).toBeCloseTo(-46, 9);
+    expect(cf).toBeCloseTo(25, 6);
   });
-
-  it('closed long gains when price rises after exit', () => {
-    const cf = counterfactualPnlUsdt(
-      { sideSign: 1, qty: 2, exitPrice: 50, realizedPnlUsdt: 5 },
-      55,
-    );
-    // marginal = (55-50)*1*2 = 10 → total = 15
-    expect(cf).toBeCloseTo(15, 9);
-  });
-
-  it('fails closed on invalid input (returns null)', () => {
-    expect(counterfactualPnlUsdt({ sideSign: -1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 }, NaN)).toBeNull();
-    expect(counterfactualPnlUsdt({ sideSign: -1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 }, -1)).toBeNull();
-    expect(counterfactualPnlUsdt({ sideSign: -1, qty: 0, exitPrice: 100, realizedPnlUsdt: -36 }, 90)).toBeNull();
-    expect(counterfactualPnlUsdt({ sideSign: 0 as 1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 }, 90)).toBeNull();
+  it('fail-closed on invalid price / qty', () => {
+    expect(counterfactualPnlUsdt({ sideSign: 1, qty: 2, exitPrice: 100, realizedPnlUsdt: 5 }, 0)).toBeNull();
+    expect(counterfactualPnlUsdt({ sideSign: 1, qty: 0, exitPrice: 100, realizedPnlUsdt: 5 }, 90)).toBeNull();
+    expect(counterfactualPnlUsdt({ sideSign: 1, qty: 2, exitPrice: -1, realizedPnlUsdt: 5 }, 90)).toBeNull();
   });
 });
 
-describe('advanceWatch', () => {
-  it('tracks the BEST (most favourable) counterfactual over a window', () => {
-    let w = watch(); // short, exit=100, realized=-36, best=-36
-    w = advanceWatch(w, 95); // cf = -36 + (95-100)*-1 = -36+5 = -31
-    expect(w.bestCounterfactualPnlUsdt).toBeCloseTo(-31, 9);
-    w = advanceWatch(w, 90); // cf = -26 (better for holding the short)
-    expect(w.bestCounterfactualPnlUsdt).toBeCloseTo(-26, 9);
-    w = advanceWatch(w, 98); // cf = -34 (worse) → best unchanged
-    expect(w.bestCounterfactualPnlUsdt).toBeCloseTo(-26, 9);
+describe('legibility gate (PURITY KEYSTONE)', () => {
+  it('legible when warp + basin agree with held side and hold was coherent', () => {
+    expect(isContinuationLegible(legibleShortBundle())).toBe(true);
   });
-
-  it('leaves best unchanged on invalid price', () => {
-    let w = watch();
-    w = advanceWatch(w, NaN);
-    expect(w.bestCounterfactualPnlUsdt).toBe(-36);
+  it('NOT legible when warp expectation disagrees with held side', () => {
+    expect(isContinuationLegible(legibleShortBundle({ warpExpectationSign: 1 }))).toBe(false);
   });
-});
-
-describe('resolveRegret — held-would-have-won (aversive)', () => {
-  it('emits negative dopamine scaled by foregone gain', () => {
-    // short closed at -36, but price kept falling: best counterfactual -10.
-    // foregone gain = -10 - (-36) = 26. margin 100 → regretFrac 0.26.
-    const d = resolveRegret(
-      { bestCounterfactualPnlUsdt: -10, realizedPnlUsdt: -36, marginUsdt: 100 },
-      [],
-    );
-    expect(d.source).toBe('hindsight_regret');
-    expect(d.foregoneGainUsdt).toBeCloseTo(26, 9);
-    expect(d.dopamineDelta).toBeLessThan(0);
-    // -tanh(0.26)*0.5 ≈ -0.127
-    expect(d.dopamineDelta).toBeCloseTo(-Math.tanh(0.26) * REGRET_DOP_CAP, 6);
+  it('NOT legible when basinDir no longer leans the held way', () => {
+    expect(isContinuationLegible(legibleShortBundle({ basinDirAtClose: 0.25 }))).toBe(false);
   });
-
-  it('bigger foregone gain stings more (monotone), up to the cap', () => {
-    const small = resolveRegret(
-      { bestCounterfactualPnlUsdt: -30, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
-    );
-    const big = resolveRegret(
-      { bestCounterfactualPnlUsdt: 50, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
-    );
-    expect(Math.abs(big.dopamineDelta)).toBeGreaterThan(Math.abs(small.dopamineDelta));
+  it('NOT legible when warp expectation was flat/observe', () => {
+    expect(isContinuationLegible(legibleShortBundle({ warpExpectationSign: 0 }))).toBe(false);
+  });
+  it('NOT legible when the hold was never coherent', () => {
+    expect(isContinuationLegible(legibleShortBundle({ coherenceStreak: 0 }))).toBe(false);
+  });
+  it('eligibility requires owned AND legible AND regime-persisted', () => {
+    expect(isEligibleForRegret(legibleShortBundle(), true)).toEqual({ eligible: true, reason: 'eligible' });
+    expect(isEligibleForRegret(legibleShortBundle({ kernelOwnedClose: false }), true).reason).toBe('not_owned');
+    expect(isEligibleForRegret(legibleShortBundle({ warpExpectationSign: 1 }), true).reason).toBe('not_legible');
+    expect(isEligibleForRegret(legibleShortBundle(), false).reason).toBe('regime_changed');
   });
 });
 
-describe('resolveRegret — held-would-have-lost (good close)', () => {
-  it('no regret + mild positive when counterfactual <= realized', () => {
-    // short closed at -36; if held it would have been -46 (price rose).
-    const d = resolveRegret(
-      { bestCounterfactualPnlUsdt: -46, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
-    );
-    expect(d.source).toBe('hindsight_good_close');
-    expect(d.foregoneGainUsdt).toBe(0);
-    expect(d.dopamineDelta).toBe(GOOD_CLOSE_DOP);
-    expect(d.dopamineDelta).toBeGreaterThan(0);
+describe('resolveHindsight — semantic cases', () => {
+  const margin = 100;
+  // Held would have won big: realized 0, horizon-end +30 → foregone 30,
+  // frac 0.30, z = 0.30/0.01 = 30 → salience ≈ 1.
+  const wonOutcome: CounterfactualOutcome = {
+    realizedPnlUsdt: 0,
+    horizonEndPnlUsdt: 30,
+    marginUsdt: margin,
+    regimePersisted: true,
+  };
+
+  it('legible premature close → full aversive regret vector with correct signs', () => {
+    const res = resolveHindsight(legibleShortBundle(), wonOutcome, PNL_FRAC_HISTORY);
+    expect(res.source).toBe('hindsight_regret');
+    // canon signs: dop<0, ser<0, ACh>0, NE>0, GABA>0, endo==0
+    expect(res.nt.dopamineDelta).toBeLessThan(0);
+    expect(res.nt.serotoninDelta).toBeLessThan(0);
+    expect(res.nt.acetylcholineDelta).toBeGreaterThan(0);
+    expect(res.nt.norepinephrineDelta).toBeGreaterThan(0);
+    expect(res.nt.gabaDelta).toBeGreaterThan(0);
+    expect(res.nt.endorphinDelta).toBe(0);
+    expect(res.gabaTarget).toBe('premature_close:aligned:short');
+    expect(res.foregoneGainUsdt).toBeCloseTo(30, 6);
   });
 
-  it('break-even (best == realized) is a good close, not regret', () => {
-    const d = resolveRegret(
-      { bestCounterfactualPnlUsdt: -36, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
+  it('NON-legible continuation → NO regret (surprise/noise), zero vector', () => {
+    // Holding would have won, but the continuation was NOT legible at close
+    // (warp pointed the other way) → it was surprise, not a learnable mistake.
+    const res = resolveHindsight(
+      legibleShortBundle({ warpExpectationSign: 1 }),
+      wonOutcome,
+      PNL_FRAC_HISTORY,
     );
-    expect(d.source).toBe('hindsight_good_close');
+    expect(res.source).toBe('ineligible_noise');
+    expect(res.nt.dopamineDelta).toBe(0);
+    expect(res.nt.gabaDelta).toBe(0);
+    expect(res.gabaTarget).toBeNull();
+  });
+
+  it('operator / non-owned close → no self-regret', () => {
+    const res = resolveHindsight(
+      legibleShortBundle({ kernelOwnedClose: false }),
+      wonOutcome,
+      PNL_FRAC_HISTORY,
+    );
+    expect(res.source).toBe('ineligible_not_owned');
+    expect(res.nt).toEqual({
+      dopamineDelta: 0, acetylcholineDelta: 0, norepinephrineDelta: 0,
+      serotoninDelta: 0, gabaDelta: 0, endorphinDelta: 0,
+    });
+  });
+
+  it('regime changed after close → no/zero regret', () => {
+    const res = resolveHindsight(
+      legibleShortBundle(),
+      { ...wonOutcome, regimePersisted: false },
+      PNL_FRAC_HISTORY,
+    );
+    expect(res.source).toBe('ineligible_noise');
+    expect(res.nt.dopamineDelta).toBe(0);
+  });
+
+  it('good close / avoided loss → relief vector (no aversion)', () => {
+    // Holding would have LOST more: realized 0, horizon-end -20 → foregone <0.
+    const res = resolveHindsight(
+      legibleShortBundle(),
+      { realizedPnlUsdt: 0, horizonEndPnlUsdt: -20, marginUsdt: margin, regimePersisted: true },
+      PNL_FRAC_HISTORY,
+    );
+    expect(res.source).toBe('hindsight_good_close');
+    // relief: dop>0, ser>0, ACh>0, endo>0, GABA==0 (no inhibition to bind)
+    expect(res.nt.dopamineDelta).toBeGreaterThan(0);
+    expect(res.nt.serotoninDelta).toBeGreaterThan(0);
+    expect(res.nt.acetylcholineDelta).toBeGreaterThan(0);
+    expect(res.nt.endorphinDelta).toBeGreaterThan(0);
+    expect(res.nt.gabaDelta).toBe(0);
+    expect(res.gabaTarget).toBeNull();
+  });
+
+  it('GABA stays TARGETED (pattern-keyed), never a global suppression flag', () => {
+    const long = resolveHindsight(
+      legibleShortBundle({ sideSign: 1, warpExpectationSign: 1, basinDirAtClose: 0.25, regimeAtClose: 'reverse_tape' }),
+      wonOutcome, PNL_FRAC_HISTORY,
+    );
+    expect(long.gabaTarget).toBe('premature_close:reverse_tape:long');
+    // The target encodes a SPECIFIC pattern — not "close less". Two different
+    // patterns produce two different keys, so binding is per-pattern.
+    expect(long.gabaTarget).not.toBe(
+      resolveHindsight(legibleShortBundle(), wonOutcome, PNL_FRAC_HISTORY).gabaTarget,
+    );
+  });
+
+  it('observer scale: magnitude tracks the kernel own MAD (no fixed cap)', () => {
+    // Same foregone fraction, but a WIDER own-distribution (10× MAD) → the
+    // same dollars are LESS surprising → smaller salience. No 0.5 cap.
+    const tight = resolveHindsight(legibleShortBundle(), wonOutcome, PNL_FRAC_HISTORY);
+    const wide = resolveHindsight(
+      legibleShortBundle(),
+      wonOutcome,
+      PNL_FRAC_HISTORY.map((x) => x * 10), // MAD 0.10
+    );
+    expect(Math.abs(wide.nt.dopamineDelta)).toBeLessThan(Math.abs(tight.nt.dopamineDelta));
+    // and a smaller foregone fraction → smaller sting on the same scale.
+    const small = resolveHindsight(
+      legibleShortBundle(),
+      { ...wonOutcome, horizonEndPnlUsdt: 1 }, // foregone 1 → frac 0.01 → z 1
+      PNL_FRAC_HISTORY,
+    );
+    expect(Math.abs(small.nt.dopamineDelta)).toBeLessThan(Math.abs(tight.nt.dopamineDelta));
+  });
+
+  it('cold-start (no trusted scale) emits nothing', () => {
+    const res = resolveHindsight(legibleShortBundle(), wonOutcome, [0.01, 0.02]); // < MIN_SAMPLES
+    expect(res.source).toBe('ineligible_noise');
+    expect(res.nt.dopamineDelta).toBe(0);
+  });
+
+  it('fail-closed: invalid margin / pnl → zero vector', () => {
+    expect(
+      resolveHindsight(legibleShortBundle(), { ...wonOutcome, marginUsdt: 0 }, PNL_FRAC_HISTORY).source,
+    ).toBe('hindsight_no_margin');
+    expect(
+      resolveHindsight(legibleShortBundle(), { ...wonOutcome, horizonEndPnlUsdt: NaN }, PNL_FRAC_HISTORY).source,
+    ).toBe('hindsight_invalid');
   });
 });
 
-describe('resolveRegret — bounded (cannot paralyse)', () => {
-  it('a huge foregone gain stays within the dopamine cap', () => {
-    const d = resolveRegret(
-      { bestCounterfactualPnlUsdt: 1_000_000, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
-    );
-    // tanh asymptotes to 1.0 → delta is bounded AT (never beyond) the cap.
-    expect(d.dopamineDelta).toBeGreaterThanOrEqual(-REGRET_DOP_CAP);
-    expect(d.dopamineDelta).toBeLessThanOrEqual(0);
-    expect(Math.abs(d.dopamineDelta)).toBeLessThanOrEqual(REGRET_DOP_CAP);
+describe('deriveMagnitude + medianAndMad', () => {
+  it('median+MAD matches the observer-scale statistic', () => {
+    const { median, mad } = medianAndMad(PNL_FRAC_HISTORY);
+    expect(median).toBeCloseTo(0, 6);
+    expect(mad).toBeCloseTo(0.01, 6);
   });
-
-  it('observer normalisation: MAD scales the sting to the kernel\'s own pnl band', () => {
-    // With a tight pnl_frac history (small MAD) the same regretFrac maps to a
-    // larger normalised value → larger (still bounded) sting.
-    const tightHistory = [0.001, 0.002, -0.001, 0.0, 0.0015];
-    const wideHistory = [0.5, -0.5, 0.3, -0.3, 0.0];
-    const tight = resolveRegret(
-      { bestCounterfactualPnlUsdt: -30, realizedPnlUsdt: -36, marginUsdt: 100 }, tightHistory,
-    );
-    const wide = resolveRegret(
-      { bestCounterfactualPnlUsdt: -30, realizedPnlUsdt: -36, marginUsdt: 100 }, wideHistory,
-    );
-    expect(Math.abs(tight.dopamineDelta)).toBeGreaterThan(Math.abs(wide.dopamineDelta));
-    expect(Math.abs(tight.dopamineDelta)).toBeLessThanOrEqual(REGRET_DOP_CAP);
-  });
-
-  it('fails closed on invalid margin / non-finite', () => {
-    expect(resolveRegret({ bestCounterfactualPnlUsdt: 10, realizedPnlUsdt: -5, marginUsdt: 0 }, []).dopamineDelta).toBe(0);
-    expect(resolveRegret({ bestCounterfactualPnlUsdt: NaN, realizedPnlUsdt: -5, marginUsdt: 100 }, []).dopamineDelta).toBe(0);
+  it('returns null below MIN_SAMPLES or zero MAD', () => {
+    expect(deriveMagnitude(0.3, [0.01])).toBeNull();
+    expect(deriveMagnitude(0.3, [0.05, 0.05, 0.05, 0.05, 0.05])).toBeNull(); // MAD 0
   });
 });
 
-describe('medianAbsoluteDeviation', () => {
-  it('matches the pushReward MAD shape', () => {
-    expect(medianAbsoluteDeviation([])).toBe(0);
-    expect(medianAbsoluteDeviation([1, 1, 1])).toBe(0);
-    // [1,2,3,4,5] median 3, devs [2,1,0,1,2] sorted [0,1,1,2,2] median 1
-    expect(medianAbsoluteDeviation([1, 2, 3, 4, 5])).toBe(1);
-  });
-});
-
-describe('flag — default OFF', () => {
-  const prev = process.env.MONKEY_HINDSIGHT_REGRET_LIVE;
+describe('flag gating', () => {
   afterEach(() => {
-    if (prev === undefined) delete process.env.MONKEY_HINDSIGHT_REGRET_LIVE;
-    else process.env.MONKEY_HINDSIGHT_REGRET_LIVE = prev;
-  });
-
-  it('is false when unset', () => {
     delete process.env.MONKEY_HINDSIGHT_REGRET_LIVE;
+  });
+  it('default OFF', () => {
     expect(isHindsightRegretLive()).toBe(false);
   });
-
-  it('is false for any value other than "true"', () => {
-    process.env.MONKEY_HINDSIGHT_REGRET_LIVE = 'false';
-    expect(isHindsightRegretLive()).toBe(false);
+  it('ON only on exact "true"', () => {
+    process.env.MONKEY_HINDSIGHT_REGRET_LIVE = 'true';
+    expect(isHindsightRegretLive()).toBe(true);
     process.env.MONKEY_HINDSIGHT_REGRET_LIVE = '1';
     expect(isHindsightRegretLive()).toBe(false);
   });
+});
 
-  it('is true only for exactly "true"', () => {
-    process.env.MONKEY_HINDSIGHT_REGRET_LIVE = 'true';
-    expect(isHindsightRegretLive()).toBe(true);
+describe('gabaTargetKey', () => {
+  it('encodes regime + side; defaults regime to unknown', () => {
+    expect(gabaTargetKey(legibleShortBundle({ regimeAtClose: '' }))).toBe('premature_close:unknown:short');
+  });
+});
+
+describe('TS↔Py fixture-level parity (exact magnitudes)', () => {
+  // These exact values are mirrored in test_hindsight_regret.py
+  // (test_parity_*). salience = tanh(|frac| / MAD), MAD = 0.01.
+  const margin = 100;
+  const salience = (frac: number, mad: number): number => Math.tanh(Math.abs(frac) / mad);
+
+  it('regret: dop = -tanh(0.30/0.01); ACh = NE = +salience', () => {
+    const res = resolveHindsight(
+      legibleShortBundle(),
+      { realizedPnlUsdt: 0, horizonEndPnlUsdt: 30, marginUsdt: margin, regimePersisted: true },
+      PNL_FRAC_HISTORY,
+    );
+    const s = salience(0.30, 0.01);
+    expect(res.nt.dopamineDelta).toBeCloseTo(-s, 9);
+    expect(res.nt.acetylcholineDelta).toBeCloseTo(s, 9);
+    expect(res.nt.norepinephrineDelta).toBeCloseTo(s, 9);
+  });
+
+  it('good close: dop = +tanh(0.20/0.01)', () => {
+    const res = resolveHindsight(
+      legibleShortBundle(),
+      { realizedPnlUsdt: 0, horizonEndPnlUsdt: -20, marginUsdt: margin, regimePersisted: true },
+      PNL_FRAC_HISTORY,
+    );
+    expect(res.nt.dopamineDelta).toBeCloseTo(salience(0.20, 0.01), 9);
+  });
+
+  it('small foregone: z == 1, dop = -tanh(1)', () => {
+    const res = resolveHindsight(
+      legibleShortBundle(),
+      { realizedPnlUsdt: 0, horizonEndPnlUsdt: 1, marginUsdt: margin, regimePersisted: true },
+      PNL_FRAC_HISTORY,
+    );
+    expect(res.predictionErrorZ).toBeCloseTo(1.0, 9);
+    expect(res.nt.dopamineDelta).toBeCloseTo(-salience(0.01, 0.01), 9);
   });
 });

--- a/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
+++ b/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
@@ -1,0 +1,206 @@
+/**
+ * hindsightRegret.test.ts — counterfactual-regret reward signal.
+ *
+ * Semantic cases (operator spec 2026-05-29):
+ *   - held-would-have-won  → aversive regret scaled by foregone gain
+ *   - held-would-have-lost → no regret / mild positive (good close)
+ *   - regret bounded        → huge foregone gain doesn't blow up chemistry
+ *   - flag OFF              → isHindsightRegretLive() false by default
+ *
+ * The asymmetry (regret ONLY when holding would have won) is the property
+ * that stops the signal from making the kernel scared to ever close.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  counterfactualPnlUsdt,
+  advanceWatch,
+  resolveRegret,
+  medianAbsoluteDeviation,
+  isHindsightRegretLive,
+  REGRET_DOP_CAP,
+  GOOD_CLOSE_DOP,
+  type HindsightWatch,
+} from '../hindsightRegret.js';
+
+function watch(overrides: Partial<HindsightWatch> = {}): HindsightWatch {
+  return {
+    symbol: 'BTC_USDT_PERP',
+    sideSign: -1, // closed short (the operator's −$36 short into a downtrend)
+    qty: 1,
+    exitPrice: 100,
+    realizedPnlUsdt: -36,
+    marginUsdt: 100,
+    closedAtMs: 0,
+    expiresAtMs: 30 * 60 * 1000,
+    bestCounterfactualPnlUsdt: -36, // seeded to realized
+    ...overrides,
+  };
+}
+
+describe('counterfactualPnlUsdt', () => {
+  it('closed short gains when price falls after exit', () => {
+    // short qty=1 exit=100, price drops to 90 → marginal = (90-100)*-1*1 = +10
+    // total = realized(-36) + 10 = -26
+    const cf = counterfactualPnlUsdt(
+      { sideSign: -1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 },
+      90,
+    );
+    expect(cf).toBeCloseTo(-26, 9);
+  });
+
+  it('closed short loses when price rises after exit', () => {
+    // price rises to 110 → marginal = (110-100)*-1*1 = -10 → total = -46
+    const cf = counterfactualPnlUsdt(
+      { sideSign: -1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 },
+      110,
+    );
+    expect(cf).toBeCloseTo(-46, 9);
+  });
+
+  it('closed long gains when price rises after exit', () => {
+    const cf = counterfactualPnlUsdt(
+      { sideSign: 1, qty: 2, exitPrice: 50, realizedPnlUsdt: 5 },
+      55,
+    );
+    // marginal = (55-50)*1*2 = 10 → total = 15
+    expect(cf).toBeCloseTo(15, 9);
+  });
+
+  it('fails closed on invalid input (returns null)', () => {
+    expect(counterfactualPnlUsdt({ sideSign: -1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 }, NaN)).toBeNull();
+    expect(counterfactualPnlUsdt({ sideSign: -1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 }, -1)).toBeNull();
+    expect(counterfactualPnlUsdt({ sideSign: -1, qty: 0, exitPrice: 100, realizedPnlUsdt: -36 }, 90)).toBeNull();
+    expect(counterfactualPnlUsdt({ sideSign: 0 as 1, qty: 1, exitPrice: 100, realizedPnlUsdt: -36 }, 90)).toBeNull();
+  });
+});
+
+describe('advanceWatch', () => {
+  it('tracks the BEST (most favourable) counterfactual over a window', () => {
+    let w = watch(); // short, exit=100, realized=-36, best=-36
+    w = advanceWatch(w, 95); // cf = -36 + (95-100)*-1 = -36+5 = -31
+    expect(w.bestCounterfactualPnlUsdt).toBeCloseTo(-31, 9);
+    w = advanceWatch(w, 90); // cf = -26 (better for holding the short)
+    expect(w.bestCounterfactualPnlUsdt).toBeCloseTo(-26, 9);
+    w = advanceWatch(w, 98); // cf = -34 (worse) → best unchanged
+    expect(w.bestCounterfactualPnlUsdt).toBeCloseTo(-26, 9);
+  });
+
+  it('leaves best unchanged on invalid price', () => {
+    let w = watch();
+    w = advanceWatch(w, NaN);
+    expect(w.bestCounterfactualPnlUsdt).toBe(-36);
+  });
+});
+
+describe('resolveRegret — held-would-have-won (aversive)', () => {
+  it('emits negative dopamine scaled by foregone gain', () => {
+    // short closed at -36, but price kept falling: best counterfactual -10.
+    // foregone gain = -10 - (-36) = 26. margin 100 → regretFrac 0.26.
+    const d = resolveRegret(
+      { bestCounterfactualPnlUsdt: -10, realizedPnlUsdt: -36, marginUsdt: 100 },
+      [],
+    );
+    expect(d.source).toBe('hindsight_regret');
+    expect(d.foregoneGainUsdt).toBeCloseTo(26, 9);
+    expect(d.dopamineDelta).toBeLessThan(0);
+    // -tanh(0.26)*0.5 ≈ -0.127
+    expect(d.dopamineDelta).toBeCloseTo(-Math.tanh(0.26) * REGRET_DOP_CAP, 6);
+  });
+
+  it('bigger foregone gain stings more (monotone), up to the cap', () => {
+    const small = resolveRegret(
+      { bestCounterfactualPnlUsdt: -30, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
+    );
+    const big = resolveRegret(
+      { bestCounterfactualPnlUsdt: 50, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
+    );
+    expect(Math.abs(big.dopamineDelta)).toBeGreaterThan(Math.abs(small.dopamineDelta));
+  });
+});
+
+describe('resolveRegret — held-would-have-lost (good close)', () => {
+  it('no regret + mild positive when counterfactual <= realized', () => {
+    // short closed at -36; if held it would have been -46 (price rose).
+    const d = resolveRegret(
+      { bestCounterfactualPnlUsdt: -46, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
+    );
+    expect(d.source).toBe('hindsight_good_close');
+    expect(d.foregoneGainUsdt).toBe(0);
+    expect(d.dopamineDelta).toBe(GOOD_CLOSE_DOP);
+    expect(d.dopamineDelta).toBeGreaterThan(0);
+  });
+
+  it('break-even (best == realized) is a good close, not regret', () => {
+    const d = resolveRegret(
+      { bestCounterfactualPnlUsdt: -36, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
+    );
+    expect(d.source).toBe('hindsight_good_close');
+  });
+});
+
+describe('resolveRegret — bounded (cannot paralyse)', () => {
+  it('a huge foregone gain stays within the dopamine cap', () => {
+    const d = resolveRegret(
+      { bestCounterfactualPnlUsdt: 1_000_000, realizedPnlUsdt: -36, marginUsdt: 100 }, [],
+    );
+    // tanh asymptotes to 1.0 → delta is bounded AT (never beyond) the cap.
+    expect(d.dopamineDelta).toBeGreaterThanOrEqual(-REGRET_DOP_CAP);
+    expect(d.dopamineDelta).toBeLessThanOrEqual(0);
+    expect(Math.abs(d.dopamineDelta)).toBeLessThanOrEqual(REGRET_DOP_CAP);
+  });
+
+  it('observer normalisation: MAD scales the sting to the kernel\'s own pnl band', () => {
+    // With a tight pnl_frac history (small MAD) the same regretFrac maps to a
+    // larger normalised value → larger (still bounded) sting.
+    const tightHistory = [0.001, 0.002, -0.001, 0.0, 0.0015];
+    const wideHistory = [0.5, -0.5, 0.3, -0.3, 0.0];
+    const tight = resolveRegret(
+      { bestCounterfactualPnlUsdt: -30, realizedPnlUsdt: -36, marginUsdt: 100 }, tightHistory,
+    );
+    const wide = resolveRegret(
+      { bestCounterfactualPnlUsdt: -30, realizedPnlUsdt: -36, marginUsdt: 100 }, wideHistory,
+    );
+    expect(Math.abs(tight.dopamineDelta)).toBeGreaterThan(Math.abs(wide.dopamineDelta));
+    expect(Math.abs(tight.dopamineDelta)).toBeLessThanOrEqual(REGRET_DOP_CAP);
+  });
+
+  it('fails closed on invalid margin / non-finite', () => {
+    expect(resolveRegret({ bestCounterfactualPnlUsdt: 10, realizedPnlUsdt: -5, marginUsdt: 0 }, []).dopamineDelta).toBe(0);
+    expect(resolveRegret({ bestCounterfactualPnlUsdt: NaN, realizedPnlUsdt: -5, marginUsdt: 100 }, []).dopamineDelta).toBe(0);
+  });
+});
+
+describe('medianAbsoluteDeviation', () => {
+  it('matches the pushReward MAD shape', () => {
+    expect(medianAbsoluteDeviation([])).toBe(0);
+    expect(medianAbsoluteDeviation([1, 1, 1])).toBe(0);
+    // [1,2,3,4,5] median 3, devs [2,1,0,1,2] sorted [0,1,1,2,2] median 1
+    expect(medianAbsoluteDeviation([1, 2, 3, 4, 5])).toBe(1);
+  });
+});
+
+describe('flag — default OFF', () => {
+  const prev = process.env.MONKEY_HINDSIGHT_REGRET_LIVE;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.MONKEY_HINDSIGHT_REGRET_LIVE;
+    else process.env.MONKEY_HINDSIGHT_REGRET_LIVE = prev;
+  });
+
+  it('is false when unset', () => {
+    delete process.env.MONKEY_HINDSIGHT_REGRET_LIVE;
+    expect(isHindsightRegretLive()).toBe(false);
+  });
+
+  it('is false for any value other than "true"', () => {
+    process.env.MONKEY_HINDSIGHT_REGRET_LIVE = 'false';
+    expect(isHindsightRegretLive()).toBe(false);
+    process.env.MONKEY_HINDSIGHT_REGRET_LIVE = '1';
+    expect(isHindsightRegretLive()).toBe(false);
+  });
+
+  it('is true only for exactly "true"', () => {
+    process.env.MONKEY_HINDSIGHT_REGRET_LIVE = 'true';
+    expect(isHindsightRegretLive()).toBe(true);
+  });
+});

--- a/apps/api/src/services/monkey/autonomic_client.ts
+++ b/apps/api/src/services/monkey/autonomic_client.ts
@@ -184,6 +184,54 @@ export async function callAutonomicPredictionReward(req: {
   }
 }
 
+/**
+ * Fan the resolved hindsight NT vector to the Py autonomic surface
+ * (MONKEY_HINDSIGHT_REGRET_LIVE — DESIGN HYPOTHESIS). Mirrors
+ * callAutonomicPredictionReward: best-effort, non-fatal, REPLACES the Py
+ * cached hindsight vector. Keeps the Py chemistry (which drives executive
+ * sizing + survives restarts) in parity with the TS fold. */
+export async function callAutonomicHindsight(req: {
+  instanceId: string;
+  dopamineDelta: number;
+  serotoninDelta: number;
+  acetylcholineDelta: number;
+  norepinephrineDelta: number;
+  gabaDelta: number;
+  endorphinDelta: number;
+}): Promise<void> {
+  const body = JSON.stringify({
+    instance_id: req.instanceId,
+    dopamine_delta: req.dopamineDelta,
+    serotonin_delta: req.serotoninDelta,
+    acetylcholine_delta: req.acetylcholineDelta,
+    norepinephrine_delta: req.norepinephrineDelta,
+    gaba_delta: req.gabaDelta,
+    endorphin_delta: req.endorphinDelta,
+  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${ML_WORKER_URL}/monkey/autonomic/hindsight`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      logger.warn('[autonomic_client] hindsight push failed', {
+        status: res.status,
+        body: await res.text(),
+      });
+    }
+  } catch (err) {
+    logger.warn('[autonomic_client] hindsight push threw', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /** Feature-flag helper. */
 export function isPythonKernelEnabled(): boolean {
   return process.env.MONKEY_KERNEL_PY === 'true';

--- a/apps/api/src/services/monkey/expectation_client.ts
+++ b/apps/api/src/services/monkey/expectation_client.ts
@@ -43,6 +43,15 @@ export interface ExpectationDecision {
   qig_warp_source: 'QIG_WARP_RUNTIME' | 'QIG_WARP_UNAVAILABLE' | 'QIG_WARP_DISABLED';
   tape_trend: number;
   basin_direction: number;
+  /**
+   * 2026-05-29 hindsight (DESIGN HYPOTHESIS): observed regime-persistence
+   * horizon in HOURS, surfaced by the bubble from
+   * forecast_horizon_observer.temporal_scale_for(regime) (the e-fold
+   * autocorrelation decay lag converted to hours). The hindsight subsystem
+   * uses this as its watch WINDOW (per doctrine: window = the kernel's own
+   * forecast horizon). Optional — when the bubble does not supply it, the
+   * caller derives a documented fallback. */
+  qig_warp_horizon_hours?: number;
   tape_basin_disagreement: number;
   reverse_tape_window: boolean;
   reverse_tape_side: 'long' | 'short' | null;

--- a/apps/api/src/services/monkey/hindsightRegret.ts
+++ b/apps/api/src/services/monkey/hindsightRegret.ts
@@ -1,247 +1,411 @@
 /**
- * hindsightRegret.ts — counterfactual-regret reward signal.
+ * hindsightRegret.ts — legibility-gated counterfactual PREDICTION ERROR.
  *
- * Operator intent (2026-05-29, verbatim): "rather than a knob, it needs to
- * feel the pain of this. not so much that its scared to make a trade but
- * enough that it thinks about thinking about the trend a second time before
- * closing." + "something akin to hindsight. e.g. 'if i just left it i would
- * have got the reward'."
+ * DESIGN HYPOTHESIS (operator-approved redesign of PR #1038, 2026-05-29).
+ * Built cleanly, flag-gated OFF (MONKEY_HINDSIGHT_REGRET_LIVE), for operator
+ * review — NOT a finished truth. Replaces the rejected v1 (fixed 30-min
+ * window + fixed dopamine caps + best-favourable-excursion target +
+ * dopamine-only "pain") which was a knob dressed as chemistry.
  *
- * CONCEPT (counterfactual regret minimisation):
- *   When the kernel closes a position, we keep watching the symbol for a
- *   forward window. We track what the *closed* position WOULD have earned
- *   had it been held. If holding would have beaten the realised close
- *   (the trend continued in the position's favour) we emit an AVERSIVE
- *   "closed too early" chemistry signal scaled by the foregone gain. If
- *   closing was correct (price moved against the old position, holding
- *   would have lost more) we emit NO regret — optionally a mild positive
- *   "good close" reinforcement.
+ * ── WHAT CHANGED FROM v1 (all four rejected mechanisms removed) ──────────
+ *   1. NOT fixed pain. The signal is legibility-gated counterfactual
+ *      PREDICTION ERROR, scaled by the kernel's OWN outcome distribution
+ *      (median+MAD z-score — the same observer scale observerFibCoefficient
+ *      / pushReward use). No 0.5 / 0.3 / 0.05 taste constants.
+ *   2. WINDOW is the kernel's own qig-warp / foresight expectation HORIZON
+ *      (passed in at registration), not 30 min. Fallback horizon is derived
+ *      from observed regime persistence, documented at the call site.
+ *   3. Counterfactual target = pnl at END OF THE DERIVED HORIZON (and/or
+ *      bounded by an observed regime flip), NOT the max favourable excursion.
+ *   4. Full NT VECTOR (not dopamine-only): dopamine (signed prediction
+ *      error), ACh (bind the cues), NE (salience), serotonin (patience /
+ *      temporal-trust), GABA (TARGETED to the same premature-close pattern,
+ *      never global), endorphin (relief on a good close).
  *
- *   The ASYMMETRY is load-bearing: regret fires ONLY when holding would
- *   have won. That is what stops the signal from making the kernel scared
- *   to ever close — there is no penalty for a correct exit, only for an
- *   exit that left money on the table in a continuing favourable trend.
+ * ── PURITY KEYSTONE: the eligibility / legibility gate ───────────────────
+ * Regret fires strongly ONLY when ALL THREE hold (see `isEligibleForRegret`):
+ *   (1) the kernel OWNED the close (kernel-initiated; operator / manual /
+ *       liquidation closes are NOT self-regret),
+ *   (2) the continuation was LEGIBLE at close time — the close-time sense
+ *       bundle showed evidence to HOLD (qig-warp expectation favoured the
+ *       held side, basin direction still with the position, trend coherent),
+ *   (3) the SAME REGIME persisted through the derived horizon.
+ * If continuation was NOT legible → the move is SURPRISE / NOISE, not regret
+ * → NO aversive signal. This maps directly onto QIG canon §31 (Sensory
+ * Intake & Predictive Coding): a prediction error you could NOT have
+ * predicted is surprise, not a learnable mistake. Regret = a LEGIBLE
+ * prediction error (low surprise at close, continuation foreseeable).
+ *
+ * ── QIG canon alignment (vex/kernel/consciousness/neurochemistry.py §29) ─
+ *   The six-chemical model = six Cartan generators of E6:
+ *     ACh  (ENTRAIN/E1)  — intake/consolidation gate → bind the cues
+ *     dop  (AMPLIFY/E2)  — reward signal / prediction error
+ *     GABA (DAMPEN/E3)   — inhibition (here: TARGETED, not global)
+ *     ser  (ROTATE/E4)   — stability / patience / temporal trust
+ *     NE   (NUCLEATE/E5) — salience / surprise magnitude (observer-scaled)
+ *     endo (DISSOLVE/E6) — convergence reward / relief
+ *   We do NOT invent chemistry semantics; the signs below follow canon's
+ *   role of each chemical.
  *
  * DOCTRINAL ANCHORS:
- *   - P1 (Observer sets all params from frozen facts): the regret MAGNITUDE
- *     is normalised against the kernel's own realised pnl_frac distribution
- *     (MAD), exactly like observerFibCoefficient / pushReward. There is no
- *     hardcoded "how much a foregone gain should sting" knob. The transform
- *     shape (tanh) and the output cap are STRUCTURAL design constants,
- *     mirroring the trade-outcome reward channel.
- *   - P14 (Variable Separation): hindsight regret is its OWN chemistry
- *     channel. It is NOT folded into the realised-pnl reward — a position
- *     that closed at a tiny realised win can still produce a large regret
- *     signal if the trend ran on without it. The realised reward already
- *     fired at close; regret is computed later, from the counterfactual.
- *   - P15 (Fail-Closed Safety): all inputs are validated; non-finite inputs
- *     produce zero deltas. Never blocks trading.
+ *   - P1 (Observer sets all params): every magnitude is normalised against
+ *     the kernel's own realised pnl_frac distribution (median+MAD). No
+ *     hardcoded sting amplitude, no caps chosen by intuition.
+ *   - P14 (Variable Separation): hindsight is its OWN chemistry channel,
+ *     not folded into the realised-pnl reward.
+ *   - P15 (Fail-Closed Safety): invalid price/margin/qty/side/history →
+ *     NO chemistry mutation (zero vector). Never blocks trading.
  *
- * This module is PURE (no I/O, no time, no DB). The orchestration that
- * registers a watch at close, advances it with live price each tick, and
- * pushes the resulting deltas lives in loop.ts behind
- * MONKEY_HINDSIGHT_REGRET_LIVE (default OFF).
+ * This module is PURE (no I/O, no time, no DB). Orchestration (register a
+ * watch at close with the sense bundle + horizon, advance with live price,
+ * resolve at horizon end) lives in loop.ts behind the flag.
  */
 
-/** A position that was closed and is now being watched for counterfactual pnl. */
-export interface HindsightWatch {
-  symbol: string;
-  /** +1 for a closed long, -1 for a closed short. */
-  sideSign: 1 | -1;
-  /** Base-asset quantity that was closed (magnitude, > 0). */
-  qty: number;
-  /** Price at which the position was closed (exit price). */
-  exitPrice: number;
-  /** Realised net pnl (USDT) the close actually booked (Polo-authoritative). */
-  realizedPnlUsdt: number;
-  /** Margin (USDT) backing the closed position — for pnl_frac normalisation. */
-  marginUsdt: number;
-  /** ms epoch the close happened. */
-  closedAtMs: number;
-  /** ms epoch this watch should stop being evaluated and be retired. */
-  expiresAtMs: number;
-  /**
-   * Best (most favourable) counterfactual pnl seen so far over the window.
-   * For a closed long this is the pnl at the HIGHEST price seen since close;
-   * for a closed short, at the LOWEST. Seeded to realizedPnlUsdt so a window
-   * that only ever moves adversely yields zero foregone gain (no regret).
-   */
-  bestCounterfactualPnlUsdt: number;
+// ── E6 six-chemical NT delta vector (canon §29.1) ────────────────────────
+// Signs are the chemistry's CANONICAL ROLE, not free parameters. Magnitudes
+// are observer-scaled (see deriveMagnitude). Flag-OFF callers never read it.
+export interface HindsightNtDeltas {
+  /** Signed prediction error. <0 on a legible premature close (the trade
+   *  was right, the exit wrong); small >0 relief on a good close. */
+  dopamineDelta: number;
+  /** ACh ↑ — bind the close-time cues for next time (intake/consolidation
+   *  gate). Non-negative; salient on both regret and good-close. */
+  acetylcholineDelta: number;
+  /** NE ↑ — salience of the event, observer-scaled. Non-negative. */
+  norepinephrineDelta: number;
+  /** serotonin — patience / temporal-trust. <0 on premature close (correct
+   *  the impatience), >0 on a good close (timing confidence). */
+  serotoninDelta: number;
+  /** GABA ↑ — TARGETED inhibition keyed to the premature-close PATTERN
+   *  (regime + side), NOT global suppression. Non-negative; only on regret.
+   *  Carries `gabaTarget` so the kernel binds it to a pattern, not to "close
+   *  less often". */
+  gabaDelta: number;
+  /** endorphin — relief on a good close (avoided a worse counterfactual).
+   *  Non-negative; zero on regret. */
+  endorphinDelta: number;
 }
 
-/** Output of the regret transform — a chemistry delta plus telemetry. */
-export interface HindsightRegretDeltas {
-  /**
-   * Aversive dopamine delta (<= 0) when holding would have won; a small
-   * positive "good close" reinforcement (>= 0) when closing was correct;
-   * 0 when neither (e.g. break-even or insufficient data).
-   */
-  dopamineDelta: number;
-  /** Foregone gain (USDT): max(0, bestCounterfactual - realized). */
+/** A pattern key the targeted-GABA delta is bound to (regime|side), so the
+ *  kernel learns "don't cut THIS kind of position early" rather than "fear
+ *  closing". null when not a regret (no target to bind). */
+export type GabaTarget = string | null;
+
+/** The close-time SENSE BUNDLE — captured at the moment of a kernel close.
+ *  Drives the legibility gate (§31 predictive coding) and the targeted-GABA
+ *  binding. Every field is a sense already available in SymbolState / the
+ *  qig-warp expectation at the close site (see loop.ts mapping). */
+export interface CloseSenseBundle {
+  // ── ownership (gate condition 1) ──
+  /** True iff the kernel initiated this close (own exit policy fired).
+   *  Operator/manual/liquidation closes are false → routed to exemplar
+   *  learning, never self-regret. */
+  kernelOwnedClose: boolean;
+
+  // ── market senses at close ──
+  /** Held side as a sign: +1 long, -1 short. */
+  sideSign: 1 | -1;
+  /** qig-warp expectation direction at close (-1 short-favoured, 0 flat/
+   *  observe, +1 long-favoured). From ExpectationDecision.expectation_direction. */
+  warpExpectationSign: -1 | 0 | 1;
+  /** qig-warp expectation confidence at close [0,1].
+   *  From ExpectationDecision.expectation_confidence. */
+  warpExpectationConfidence: number;
+  /** qig-warp regime label at close (e.g. 'aligned'|'reverse_tape'|'chop'). */
+  regimeAtClose: string;
+  /** basinDir at close (signed market direction; +long/-short lean). */
+  basinDirAtClose: number;
+  /** tape trend at close (signed). */
+  tapeTrendAtClose: number;
+  /** coherenceStreak at close — consecutive ticks the kernel's own
+   *  perception+forecast stayed coherent on the held position. Higher =
+   *  the hold was more legible. */
+  coherenceStreak: number;
+}
+
+/** The counterfactual outcome resolved at the END of the derived horizon. */
+export interface CounterfactualOutcome {
+  /** Realised net pnl (USDT) the close actually booked (Polo-authoritative). */
+  realizedPnlUsdt: number;
+  /** Counterfactual pnl (USDT) of having HELD to the end of the horizon
+   *  (or to the observed regime flip, whichever bounded first). NOT max
+   *  favourable excursion. */
+  horizonEndPnlUsdt: number;
+  /** Margin (USDT) backing the closed position — for pnl_frac normalisation. */
+  marginUsdt: number;
+  /** True iff the SAME regime that was legible at close persisted through
+   *  the horizon (gate condition 3). If the regime flipped to an unrelated
+   *  move, the continuation is not the one the kernel could have foreseen. */
+  regimePersisted: boolean;
+}
+
+/** Output of the resolve transform — the NT vector, its GABA target, and
+ *  telemetry. */
+export interface HindsightResult {
+  nt: HindsightNtDeltas;
+  gabaTarget: GabaTarget;
+  /** Foregone gain (USDT): max(0, horizonEnd - realized). 0 on a good close. */
   foregoneGainUsdt: number;
-  /** The pnl_frac that the regret transform actually consumed (normalised). */
-  regretFrac: number;
+  /** The observer-scaled prediction-error magnitude actually consumed
+   *  (z-scored regret fraction). */
+  predictionErrorZ: number;
+  /** Which branch fired:
+   *    'hindsight_regret'      — eligible + holding would have won
+   *    'hindsight_good_close'  — eligible + close avoided a worse outcome
+   *    'ineligible_noise'      — gate failed (surprise/noise) → zero vector
+   *    'ineligible_not_owned'  — not a kernel close → routed elsewhere
+   *    'hindsight_invalid' / 'hindsight_no_margin' — fail-closed */
   source: string;
 }
 
-// ── Structural constants (NOT operator knobs) ───────────────────────────
-//
-// REGRET_DOP_CAP mirrors the trade-outcome dopamine cap (0.5 in pushReward).
-// Regret is the same CLASS of signal as a realised loss ("the kernel was
-// wrong about when to exit"), so the foregone gain must be able to sting
-// comparably to a real loss. But it is BOUNDED so a huge foregone gain
-// cannot produce unbounded aversion — the kernel must still be willing to
-// close when it should. tanh saturates the magnitude into [0, CAP).
-export const REGRET_DOP_CAP = 0.5;
-
-// GOOD_CLOSE_DOP small positive reinforcement when the close avoided a worse
-// outcome (counterfactual <= realized). Kept much smaller than the regret
-// cap so the asymmetry favours "don't punish closing" without actively
-// teaching the kernel to close eagerly. Mirrors the loss-side mood-dip cap
-// (0.1) magnitude in pushReward, applied here as a *reward* for good timing.
-export const GOOD_CLOSE_DOP = 0.05;
-
 const EPS = 1e-12;
+/** Minimum samples before the observer scale is trusted (mirrors pushReward
+ *  / observer_fib_coefficient). Below this we fall through with no signal —
+ *  cold-start must NOT emit chemistry from an unestablished scale. */
+const MIN_SAMPLES = 5;
 
 function isFiniteNumber(x: unknown): x is number {
   return typeof x === 'number' && Number.isFinite(x);
 }
 
-/**
- * Counterfactual pnl (USDT) of holding the CLOSED position to `price`.
- *
- *   long  : (price - exitPrice) * qty   — gains if price rises after exit
- *   short : (exitPrice - price) * qty   — gains if price falls after exit
- *
- * This is the pnl the position would have ADDED beyond the exit, i.e. the
- * marginal pnl of NOT closing. Added to the realised pnl it gives the total
- * "if I'd just left it" pnl.
- *
- * Returns null on any non-finite / invalid input (fail-closed).
- */
-export function counterfactualPnlUsdt(
-  watch: Pick<HindsightWatch, 'sideSign' | 'qty' | 'exitPrice' | 'realizedPnlUsdt'>,
-  price: number,
-): number | null {
-  if (!isFiniteNumber(price) || price <= 0) return null;
-  if (!isFiniteNumber(watch.qty) || watch.qty <= 0) return null;
-  if (!isFiniteNumber(watch.exitPrice) || watch.exitPrice <= 0) return null;
-  if (!isFiniteNumber(watch.realizedPnlUsdt)) return null;
-  if (watch.sideSign !== 1 && watch.sideSign !== -1) return null;
-  // Marginal pnl of holding past the exit, then add what was already booked.
-  const marginal = (price - watch.exitPrice) * watch.sideSign * watch.qty;
-  return watch.realizedPnlUsdt + marginal;
-}
+const ZERO_NT: HindsightNtDeltas = Object.freeze({
+  dopamineDelta: 0,
+  acetylcholineDelta: 0,
+  norepinephrineDelta: 0,
+  serotoninDelta: 0,
+  gabaDelta: 0,
+  endorphinDelta: 0,
+});
 
-/**
- * Advance a watch with a fresh observed price: update the running "best
- * counterfactual pnl" (most favourable to having held). Pure — returns a
- * new watch object, does not mutate the input.
- *
- * On invalid price the watch is returned unchanged (best-effort).
- */
-export function advanceWatch(watch: HindsightWatch, price: number): HindsightWatch {
-  const cf = counterfactualPnlUsdt(watch, price);
-  if (cf === null) return watch;
-  if (cf > watch.bestCounterfactualPnlUsdt) {
-    return { ...watch, bestCounterfactualPnlUsdt: cf };
-  }
-  return watch;
+function ineligible(source: string): HindsightResult {
+  return {
+    nt: { ...ZERO_NT },
+    gabaTarget: null,
+    foregoneGainUsdt: 0,
+    predictionErrorZ: 0,
+    source,
+  };
 }
 
 /**
  * Median absolute deviation around the median. Robust to outliers — the
- * same statistic pushReward uses to normalise pnl_frac.
+ * SAME statistic observerFibCoefficient / pushReward use for the observer
+ * scale. Returns the (median, mad) pair so the z-score matches canon.
  */
-export function medianAbsoluteDeviation(xs: number[]): number {
+export function medianAndMad(xs: number[]): { median: number; mad: number } {
   const finite = xs.filter(isFiniteNumber);
-  if (finite.length === 0) return 0;
+  if (finite.length === 0) return { median: 0, mad: 0 };
   const sorted = [...finite].sort((a, b) => a - b);
-  const median = sorted.length % 2 === 0
-    ? (sorted[sorted.length / 2 - 1]! + sorted[sorted.length / 2]!) / 2
-    : sorted[Math.floor(sorted.length / 2)]!;
+  const med = (arr: number[]): number =>
+    arr.length % 2 === 0
+      ? (arr[arr.length / 2 - 1]! + arr[arr.length / 2]!) / 2
+      : arr[Math.floor(arr.length / 2)]!;
+  const median = med(sorted);
   const devs = sorted.map((x) => Math.abs(x - median)).sort((a, b) => a - b);
-  return devs.length % 2 === 0
-    ? (devs[devs.length / 2 - 1]! + devs[devs.length / 2]!) / 2
-    : devs[Math.floor(devs.length / 2)]!;
+  return { median, mad: med(devs) };
 }
 
 /**
- * Pure regret transform: resolve a (expired) watch into a chemistry delta.
- *
- * @param watch        the watch being resolved (with its accumulated best
- *                     counterfactual pnl).
- * @param pnlFracHistory  the kernel's own realised pnl_frac distribution —
- *                     used to derive the normalisation scale (MAD), exactly
- *                     like pushReward / observerFibCoefficient. Observer-set,
- *                     no hardcoded magnitude.
- *
- * Semantics:
- *   - foregoneGain = max(0, bestCounterfactual - realized).
- *     If holding would NOT have beaten the close (price moved against the
- *     old position) foregoneGain == 0 → no regret. Optionally a small
- *     positive "good close" reinforcement when the close strictly avoided a
- *     worse outcome.
- *   - regretFrac = foregoneGain / margin (the foregone gain as a fraction of
- *     the capital that was at risk), then normalised by the MAD of the
- *     kernel's realised pnl_frac history so the sting is measured in the
- *     same units the kernel feels its real wins/losses.
- *   - dopamineDelta = -tanh(regretFracNormalized) * REGRET_DOP_CAP  (<= 0).
- *
- * Fail-closed: invalid margin / non-finite values → zero delta.
+ * Counterfactual pnl (USDT) of holding the CLOSED position to `price`.
+ *   long  : (price - exitPrice) * qty   — gains if price rises after exit
+ *   short : (exitPrice - price) * qty   — gains if price falls after exit
+ * Added to realised pnl → total "if I'd just left it" pnl. null on invalid.
  */
-export function resolveRegret(
-  watch: Pick<
-    HindsightWatch,
-    'bestCounterfactualPnlUsdt' | 'realizedPnlUsdt' | 'marginUsdt'
-  >,
-  pnlFracHistory: number[],
-): HindsightRegretDeltas {
-  const { bestCounterfactualPnlUsdt: best, realizedPnlUsdt: realized, marginUsdt } = watch;
+export function counterfactualPnlUsdt(
+  args: { sideSign: 1 | -1; qty: number; exitPrice: number; realizedPnlUsdt: number },
+  price: number,
+): number | null {
+  if (!isFiniteNumber(price) || price <= 0) return null;
+  if (!isFiniteNumber(args.qty) || args.qty <= 0) return null;
+  if (!isFiniteNumber(args.exitPrice) || args.exitPrice <= 0) return null;
+  if (!isFiniteNumber(args.realizedPnlUsdt)) return null;
+  if (args.sideSign !== 1 && args.sideSign !== -1) return null;
+  const marginal = (price - args.exitPrice) * args.sideSign * args.qty;
+  return args.realizedPnlUsdt + marginal;
+}
 
-  if (!isFiniteNumber(best) || !isFiniteNumber(realized)) {
-    return { dopamineDelta: 0, foregoneGainUsdt: 0, regretFrac: 0, source: 'hindsight_invalid' };
+/**
+ * PURITY KEYSTONE — the eligibility / legibility gate.
+ *
+ * Returns true iff regret may fire STRONGLY. All three conditions:
+ *   (1) kernel owned the close,
+ *   (2) the continuation was LEGIBLE at close — the close-time senses showed
+ *       evidence to HOLD: qig-warp expectation favoured the held side with
+ *       confidence, basin direction still leaned with the position, and the
+ *       hold was coherent (coherenceStreak > 0). "Legible" = the kernel's
+ *       OWN forecast pointed at continuation (low surprise per §31), so a
+ *       continuation is a prediction error it could have avoided.
+ *   (3) the same regime persisted through the horizon.
+ *
+ * Legibility uses the kernel's own observer-relative signal, NOT a fixed
+ * threshold: the warp expectation must be ALIGNED with the held side and
+ * carry positive confidence, AND basinDir must still lean the held way.
+ * A single coherent tick (coherenceStreak > 0) is the floor — the kernel
+ * had at least one tick of evidence the hold was justified.
+ *
+ * If legibility fails → SURPRISE / NOISE → no aversive signal (canon §31:
+ * unpredictable continuation is surprise, not a learnable mistake).
+ */
+export function isContinuationLegible(b: CloseSenseBundle): boolean {
+  // qig-warp expectation must have favoured the HELD side (continuation),
+  // i.e. expectation direction agrees with sideSign, with > 0 confidence.
+  const warpFavouredHold =
+    b.warpExpectationSign === b.sideSign &&
+    isFiniteNumber(b.warpExpectationConfidence) &&
+    b.warpExpectationConfidence > 0;
+  // basin direction must still lean the held way (sign agreement).
+  const basinFavouredHold =
+    isFiniteNumber(b.basinDirAtClose) &&
+    Math.sign(b.basinDirAtClose) === b.sideSign;
+  // the hold must have been coherent for at least one tick.
+  const wasCoherent = isFiniteNumber(b.coherenceStreak) && b.coherenceStreak > 0;
+  return warpFavouredHold && basinFavouredHold && wasCoherent;
+}
+
+/** Full eligibility = owned ∧ legible-at-close ∧ regime-persisted. */
+export function isEligibleForRegret(
+  b: CloseSenseBundle,
+  regimePersisted: boolean,
+): { eligible: boolean; reason: 'eligible' | 'not_owned' | 'not_legible' | 'regime_changed' } {
+  if (!b.kernelOwnedClose) return { eligible: false, reason: 'not_owned' };
+  if (!isContinuationLegible(b)) return { eligible: false, reason: 'not_legible' };
+  if (!regimePersisted) return { eligible: false, reason: 'regime_changed' };
+  return { eligible: true, reason: 'eligible' };
+}
+
+/**
+ * Observer-scaled prediction-error magnitude. `frac` is foregoneGain/margin
+ * (a pnl-fraction). z-scored against the kernel's own pnl_frac distribution
+ * (median+MAD), exactly like observerFibCoefficient. Returns the z-magnitude
+ * (>= 0) and the salience weight tanh(z) ∈ [0,1) used to scale every NT
+ * channel. With < MIN_SAMPLES or zero MAD → returns null (no trusted scale
+ * → caller emits nothing; cold-start must not fabricate chemistry).
+ */
+export function deriveMagnitude(
+  frac: number,
+  pnlFracHistory: number[],
+): { z: number; salience: number } | null {
+  if (!isFiniteNumber(frac)) return null;
+  if (pnlFracHistory.length < MIN_SAMPLES) return null;
+  const { mad } = medianAndMad(pnlFracHistory);
+  if (mad <= EPS) return null;
+  const z = Math.abs(frac) / mad;
+  return { z, salience: Math.tanh(z) };
+}
+
+/** GABA target key: bind targeted inhibition to the (regime, side) pattern
+ *  of the premature close so the kernel learns "don't cut THIS kind of
+ *  position early" — NOT "close less". */
+export function gabaTargetKey(b: CloseSenseBundle): string {
+  const side = b.sideSign === 1 ? 'long' : 'short';
+  const regime = typeof b.regimeAtClose === 'string' && b.regimeAtClose.length > 0
+    ? b.regimeAtClose
+    : 'unknown';
+  return `premature_close:${regime}:${side}`;
+}
+
+/**
+ * Resolve a watch at horizon end into the full NT vector. PURE.
+ *
+ * Branches:
+ *   - fail-closed (invalid pnl/margin) → zero vector.
+ *   - not owned → 'ineligible_not_owned', zero vector (route to exemplar
+ *     learning is the caller's job; this signal emits nothing).
+ *   - foregoneGain <= 0 (close avoided a worse outcome) AND eligible-by-
+ *     ownership → 'hindsight_good_close': relief vector (dop small+, ACh+,
+ *     ser+, endo+, NE if salient, GABA 0).
+ *   - foregoneGain > 0 but NOT legible / regime changed → 'ineligible_noise',
+ *     zero vector (the continuation was surprise, not a foreseeable mistake).
+ *   - foregoneGain > 0 AND eligible → 'hindsight_regret': aversive vector
+ *     (dop-, ACh+, NE+, ser-, GABA+ TARGETED, endo 0), all observer-scaled.
+ */
+export function resolveHindsight(
+  bundle: CloseSenseBundle,
+  outcome: CounterfactualOutcome,
+  pnlFracHistory: number[],
+): HindsightResult {
+  const { realizedPnlUsdt: realized, horizonEndPnlUsdt: horizonEnd, marginUsdt } = outcome;
+
+  // ── fail-closed ───────────────────────────────────────────────────────
+  if (!isFiniteNumber(realized) || !isFiniteNumber(horizonEnd)) {
+    return ineligible('hindsight_invalid');
   }
   if (!isFiniteNumber(marginUsdt) || marginUsdt <= 0) {
-    return { dopamineDelta: 0, foregoneGainUsdt: 0, regretFrac: 0, source: 'hindsight_no_margin' };
+    return ineligible('hindsight_no_margin');
   }
 
-  const foregoneGainUsdt = best - realized;
+  // ── ownership gate (condition 1) ────────────────────────────────────────
+  // A non-owned close is not self-regret; emit nothing here (caller routes
+  // to exemplar learning).
+  if (!bundle.kernelOwnedClose) {
+    return ineligible('ineligible_not_owned');
+  }
 
-  // ── Good-close branch: holding would NOT have beaten the close ────────
-  // (foregoneGain <= 0). The exit avoided a worse outcome. No regret; mild
-  // positive reinforcement so correct exits are gently encouraged without
-  // teaching eager closing.
+  const foregoneGainUsdt = horizonEnd - realized;
+
+  // ── good-close branch (close avoided a worse / equal outcome) ───────────
+  // Holding would NOT have beaten the close. Relief, not regret. We still
+  // require an established observer scale so the magnitude is meaningful.
   if (foregoneGainUsdt <= EPS) {
+    const avoidedLossFrac = Math.abs(foregoneGainUsdt) / marginUsdt;
+    const mag = deriveMagnitude(avoidedLossFrac, pnlFracHistory);
+    if (mag === null) return ineligible('ineligible_noise'); // no trusted scale
+    const s = mag.salience;
+    // Relief vector (canon roles): dopamine small + (avoided counterfactual
+    // loss, observer-scaled — NOT a fixed +0.05), ACh + (bind the good
+    // timing), serotonin + (timing confidence / temporal trust), endorphin +
+    // (relief / convergence), NE + only if salient, GABA 0 (no inhibition to
+    // bind — closing was correct).
     return {
-      dopamineDelta: GOOD_CLOSE_DOP,
+      nt: {
+        dopamineDelta: s,
+        acetylcholineDelta: s,
+        norepinephrineDelta: s,
+        serotoninDelta: s,
+        gabaDelta: 0,
+        endorphinDelta: s,
+      },
+      gabaTarget: null,
       foregoneGainUsdt: 0,
-      regretFrac: 0,
+      predictionErrorZ: mag.z,
       source: 'hindsight_good_close',
     };
   }
 
-  // ── Regret branch: holding would have won. Aversive, bounded. ─────────
-  const regretFrac = foregoneGainUsdt / marginUsdt;
-
-  // Observer-derived normalisation: scale the regret fraction by the MAD of
-  // the kernel's own realised pnl_frac history, mirroring pushReward's
-  // pnlFracNormalized. With < MIN_SAMPLES or zero MAD we fall back to the
-  // raw fraction (still bounded by tanh + cap). This keeps the sting in the
-  // same magnitude band as the kernel's real wins/losses.
-  const MIN_SAMPLES = 5;
-  let regretFracNormalized = regretFrac;
-  if (pnlFracHistory.length >= MIN_SAMPLES) {
-    const mad = medianAbsoluteDeviation(pnlFracHistory);
-    if (mad > EPS) regretFracNormalized = regretFrac / mad;
+  // ── legibility + regime-persistence gate (conditions 2 & 3) ─────────────
+  // foregoneGain > 0: holding WOULD have won. But only counts as regret if
+  // the continuation was LEGIBLE at close AND the same regime persisted.
+  // Otherwise it was surprise/noise — emit nothing.
+  const gate = isEligibleForRegret(bundle, outcome.regimePersisted);
+  if (!gate.eligible) {
+    return ineligible('ineligible_noise');
   }
 
-  const dopamineDelta = -Math.tanh(regretFracNormalized) * REGRET_DOP_CAP;
+  // ── regret branch: legible premature close, observer-scaled ─────────────
+  const regretFrac = foregoneGainUsdt / marginUsdt;
+  const mag = deriveMagnitude(regretFrac, pnlFracHistory);
+  if (mag === null) return ineligible('ineligible_noise'); // no trusted scale
+  const s = mag.salience; // ∈ (0,1)
 
+  // Aversive vector. Signs follow canon §29.1 roles; magnitudes = salience
+  // (observer-scaled). dopamine NEGATIVE (signed prediction error — the
+  // trade was right, the exit wrong); ACh + (bind the close-time cues);
+  // NE + (salience of the surprise-avoidable error); serotonin NEGATIVE
+  // (patience/temporal-trust correction — the kernel was too impatient);
+  // GABA + TARGETED to the (regime,side) pattern (NOT global — see
+  // gabaTarget); endorphin 0 (no relief — this was a mistake).
   return {
-    dopamineDelta,
+    nt: {
+      dopamineDelta: -s,
+      acetylcholineDelta: s,
+      norepinephrineDelta: s,
+      serotoninDelta: -s,
+      gabaDelta: s,
+      endorphinDelta: 0,
+    },
+    gabaTarget: gabaTargetKey(bundle),
     foregoneGainUsdt,
-    regretFrac,
+    predictionErrorZ: mag.z,
     source: 'hindsight_regret',
   };
 }

--- a/apps/api/src/services/monkey/hindsightRegret.ts
+++ b/apps/api/src/services/monkey/hindsightRegret.ts
@@ -1,0 +1,252 @@
+/**
+ * hindsightRegret.ts — counterfactual-regret reward signal.
+ *
+ * Operator intent (2026-05-29, verbatim): "rather than a knob, it needs to
+ * feel the pain of this. not so much that its scared to make a trade but
+ * enough that it thinks about thinking about the trend a second time before
+ * closing." + "something akin to hindsight. e.g. 'if i just left it i would
+ * have got the reward'."
+ *
+ * CONCEPT (counterfactual regret minimisation):
+ *   When the kernel closes a position, we keep watching the symbol for a
+ *   forward window. We track what the *closed* position WOULD have earned
+ *   had it been held. If holding would have beaten the realised close
+ *   (the trend continued in the position's favour) we emit an AVERSIVE
+ *   "closed too early" chemistry signal scaled by the foregone gain. If
+ *   closing was correct (price moved against the old position, holding
+ *   would have lost more) we emit NO regret — optionally a mild positive
+ *   "good close" reinforcement.
+ *
+ *   The ASYMMETRY is load-bearing: regret fires ONLY when holding would
+ *   have won. That is what stops the signal from making the kernel scared
+ *   to ever close — there is no penalty for a correct exit, only for an
+ *   exit that left money on the table in a continuing favourable trend.
+ *
+ * DOCTRINAL ANCHORS:
+ *   - P1 (Observer sets all params from frozen facts): the regret MAGNITUDE
+ *     is normalised against the kernel's own realised pnl_frac distribution
+ *     (MAD), exactly like observerFibCoefficient / pushReward. There is no
+ *     hardcoded "how much a foregone gain should sting" knob. The transform
+ *     shape (tanh) and the output cap are STRUCTURAL design constants,
+ *     mirroring the trade-outcome reward channel.
+ *   - P14 (Variable Separation): hindsight regret is its OWN chemistry
+ *     channel. It is NOT folded into the realised-pnl reward — a position
+ *     that closed at a tiny realised win can still produce a large regret
+ *     signal if the trend ran on without it. The realised reward already
+ *     fired at close; regret is computed later, from the counterfactual.
+ *   - P15 (Fail-Closed Safety): all inputs are validated; non-finite inputs
+ *     produce zero deltas. Never blocks trading.
+ *
+ * This module is PURE (no I/O, no time, no DB). The orchestration that
+ * registers a watch at close, advances it with live price each tick, and
+ * pushes the resulting deltas lives in loop.ts behind
+ * MONKEY_HINDSIGHT_REGRET_LIVE (default OFF).
+ */
+
+/** A position that was closed and is now being watched for counterfactual pnl. */
+export interface HindsightWatch {
+  symbol: string;
+  /** +1 for a closed long, -1 for a closed short. */
+  sideSign: 1 | -1;
+  /** Base-asset quantity that was closed (magnitude, > 0). */
+  qty: number;
+  /** Price at which the position was closed (exit price). */
+  exitPrice: number;
+  /** Realised net pnl (USDT) the close actually booked (Polo-authoritative). */
+  realizedPnlUsdt: number;
+  /** Margin (USDT) backing the closed position — for pnl_frac normalisation. */
+  marginUsdt: number;
+  /** ms epoch the close happened. */
+  closedAtMs: number;
+  /** ms epoch this watch should stop being evaluated and be retired. */
+  expiresAtMs: number;
+  /**
+   * Best (most favourable) counterfactual pnl seen so far over the window.
+   * For a closed long this is the pnl at the HIGHEST price seen since close;
+   * for a closed short, at the LOWEST. Seeded to realizedPnlUsdt so a window
+   * that only ever moves adversely yields zero foregone gain (no regret).
+   */
+  bestCounterfactualPnlUsdt: number;
+}
+
+/** Output of the regret transform — a chemistry delta plus telemetry. */
+export interface HindsightRegretDeltas {
+  /**
+   * Aversive dopamine delta (<= 0) when holding would have won; a small
+   * positive "good close" reinforcement (>= 0) when closing was correct;
+   * 0 when neither (e.g. break-even or insufficient data).
+   */
+  dopamineDelta: number;
+  /** Foregone gain (USDT): max(0, bestCounterfactual - realized). */
+  foregoneGainUsdt: number;
+  /** The pnl_frac that the regret transform actually consumed (normalised). */
+  regretFrac: number;
+  source: string;
+}
+
+// ── Structural constants (NOT operator knobs) ───────────────────────────
+//
+// REGRET_DOP_CAP mirrors the trade-outcome dopamine cap (0.5 in pushReward).
+// Regret is the same CLASS of signal as a realised loss ("the kernel was
+// wrong about when to exit"), so the foregone gain must be able to sting
+// comparably to a real loss. But it is BOUNDED so a huge foregone gain
+// cannot produce unbounded aversion — the kernel must still be willing to
+// close when it should. tanh saturates the magnitude into [0, CAP).
+export const REGRET_DOP_CAP = 0.5;
+
+// GOOD_CLOSE_DOP small positive reinforcement when the close avoided a worse
+// outcome (counterfactual <= realized). Kept much smaller than the regret
+// cap so the asymmetry favours "don't punish closing" without actively
+// teaching the kernel to close eagerly. Mirrors the loss-side mood-dip cap
+// (0.1) magnitude in pushReward, applied here as a *reward* for good timing.
+export const GOOD_CLOSE_DOP = 0.05;
+
+const EPS = 1e-12;
+
+function isFiniteNumber(x: unknown): x is number {
+  return typeof x === 'number' && Number.isFinite(x);
+}
+
+/**
+ * Counterfactual pnl (USDT) of holding the CLOSED position to `price`.
+ *
+ *   long  : (price - exitPrice) * qty   — gains if price rises after exit
+ *   short : (exitPrice - price) * qty   — gains if price falls after exit
+ *
+ * This is the pnl the position would have ADDED beyond the exit, i.e. the
+ * marginal pnl of NOT closing. Added to the realised pnl it gives the total
+ * "if I'd just left it" pnl.
+ *
+ * Returns null on any non-finite / invalid input (fail-closed).
+ */
+export function counterfactualPnlUsdt(
+  watch: Pick<HindsightWatch, 'sideSign' | 'qty' | 'exitPrice' | 'realizedPnlUsdt'>,
+  price: number,
+): number | null {
+  if (!isFiniteNumber(price) || price <= 0) return null;
+  if (!isFiniteNumber(watch.qty) || watch.qty <= 0) return null;
+  if (!isFiniteNumber(watch.exitPrice) || watch.exitPrice <= 0) return null;
+  if (!isFiniteNumber(watch.realizedPnlUsdt)) return null;
+  if (watch.sideSign !== 1 && watch.sideSign !== -1) return null;
+  // Marginal pnl of holding past the exit, then add what was already booked.
+  const marginal = (price - watch.exitPrice) * watch.sideSign * watch.qty;
+  return watch.realizedPnlUsdt + marginal;
+}
+
+/**
+ * Advance a watch with a fresh observed price: update the running "best
+ * counterfactual pnl" (most favourable to having held). Pure — returns a
+ * new watch object, does not mutate the input.
+ *
+ * On invalid price the watch is returned unchanged (best-effort).
+ */
+export function advanceWatch(watch: HindsightWatch, price: number): HindsightWatch {
+  const cf = counterfactualPnlUsdt(watch, price);
+  if (cf === null) return watch;
+  if (cf > watch.bestCounterfactualPnlUsdt) {
+    return { ...watch, bestCounterfactualPnlUsdt: cf };
+  }
+  return watch;
+}
+
+/**
+ * Median absolute deviation around the median. Robust to outliers — the
+ * same statistic pushReward uses to normalise pnl_frac.
+ */
+export function medianAbsoluteDeviation(xs: number[]): number {
+  const finite = xs.filter(isFiniteNumber);
+  if (finite.length === 0) return 0;
+  const sorted = [...finite].sort((a, b) => a - b);
+  const median = sorted.length % 2 === 0
+    ? (sorted[sorted.length / 2 - 1]! + sorted[sorted.length / 2]!) / 2
+    : sorted[Math.floor(sorted.length / 2)]!;
+  const devs = sorted.map((x) => Math.abs(x - median)).sort((a, b) => a - b);
+  return devs.length % 2 === 0
+    ? (devs[devs.length / 2 - 1]! + devs[devs.length / 2]!) / 2
+    : devs[Math.floor(devs.length / 2)]!;
+}
+
+/**
+ * Pure regret transform: resolve a (expired) watch into a chemistry delta.
+ *
+ * @param watch        the watch being resolved (with its accumulated best
+ *                     counterfactual pnl).
+ * @param pnlFracHistory  the kernel's own realised pnl_frac distribution —
+ *                     used to derive the normalisation scale (MAD), exactly
+ *                     like pushReward / observerFibCoefficient. Observer-set,
+ *                     no hardcoded magnitude.
+ *
+ * Semantics:
+ *   - foregoneGain = max(0, bestCounterfactual - realized).
+ *     If holding would NOT have beaten the close (price moved against the
+ *     old position) foregoneGain == 0 → no regret. Optionally a small
+ *     positive "good close" reinforcement when the close strictly avoided a
+ *     worse outcome.
+ *   - regretFrac = foregoneGain / margin (the foregone gain as a fraction of
+ *     the capital that was at risk), then normalised by the MAD of the
+ *     kernel's realised pnl_frac history so the sting is measured in the
+ *     same units the kernel feels its real wins/losses.
+ *   - dopamineDelta = -tanh(regretFracNormalized) * REGRET_DOP_CAP  (<= 0).
+ *
+ * Fail-closed: invalid margin / non-finite values → zero delta.
+ */
+export function resolveRegret(
+  watch: Pick<
+    HindsightWatch,
+    'bestCounterfactualPnlUsdt' | 'realizedPnlUsdt' | 'marginUsdt'
+  >,
+  pnlFracHistory: number[],
+): HindsightRegretDeltas {
+  const { bestCounterfactualPnlUsdt: best, realizedPnlUsdt: realized, marginUsdt } = watch;
+
+  if (!isFiniteNumber(best) || !isFiniteNumber(realized)) {
+    return { dopamineDelta: 0, foregoneGainUsdt: 0, regretFrac: 0, source: 'hindsight_invalid' };
+  }
+  if (!isFiniteNumber(marginUsdt) || marginUsdt <= 0) {
+    return { dopamineDelta: 0, foregoneGainUsdt: 0, regretFrac: 0, source: 'hindsight_no_margin' };
+  }
+
+  const foregoneGainUsdt = best - realized;
+
+  // ── Good-close branch: holding would NOT have beaten the close ────────
+  // (foregoneGain <= 0). The exit avoided a worse outcome. No regret; mild
+  // positive reinforcement so correct exits are gently encouraged without
+  // teaching eager closing.
+  if (foregoneGainUsdt <= EPS) {
+    return {
+      dopamineDelta: GOOD_CLOSE_DOP,
+      foregoneGainUsdt: 0,
+      regretFrac: 0,
+      source: 'hindsight_good_close',
+    };
+  }
+
+  // ── Regret branch: holding would have won. Aversive, bounded. ─────────
+  const regretFrac = foregoneGainUsdt / marginUsdt;
+
+  // Observer-derived normalisation: scale the regret fraction by the MAD of
+  // the kernel's own realised pnl_frac history, mirroring pushReward's
+  // pnlFracNormalized. With < MIN_SAMPLES or zero MAD we fall back to the
+  // raw fraction (still bounded by tanh + cap). This keeps the sting in the
+  // same magnitude band as the kernel's real wins/losses.
+  const MIN_SAMPLES = 5;
+  let regretFracNormalized = regretFrac;
+  if (pnlFracHistory.length >= MIN_SAMPLES) {
+    const mad = medianAbsoluteDeviation(pnlFracHistory);
+    if (mad > EPS) regretFracNormalized = regretFrac / mad;
+  }
+
+  const dopamineDelta = -Math.tanh(regretFracNormalized) * REGRET_DOP_CAP;
+
+  return {
+    dopamineDelta,
+    foregoneGainUsdt,
+    regretFrac,
+    source: 'hindsight_regret',
+  };
+}
+
+/** Feature-flag helper. Default OFF — behaviour byte-identical when unset. */
+export function isHindsightRegretLive(): boolean {
+  return process.env.MONKEY_HINDSIGHT_REGRET_LIVE === 'true';
+}

--- a/apps/api/src/services/monkey/hindsightRegret.ts
+++ b/apps/api/src/services/monkey/hindsightRegret.ts
@@ -23,7 +23,7 @@
  *      never global), endorphin (relief on a good close).
  *
  * ── PURITY KEYSTONE: the eligibility / legibility gate ───────────────────
- * Regret fires strongly ONLY when ALL THREE hold (see `isEligibleForRegret`):
+ * Regret is scaled by how strongly ALL THREE hold (see `legibilityStrength`):
  *   (1) the kernel OWNED the close (kernel-initiated; operator / manual /
  *       liquidation closes are NOT self-regret),
  *   (2) the continuation was LEGIBLE at close time — the close-time sense
@@ -31,8 +31,10 @@
  *       held side, basin direction still with the position, trend coherent),
  *   (3) the SAME REGIME persisted through the derived horizon.
  * If continuation was NOT legible → the move is SURPRISE / NOISE, not regret
- * → NO aversive signal. This maps directly onto QIG canon §31 (Sensory
- * Intake & Predictive Coding): a prediction error you could NOT have
+ * → NO aversive signal. Weakly legible continuations remain learnable but
+ * weak: the observer-scaled prediction-error salience is multiplied by the
+ * close-time legibility strength. This maps directly onto QIG canon §31
+ * (Sensory Intake & Predictive Coding): a prediction error you could NOT have
  * predicted is surprise, not a learnable mistake. Regret = a LEGIBLE
  * prediction error (low surprise at close, continuation foreseeable).
  *
@@ -63,7 +65,10 @@
 
 // ── E6 six-chemical NT delta vector (canon §29.1) ────────────────────────
 // Signs are the chemistry's CANONICAL ROLE, not free parameters. Magnitudes
-// are observer-scaled (see deriveMagnitude). Flag-OFF callers never read it.
+// are observer-scaled (see deriveMagnitude) and, on regret, multiplied by
+// close-time legibility. Equal per-channel salience remains a dark-mode draft
+// hypothesis until a channel-envelope derivation is approved. Flag-OFF callers
+// never read it.
 export interface HindsightNtDeltas {
   /** Signed prediction error. <0 on a legible premature close (the trade
    *  was right, the exit wrong); small >0 relief on a good close. */
@@ -227,7 +232,9 @@ export function counterfactualPnlUsdt(
 /**
  * PURITY KEYSTONE — the eligibility / legibility gate.
  *
- * Returns true iff regret may fire STRONGLY. All three conditions:
+ * Returns true iff regret may fire. The actual regret magnitude is multiplied
+ * by `legibilityStrength`; weak evidence cannot produce full-strength regret.
+ * All three conditions:
  *   (1) kernel owned the close,
  *   (2) the continuation was LEGIBLE at close — the close-time senses showed
  *       evidence to HOLD: qig-warp expectation favoured the held side with
@@ -239,27 +246,45 @@ export function counterfactualPnlUsdt(
  *
  * Legibility uses the kernel's own observer-relative signal, NOT a fixed
  * threshold: the warp expectation must be ALIGNED with the held side and
- * carry positive confidence, AND basinDir must still lean the held way.
- * A single coherent tick (coherenceStreak > 0) is the floor — the kernel
- * had at least one tick of evidence the hold was justified.
+ * carry positive confidence, AND basinDir must still lean the held way. The
+ * strength is continuous: confidence × basin-alignment magnitude × coherence
+ * strength × regime-persistence.
  *
  * If legibility fails → SURPRISE / NOISE → no aversive signal (canon §31:
  * unpredictable continuation is surprise, not a learnable mistake).
  */
-export function isContinuationLegible(b: CloseSenseBundle): boolean {
+function clamp01(x: number): number {
+  if (!isFiniteNumber(x)) return 0;
+  return Math.max(0, Math.min(1, x));
+}
+
+/** Continuous legibility multiplier ∈ [0,1]. Weak confidence / tiny basin
+ *  lean / one-tick coherence scales regret down instead of merely opening a
+ *  Boolean gate. Regime persistence is currently observed as a latch, so its
+ *  strength is 1 when persisted and 0 after a flip. */
+export function legibilityStrength(b: CloseSenseBundle, regimePersisted = true): number {
+  if (!regimePersisted) return 0;
   // qig-warp expectation must have favoured the HELD side (continuation),
   // i.e. expectation direction agrees with sideSign, with > 0 confidence.
-  const warpFavouredHold =
-    b.warpExpectationSign === b.sideSign &&
-    isFiniteNumber(b.warpExpectationConfidence) &&
-    b.warpExpectationConfidence > 0;
+  const warpStrength =
+    b.warpExpectationSign === b.sideSign
+      ? clamp01(b.warpExpectationConfidence)
+      : 0;
   // basin direction must still lean the held way (sign agreement).
-  const basinFavouredHold =
+  const basinStrength =
     isFiniteNumber(b.basinDirAtClose) &&
-    Math.sign(b.basinDirAtClose) === b.sideSign;
-  // the hold must have been coherent for at least one tick.
-  const wasCoherent = isFiniteNumber(b.coherenceStreak) && b.coherenceStreak > 0;
-  return warpFavouredHold && basinFavouredHold && wasCoherent;
+    Math.sign(b.basinDirAtClose) === b.sideSign
+      ? Math.tanh(Math.abs(b.basinDirAtClose))
+      : 0;
+  const coherence =
+    isFiniteNumber(b.coherenceStreak) && b.coherenceStreak > 0
+      ? b.coherenceStreak / (b.coherenceStreak + 1)
+      : 0;
+  return clamp01(warpStrength * basinStrength * coherence);
+}
+
+export function isContinuationLegible(b: CloseSenseBundle): boolean {
+  return legibilityStrength(b) > EPS;
 }
 
 /** Full eligibility = owned ∧ legible-at-close ∧ regime-persisted. */
@@ -385,7 +410,9 @@ export function resolveHindsight(
   const regretFrac = foregoneGainUsdt / marginUsdt;
   const mag = deriveMagnitude(regretFrac, pnlFracHistory);
   if (mag === null) return ineligible('ineligible_noise'); // no trusted scale
-  const s = mag.salience; // ∈ (0,1)
+  const legibility = legibilityStrength(bundle, outcome.regimePersisted);
+  if (legibility <= EPS) return ineligible('ineligible_noise');
+  const s = mag.salience * legibility; // ∈ (0,1), observer-scale × legibility
 
   // Aversive vector. Signs follow canon §29.1 roles; magnitudes = salience
   // (observer-scaled). dopamine NEGATIVE (signed prediction error — the

--- a/apps/api/src/services/monkey/hindsightRegret.ts
+++ b/apps/api/src/services/monkey/hindsightRegret.ts
@@ -276,6 +276,9 @@ export function legibilityStrength(b: CloseSenseBundle, regimePersisted = true):
     Math.sign(b.basinDirAtClose) === b.sideSign
       ? Math.tanh(Math.abs(b.basinDirAtClose))
       : 0;
+  // n/(n+1) is the structural odds form: one coherent tick is evidence but
+  // not certainty, and longer streaks approach full trust asymptotically
+  // without introducing a tunable saturation window.
   const coherence =
     isFiniteNumber(b.coherenceStreak) && b.coherenceStreak > 0
       ? b.coherenceStreak / (b.coherenceStreak + 1)

--- a/apps/api/src/services/monkey/hindsightRegret.ts
+++ b/apps/api/src/services/monkey/hindsightRegret.ts
@@ -253,7 +253,7 @@ export function counterfactualPnlUsdt(
  * If legibility fails → SURPRISE / NOISE → no aversive signal (canon §31:
  * unpredictable continuation is surprise, not a learnable mistake).
  */
-function clamp01(x: number): number {
+function clampToUnitInterval(x: number): number {
   if (!isFiniteNumber(x)) return 0;
   return Math.max(0, Math.min(1, x));
 }
@@ -268,7 +268,7 @@ export function legibilityStrength(b: CloseSenseBundle, regimePersisted = true):
   // i.e. expectation direction agrees with sideSign, with > 0 confidence.
   const warpStrength =
     b.warpExpectationSign === b.sideSign
-      ? clamp01(b.warpExpectationConfidence)
+      ? clampToUnitInterval(b.warpExpectationConfidence)
       : 0;
   // basin direction must still lean the held way (sign agreement).
   const basinStrength =
@@ -280,7 +280,7 @@ export function legibilityStrength(b: CloseSenseBundle, regimePersisted = true):
     isFiniteNumber(b.coherenceStreak) && b.coherenceStreak > 0
       ? b.coherenceStreak / (b.coherenceStreak + 1)
       : 0;
-  return clamp01(warpStrength * basinStrength * coherence);
+  return clampToUnitInterval(warpStrength * basinStrength * coherence);
 }
 
 export function isContinuationLegible(b: CloseSenseBundle): boolean {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -8214,6 +8214,10 @@ export class MonkeyKernel extends EventEmitter {
           side: heldSide,
           grossPnlByRow: grossById,
           credentials: (this as any).credentials ?? null,
+          closeLane,
+          regimeAtClose: closeLane
+            ? this.symbolStates.get(symbol)?.regimeAtOpenByLane[closeLane]
+            : undefined,
         });
       }
     } catch (err) {
@@ -9506,6 +9510,8 @@ export class MonkeyKernel extends EventEmitter {
     side: 'long' | 'short';
     grossPnlByRow?: Record<string, number>; // synthetic gross per row id (optional)
     credentials?: any;            // optional: caller-provided creds; if omitted, fetched inline
+    closeLane?: 'scalp' | 'swing' | 'trend';
+    regimeAtClose?: string;
   }): Promise<void> {
     const { tradeIds, symbol, closeTimeMs, side, grossPnlByRow } = params;
     const closeOrderIds = params.closeOrderIds ?? [];
@@ -9975,10 +9981,21 @@ export class MonkeyKernel extends EventEmitter {
         try {
           const sideSign: 1 | -1 = side === 'long' ? 1 : -1;
           // qty + exit price + ownership (reason) from the closed rows.
-          const qres = await pool.query<{ qty: string; exit_price: string; any_adopted: boolean }>(
-            `SELECT COALESCE(SUM(COALESCE(quantity, 0)), 0) AS qty,
-                    COALESCE(AVG(NULLIF(exit_price, 0)), 0) AS exit_price,
-                    bool_or(COALESCE(reason, '') LIKE '%|adopted|%') AS any_adopted
+          const qres = await pool.query<{ qty: string; exit_price: string; any_adopted: boolean; close_lane: string | null }>(
+            `SELECT COALESCE(SUM(ABS(COALESCE(quantity, 0))), 0) AS qty,
+                    COALESCE(
+                      SUM(ABS(COALESCE(quantity, 0)) * NULLIF(exit_price, 0))
+                        / NULLIF(SUM(
+                            CASE
+                              WHEN NULLIF(exit_price, 0) IS NOT NULL
+                                THEN ABS(COALESCE(quantity, 0))
+                              ELSE 0
+                            END
+                          ), 0),
+                      0
+                    ) AS exit_price,
+                    bool_or(COALESCE(reason, '') LIKE '%|adopted|%') AS any_adopted,
+                    (array_agg(lane ORDER BY ABS(COALESCE(quantity, 0)) DESC) FILTER (WHERE lane IS NOT NULL))[1] AS close_lane
                FROM autonomous_trades
               WHERE id = ANY($1)`,
             [tradeIds],
@@ -10022,10 +10039,14 @@ export class MonkeyKernel extends EventEmitter {
             const warpDir = lastExp?.direction;
             const warpExpectationSign: -1 | 0 | 1 =
               warpDir === 'long' ? 1 : warpDir === 'short' ? -1 : 0;
+            const closeLane = params.closeLane ?? qres.rows[0]?.close_lane ?? undefined;
             const regimeAtClose =
-              symState?.regimeAtOpenByLane
-                ? (Object.values(symState.regimeAtOpenByLane)[0] ?? lastExp?.regime ?? 'unknown')
-                : (lastExp?.regime ?? 'unknown');
+              params.regimeAtClose ??
+              (closeLane && symState?.regimeAtOpenByLane
+                ? symState.regimeAtOpenByLane[closeLane]
+                : undefined) ??
+              lastExp?.regime ??
+              'unknown';
             const bundle: CloseSenseBundle = {
               kernelOwnedClose,
               sideSign,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -102,6 +102,8 @@ import {
   callAutonomicTick,
   callAutonomicReward,
   callAutonomicPredictionReward,
+  callAutonomicHindsight,
+  isPythonKernelEnabled,
 } from './autonomic_client.js';
 import { aggregatePeakTracker } from './aggregate_peak.js';
 import { wsPositionCache } from './ws_position_cache.js';
@@ -218,10 +220,11 @@ import {
   type PredictionChemistryDeltas,
 } from './predictionRewardEmitter.js';
 import {
-  advanceWatch,
-  resolveRegret,
+  counterfactualPnlUsdt,
+  resolveHindsight,
   isHindsightRegretLive,
-  type HindsightWatch,
+  type CloseSenseBundle,
+  type CounterfactualOutcome,
 } from './hindsightRegret.js';
 import { tryAcquireClose, releaseClose, isLikelyRaceLoss } from './close_coordinator.js';
 import { observeEquity, sizeDeflection, type EquityRichContext } from './equity_gradient.js';
@@ -668,6 +671,34 @@ export interface MonkeyKernelConfig {
   sizeFraction?: number;
 }
 
+/**
+ * Orchestration state for one hindsight watch (loop-owned; the pure transform
+ * in hindsightRegret.ts is stateless). Holds the close-time sense bundle, the
+ * derived horizon, and the per-tick-advanced counterfactual + regime-
+ * persistence trackers. Resolved at horizon end into the NT vector.
+ */
+interface HindsightWatchOrch {
+  symbol: string;
+  /** +1 closed long, -1 closed short. */
+  sideSign: 1 | -1;
+  qty: number;
+  exitPrice: number;
+  realizedPnlUsdt: number;
+  marginUsdt: number;
+  closedAtMs: number;
+  /** ms epoch this watch resolves — derived from the kernel's own observed
+   *  regime-persistence horizon at registration, NOT a fixed window. */
+  expiresAtMs: number;
+  /** Close-time senses for the legibility gate + GABA target. */
+  bundle: CloseSenseBundle;
+  /** Most recent counterfactual pnl (of having held) — updated each tick;
+   *  this is the HORIZON-END pnl when the watch resolves (NOT max excursion). */
+  lastCounterfactualPnlUsdt: number;
+  /** True while the regime observed at close still holds; set false the
+   *  first tick the live regime differs from `bundle.regimeAtClose`. */
+  regimePersisted: boolean;
+}
+
 interface SymbolState {
   lastBasin: Basin;
   /** Identity basin — starts uniform, crystallizes after N lived trades per §3.4 */
@@ -794,6 +825,22 @@ interface SymbolState {
   latestBasinSnapshot: {
     basinDir: number;
     tapeTrend: number;
+    computedAtMs: number;
+  } | null;
+  /** 2026-05-29 hindsight (flag-gated): the most recent qig-warp expectation
+   *  decision computed for this symbol (entry path), kept so the hindsight
+   *  legibility gate at close time can read the kernel's own latest forecast
+   *  direction + confidence + observed regime-persistence horizon. Null until
+   *  the first reverse-tape expectation call. Best-effort — when null, the
+   *  hindsight gate treats the continuation as NOT legible (no signal). */
+  lastExpectation: {
+    direction: 'long' | 'short' | 'flat' | 'observe';
+    confidence: number;
+    regime: string;
+    /** Observed regime-persistence horizon in HOURS, surfaced by the bubble
+     *  (qig_warp_horizon_hours) when available; else null → caller derives a
+     *  fallback from the kernel's own regime-coherence and documents it. */
+    horizonHours: number | null;
     computedAtMs: number;
   } | null;
   /** v0.8.8 per-agent reactive cognition state. Each of K/M/T/L gets
@@ -1037,21 +1084,35 @@ export class MonkeyKernel extends EventEmitter {
   private cachedPredictionChemistry: PredictionChemistryDeltas | null = null;
   /**
    * Hindsight / counterfactual-regret subsystem (MONKEY_HINDSIGHT_REGRET_LIVE,
-   * default OFF). After a kernel close we keep watching the symbol for a
-   * forward window; if holding would have beaten the realised close (the
-   * trend continued in the position's favour) we emit an aversive dopamine
-   * delta scaled by the foregone gain. Asymmetric: a correct close earns a
-   * mild positive, never a penalty. In-memory + best-effort — never blocks
-   * trading, no DB.
+   * default OFF; DESIGN HYPOTHESIS for operator review — see hindsightRegret.ts).
    *
-   * `hindsightWatches`: symbol → list of active watches (a symbol can have
-   * several overlapping closes in the window). `cachedHindsightDopamine` is
-   * folded additively into rewardDopamineDelta in tick(), exactly like
-   * predDop. It decays toward 0 each tick so a resolved regret is a transient
-   * mood event, not a permanent bias.
+   * After a KERNEL-OWNED close we keep watching the symbol until the derived
+   * HORIZON elapses (observer-derived regime-persistence window — NOT a fixed
+   * 30 min). We track the pnl of having HELD to the horizon end (NOT max
+   * favourable excursion) and whether the SAME regime persisted. At horizon
+   * end we resolve the close-time SENSE BUNDLE + the counterfactual through
+   * the legibility-gated transform (resolveHindsight). Regret fires ONLY when
+   * the close was owned, the continuation was legible at close, and the regime
+   * persisted; otherwise the move is surprise/noise and NO aversive signal is
+   * emitted. The full E6 NT vector is folded into decaying caches.
+   *
+   * `hindsightWatches`: symbol → list of active orchestration watches. The
+   * `cachedHindsight*` caches each carry one NT channel, folded additively
+   * into the corresponding reward delta in tick() and decayed toward 0 so a
+   * resolved hindsight event is transient, not a permanent bias. P14: own
+   * channels, not folded into pnl-frac history.
    */
-  private hindsightWatches: Map<string, HindsightWatch[]> = new Map();
+  private hindsightWatches: Map<string, HindsightWatchOrch[]> = new Map();
   private cachedHindsightDopamine = 0;
+  private cachedHindsightSerotonin = 0;
+  private cachedHindsightAcetylcholine = 0;
+  private cachedHindsightNorepinephrine = 0;
+  private cachedHindsightGaba = 0;
+  private cachedHindsightEndorphin = 0;
+  /** Targeted-GABA bindings: pattern key (premature_close:regime:side) →
+   *  decaying weight. Read by the executive's per-pattern caution, NOT by a
+   *  global "close less" gate — this is what keeps GABA targeted. */
+  private hindsightGabaTargets: Map<string, number> = new Map();
   private tickMs: number;
   private readonly baseTickMs: number;
   private readonly symbols: string[];
@@ -1990,6 +2051,7 @@ export class MonkeyKernel extends EventEmitter {
       entryTimeMsByLane: {},
       integrationHistory: [],
       latestBasinSnapshot: null,
+      lastExpectation: null,
       agentStates: {
         K: newPerAgentState(),
         M: newPerAgentState(),
@@ -2251,13 +2313,10 @@ export class MonkeyKernel extends EventEmitter {
       price: lastPrice,
     });
 
-    // Hindsight / counterfactual-regret evaluation (flag-gated, default OFF).
-    // Advance any active watches for this symbol with the fresh price and
-    // resolve the ones whose window has elapsed into a dopamine delta.
-    // Best-effort; never throws into the tick.
-    if (isHindsightRegretLive()) {
-      this.evaluateHindsightWatches(symbol, lastPrice);
-    }
+    // Hindsight / counterfactual-regret evaluation runs BELOW regime
+    // classification (it needs the live regime to track regime-persistence
+    // for the legibility gate). See the evaluateHindsightWatches() call after
+    // `regimeReading` is computed.
 
     // SENSE-2 Phase 2 (#768) — BTC beacon shared price cache. BTC ticks
     // write the latest mark; non-BTC ticks read it for cross-symbol
@@ -2523,20 +2582,48 @@ export class MonkeyKernel extends EventEmitter {
     const predDop = predChem?.dopamineDelta ?? 0;
     const predSer = predChem?.serotoninDelta ?? 0;
 
-    // Hindsight / counterfactual-regret dopamine (flag-gated, default OFF).
-    // `cachedHindsightDopamine` accumulates resolved regret deltas
-    // (evaluateHindsightWatches) and decays toward 0 each tick so the
-    // "closed too early" sting is a transient mood event, not a permanent
-    // bias. Decay uses the same 20-min half-life as the reward queue: a
-    // per-tick factor of 0.5^(tickMs / halfLife). P14: its own channel,
-    // not folded into pnl-frac history.
+    // Hindsight / counterfactual-regret NT vector (flag-gated, default OFF).
+    // The `cachedHindsight*` caches accumulate the resolved E6 NT deltas
+    // (evaluateHindsightWatches) and decay toward 0 each tick so a resolved
+    // hindsight event is a transient mood event, not a permanent bias. Decay
+    // uses the same 20-min half-life as the reward queue. P14: own channels,
+    // not folded into pnl-frac history. The dopamine + serotonin channels are
+    // folded into rewardDopamineDelta / rewardSerotoninDelta below; ACh / NE /
+    // GABA / endorphin are folded via the dedicated reward-delta inputs.
     let hindsightDop = 0;
+    let hindsightSer = 0;
+    let hindsightAch = 0;
+    let hindsightNe = 0;
+    let hindsightGaba = 0;
+    let hindsightEndo = 0;
     if (isHindsightRegretLive()) {
       hindsightDop = this.cachedHindsightDopamine;
+      hindsightSer = this.cachedHindsightSerotonin;
+      hindsightAch = this.cachedHindsightAcetylcholine;
+      hindsightNe = this.cachedHindsightNorepinephrine;
+      hindsightGaba = this.cachedHindsightGaba;
+      hindsightEndo = this.cachedHindsightEndorphin;
       const HINDSIGHT_HALF_LIFE_MS = 20 * 60 * 1000;
       const decay = Math.pow(0.5, this.tickMs / HINDSIGHT_HALF_LIFE_MS);
       this.cachedHindsightDopamine *= decay;
-      if (Math.abs(this.cachedHindsightDopamine) < 1e-6) this.cachedHindsightDopamine = 0;
+      this.cachedHindsightSerotonin *= decay;
+      this.cachedHindsightAcetylcholine *= decay;
+      this.cachedHindsightNorepinephrine *= decay;
+      this.cachedHindsightGaba *= decay;
+      this.cachedHindsightEndorphin *= decay;
+      const z = (v: number): number => (Math.abs(v) < 1e-6 ? 0 : v);
+      this.cachedHindsightDopamine = z(this.cachedHindsightDopamine);
+      this.cachedHindsightSerotonin = z(this.cachedHindsightSerotonin);
+      this.cachedHindsightAcetylcholine = z(this.cachedHindsightAcetylcholine);
+      this.cachedHindsightNorepinephrine = z(this.cachedHindsightNorepinephrine);
+      this.cachedHindsightGaba = z(this.cachedHindsightGaba);
+      this.cachedHindsightEndorphin = z(this.cachedHindsightEndorphin);
+      // Decay the targeted-GABA bindings on the same half-life and prune.
+      for (const [k, w] of this.hindsightGabaTargets) {
+        const nw = w * decay;
+        if (nw < 1e-6) this.hindsightGabaTargets.delete(k);
+        else this.hindsightGabaTargets.set(k, nw);
+      }
     }
 
     // 2026-05-16 (#715/#716/#717 derivation refactor): build the
@@ -2559,8 +2646,11 @@ export class MonkeyKernel extends EventEmitter {
       kappa: state.kappa,
       externalCoupling: couplingHealth,
       rewardDopamineDelta: rewardDeltas.dopamine + predDop + hindsightDop,
-      rewardSerotoninDelta: rewardDeltas.serotonin + predSer,
-      rewardEndorphinDelta: rewardDeltas.endorphin,
+      rewardSerotoninDelta: rewardDeltas.serotonin + predSer + hindsightSer,
+      rewardEndorphinDelta: rewardDeltas.endorphin + hindsightEndo,
+      rewardAcetylcholineDelta: hindsightAch,
+      rewardNorepinephrineDelta: hindsightNe,
+      rewardGabaDelta: hindsightGaba,
       observables: {
         phiHistory: state.phiHistory,
         surpriseHistory: state.surpriseHistory,
@@ -2829,6 +2919,15 @@ export class MonkeyKernel extends EventEmitter {
       ...state.basinHistory,
       basin,
     ]);
+
+    // Hindsight / counterfactual-regret evaluation (flag-gated, default OFF).
+    // Advance any active watches for this symbol with the fresh price + live
+    // regime: track the horizon-end counterfactual pnl and whether the regime
+    // observed at close still holds. Resolve the watches whose derived horizon
+    // has elapsed into the E6 NT vector. Best-effort; never throws into tick.
+    if (isHindsightRegretLive()) {
+      this.evaluateHindsightWatches(symbol, lastPrice, String(regimeReading.regime));
+    }
 
     // Phase B — geometry-derived TP/SL bracket. Recompute each tick from
     // the current φ, regime confidence and ATR(14); stash on symbol state
@@ -4313,6 +4412,23 @@ export class MonkeyKernel extends EventEmitter {
           });
         } catch (err) {
           expectationDecision = null;
+        }
+        // 2026-05-29 hindsight (flag-gated): persist the kernel's latest
+        // qig-warp forecast so the close-time legibility gate can read it.
+        // Stored regardless of the flag (cheap, no behavioural effect when
+        // the flag is OFF — nothing reads it).
+        if (expectationDecision !== null) {
+          state.lastExpectation = {
+            direction: expectationDecision.expectation_direction,
+            confidence: expectationDecision.expectation_confidence,
+            regime: String(expectationDecision.expectation_regime ?? ''),
+            horizonHours:
+              typeof expectationDecision.qig_warp_horizon_hours === 'number' &&
+              Number.isFinite(expectationDecision.qig_warp_horizon_hours)
+                ? expectationDecision.qig_warp_horizon_hours
+                : null,
+            computedAtMs: Date.now(),
+          };
         }
       }
 
@@ -9225,51 +9341,114 @@ export class MonkeyKernel extends EventEmitter {
   }
 
   /**
-   * Advance + resolve hindsight/counterfactual-regret watches for one
-   * symbol (MONKEY_HINDSIGHT_REGRET_LIVE, default OFF; caller gates).
+   * Advance + resolve hindsight/counterfactual-regret watches for one symbol
+   * (MONKEY_HINDSIGHT_REGRET_LIVE, default OFF; caller gates; DESIGN HYPOTHESIS).
    *
-   * For each active watch: update its running best counterfactual pnl with
-   * the fresh price. When a watch's forward window has elapsed, resolve it
-   * into a dopamine delta (aversive iff holding would have beaten the close;
-   * mild positive for a correct close) and fold the delta into the decaying
-   * `cachedHindsightDopamine` cache, which tick() adds to rewardDopamineDelta.
+   * For each active watch this tick:
+   *   1. update `lastCounterfactualPnlUsdt` = pnl of having HELD to NOW (this
+   *      becomes the horizon-end pnl when the watch resolves — NOT a running
+   *      max-favourable-excursion).
+   *   2. clear `regimePersisted` the first tick the live regime differs from
+   *      the regime observed at close (gate condition 3).
+   * When a watch's DERIVED horizon has elapsed, resolve the close-time sense
+   * bundle + the counterfactual through the legibility-gated transform
+   * (resolveHindsight) into the E6 NT vector + targeted-GABA binding, and
+   * fold the deltas into the decaying `cachedHindsight*` caches that tick()
+   * reads. Pure helpers do all the math; this method is orchestration only.
+   * Best-effort — wrapped so it never disturbs the tick.
    *
-   * Pure helpers do the math (hindsightRegret.ts); this method only does the
-   * orchestration. Best-effort — wrapped so it never disturbs the tick.
+   * @param currentRegime  the live regime label this tick (from regimeReading)
+   *                       — compared to each watch's close-time regime for the
+   *                       regime-persistence gate.
    */
-  private evaluateHindsightWatches(symbol: string, price: number): void {
+  private evaluateHindsightWatches(symbol: string, price: number, currentRegime: string): void {
     try {
       const list = this.hindsightWatches.get(symbol);
       if (!list || list.length === 0) return;
       const now = Date.now();
       const symState = this.symbolStates.get(symbol);
       const pnlFracHistory = symState?.pnlFracHistory ?? [];
-      const survivors: HindsightWatch[] = [];
-      for (let w of list) {
-        w = advanceWatch(w, price);
+      const liveRegime = (currentRegime ?? '').trim().toLowerCase();
+      const survivors: HindsightWatchOrch[] = [];
+      for (const w of list) {
+        // 1. Advance the horizon-end counterfactual with the fresh price.
+        const cf = counterfactualPnlUsdt(
+          { sideSign: w.sideSign, qty: w.qty, exitPrice: w.exitPrice, realizedPnlUsdt: w.realizedPnlUsdt },
+          price,
+        );
+        if (cf !== null) w.lastCounterfactualPnlUsdt = cf;
+        // 2. Regime-persistence: once the live regime diverges from the
+        //    close-time regime, the continuation is no longer the foreseeable
+        //    one. Latch false (a later re-match does not revive it).
+        if (w.regimePersisted && liveRegime.length > 0) {
+          const closeRegime = (w.bundle.regimeAtClose ?? '').trim().toLowerCase();
+          if (closeRegime.length > 0 && liveRegime !== closeRegime) {
+            w.regimePersisted = false;
+          }
+        }
         if (now < w.expiresAtMs) {
           survivors.push(w);
           continue;
         }
-        // Window elapsed — resolve into a chemistry delta.
-        const deltas = resolveRegret(w, pnlFracHistory);
-        // Fold additively into the decaying cache. K-only: hindsight is a
-        // mood event for the kernel that did the closing, like the K-scoped
-        // reward channel in tick().
-        this.cachedHindsightDopamine += deltas.dopamineDelta;
+        // Horizon elapsed — resolve through the legibility-gated transform.
+        const outcome: CounterfactualOutcome = {
+          realizedPnlUsdt: w.realizedPnlUsdt,
+          horizonEndPnlUsdt: w.lastCounterfactualPnlUsdt,
+          marginUsdt: w.marginUsdt,
+          regimePersisted: w.regimePersisted,
+        };
+        const res = resolveHindsight(w.bundle, outcome, pnlFracHistory);
+        // Fold the full NT vector into the decaying caches. K-only: hindsight
+        // is a mood event for the kernel that owned the close.
+        this.cachedHindsightDopamine += res.nt.dopamineDelta;
+        this.cachedHindsightSerotonin += res.nt.serotoninDelta;
+        this.cachedHindsightAcetylcholine += res.nt.acetylcholineDelta;
+        this.cachedHindsightNorepinephrine += res.nt.norepinephrineDelta;
+        this.cachedHindsightGaba += res.nt.gabaDelta;
+        this.cachedHindsightEndorphin += res.nt.endorphinDelta;
+        // Targeted GABA binding — pattern-keyed, NOT global. This is what
+        // keeps the kernel from becoming "afraid to close": the caution is
+        // bound to (regime, side) of the premature close, not to closing.
+        if (res.gabaTarget !== null && res.nt.gabaDelta > 0) {
+          const prev = this.hindsightGabaTargets.get(res.gabaTarget) ?? 0;
+          this.hindsightGabaTargets.set(res.gabaTarget, prev + res.nt.gabaDelta);
+        }
         logger.info('[Monkey] hindsight watch resolved', {
           symbol,
-          source: deltas.source,
-          foregoneGainUsdt: deltas.foregoneGainUsdt.toFixed(4),
+          source: res.source,
+          gabaTarget: res.gabaTarget,
+          foregoneGainUsdt: res.foregoneGainUsdt.toFixed(4),
           realizedPnl: w.realizedPnlUsdt.toFixed(4),
-          bestCounterfactual: w.bestCounterfactualPnlUsdt.toFixed(4),
-          dopamineDelta: deltas.dopamineDelta.toFixed(4),
+          horizonEndPnl: w.lastCounterfactualPnlUsdt.toFixed(4),
+          predictionErrorZ: res.predictionErrorZ.toFixed(3),
+          regimePersisted: w.regimePersisted,
+          dop: res.nt.dopamineDelta.toFixed(4),
+          ser: res.nt.serotoninDelta.toFixed(4),
+          ach: res.nt.acetylcholineDelta.toFixed(4),
+          ne: res.nt.norepinephrineDelta.toFixed(4),
+          gaba: res.nt.gabaDelta.toFixed(4),
+          endo: res.nt.endorphinDelta.toFixed(4),
         });
       }
       if (survivors.length === 0) {
         this.hindsightWatches.delete(symbol);
       } else {
         this.hindsightWatches.set(symbol, survivors);
+      }
+      // TS→Py parity fanout: push the current decayed hindsight NT vector to
+      // the Py autonomic surface so its chemistry (which drives executive
+      // sizing + survives restarts) matches the TS fold. Best-effort, gated
+      // on the Python kernel being enabled. Mirrors callAutonomicPredictionReward.
+      if (isPythonKernelEnabled()) {
+        void callAutonomicHindsight({
+          instanceId: this.instanceId,
+          dopamineDelta: this.cachedHindsightDopamine,
+          serotoninDelta: this.cachedHindsightSerotonin,
+          acetylcholineDelta: this.cachedHindsightAcetylcholine,
+          norepinephrineDelta: this.cachedHindsightNorepinephrine,
+          gabaDelta: this.cachedHindsightGaba,
+          endorphinDelta: this.cachedHindsightEndorphin,
+        });
       }
     } catch (err) {
       logger.warn('[Monkey] hindsight evaluation failed (non-fatal)', {
@@ -9770,41 +9949,83 @@ export class MonkeyKernel extends EventEmitter {
       noteHeartClose(symbol, Date.now(), poloRealized);
 
       // Hindsight / counterfactual-regret watch registration (flag-gated,
-      // default OFF). Operator 2026-05-29: the kernel "needs to feel the
-      // pain of [cutting a winning-direction position on noise]... enough
-      // that it thinks about thinking about the trend a second time before
-      // closing." We register a forward watch on the symbol; if the trend
-      // continues in the CLOSED position's favour over the window, the
-      // kernel pays an aversive dopamine delta scaled by the foregone gain
-      // (asymmetric — a correct close never incurs a penalty). Best-effort:
+      // default OFF; DESIGN HYPOTHESIS — see hindsightRegret.ts). Operator
+      // 2026-05-29: the kernel "needs to feel the pain of [cutting a
+      // winning-direction position on noise]... enough that it thinks about
+      // thinking about the trend a second time before closing" — but ONLY
+      // when the continuation was foreseeable (legible) at close. We capture
+      // the close-time SENSE BUNDLE + derive the watch HORIZON from the
+      // kernel's own forecast, then watch the symbol until the horizon
+      // elapses. resolveHindsight() applies the legibility gate. Best-effort:
       // wrapped so a bad row never disturbs the close path.
       if (isHindsightRegretLive()) {
         try {
           const sideSign: 1 | -1 = side === 'long' ? 1 : -1;
-          // qty + exit price from the closed rows we just persisted.
-          const qres = await pool.query<{ qty: string; exit_price: string }>(
+          // qty + exit price + ownership (reason) from the closed rows.
+          const qres = await pool.query<{ qty: string; exit_price: string; any_adopted: boolean }>(
             `SELECT COALESCE(SUM(COALESCE(quantity, 0)), 0) AS qty,
-                    COALESCE(AVG(NULLIF(exit_price, 0)), 0) AS exit_price
+                    COALESCE(AVG(NULLIF(exit_price, 0)), 0) AS exit_price,
+                    bool_or(COALESCE(reason, '') LIKE '%|adopted|%') AS any_adopted
                FROM autonomous_trades
               WHERE id = ANY($1)`,
             [tradeIds],
           );
           const qty = Number(qres.rows[0]?.qty ?? 0);
           const exitPrice = Number(qres.rows[0]?.exit_price ?? 0);
-          // Best-effort: skip the watch when we have no authoritative exit
-          // price (some close paths don't persist it). No fallback guess —
+          // Ownership (gate condition 1): a row that was reconciler-adopted
+          // from an operator-opened position is NOT a kernel-initiated close
+          // → not self-regret. (Operator/manual/liquidation closes that never
+          // reach this kernel path are excluded by construction.)
+          const kernelOwnedClose = qres.rows[0]?.any_adopted !== true;
+          // Best-effort: skip the watch with no authoritative exit price —
           // a wrong exit price would produce a wrong counterfactual.
           if (Number.isFinite(qty) && qty > 0 && Number.isFinite(exitPrice) && exitPrice > 0) {
-            // Forward window length — FLAGGED FOR OPERATOR REVIEW. 30 min is
-            // a deliberately conservative bound: long enough that a genuine
-            // continuing trend registers, short enough that the watch is
-            // retired before the regime turns over (mirrors the 20-min
-            // reward half-life + the predictionRewardEmitter 5-min scan
-            // window). This is the single non-observer-derived constant in
-            // the signal; see the PR body for the calibration discussion.
-            const HINDSIGHT_WINDOW_MS = 30 * 60 * 1000;
+            const symState = this.symbolStates.get(symbol);
+            const snap = symState?.latestBasinSnapshot;
+            const lastExp = symState?.lastExpectation ?? null;
+
+            // ── Derive the watch HORIZON (doctrine: window = the kernel's own
+            // forecast horizon, NOT a fixed 30 min). Priority:
+            //   (a) the qig-warp expectation horizon (observed regime-
+            //       persistence in HOURS) if the bubble surfaced it;
+            //   (b) FALLBACK — the kernel's own observed coherence horizon:
+            //       coherenceStreak ticks (how long perception+forecast
+            //       stayed coherent on the held position) × tickMs. This is
+            //       derived from lived observation, not a designer table.
+            //       Documented as a fallback per doctrine.
+            // Floored at one tick so a watch always has positive duration.
+            const horizonFromWarpMs =
+              lastExp && lastExp.horizonHours !== null
+                ? lastExp.horizonHours * 60 * 60 * 1000
+                : null;
+            const coherenceTicks = Math.max(1, symState?.coherenceStreak ?? 1);
+            const horizonFallbackMs = coherenceTicks * this.tickMs;
+            const horizonMs = horizonFromWarpMs ?? horizonFallbackMs;
+
+            // ── Close-time SENSE BUNDLE (legibility gate + GABA target). ──
+            // warp expectation direction → sign; basinDir / tapeTrend from
+            // the latest snapshot; regime from the lane's open anchor (the
+            // regime the kernel committed to); coherenceStreak as legibility.
+            const warpDir = lastExp?.direction;
+            const warpExpectationSign: -1 | 0 | 1 =
+              warpDir === 'long' ? 1 : warpDir === 'short' ? -1 : 0;
+            const regimeAtClose =
+              symState?.regimeAtOpenByLane
+                ? (Object.values(symState.regimeAtOpenByLane)[0] ?? lastExp?.regime ?? 'unknown')
+                : (lastExp?.regime ?? 'unknown');
+            const bundle: CloseSenseBundle = {
+              kernelOwnedClose,
+              sideSign,
+              warpExpectationSign,
+              warpExpectationConfidence: lastExp?.confidence ?? 0,
+              regimeAtClose: String(regimeAtClose),
+              basinDirAtClose: snap?.basinDir ?? 0,
+              tapeTrendAtClose: snap?.tapeTrend ?? 0,
+              coherenceStreak: symState?.coherenceStreak ?? 0,
+            };
+
             const now = Date.now();
-            const watch: HindsightWatch = {
+            const watch: HindsightWatchOrch = {
               symbol,
               sideSign,
               qty,
@@ -9812,18 +10033,25 @@ export class MonkeyKernel extends EventEmitter {
               realizedPnlUsdt: poloRealized,
               marginUsdt,
               closedAtMs: now,
-              expiresAtMs: now + HINDSIGHT_WINDOW_MS,
-              bestCounterfactualPnlUsdt: poloRealized,
+              expiresAtMs: now + horizonMs,
+              bundle,
+              lastCounterfactualPnlUsdt: poloRealized,
+              regimePersisted: true,
             };
             const list = this.hindsightWatches.get(symbol) ?? [];
             list.push(watch);
-            // Bound per-symbol watch list to avoid unbounded growth on a
-            // symbol that closes repeatedly.
+            // Bound per-symbol watch list to avoid unbounded growth.
             if (list.length > 16) list.shift();
             this.hindsightWatches.set(symbol, list);
             logger.info('[Monkey] hindsight watch registered', {
               symbol, side, qty, exitPrice, realizedPnl: poloRealized.toFixed(4),
-              expiresInMs: HINDSIGHT_WINDOW_MS,
+              kernelOwnedClose,
+              warpExpectationSign,
+              warpConfidence: (lastExp?.confidence ?? 0).toFixed(3),
+              regimeAtClose: String(regimeAtClose),
+              coherenceStreak: symState?.coherenceStreak ?? 0,
+              horizonSource: horizonFromWarpMs !== null ? 'qig_warp' : 'coherence_fallback',
+              horizonMs: Math.round(horizonMs),
             });
           }
         } catch (err) {

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -217,6 +217,12 @@ import {
   computePredictionChemistry,
   type PredictionChemistryDeltas,
 } from './predictionRewardEmitter.js';
+import {
+  advanceWatch,
+  resolveRegret,
+  isHindsightRegretLive,
+  type HindsightWatch,
+} from './hindsightRegret.js';
 import { tryAcquireClose, releaseClose, isLikelyRaceLoss } from './close_coordinator.js';
 import { observeEquity, sizeDeflection, type EquityRichContext } from './equity_gradient.js';
 import {
@@ -1029,6 +1035,23 @@ export class MonkeyKernel extends EventEmitter {
   /** Cached prediction-error chemistry deltas, refreshed by
    *  predictionEmitterTimer. Null until the first emitter pass. */
   private cachedPredictionChemistry: PredictionChemistryDeltas | null = null;
+  /**
+   * Hindsight / counterfactual-regret subsystem (MONKEY_HINDSIGHT_REGRET_LIVE,
+   * default OFF). After a kernel close we keep watching the symbol for a
+   * forward window; if holding would have beaten the realised close (the
+   * trend continued in the position's favour) we emit an aversive dopamine
+   * delta scaled by the foregone gain. Asymmetric: a correct close earns a
+   * mild positive, never a penalty. In-memory + best-effort — never blocks
+   * trading, no DB.
+   *
+   * `hindsightWatches`: symbol → list of active watches (a symbol can have
+   * several overlapping closes in the window). `cachedHindsightDopamine` is
+   * folded additively into rewardDopamineDelta in tick(), exactly like
+   * predDop. It decays toward 0 each tick so a resolved regret is a transient
+   * mood event, not a permanent bias.
+   */
+  private hindsightWatches: Map<string, HindsightWatch[]> = new Map();
+  private cachedHindsightDopamine = 0;
   private tickMs: number;
   private readonly baseTickMs: number;
   private readonly symbols: string[];
@@ -2228,6 +2251,14 @@ export class MonkeyKernel extends EventEmitter {
       price: lastPrice,
     });
 
+    // Hindsight / counterfactual-regret evaluation (flag-gated, default OFF).
+    // Advance any active watches for this symbol with the fresh price and
+    // resolve the ones whose window has elapsed into a dopamine delta.
+    // Best-effort; never throws into the tick.
+    if (isHindsightRegretLive()) {
+      this.evaluateHindsightWatches(symbol, lastPrice);
+    }
+
     // SENSE-2 Phase 2 (#768) — BTC beacon shared price cache. BTC ticks
     // write the latest mark; non-BTC ticks read it for cross-symbol
     // correlation. The beacon reading itself is computed below (after
@@ -2492,6 +2523,22 @@ export class MonkeyKernel extends EventEmitter {
     const predDop = predChem?.dopamineDelta ?? 0;
     const predSer = predChem?.serotoninDelta ?? 0;
 
+    // Hindsight / counterfactual-regret dopamine (flag-gated, default OFF).
+    // `cachedHindsightDopamine` accumulates resolved regret deltas
+    // (evaluateHindsightWatches) and decays toward 0 each tick so the
+    // "closed too early" sting is a transient mood event, not a permanent
+    // bias. Decay uses the same 20-min half-life as the reward queue: a
+    // per-tick factor of 0.5^(tickMs / halfLife). P14: its own channel,
+    // not folded into pnl-frac history.
+    let hindsightDop = 0;
+    if (isHindsightRegretLive()) {
+      hindsightDop = this.cachedHindsightDopamine;
+      const HINDSIGHT_HALF_LIFE_MS = 20 * 60 * 1000;
+      const decay = Math.pow(0.5, this.tickMs / HINDSIGHT_HALF_LIFE_MS);
+      this.cachedHindsightDopamine *= decay;
+      if (Math.abs(this.cachedHindsightDopamine) < 1e-6) this.cachedHindsightDopamine = 0;
+    }
+
     // 2026-05-16 (#715/#716/#717 derivation refactor): build the
     // BasinObservables block from the basin's OWN per-tick history.
     // Every chemical's per-tick scale is set by what's typical FOR
@@ -2511,7 +2558,7 @@ export class MonkeyKernel extends EventEmitter {
       quantumWeight: regimeWeights.quantum,
       kappa: state.kappa,
       externalCoupling: couplingHealth,
-      rewardDopamineDelta: rewardDeltas.dopamine + predDop,
+      rewardDopamineDelta: rewardDeltas.dopamine + predDop + hindsightDop,
       rewardSerotoninDelta: rewardDeltas.serotonin + predSer,
       rewardEndorphinDelta: rewardDeltas.endorphin,
       observables: {
@@ -9178,6 +9225,60 @@ export class MonkeyKernel extends EventEmitter {
   }
 
   /**
+   * Advance + resolve hindsight/counterfactual-regret watches for one
+   * symbol (MONKEY_HINDSIGHT_REGRET_LIVE, default OFF; caller gates).
+   *
+   * For each active watch: update its running best counterfactual pnl with
+   * the fresh price. When a watch's forward window has elapsed, resolve it
+   * into a dopamine delta (aversive iff holding would have beaten the close;
+   * mild positive for a correct close) and fold the delta into the decaying
+   * `cachedHindsightDopamine` cache, which tick() adds to rewardDopamineDelta.
+   *
+   * Pure helpers do the math (hindsightRegret.ts); this method only does the
+   * orchestration. Best-effort — wrapped so it never disturbs the tick.
+   */
+  private evaluateHindsightWatches(symbol: string, price: number): void {
+    try {
+      const list = this.hindsightWatches.get(symbol);
+      if (!list || list.length === 0) return;
+      const now = Date.now();
+      const symState = this.symbolStates.get(symbol);
+      const pnlFracHistory = symState?.pnlFracHistory ?? [];
+      const survivors: HindsightWatch[] = [];
+      for (let w of list) {
+        w = advanceWatch(w, price);
+        if (now < w.expiresAtMs) {
+          survivors.push(w);
+          continue;
+        }
+        // Window elapsed — resolve into a chemistry delta.
+        const deltas = resolveRegret(w, pnlFracHistory);
+        // Fold additively into the decaying cache. K-only: hindsight is a
+        // mood event for the kernel that did the closing, like the K-scoped
+        // reward channel in tick().
+        this.cachedHindsightDopamine += deltas.dopamineDelta;
+        logger.info('[Monkey] hindsight watch resolved', {
+          symbol,
+          source: deltas.source,
+          foregoneGainUsdt: deltas.foregoneGainUsdt.toFixed(4),
+          realizedPnl: w.realizedPnlUsdt.toFixed(4),
+          bestCounterfactual: w.bestCounterfactualPnlUsdt.toFixed(4),
+          dopamineDelta: deltas.dopamineDelta.toFixed(4),
+        });
+      }
+      if (survivors.length === 0) {
+        this.hindsightWatches.delete(symbol);
+      } else {
+        this.hindsightWatches.set(symbol, survivors);
+      }
+    } catch (err) {
+      logger.warn('[Monkey] hindsight evaluation failed (non-fatal)', {
+        symbol, err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
    * Canonical Polo-authoritative PnL surface (user-specified 2026-05-28).
    *
    * After a close order fills successfully:
@@ -9667,6 +9768,70 @@ export class MonkeyKernel extends EventEmitter {
       // mark-based gross, or tiny gross wins that net out as losses
       // post-fees are missed as chain samples.
       noteHeartClose(symbol, Date.now(), poloRealized);
+
+      // Hindsight / counterfactual-regret watch registration (flag-gated,
+      // default OFF). Operator 2026-05-29: the kernel "needs to feel the
+      // pain of [cutting a winning-direction position on noise]... enough
+      // that it thinks about thinking about the trend a second time before
+      // closing." We register a forward watch on the symbol; if the trend
+      // continues in the CLOSED position's favour over the window, the
+      // kernel pays an aversive dopamine delta scaled by the foregone gain
+      // (asymmetric — a correct close never incurs a penalty). Best-effort:
+      // wrapped so a bad row never disturbs the close path.
+      if (isHindsightRegretLive()) {
+        try {
+          const sideSign: 1 | -1 = side === 'long' ? 1 : -1;
+          // qty + exit price from the closed rows we just persisted.
+          const qres = await pool.query<{ qty: string; exit_price: string }>(
+            `SELECT COALESCE(SUM(COALESCE(quantity, 0)), 0) AS qty,
+                    COALESCE(AVG(NULLIF(exit_price, 0)), 0) AS exit_price
+               FROM autonomous_trades
+              WHERE id = ANY($1)`,
+            [tradeIds],
+          );
+          const qty = Number(qres.rows[0]?.qty ?? 0);
+          const exitPrice = Number(qres.rows[0]?.exit_price ?? 0);
+          // Best-effort: skip the watch when we have no authoritative exit
+          // price (some close paths don't persist it). No fallback guess —
+          // a wrong exit price would produce a wrong counterfactual.
+          if (Number.isFinite(qty) && qty > 0 && Number.isFinite(exitPrice) && exitPrice > 0) {
+            // Forward window length — FLAGGED FOR OPERATOR REVIEW. 30 min is
+            // a deliberately conservative bound: long enough that a genuine
+            // continuing trend registers, short enough that the watch is
+            // retired before the regime turns over (mirrors the 20-min
+            // reward half-life + the predictionRewardEmitter 5-min scan
+            // window). This is the single non-observer-derived constant in
+            // the signal; see the PR body for the calibration discussion.
+            const HINDSIGHT_WINDOW_MS = 30 * 60 * 1000;
+            const now = Date.now();
+            const watch: HindsightWatch = {
+              symbol,
+              sideSign,
+              qty,
+              exitPrice,
+              realizedPnlUsdt: poloRealized,
+              marginUsdt,
+              closedAtMs: now,
+              expiresAtMs: now + HINDSIGHT_WINDOW_MS,
+              bestCounterfactualPnlUsdt: poloRealized,
+            };
+            const list = this.hindsightWatches.get(symbol) ?? [];
+            list.push(watch);
+            // Bound per-symbol watch list to avoid unbounded growth on a
+            // symbol that closes repeatedly.
+            if (list.length > 16) list.shift();
+            this.hindsightWatches.set(symbol, list);
+            logger.info('[Monkey] hindsight watch registered', {
+              symbol, side, qty, exitPrice, realizedPnl: poloRealized.toFixed(4),
+              expiresInMs: HINDSIGHT_WINDOW_MS,
+            });
+          }
+        } catch (err) {
+          logger.warn('[Monkey] hindsight watch registration failed (non-fatal)', {
+            symbol, err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
 
       // PR #992 fan-out (completes the 2026-05-28 CC1): mirror the Polo-authoritative
       // net reward (with correct margin) into Python autonomic so BOTH chemistry

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1113,8 +1113,8 @@ export class MonkeyKernel extends EventEmitter {
   private cachedHindsightGaba = 0;
   private cachedHindsightEndorphin = 0;
   /** Targeted-GABA bindings: pattern key (premature_close:regime:side) →
-   *  decaying weight. Read by the executive's per-pattern caution, NOT by a
-   *  global "close less" gate — this is what keeps GABA targeted. */
+   *  decaying weight. Not folded into global GABA; executive consumption is
+   *  the follow-up surface that will read this per-pattern caution. */
   private hindsightGabaTargets: Map<string, number> = new Map();
   private tickMs: number;
   private readonly baseTickMs: number;
@@ -2102,6 +2102,7 @@ export class MonkeyKernel extends EventEmitter {
     }
     this.tickInFlight = true;
     try {
+      this.decayHindsightCachesOncePerTick();
       // LIMIT_MAKER #793 — cancel any stale post-only scalp orders before
       // running the per-symbol pipeline. Stale = older than
       // LIMIT_MAKER_STALE_MS (2 min). Errors are non-fatal — the next
@@ -2120,6 +2121,33 @@ export class MonkeyKernel extends EventEmitter {
       this.tickInFlight = false;
     }
   }
+
+  private decayHindsightCachesOncePerTick(): void {
+    if (!isHindsightRegretLive()) return;
+    const HINDSIGHT_HALF_LIFE_MS = 20 * 60 * 1000;
+    const decay = Math.pow(0.5, this.tickMs / HINDSIGHT_HALF_LIFE_MS);
+    this.cachedHindsightDopamine *= decay;
+    this.cachedHindsightSerotonin *= decay;
+    this.cachedHindsightAcetylcholine *= decay;
+    this.cachedHindsightNorepinephrine *= decay;
+    this.cachedHindsightGaba *= decay;
+    this.cachedHindsightEndorphin *= decay;
+    const z = (v: number): number => (Math.abs(v) < 1e-6 ? 0 : v);
+    this.cachedHindsightDopamine = z(this.cachedHindsightDopamine);
+    this.cachedHindsightSerotonin = z(this.cachedHindsightSerotonin);
+    this.cachedHindsightAcetylcholine = z(this.cachedHindsightAcetylcholine);
+    this.cachedHindsightNorepinephrine = z(this.cachedHindsightNorepinephrine);
+    this.cachedHindsightGaba = z(this.cachedHindsightGaba);
+    this.cachedHindsightEndorphin = z(this.cachedHindsightEndorphin);
+    // Decay targeted-GABA bindings once per kernel tick, not once per symbol,
+    // so their lifetime is independent of symbol ordering / symbol count.
+    for (const [k, w] of this.hindsightGabaTargets) {
+      const nw = w * decay;
+      if (nw < 1e-6) this.hindsightGabaTargets.delete(k);
+      else this.hindsightGabaTargets.set(k, nw);
+    }
+  }
+
 
   /**
    * Resolve the user_id used for Poloniex credentials. Same query
@@ -2597,46 +2625,24 @@ export class MonkeyKernel extends EventEmitter {
 
     // Hindsight / counterfactual-regret NT vector (flag-gated, default OFF).
     // The `cachedHindsight*` caches accumulate the resolved E6 NT deltas
-    // (evaluateHindsightWatches) and decay toward 0 each tick so a resolved
-    // hindsight event is a transient mood event, not a permanent bias. Decay
-    // uses the same 20-min half-life as the reward queue. P14: own channels,
-    // not folded into pnl-frac history. The dopamine + serotonin channels are
-    // folded into rewardDopamineDelta / rewardSerotoninDelta below; ACh / NE /
-    // GABA / endorphin are folded via the dedicated reward-delta inputs.
+    // (evaluateHindsightWatches). tick() decays them ONCE before the per-symbol
+    // loop so all symbols see the same vector for a kernel tick (no symbol-order
+    // dependency). P14: own channels, not folded into pnl-frac history. The
+    // dopamine + serotonin channels are folded into rewardDopamineDelta /
+    // rewardSerotoninDelta below; ACh / NE / endorphin are folded via dedicated
+    // reward-delta inputs. GABA is not folded globally; it remains in the
+    // targeted hindsightGabaTargets map until executive consumption is wired.
     let hindsightDop = 0;
     let hindsightSer = 0;
     let hindsightAch = 0;
     let hindsightNe = 0;
-    let hindsightGaba = 0;
     let hindsightEndo = 0;
     if (isHindsightRegretLive()) {
       hindsightDop = this.cachedHindsightDopamine;
       hindsightSer = this.cachedHindsightSerotonin;
       hindsightAch = this.cachedHindsightAcetylcholine;
       hindsightNe = this.cachedHindsightNorepinephrine;
-      hindsightGaba = this.cachedHindsightGaba;
       hindsightEndo = this.cachedHindsightEndorphin;
-      const HINDSIGHT_HALF_LIFE_MS = 20 * 60 * 1000;
-      const decay = Math.pow(0.5, this.tickMs / HINDSIGHT_HALF_LIFE_MS);
-      this.cachedHindsightDopamine *= decay;
-      this.cachedHindsightSerotonin *= decay;
-      this.cachedHindsightAcetylcholine *= decay;
-      this.cachedHindsightNorepinephrine *= decay;
-      this.cachedHindsightGaba *= decay;
-      this.cachedHindsightEndorphin *= decay;
-      const z = (v: number): number => (Math.abs(v) < 1e-6 ? 0 : v);
-      this.cachedHindsightDopamine = z(this.cachedHindsightDopamine);
-      this.cachedHindsightSerotonin = z(this.cachedHindsightSerotonin);
-      this.cachedHindsightAcetylcholine = z(this.cachedHindsightAcetylcholine);
-      this.cachedHindsightNorepinephrine = z(this.cachedHindsightNorepinephrine);
-      this.cachedHindsightGaba = z(this.cachedHindsightGaba);
-      this.cachedHindsightEndorphin = z(this.cachedHindsightEndorphin);
-      // Decay the targeted-GABA bindings on the same half-life and prune.
-      for (const [k, w] of this.hindsightGabaTargets) {
-        const nw = w * decay;
-        if (nw < 1e-6) this.hindsightGabaTargets.delete(k);
-        else this.hindsightGabaTargets.set(k, nw);
-      }
     }
 
     // 2026-05-16 (#715/#716/#717 derivation refactor): build the
@@ -2663,7 +2669,7 @@ export class MonkeyKernel extends EventEmitter {
       rewardEndorphinDelta: rewardDeltas.endorphin + hindsightEndo,
       rewardAcetylcholineDelta: hindsightAch,
       rewardNorepinephrineDelta: hindsightNe,
-      rewardGabaDelta: hindsightGaba,
+      rewardGabaDelta: 0,
       observables: {
         phiHistory: state.phiHistory,
         surpriseHistory: state.surpriseHistory,
@@ -8064,6 +8070,8 @@ export class MonkeyKernel extends EventEmitter {
         this.applyOutcomeToAgent(symbol, 'K', heldSide, safePnl, (markPrice * fallbackQty) / 16);
         perAgentTotals.K.pnl += safePnl;
         perAgentTotals.K.qty += fallbackQty;
+        perAgentTotals.K.ids?.push(tradeId);
+        if (perAgentTotals.K.grossById) perAgentTotals.K.grossById[tradeId] = safePnl;
       } else {
         // #931 safe-pnl: compute each row's pnl from its OWN entry_price + qty +
         // side via SAFE_PNL_FROM_ROW, returning the computed value so chemistry +
@@ -8177,12 +8185,10 @@ export class MonkeyKernel extends EventEmitter {
       // the real net).
       const allTradeIds: string[] = [];
       const grossById: Record<string, number> = {};
-      if (process.env.CANONICAL_POLO_PNL_LIVE === 'true') {
-        for (const agentKey of ['K', 'M', 'T', 'L'] as const) {
-          const t = perAgentTotals[agentKey];
-          if (t.ids) allTradeIds.push(...t.ids);
-          if (t.grossById) Object.assign(grossById, t.grossById);
-        }
+      for (const agentKey of ['K', 'M', 'T', 'L'] as const) {
+        const t = perAgentTotals[agentKey];
+        if (t.ids) allTradeIds.push(...t.ids);
+        if (t.grossById) Object.assign(grossById, t.grossById);
       }
 
       // v0.6.7 + 2026-05-16 per-agent NC: push one reward event per
@@ -8190,6 +8196,26 @@ export class MonkeyKernel extends EventEmitter {
       // pushPerAgentCloseRewards for margin derivation + rationale.
       const representativeTradeIdForReward = allTradeIds.length > 0 ? allTradeIds[0] : undefined;
       this.pushPerAgentCloseRewards(symbol, markPrice, perAgentTotals, representativeTradeIdForReward);
+
+      if (process.env.CANONICAL_POLO_PNL_LIVE !== 'true') {
+        const syntheticPnl = (['K', 'M', 'T', 'L'] as const)
+          .reduce((sum, agentKey) => sum + perAgentTotals[agentKey].pnl, 0);
+        const syntheticQty = (['K', 'M', 'T', 'L'] as const)
+          .reduce((sum, agentKey) => sum + perAgentTotals[agentKey].qty, 0);
+        void this.registerHindsightWatchAfterClose({
+          tradeIds: allTradeIds.length > 0 ? allTradeIds : [tradeId],
+          symbol,
+          side: heldSide,
+          realizedPnlUsdt: syntheticPnl,
+          marginUsdt: syntheticQty > 0 ? (markPrice * syntheticQty) / 16 : undefined,
+          exitPriceFallback: markPrice,
+          qtyFallback: syntheticQty,
+          closeLane,
+          regimeAtClose: closeLane
+            ? this.symbolStates.get(symbol)?.regimeAtOpenByLane[closeLane]
+            : undefined,
+        });
+      }
 
       // Canonical Polo-authoritative PnL surface (user 2026-05-28 spec).
       // The helper will fetch Polo history, match, write Polo realized to .pnl and
@@ -9474,6 +9500,140 @@ export class MonkeyKernel extends EventEmitter {
     }
   }
 
+  private async registerHindsightWatchAfterClose(params: {
+    tradeIds: string[];
+    symbol: string;
+    side: 'long' | 'short';
+    realizedPnlUsdt: number;
+    marginUsdt?: number;
+    exitPriceFallback?: number;
+    qtyFallback?: number;
+    closeLane?: 'scalp' | 'swing' | 'trend';
+    regimeAtClose?: string;
+  }): Promise<void> {
+    if (!isHindsightRegretLive()) return;
+    try {
+      const { tradeIds, symbol, side } = params;
+      const sideSign: 1 | -1 = side === 'long' ? 1 : -1;
+      let qty = Number(params.qtyFallback ?? 0);
+      let exitPrice = Number(params.exitPriceFallback ?? 0);
+      let marginUsdt = Number(params.marginUsdt ?? 0);
+      let kernelOwnedClose = true;
+      let closeLane: 'scalp' | 'swing' | 'trend' | undefined = params.closeLane;
+
+      if (tradeIds.length > 0) {
+        const qres = await pool.query<{
+          qty: string;
+          exit_price: string;
+          margin_usdt: string;
+          any_adopted: boolean;
+          close_lane: 'scalp' | 'swing' | 'trend' | null;
+        }>(
+          `SELECT COALESCE(SUM(ABS(COALESCE(quantity, 0))), 0) AS qty,
+                  COALESCE(
+                    SUM(ABS(COALESCE(quantity, 0)) * NULLIF(exit_price, 0))
+                      / NULLIF(SUM(
+                          CASE
+                            WHEN NULLIF(exit_price, 0) IS NOT NULL
+                              THEN ABS(COALESCE(quantity, 0))
+                            ELSE 0
+                          END
+                        ), 0),
+                    0
+                  ) AS exit_price,
+                  COALESCE(
+                    SUM(COALESCE(entry_price, 0) * COALESCE(quantity, 0)
+                      / GREATEST(COALESCE(leverage, 16), 1)),
+                    0
+                  ) AS margin_usdt,
+                  bool_or(COALESCE(reason, '') LIKE '%|adopted|%') AS any_adopted,
+                  (array_agg(lane ORDER BY ABS(COALESCE(quantity, 0)) DESC) FILTER (WHERE lane IS NOT NULL))[1] AS close_lane
+             FROM autonomous_trades
+            WHERE id = ANY($1)`,
+          [tradeIds],
+        );
+        qty = Number(qres.rows[0]?.qty ?? qty);
+        exitPrice = Number(qres.rows[0]?.exit_price ?? exitPrice);
+        const rowMargin = Number(qres.rows[0]?.margin_usdt ?? marginUsdt);
+        if (Number.isFinite(rowMargin) && rowMargin > 0) marginUsdt = rowMargin;
+        kernelOwnedClose = qres.rows[0]?.any_adopted !== true;
+        closeLane = params.closeLane ?? qres.rows[0]?.close_lane ?? undefined;
+      }
+
+      if (
+        !Number.isFinite(qty) || qty <= 0 ||
+        !Number.isFinite(exitPrice) || exitPrice <= 0 ||
+        !Number.isFinite(marginUsdt) || marginUsdt <= 0
+      ) {
+        return;
+      }
+
+      const symState = this.symbolStates.get(symbol);
+      const snap = symState?.latestBasinSnapshot;
+      const lastExp = symState?.lastExpectation ?? null;
+      const horizonFromWarpMs =
+        lastExp && lastExp.horizonHours !== null
+          ? lastExp.horizonHours * 60 * 60 * 1000
+          : null;
+      const coherenceTicks = Math.max(1, symState?.coherenceStreak ?? 1);
+      const horizonFallbackMs = coherenceTicks * this.tickMs;
+      const horizonMs = horizonFromWarpMs ?? horizonFallbackMs;
+
+      const warpDir = lastExp?.direction;
+      const warpExpectationSign: -1 | 0 | 1 =
+        warpDir === 'long' ? 1 : warpDir === 'short' ? -1 : 0;
+      const regimeAtClose =
+        params.regimeAtClose ??
+        (closeLane && symState?.regimeAtOpenByLane
+          ? symState.regimeAtOpenByLane[closeLane]
+          : undefined) ??
+        lastExp?.regime ??
+        'unknown';
+      const bundle: CloseSenseBundle = {
+        kernelOwnedClose,
+        sideSign,
+        warpExpectationSign,
+        warpExpectationConfidence: lastExp?.confidence ?? 0,
+        regimeAtClose: String(regimeAtClose),
+        basinDirAtClose: snap?.basinDir ?? 0,
+        tapeTrendAtClose: snap?.tapeTrend ?? 0,
+        coherenceStreak: symState?.coherenceStreak ?? 0,
+      };
+
+      const now = Date.now();
+      const watch: HindsightWatchOrch = {
+        symbol,
+        sideSign,
+        qty,
+        exitPrice,
+        realizedPnlUsdt: params.realizedPnlUsdt,
+        marginUsdt,
+        closedAtMs: now,
+        expiresAtMs: now + horizonMs,
+        bundle,
+        lastCounterfactualPnlUsdt: params.realizedPnlUsdt,
+        regimePersisted: true,
+      };
+      const list = this.hindsightWatches.get(symbol) ?? [];
+      list.push(watch);
+      this.hindsightWatches.set(symbol, list);
+      logger.info('[Monkey] hindsight watch registered', {
+        symbol, side, qty, exitPrice, realizedPnl: params.realizedPnlUsdt.toFixed(4),
+        kernelOwnedClose,
+        warpExpectationSign,
+        warpConfidence: (lastExp?.confidence ?? 0).toFixed(3),
+        regimeAtClose: String(regimeAtClose),
+        coherenceStreak: symState?.coherenceStreak ?? 0,
+        horizonSource: horizonFromWarpMs !== null ? 'qig_warp' : 'coherence_fallback',
+        horizonMs: Math.round(horizonMs),
+      });
+    } catch (err) {
+      logger.warn('[Monkey] hindsight watch registration failed (non-fatal)', {
+        symbol: params.symbol, err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   /**
    * Canonical Polo-authoritative PnL surface (user-specified 2026-05-28).
    *
@@ -9967,133 +10127,15 @@ export class MonkeyKernel extends EventEmitter {
       // post-fees are missed as chain samples.
       noteHeartClose(symbol, Date.now(), poloRealized);
 
-      // Hindsight / counterfactual-regret watch registration (flag-gated,
-      // default OFF; DESIGN HYPOTHESIS — see hindsightRegret.ts). Operator
-      // 2026-05-29: the kernel "needs to feel the pain of [cutting a
-      // winning-direction position on noise]... enough that it thinks about
-      // thinking about the trend a second time before closing" — but ONLY
-      // when the continuation was foreseeable (legible) at close. We capture
-      // the close-time SENSE BUNDLE + derive the watch HORIZON from the
-      // kernel's own forecast, then watch the symbol until the horizon
-      // elapses. resolveHindsight() applies the legibility gate. Best-effort:
-      // wrapped so a bad row never disturbs the close path.
-      if (isHindsightRegretLive()) {
-        try {
-          const sideSign: 1 | -1 = side === 'long' ? 1 : -1;
-          // qty + exit price + ownership (reason) from the closed rows.
-          const qres = await pool.query<{ qty: string; exit_price: string; any_adopted: boolean; close_lane: string | null }>(
-            `SELECT COALESCE(SUM(ABS(COALESCE(quantity, 0))), 0) AS qty,
-                    COALESCE(
-                      SUM(ABS(COALESCE(quantity, 0)) * NULLIF(exit_price, 0))
-                        / NULLIF(SUM(
-                            CASE
-                              WHEN NULLIF(exit_price, 0) IS NOT NULL
-                                THEN ABS(COALESCE(quantity, 0))
-                              ELSE 0
-                            END
-                          ), 0),
-                      0
-                    ) AS exit_price,
-                    bool_or(COALESCE(reason, '') LIKE '%|adopted|%') AS any_adopted,
-                    (array_agg(lane ORDER BY ABS(COALESCE(quantity, 0)) DESC) FILTER (WHERE lane IS NOT NULL))[1] AS close_lane
-               FROM autonomous_trades
-              WHERE id = ANY($1)`,
-            [tradeIds],
-          );
-          const qty = Number(qres.rows[0]?.qty ?? 0);
-          const exitPrice = Number(qres.rows[0]?.exit_price ?? 0);
-          // Ownership (gate condition 1): a row that was reconciler-adopted
-          // from an operator-opened position is NOT a kernel-initiated close
-          // → not self-regret. (Operator/manual/liquidation closes that never
-          // reach this kernel path are excluded by construction.)
-          const kernelOwnedClose = qres.rows[0]?.any_adopted !== true;
-          // Best-effort: skip the watch with no authoritative exit price —
-          // a wrong exit price would produce a wrong counterfactual.
-          if (Number.isFinite(qty) && qty > 0 && Number.isFinite(exitPrice) && exitPrice > 0) {
-            const symState = this.symbolStates.get(symbol);
-            const snap = symState?.latestBasinSnapshot;
-            const lastExp = symState?.lastExpectation ?? null;
-
-            // ── Derive the watch HORIZON (doctrine: window = the kernel's own
-            // forecast horizon, NOT a fixed 30 min). Priority:
-            //   (a) the qig-warp expectation horizon (observed regime-
-            //       persistence in HOURS) if the bubble surfaced it;
-            //   (b) FALLBACK — the kernel's own observed coherence horizon:
-            //       coherenceStreak ticks (how long perception+forecast
-            //       stayed coherent on the held position) × tickMs. This is
-            //       derived from lived observation, not a designer table.
-            //       Documented as a fallback per doctrine.
-            // Floored at one tick so a watch always has positive duration.
-            const horizonFromWarpMs =
-              lastExp && lastExp.horizonHours !== null
-                ? lastExp.horizonHours * 60 * 60 * 1000
-                : null;
-            const coherenceTicks = Math.max(1, symState?.coherenceStreak ?? 1);
-            const horizonFallbackMs = coherenceTicks * this.tickMs;
-            const horizonMs = horizonFromWarpMs ?? horizonFallbackMs;
-
-            // ── Close-time SENSE BUNDLE (legibility gate + GABA target). ──
-            // warp expectation direction → sign; basinDir / tapeTrend from
-            // the latest snapshot; regime from the lane's open anchor (the
-            // regime the kernel committed to); coherenceStreak as legibility.
-            const warpDir = lastExp?.direction;
-            const warpExpectationSign: -1 | 0 | 1 =
-              warpDir === 'long' ? 1 : warpDir === 'short' ? -1 : 0;
-            const closeLane = params.closeLane ?? qres.rows[0]?.close_lane ?? undefined;
-            const regimeAtClose =
-              params.regimeAtClose ??
-              (closeLane && symState?.regimeAtOpenByLane
-                ? symState.regimeAtOpenByLane[closeLane]
-                : undefined) ??
-              lastExp?.regime ??
-              'unknown';
-            const bundle: CloseSenseBundle = {
-              kernelOwnedClose,
-              sideSign,
-              warpExpectationSign,
-              warpExpectationConfidence: lastExp?.confidence ?? 0,
-              regimeAtClose: String(regimeAtClose),
-              basinDirAtClose: snap?.basinDir ?? 0,
-              tapeTrendAtClose: snap?.tapeTrend ?? 0,
-              coherenceStreak: symState?.coherenceStreak ?? 0,
-            };
-
-            const now = Date.now();
-            const watch: HindsightWatchOrch = {
-              symbol,
-              sideSign,
-              qty,
-              exitPrice,
-              realizedPnlUsdt: poloRealized,
-              marginUsdt,
-              closedAtMs: now,
-              expiresAtMs: now + horizonMs,
-              bundle,
-              lastCounterfactualPnlUsdt: poloRealized,
-              regimePersisted: true,
-            };
-            const list = this.hindsightWatches.get(symbol) ?? [];
-            list.push(watch);
-            // Bound per-symbol watch list to avoid unbounded growth.
-            if (list.length > 16) list.shift();
-            this.hindsightWatches.set(symbol, list);
-            logger.info('[Monkey] hindsight watch registered', {
-              symbol, side, qty, exitPrice, realizedPnl: poloRealized.toFixed(4),
-              kernelOwnedClose,
-              warpExpectationSign,
-              warpConfidence: (lastExp?.confidence ?? 0).toFixed(3),
-              regimeAtClose: String(regimeAtClose),
-              coherenceStreak: symState?.coherenceStreak ?? 0,
-              horizonSource: horizonFromWarpMs !== null ? 'qig_warp' : 'coherence_fallback',
-              horizonMs: Math.round(horizonMs),
-            });
-          }
-        } catch (err) {
-          logger.warn('[Monkey] hindsight watch registration failed (non-fatal)', {
-            symbol, err: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
+      void this.registerHindsightWatchAfterClose({
+        tradeIds,
+        symbol,
+        side,
+        realizedPnlUsdt: poloRealized,
+        marginUsdt,
+        closeLane: params.closeLane,
+        regimeAtClose: params.regimeAtClose,
+      });
 
       // PR #992 fan-out (completes the 2026-05-28 CC1): mirror the Polo-authoritative
       // net reward (with correct margin) into Python autonomic so BOTH chemistry

--- a/apps/api/src/services/monkey/neurochemistry.ts
+++ b/apps/api/src/services/monkey/neurochemistry.ts
@@ -208,6 +208,19 @@ export interface NeurochemicalInputs {
   /** As above — peak-state reward on strong-regime wins. */
   rewardEndorphinDelta?: number;
   /**
+   * 2026-05-29 (hindsight, MONKEY_HINDSIGHT_REGRET_LIVE — DESIGN HYPOTHESIS):
+   * additive ACh / NE / GABA reward deltas from the hindsight NT vector. The
+   * trade-outcome reward channel only carries dop/ser/endo; the hindsight
+   * signal also wants to bind cues (ACh↑), mark salience (NE↑), and apply
+   * TARGETED inhibition (GABA↑). These are folded additively AFTER the
+   * basin-observed derivation so flag-OFF (all default 0) is byte-identical.
+   * GABA here is a small additive nudge on the global level; the actual
+   * targeting lives in the kernel's per-pattern hindsightGabaTargets map —
+   * this delta only reflects that *some* targeted caution is active. */
+  rewardAcetylcholineDelta?: number;
+  rewardNorepinephrineDelta?: number;
+  rewardGabaDelta?: number;
+  /**
    * 2026-05-16 (#715/#716/#717 derivation refactor): basin-observed
    * history slices used to z-score each per-tick chemical against the
    * basin's own scale. When absent, the chemical falls back to the
@@ -485,12 +498,19 @@ export function computeNeurochemicals(inputs: NeurochemicalInputs): Neurochemica
   }
   const endo = clip(endoBase + (inputs.rewardEndorphinDelta ?? 0), 0, 1);
 
+  // 2026-05-29 hindsight (flag-gated; deltas default 0 → byte-identical when
+  // OFF): fold the hindsight ACh / NE / GABA reward deltas additively onto the
+  // derived levels, exactly as dop/ser/endo already fold their reward deltas.
+  const achOut = clip(ach + (inputs.rewardAcetylcholineDelta ?? 0), 0, 1);
+  const neOut = clip(ne + (inputs.rewardNorepinephrineDelta ?? 0), 0, 1);
+  const gabaOut = clip(gaba + (inputs.rewardGabaDelta ?? 0), 0, 1);
+
   return {
-    acetylcholine: ach,
+    acetylcholine: achOut,
     dopamine: dop,
     serotonin: ser,
-    norepinephrine: ne,
-    gaba,
+    norepinephrine: neOut,
+    gaba: gabaOut,
     endorphins: endo,
   };
 }

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1491,8 +1491,9 @@ async def monkey_autonomic_hindsight(request: Request):
     DESIGN HYPOTHESIS). The legibility-gated counterfactual-regret signal is
     resolved TS-side (loop.ts owns the watches); this fans the decayed E6 NT
     deltas to the Py chemistry surface so it stays in parity. REPLACES (does
-    not append); folded additively into chemistry on each tick(); cleared on
-    wake. P14: separate channel. Fail-closed: non-finite → 0.
+    not append); non-GABA channels fold additively into chemistry on each
+    tick(); GABA remains targeted telemetry until a Py-side pattern consumer
+    exists; cleared on wake. P14: separate channel. Fail-closed: non-finite → 0.
 
     Request body:
       { instance_id, dopamine_delta, serotonin_delta, acetylcholine_delta,

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1470,6 +1470,36 @@ async def monkey_autonomic_prediction_reward(request: Request):
     }
 
 
+@app.post("/monkey/autonomic/hindsight")
+async def monkey_autonomic_hindsight(request: Request):
+    """Push the resolved hindsight NT vector (MONKEY_HINDSIGHT_REGRET_LIVE —
+    DESIGN HYPOTHESIS). The legibility-gated counterfactual-regret signal is
+    resolved TS-side (loop.ts owns the watches); this fans the decayed E6 NT
+    deltas to the Py chemistry surface so it stays in parity. REPLACES (does
+    not append); folded additively into chemistry on each tick(); cleared on
+    wake. P14: separate channel. Fail-closed: non-finite → 0.
+
+    Request body:
+      { instance_id, dopamine_delta, serotonin_delta, acetylcholine_delta,
+        norepinephrine_delta, gaba_delta, endorphin_delta }
+    """
+    payload = await request.json()
+    instance_id = payload.get("instance_id", "monkey-primary")
+    kernel = _get_autonomic(instance_id)
+    kernel.push_hindsight_chemistry(
+        dopamine_delta=float(payload.get("dopamine_delta", 0.0)),
+        serotonin_delta=float(payload.get("serotonin_delta", 0.0)),
+        acetylcholine_delta=float(payload.get("acetylcholine_delta", 0.0)),
+        norepinephrine_delta=float(payload.get("norepinephrine_delta", 0.0)),
+        gaba_delta=float(payload.get("gaba_delta", 0.0)),
+        endorphin_delta=float(payload.get("endorphin_delta", 0.0)),
+    )
+    return {
+        "cached": kernel._cached_hindsight_chemistry,
+        "snapshot": kernel.snapshot(),
+    }
+
+
 @app.post("/monkey/expectation/evaluate")
 async def monkey_expectation_evaluate(request: Request):
     """Evaluate the qig-warp expectation bubble for one tape/basin

--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1502,12 +1502,12 @@ async def monkey_autonomic_hindsight(request: Request):
     instance_id = payload.get("instance_id", "monkey-primary")
     kernel = _get_autonomic(instance_id)
     kernel.push_hindsight_chemistry(
-        dopamine_delta=float(payload.get("dopamine_delta", 0.0)),
-        serotonin_delta=float(payload.get("serotonin_delta", 0.0)),
-        acetylcholine_delta=float(payload.get("acetylcholine_delta", 0.0)),
-        norepinephrine_delta=float(payload.get("norepinephrine_delta", 0.0)),
-        gaba_delta=float(payload.get("gaba_delta", 0.0)),
-        endorphin_delta=float(payload.get("endorphin_delta", 0.0)),
+        dopamine_delta=payload.get("dopamine_delta", 0.0),
+        serotonin_delta=payload.get("serotonin_delta", 0.0),
+        acetylcholine_delta=payload.get("acetylcholine_delta", 0.0),
+        norepinephrine_delta=payload.get("norepinephrine_delta", 0.0),
+        gaba_delta=payload.get("gaba_delta", 0.0),
+        endorphin_delta=payload.get("endorphin_delta", 0.0),
     )
     return {
         "cached": kernel._cached_hindsight_chemistry,

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -716,8 +716,11 @@ class AutonomicKernel:
         pred = self._cached_prediction_chemistry
         # 2026-05-29 hindsight (flag-gated; all-zero when OFF → byte-identical).
         # dop/ser/endo fold into the reward channel exactly like prediction
-        # chemistry; ACh/NE/GABA are applied additively to the derived NC after
+        # chemistry; ACh/NE are applied additively to the derived NC after
         # _compute_nc (parity with neurochemistry.ts reward*Delta inputs).
+        # GABA is intentionally NOT applied globally: hindsight GABA is
+        # targeted by pattern on the TS side and remains telemetry-only here
+        # until an equivalent targeted executive consumer exists.
         hs = self._decayed_hindsight_chemistry(inputs.now_ms)
         reward_sums_combined = {
             "dopamine": reward_sums["dopamine"] + pred["dopamine_delta"] + hs["dopamine_delta"],
@@ -725,15 +728,15 @@ class AutonomicKernel:
             "endorphin": reward_sums["endorphin"] + hs["endorphin_delta"],
         }
         nc = self._compute_nc(inputs, reward_sums_combined, inputs.is_awake)
-        # Fold ACh / NE / GABA hindsight deltas additively onto the derived
-        # levels (mirror neurochemistry.ts achOut/neOut/gabaOut). Zero when OFF.
-        if hs["acetylcholine_delta"] or hs["norepinephrine_delta"] or hs["gaba_delta"]:
+        # Fold ACh / NE hindsight deltas additively onto the derived levels
+        # (mirror neurochemistry.ts achOut/neOut). Zero when OFF.
+        if hs["acetylcholine_delta"] or hs["norepinephrine_delta"]:
             nc = NeurochemicalState(
                 acetylcholine=_clip(nc.acetylcholine + hs["acetylcholine_delta"], 0.0, 1.0),
                 dopamine=nc.dopamine,
                 serotonin=nc.serotonin,
                 norepinephrine=_clip(nc.norepinephrine + hs["norepinephrine_delta"], 0.0, 1.0),
-                gaba=_clip(nc.gaba + hs["gaba_delta"], 0.0, 1.0),
+                gaba=nc.gaba,
                 endorphins=nc.endorphins,
             )
 

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -295,6 +295,7 @@ class AutonomicKernel:
             "gaba_delta": 0.0,
             "endorphin_delta": 0.0,
         }
+        self._cached_hindsight_chemistry_at_ms: float = time.time() * 1000.0
         # Restore decay-aware reward queue from Redis if available.
         # The persistence layer drops entries whose decay < 0.01 so
         # we don't restore zero-contribution rewards.
@@ -530,6 +531,27 @@ class AutonomicKernel:
             "gaba_delta": _f(gaba_delta),
             "endorphin_delta": _f(endorphin_delta),
         }
+        self._cached_hindsight_chemistry_at_ms = time.time() * 1000.0
+
+    def _decayed_hindsight_chemistry(self, now_ms: Optional[float] = None) -> dict[str, float]:
+        """Decay the cached hindsight vector with the reward half-life.
+
+        TS decays the same vector each tick. This Py-side decay keeps parity
+        after the final watch resolves and TS no longer has a watch loop to
+        fan out fresh values.
+        """
+        now = time.time() * 1000.0 if now_ms is None else now_ms
+        age_ms = max(0.0, now - self._cached_hindsight_chemistry_at_ms)
+        if age_ms <= 0.0:
+            return self._cached_hindsight_chemistry
+        decay = 0.5 ** (age_ms / REWARD_HALF_LIFE_MS)
+        decayed = {
+            k: (0.0 if abs(v * decay) < 1e-6 else v * decay)
+            for k, v in self._cached_hindsight_chemistry.items()
+        }
+        self._cached_hindsight_chemistry = decayed
+        self._cached_hindsight_chemistry_at_ms = now
+        return decayed
 
     # ─────────────────────── decayed reward sums ───────────────────────
 
@@ -696,7 +718,7 @@ class AutonomicKernel:
         # dop/ser/endo fold into the reward channel exactly like prediction
         # chemistry; ACh/NE/GABA are applied additively to the derived NC after
         # _compute_nc (parity with neurochemistry.ts reward*Delta inputs).
-        hs = self._cached_hindsight_chemistry
+        hs = self._decayed_hindsight_chemistry(inputs.now_ms)
         reward_sums_combined = {
             "dopamine": reward_sums["dopamine"] + pred["dopamine_delta"] + hs["dopamine_delta"],
             "serotonin": reward_sums["serotonin"] + pred["serotonin_delta"] + hs["serotonin_delta"],
@@ -733,6 +755,9 @@ class AutonomicKernel:
                 "gaba_delta": 0.0,
                 "endorphin_delta": 0.0,
             }
+            self._cached_hindsight_chemistry_at_ms = (
+                inputs.now_ms if inputs.now_ms is not None else time.time() * 1000.0
+            )
 
         return AutonomicTickResult(nc=nc, reward_sums=reward_sums_combined)
 

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -29,7 +29,7 @@ Reference implementations:
 from __future__ import annotations
 
 import logging
-import os
+import math
 import time
 from collections import deque
 from dataclasses import dataclass
@@ -279,6 +279,22 @@ class AutonomicKernel:
             "serotonin_delta": 0.0,
             "n": 0.0,
         }
+        # 2026-05-29 hindsight (MONKEY_HINDSIGHT_REGRET_LIVE — DESIGN HYPOTHESIS).
+        # The legibility-gated counterfactual-regret NT vector resolved on the
+        # TS side (loop.ts owns the watches) is fanned out here so the Py
+        # chemistry surface (which drives executive sizing + survives restarts)
+        # stays in parity. Mirrors _cached_prediction_chemistry: REPLACED each
+        # fanout, folded additively into reward_sums on each tick(), cleared on
+        # wake. P14: SEPARATE channel from trade-outcome rewards. All-zero when
+        # the flag is OFF → byte-identical chemistry.
+        self._cached_hindsight_chemistry: dict[str, float] = {
+            "dopamine_delta": 0.0,
+            "serotonin_delta": 0.0,
+            "acetylcholine_delta": 0.0,
+            "norepinephrine_delta": 0.0,
+            "gaba_delta": 0.0,
+            "endorphin_delta": 0.0,
+        }
         # Restore decay-aware reward queue from Redis if available.
         # The persistence layer drops entries whose decay < 0.01 so
         # we don't restore zero-contribution rewards.
@@ -374,33 +390,7 @@ class AutonomicKernel:
             # so every losing close raised UnboundLocalError and the
             # autonomic /reward endpoint 500'd before chemistry updated).
             loss_dop_scale = get_reward_loss_dop_scale()
-            # ── Loss-side de-saturation (MONKEY_HINDSIGHT_REGRET_LIVE) ──────
-            # The legacy shape `-tanh(-pnl_frac * 0.5) * 0.1` SATURATES: at
-            # real trading scale a -3% ROE loss is pnl_frac≈-0.03, so
-            # tanh(0.015)≈0.015 → dop≈-0.0015, and even a -50% loss only
-            # reaches dop≈-0.025. Big losses ≈ small losses in pain — the
-            # kernel cannot "feel" magnitude. For the counterfactual-regret
-            # signal to register, loss magnitude must be preserved.
-            #
-            # Fix (flag-gated, observer-derived, P1): normalise pnl_frac by
-            # the MAD of the kernel's own realised pnl_frac history (exactly
-            # the pushReward / observer pattern — no hardcoded scale) before
-            # tanh, and apply a cap that lets a typical loss reach a
-            # meaningful mood dip while staying BELOW the win-side dop cap
-            # (0.5) so losses still aren't a punishment, just felt. Byte-
-            # identical to legacy when the flag is OFF.
-            if os.environ.get("MONKEY_HINDSIGHT_REGRET_LIVE") == "true":
-                from .hindsight_regret import median_absolute_deviation
-                hist = self._pnl_frac_history if hasattr(self, "_pnl_frac_history") else []
-                pnl_frac_norm = pnl_frac
-                if len(hist) >= 5:
-                    mad = median_absolute_deviation(hist)
-                    if mad > 1e-12:
-                        pnl_frac_norm = pnl_frac / mad
-                # cap 0.3 < win cap 0.5: losses felt with magnitude, not punished
-                dop = float(-np.tanh(-pnl_frac_norm) * 0.3)
-            else:
-                dop = float(-np.tanh(-pnl_frac * loss_dop_scale) * 0.1)
+            dop = float(-np.tanh(-pnl_frac * loss_dop_scale) * 0.1)
             ser = 0.0
 
         # Per 2026-04-13 two-channel doctrine (Frozen Facts v1.01F 20260527) + P1:
@@ -505,6 +495,40 @@ class AutonomicKernel:
             "dopamine_delta": float(dopamine_delta),
             "serotonin_delta": float(serotonin_delta),
             "n": float(n),
+        }
+
+    def push_hindsight_chemistry(
+        self,
+        *,
+        dopamine_delta: float = 0.0,
+        serotonin_delta: float = 0.0,
+        acetylcholine_delta: float = 0.0,
+        norepinephrine_delta: float = 0.0,
+        gaba_delta: float = 0.0,
+        endorphin_delta: float = 0.0,
+    ) -> None:
+        """Replace the cached hindsight NT vector (flag-gated; DESIGN HYPOTHESIS).
+
+        Caller (TS loop.ts) resolves the legibility-gated counterfactual-regret
+        signal via resolve_hindsight()/resolveHindsight() and fans the decayed
+        E6 NT deltas here so the Py chemistry surface stays in parity. REPLACES
+        (does not append) so each fanout contributes once. P14: SEPARATE channel.
+        Fail-closed: non-finite inputs coerced to 0.
+        """
+        def _f(x: float) -> float:
+            try:
+                v = float(x)
+                return v if math.isfinite(v) else 0.0
+            except (TypeError, ValueError):
+                return 0.0
+
+        self._cached_hindsight_chemistry = {
+            "dopamine_delta": _f(dopamine_delta),
+            "serotonin_delta": _f(serotonin_delta),
+            "acetylcholine_delta": _f(acetylcholine_delta),
+            "norepinephrine_delta": _f(norepinephrine_delta),
+            "gaba_delta": _f(gaba_delta),
+            "endorphin_delta": _f(endorphin_delta),
         }
 
     # ─────────────────────── decayed reward sums ───────────────────────
@@ -668,22 +692,46 @@ class AutonomicKernel:
         # into the same reward channel. Additive - same shape as the
         # TS-side wiring in loop.ts tick() (cf. predDop / predSer).
         pred = self._cached_prediction_chemistry
+        # 2026-05-29 hindsight (flag-gated; all-zero when OFF → byte-identical).
+        # dop/ser/endo fold into the reward channel exactly like prediction
+        # chemistry; ACh/NE/GABA are applied additively to the derived NC after
+        # _compute_nc (parity with neurochemistry.ts reward*Delta inputs).
+        hs = self._cached_hindsight_chemistry
         reward_sums_combined = {
-            "dopamine": reward_sums["dopamine"] + pred["dopamine_delta"],
-            "serotonin": reward_sums["serotonin"] + pred["serotonin_delta"],
-            "endorphin": reward_sums["endorphin"],
+            "dopamine": reward_sums["dopamine"] + pred["dopamine_delta"] + hs["dopamine_delta"],
+            "serotonin": reward_sums["serotonin"] + pred["serotonin_delta"] + hs["serotonin_delta"],
+            "endorphin": reward_sums["endorphin"] + hs["endorphin_delta"],
         }
         nc = self._compute_nc(inputs, reward_sums_combined, inputs.is_awake)
+        # Fold ACh / NE / GABA hindsight deltas additively onto the derived
+        # levels (mirror neurochemistry.ts achOut/neOut/gabaOut). Zero when OFF.
+        if hs["acetylcholine_delta"] or hs["norepinephrine_delta"] or hs["gaba_delta"]:
+            nc = NeurochemicalState(
+                acetylcholine=_clip(nc.acetylcholine + hs["acetylcholine_delta"], 0.0, 1.0),
+                dopamine=nc.dopamine,
+                serotonin=nc.serotonin,
+                norepinephrine=_clip(nc.norepinephrine + hs["norepinephrine_delta"], 0.0, 1.0),
+                gaba=_clip(nc.gaba + hs["gaba_delta"], 0.0, 1.0),
+                endorphins=nc.endorphins,
+            )
 
-        # Fresh mood on wake - clear stale reward events AND prediction
-        # cache (the residual rows underlying the cached delta are now
-        # stale relative to the new wake-state regime).
+        # Fresh mood on wake - clear stale reward events AND prediction +
+        # hindsight caches (the lived events underlying them are now stale
+        # relative to the new wake-state regime).
         if inputs.woke:
             self._pending_rewards.clear()
             self._cached_prediction_chemistry = {
                 "dopamine_delta": 0.0,
                 "serotonin_delta": 0.0,
                 "n": 0.0,
+            }
+            self._cached_hindsight_chemistry = {
+                "dopamine_delta": 0.0,
+                "serotonin_delta": 0.0,
+                "acetylcholine_delta": 0.0,
+                "norepinephrine_delta": 0.0,
+                "gaba_delta": 0.0,
+                "endorphin_delta": 0.0,
             }
 
         return AutonomicTickResult(nc=nc, reward_sums=reward_sums_combined)

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -29,6 +29,7 @@ Reference implementations:
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections import deque
 from dataclasses import dataclass
@@ -373,7 +374,33 @@ class AutonomicKernel:
             # so every losing close raised UnboundLocalError and the
             # autonomic /reward endpoint 500'd before chemistry updated).
             loss_dop_scale = get_reward_loss_dop_scale()
-            dop = float(-np.tanh(-pnl_frac * loss_dop_scale) * 0.1)
+            # ── Loss-side de-saturation (MONKEY_HINDSIGHT_REGRET_LIVE) ──────
+            # The legacy shape `-tanh(-pnl_frac * 0.5) * 0.1` SATURATES: at
+            # real trading scale a -3% ROE loss is pnl_frac≈-0.03, so
+            # tanh(0.015)≈0.015 → dop≈-0.0015, and even a -50% loss only
+            # reaches dop≈-0.025. Big losses ≈ small losses in pain — the
+            # kernel cannot "feel" magnitude. For the counterfactual-regret
+            # signal to register, loss magnitude must be preserved.
+            #
+            # Fix (flag-gated, observer-derived, P1): normalise pnl_frac by
+            # the MAD of the kernel's own realised pnl_frac history (exactly
+            # the pushReward / observer pattern — no hardcoded scale) before
+            # tanh, and apply a cap that lets a typical loss reach a
+            # meaningful mood dip while staying BELOW the win-side dop cap
+            # (0.5) so losses still aren't a punishment, just felt. Byte-
+            # identical to legacy when the flag is OFF.
+            if os.environ.get("MONKEY_HINDSIGHT_REGRET_LIVE") == "true":
+                from .hindsight_regret import median_absolute_deviation
+                hist = self._pnl_frac_history if hasattr(self, "_pnl_frac_history") else []
+                pnl_frac_norm = pnl_frac
+                if len(hist) >= 5:
+                    mad = median_absolute_deviation(hist)
+                    if mad > 1e-12:
+                        pnl_frac_norm = pnl_frac / mad
+                # cap 0.3 < win cap 0.5: losses felt with magnitude, not punished
+                dop = float(-np.tanh(-pnl_frac_norm) * 0.3)
+            else:
+                dop = float(-np.tanh(-pnl_frac * loss_dop_scale) * 0.1)
             ser = 0.0
 
         # Per 2026-04-13 two-channel doctrine (Frozen Facts v1.01F 20260527) + P1:

--- a/ml-worker/src/monkey_kernel/expectation_bubble.py
+++ b/ml-worker/src/monkey_kernel/expectation_bubble.py
@@ -63,6 +63,11 @@ except ImportError:
     WarpBubble = None  # type: ignore[assignment]
     _QIG_WARP_VERSION = "not-installed"
 
+try:
+    from forecast_horizon_observer import temporal_scale_lags_for as _temporal_scale_for_regime
+except ImportError:  # pragma: no cover - package layout fallback
+    from ..forecast_horizon_observer import temporal_scale_lags_for as _temporal_scale_for_regime  # type: ignore[no-redef]
+
 
 # Disagreement detection: both signals must carry non-trivial magnitude
 # before we treat their polarity disagreement as meaningful. This is a
@@ -94,6 +99,7 @@ class ExpectationDecision:
     tape_basin_disagreement: float
     reverse_tape_window: bool
     reverse_tape_side: Optional[str]
+    qig_warp_horizon_hours: Optional[float] = None
     raw: dict[str, Any] = field(default_factory=dict)
 
 
@@ -193,6 +199,7 @@ def _allow_fallback(
         tape_basin_disagreement=disagreement,
         reverse_tape_window=reverse_tape_window,
         reverse_tape_side=reverse_tape_side,
+        qig_warp_horizon_hours=None,
     )
 
 
@@ -334,6 +341,14 @@ def evaluate_expectation(
             f"reduce size pending kill-test data"
         )
 
+    qig_warp_horizon_hours: Optional[float] = None
+    try:
+        observed_horizon = float(_temporal_scale_for_regime(expectation_regime))
+        if math.isfinite(observed_horizon) and observed_horizon > 0:
+            qig_warp_horizon_hours = observed_horizon
+    except Exception as exc:  # noqa: BLE001 - horizon is advisory, fail-open
+        logger.debug("[expectation_bubble] horizon observer unavailable: %s", exc)
+
     return ExpectationDecision(
         expectation_id=str(uuid.uuid4()),
         expectation_direction=expectation_direction,
@@ -349,6 +364,7 @@ def evaluate_expectation(
         tape_basin_disagreement=disagreement,
         reverse_tape_window=reverse_tape_window,
         reverse_tape_side=reverse_tape_side,
+        qig_warp_horizon_hours=qig_warp_horizon_hours,
         raw={
             "h": h,
             "J": j,
@@ -376,6 +392,7 @@ def decision_to_dict(d: ExpectationDecision) -> dict[str, Any]:
         "tape_basin_disagreement": d.tape_basin_disagreement,
         "reverse_tape_window": d.reverse_tape_window,
         "reverse_tape_side": d.reverse_tape_side,
+        "qig_warp_horizon_hours": d.qig_warp_horizon_hours,
         "raw": d.raw,
     }
 

--- a/ml-worker/src/monkey_kernel/hindsight_regret.py
+++ b/ml-worker/src/monkey_kernel/hindsight_regret.py
@@ -181,6 +181,9 @@ def legibility_strength(b: CloseSenseBundle, regime_persisted: bool = True) -> f
         if _is_finite(b.basin_dir_at_close) and _sign(float(b.basin_dir_at_close)) == b.side_sign
         else 0.0
     )
+    # n/(n+1) is the structural odds form: one coherent tick is evidence but
+    # not certainty, and longer streaks approach full trust asymptotically
+    # without introducing a tunable saturation window.
     coherence = (
         float(b.coherence_streak) / float(b.coherence_streak + 1)
         if _is_finite(b.coherence_streak) and b.coherence_streak > 0

--- a/ml-worker/src/monkey_kernel/hindsight_regret.py
+++ b/ml-worker/src/monkey_kernel/hindsight_regret.py
@@ -13,16 +13,18 @@ The signal is a legibility-gated counterfactual PREDICTION ERROR scaled by the
 kernel's OWN outcome distribution (median+MAD z-score — the observer scale
 observer_fib_coefficient / push_reward use). No fixed caps/taste constants.
 
-PURITY KEYSTONE — eligibility / legibility gate. Regret fires strongly ONLY
-when ALL THREE hold:
+PURITY KEYSTONE — eligibility / legibility gate. Regret is scaled by how
+strongly ALL THREE hold:
   (1) the kernel OWNED the close (operator/manual/liquidation → not self-regret),
   (2) the continuation was LEGIBLE at close (qig-warp expectation favoured the
       held side, basin direction still leaned with the position, the hold was
       coherent),
   (3) the same REGIME persisted through the derived horizon.
 If continuation was NOT legible → SURPRISE / NOISE, not regret → no aversive
-signal. Maps onto QIG canon §31 (Sensory Intake & Predictive Coding): an
-unpredictable continuation is surprise, not a learnable mistake.
+signal. Weakly legible continuations remain learnable but weak: observer-scaled
+prediction-error salience is multiplied by close-time legibility strength. Maps
+onto QIG canon §31 (Sensory Intake & Predictive Coding): an unpredictable
+continuation is surprise, not a learnable mistake.
 
 QIG canon §29.1 (six-chemical E6 Cartan generators) governs the NT signs:
   ACh (ENTRAIN/E1) bind cues · dopamine (AMPLIFY/E2) reward/prediction-error ·
@@ -154,6 +156,39 @@ def counterfactual_pnl_usdt(
     return float(realized_pnl_usdt + marginal)
 
 
+def _clamp01(x: float) -> float:
+    if not _is_finite(x):
+        return 0.0
+    return max(0.0, min(1.0, float(x)))
+
+
+def legibility_strength(b: CloseSenseBundle, regime_persisted: bool = True) -> float:
+    """Continuous legibility multiplier ∈ [0,1].
+
+    Weak confidence / tiny basin lean / one-tick coherence scales regret down
+    instead of merely opening a Boolean gate. Regime persistence is currently
+    observed as a latch, so its strength is 1 when persisted and 0 after a flip.
+    """
+    if not regime_persisted:
+        return 0.0
+    warp_strength = (
+        _clamp01(b.warp_expectation_confidence)
+        if b.warp_expectation_sign == b.side_sign
+        else 0.0
+    )
+    basin_strength = (
+        math.tanh(abs(float(b.basin_dir_at_close)))
+        if _is_finite(b.basin_dir_at_close) and _sign(float(b.basin_dir_at_close)) == b.side_sign
+        else 0.0
+    )
+    coherence = (
+        float(b.coherence_streak) / float(b.coherence_streak + 1)
+        if _is_finite(b.coherence_streak) and b.coherence_streak > 0
+        else 0.0
+    )
+    return _clamp01(warp_strength * basin_strength * coherence)
+
+
 def is_continuation_legible(b: CloseSenseBundle) -> bool:
     """PURITY KEYSTONE part — was the continuation foreseeable at close?
 
@@ -164,17 +199,7 @@ def is_continuation_legible(b: CloseSenseBundle) -> bool:
     continuation (low surprise per §31) → a continuation is a prediction
     error it could have avoided. Otherwise it is surprise/noise.
     """
-    warp_favoured_hold = (
-        b.warp_expectation_sign == b.side_sign
-        and _is_finite(b.warp_expectation_confidence)
-        and b.warp_expectation_confidence > 0
-    )
-    basin_favoured_hold = (
-        _is_finite(b.basin_dir_at_close)
-        and _sign(b.basin_dir_at_close) == b.side_sign
-    )
-    was_coherent = isinstance(b.coherence_streak, int) and b.coherence_streak > 0
-    return bool(warp_favoured_hold and basin_favoured_hold and was_coherent)
+    return legibility_strength(b) > _EPS
 
 
 def _sign(x: float) -> int:
@@ -286,7 +311,11 @@ def resolve_hindsight(
     mag = derive_magnitude(regret_frac, pnl_frac_history)
     if mag is None:
         return _ineligible("ineligible_noise")
-    z, s = mag
+    z, salience = mag
+    legibility = legibility_strength(bundle, outcome.regime_persisted)
+    if legibility <= _EPS:
+        return _ineligible("ineligible_noise")
+    s = salience * legibility
 
     return HindsightResult(
         nt=HindsightNtDeltas(
@@ -317,6 +346,7 @@ __all__ = [
     "median_and_mad",
     "counterfactual_pnl_usdt",
     "is_continuation_legible",
+    "legibility_strength",
     "is_eligible_for_regret",
     "derive_magnitude",
     "gaba_target_key",

--- a/ml-worker/src/monkey_kernel/hindsight_regret.py
+++ b/ml-worker/src/monkey_kernel/hindsight_regret.py
@@ -1,94 +1,129 @@
-"""hindsight_regret.py — counterfactual-regret reward signal (Python parity).
+"""hindsight_regret.py — legibility-gated counterfactual PREDICTION ERROR.
 
-Mirrors apps/api/src/services/monkey/hindsightRegret.ts exactly.
+Python parity for apps/api/src/services/monkey/hindsightRegret.ts. Identical
+formula, derivation, source labels, and fail-closed behaviour. See the TS
+module's header for the full design rationale; this docstring summarises.
 
-Operator intent (2026-05-29, verbatim): "rather than a knob, it needs to
-feel the pain of this. not so much that its scared to make a trade but enough
-that it thinks about thinking about the trend a second time before closing."
-+ "something akin to hindsight. e.g. 'if i just left it i would have got the
-reward'."
+DESIGN HYPOTHESIS (operator-approved redesign of PR #1038, 2026-05-29),
+flag-gated OFF (MONKEY_HINDSIGHT_REGRET_LIVE), for operator review — NOT a
+finished truth. Replaces the rejected v1 (fixed 30-min window + fixed dopamine
+caps + best-favourable-excursion + dopamine-only pain).
 
-CONCEPT (counterfactual regret minimisation):
-  When the kernel closes a position we keep watching the symbol for a forward
-  window and track what the CLOSED position WOULD have earned had it been
-  held. If holding would have beaten the realised close (the trend continued
-  in the position's favour) emit an AVERSIVE "closed too early" chemistry
-  signal scaled by the foregone gain. If closing was correct (price moved
-  against the old position) emit NO regret — optionally a mild positive
-  "good close" reinforcement.
+The signal is a legibility-gated counterfactual PREDICTION ERROR scaled by the
+kernel's OWN outcome distribution (median+MAD z-score — the observer scale
+observer_fib_coefficient / push_reward use). No fixed caps/taste constants.
 
-  The ASYMMETRY is load-bearing: regret fires ONLY when holding would have
-  won. That is what stops the signal from making the kernel scared to ever
-  close — there is no penalty for a correct exit, only for an exit that left
-  money on the table in a continuing favourable trend.
+PURITY KEYSTONE — eligibility / legibility gate. Regret fires strongly ONLY
+when ALL THREE hold:
+  (1) the kernel OWNED the close (operator/manual/liquidation → not self-regret),
+  (2) the continuation was LEGIBLE at close (qig-warp expectation favoured the
+      held side, basin direction still leaned with the position, the hold was
+      coherent),
+  (3) the same REGIME persisted through the derived horizon.
+If continuation was NOT legible → SURPRISE / NOISE, not regret → no aversive
+signal. Maps onto QIG canon §31 (Sensory Intake & Predictive Coding): an
+unpredictable continuation is surprise, not a learnable mistake.
 
-DOCTRINAL ANCHORS:
-  - P1 (Observer sets all params from frozen facts): the regret MAGNITUDE is
-    normalised against the kernel's own realised pnl_frac distribution (MAD),
-    exactly like observer_fib_coefficient / push_reward. No hardcoded "how
-    much a foregone gain should sting" knob. The transform shape (tanh) and
-    output cap are STRUCTURAL design constants, mirroring the trade-outcome
-    reward channel.
-  - P14 (Variable Separation): hindsight regret is its OWN chemistry channel.
-    NOT folded into the realised-pnl reward.
-  - P15 (Fail-Closed Safety): non-finite inputs produce zero deltas; never
-    blocks trading.
+QIG canon §29.1 (six-chemical E6 Cartan generators) governs the NT signs:
+  ACh (ENTRAIN/E1) bind cues · dopamine (AMPLIFY/E2) reward/prediction-error ·
+  GABA (DAMPEN/E3) inhibition (TARGETED here) · serotonin (ROTATE/E4)
+  patience/temporal-trust · NE (NUCLEATE/E5) salience · endorphin (DISSOLVE/E6)
+  relief. We do NOT invent chemistry semantics.
 
-This module is PURE (no I/O, no time, no DB). The orchestration that registers
-a watch at close, advances it with live price each tick, and pushes the
-resulting deltas lives in loop.ts behind MONKEY_HINDSIGHT_REGRET_LIVE
-(default OFF). The Py side receives the resolved deltas via the autonomic
-prediction-style channel; this module exists for parity + unit-testable math.
+DOCTRINAL ANCHORS: P1 (observer-set magnitudes via median+MAD), P14 (own
+channel), P15 (fail-closed — invalid price/margin → zero vector, never blocks).
+
+PURE module (no I/O, no time, no DB).
 """
 
 from __future__ import annotations
 
 import math
 import os
-from dataclasses import dataclass, replace
-from typing import Optional
-
-# ── Structural constants (NOT operator knobs) ──────────────────────────────
-# REGRET_DOP_CAP mirrors the trade-outcome dopamine cap (0.5 in push_reward).
-# Regret is the same CLASS of signal as a realised loss, so the foregone gain
-# must be able to sting comparably to a real loss — but BOUNDED so a huge
-# foregone gain cannot produce unbounded aversion. tanh saturates into [0, CAP).
-REGRET_DOP_CAP: float = 0.5
-
-# Small positive "good close" reinforcement when the close avoided a worse
-# outcome (counterfactual <= realized). Much smaller than the regret cap so
-# the asymmetry favours "don't punish closing" without teaching eager closing.
-GOOD_CLOSE_DOP: float = 0.05
+from dataclasses import dataclass
+from typing import Literal, Optional
 
 _EPS: float = 1e-12
+# Minimum samples before the observer scale is trusted (mirrors push_reward /
+# observer_fib_coefficient). Below → no signal (cold-start must not fabricate).
 _MIN_SAMPLES: int = 5
 
 
 def _is_finite(x: object) -> bool:
-    return isinstance(x, (int, float)) and math.isfinite(float(x))
+    return isinstance(x, (int, float)) and not isinstance(x, bool) and math.isfinite(float(x))
 
 
 @dataclass
-class HindsightWatch:
-    """A position that was closed and is now watched for counterfactual pnl."""
+class HindsightNtDeltas:
+    """E6 six-chemical NT delta vector (canon §29.1). Signs are canonical
+    roles; magnitudes are observer-scaled. Flag-OFF callers never read it."""
 
-    symbol: str
-    side_sign: int  # +1 closed long, -1 closed short
-    qty: float
-    exit_price: float
+    dopamine_delta: float = 0.0
+    acetylcholine_delta: float = 0.0
+    norepinephrine_delta: float = 0.0
+    serotonin_delta: float = 0.0
+    gaba_delta: float = 0.0
+    endorphin_delta: float = 0.0
+
+
+@dataclass
+class CloseSenseBundle:
+    """Close-time sense bundle — drives the legibility gate + GABA binding."""
+
+    kernel_owned_close: bool
+    side_sign: int  # +1 long, -1 short
+    warp_expectation_sign: int  # -1 short, 0 flat/observe, +1 long
+    warp_expectation_confidence: float
+    regime_at_close: str
+    basin_dir_at_close: float
+    tape_trend_at_close: float
+    coherence_streak: int
+
+
+@dataclass
+class CounterfactualOutcome:
+    """Counterfactual outcome resolved at the END of the derived horizon."""
+
     realized_pnl_usdt: float
+    horizon_end_pnl_usdt: float  # NOT max favourable excursion
     margin_usdt: float
-    closed_at_ms: float
-    expires_at_ms: float
-    best_counterfactual_pnl_usdt: float
+    regime_persisted: bool
 
 
 @dataclass
-class HindsightRegretDeltas:
-    dopamine_delta: float
+class HindsightResult:
+    nt: HindsightNtDeltas
+    gaba_target: Optional[str]
     foregone_gain_usdt: float
-    regret_frac: float
+    prediction_error_z: float
     source: str
+
+
+def _ineligible(source: str) -> HindsightResult:
+    return HindsightResult(
+        nt=HindsightNtDeltas(),
+        gaba_target=None,
+        foregone_gain_usdt=0.0,
+        prediction_error_z=0.0,
+        source=source,
+    )
+
+
+def median_and_mad(xs: list[float]) -> tuple[float, float]:
+    """(median, MAD) — the observer scale observer_fib_coefficient uses."""
+    finite = [float(x) for x in xs if _is_finite(x)]
+    if not finite:
+        return (0.0, 0.0)
+    s = sorted(finite)
+    n = len(s)
+
+    def _med(arr: list[float]) -> float:
+        m = len(arr)
+        return (arr[m // 2 - 1] + arr[m // 2]) / 2 if m % 2 == 0 else arr[m // 2]
+
+    median = _med(s)
+    devs = sorted(abs(x - median) for x in s)
+    return (median, _med(devs))
 
 
 def counterfactual_pnl_usdt(
@@ -103,9 +138,7 @@ def counterfactual_pnl_usdt(
 
     long  : (price - exit_price) * qty
     short : (exit_price - price) * qty
-
-    Returns the realised pnl PLUS the marginal pnl of holding past the exit
-    (i.e. total "if I'd just left it"). None on any invalid input.
+    Returns realised + marginal. None on any invalid input (fail-closed).
     """
     if not _is_finite(price) or price <= 0:
         return None
@@ -121,77 +154,152 @@ def counterfactual_pnl_usdt(
     return float(realized_pnl_usdt + marginal)
 
 
-def advance_watch(watch: HindsightWatch, price: float) -> HindsightWatch:
-    """Update the running best (most favourable) counterfactual pnl. Pure."""
-    cf = counterfactual_pnl_usdt(
-        side_sign=watch.side_sign,
-        qty=watch.qty,
-        exit_price=watch.exit_price,
-        realized_pnl_usdt=watch.realized_pnl_usdt,
-        price=price,
+def is_continuation_legible(b: CloseSenseBundle) -> bool:
+    """PURITY KEYSTONE part — was the continuation foreseeable at close?
+
+    True iff the close-time senses showed evidence to HOLD: qig-warp
+    expectation favoured the held side with positive confidence, basin
+    direction still leaned the held way, and the hold was coherent for at
+    least one tick. "Legible" = the kernel's own forecast pointed at
+    continuation (low surprise per §31) → a continuation is a prediction
+    error it could have avoided. Otherwise it is surprise/noise.
+    """
+    warp_favoured_hold = (
+        b.warp_expectation_sign == b.side_sign
+        and _is_finite(b.warp_expectation_confidence)
+        and b.warp_expectation_confidence > 0
     )
-    if cf is None:
-        return watch
-    if cf > watch.best_counterfactual_pnl_usdt:
-        return replace(watch, best_counterfactual_pnl_usdt=cf)
-    return watch
+    basin_favoured_hold = (
+        _is_finite(b.basin_dir_at_close)
+        and _sign(b.basin_dir_at_close) == b.side_sign
+    )
+    was_coherent = isinstance(b.coherence_streak, int) and b.coherence_streak > 0
+    return bool(warp_favoured_hold and basin_favoured_hold and was_coherent)
 
 
-def median_absolute_deviation(xs: list[float]) -> float:
-    """MAD around the median — robust statistic mirroring push_reward."""
-    finite = [float(x) for x in xs if _is_finite(x)]
-    if not finite:
-        return 0.0
-    s = sorted(finite)
-    n = len(s)
-    median = (s[n // 2 - 1] + s[n // 2]) / 2 if n % 2 == 0 else s[n // 2]
-    devs = sorted(abs(x - median) for x in s)
-    return (devs[n // 2 - 1] + devs[n // 2]) / 2 if n % 2 == 0 else devs[n // 2]
+def _sign(x: float) -> int:
+    if x > 0:
+        return 1
+    if x < 0:
+        return -1
+    return 0
 
 
-def resolve_regret(
-    watch: HindsightWatch,
+def is_eligible_for_regret(
+    b: CloseSenseBundle,
+    regime_persisted: bool,
+) -> tuple[bool, Literal["eligible", "not_owned", "not_legible", "regime_changed"]]:
+    """owned ∧ legible-at-close ∧ regime-persisted."""
+    if not b.kernel_owned_close:
+        return (False, "not_owned")
+    if not is_continuation_legible(b):
+        return (False, "not_legible")
+    if not regime_persisted:
+        return (False, "regime_changed")
+    return (True, "eligible")
+
+
+def derive_magnitude(
+    frac: float,
+    pnl_frac_history: list[float],
+) -> Optional[tuple[float, float]]:
+    """(z, salience) observer-scaled magnitude, or None if no trusted scale.
+
+    z = |frac| / MAD(history); salience = tanh(z) ∈ [0,1). With < MIN_SAMPLES
+    or MAD≈0 → None (cold-start must not fabricate chemistry).
+    """
+    if not _is_finite(frac):
+        return None
+    if len(pnl_frac_history) < _MIN_SAMPLES:
+        return None
+    _, mad = median_and_mad(pnl_frac_history)
+    if mad <= _EPS:
+        return None
+    z = abs(frac) / mad
+    return (z, math.tanh(z))
+
+
+def gaba_target_key(b: CloseSenseBundle) -> str:
+    """Bind targeted GABA to the (regime, side) premature-close pattern."""
+    side = "long" if b.side_sign == 1 else "short"
+    regime = b.regime_at_close if isinstance(b.regime_at_close, str) and b.regime_at_close else "unknown"
+    return f"premature_close:{regime}:{side}"
+
+
+def resolve_hindsight(
+    bundle: CloseSenseBundle,
+    outcome: CounterfactualOutcome,
     pnl_frac_history: Optional[list[float]] = None,
-) -> HindsightRegretDeltas:
-    """Resolve an (expired) watch into a chemistry delta. Pure.
+) -> HindsightResult:
+    """Resolve a watch at horizon end into the full NT vector. PURE.
 
-    foregone_gain = max(0, best_counterfactual - realized).
-      - <= 0 → close avoided a worse outcome → no regret, mild positive.
-      - > 0  → holding would have won → aversive, bounded.
-
-    regret_frac = foregone_gain / margin, then normalised by the MAD of the
-    kernel's own realised pnl_frac history (observer-derived scale, no
-    hardcoded magnitude). dopamine_delta = -tanh(normalised) * REGRET_DOP_CAP.
+    Mirrors resolveHindsight() in hindsightRegret.ts exactly.
     """
     if pnl_frac_history is None:
         pnl_frac_history = []
 
-    best = watch.best_counterfactual_pnl_usdt
-    realized = watch.realized_pnl_usdt
-    margin = watch.margin_usdt
+    realized = outcome.realized_pnl_usdt
+    horizon_end = outcome.horizon_end_pnl_usdt
+    margin = outcome.margin_usdt
 
-    if not _is_finite(best) or not _is_finite(realized):
-        return HindsightRegretDeltas(0.0, 0.0, 0.0, "hindsight_invalid")
+    # fail-closed
+    if not _is_finite(realized) or not _is_finite(horizon_end):
+        return _ineligible("hindsight_invalid")
     if not _is_finite(margin) or margin <= 0:
-        return HindsightRegretDeltas(0.0, 0.0, 0.0, "hindsight_no_margin")
+        return _ineligible("hindsight_no_margin")
 
-    foregone_gain = best - realized
+    # ownership gate (condition 1)
+    if not bundle.kernel_owned_close:
+        return _ineligible("ineligible_not_owned")
 
+    foregone_gain = horizon_end - realized
+
+    # good-close branch (avoided a worse/equal outcome)
     if foregone_gain <= _EPS:
-        return HindsightRegretDeltas(GOOD_CLOSE_DOP, 0.0, 0.0, "hindsight_good_close")
+        avoided_loss_frac = abs(foregone_gain) / margin
+        mag = derive_magnitude(avoided_loss_frac, pnl_frac_history)
+        if mag is None:
+            return _ineligible("ineligible_noise")
+        _z, s = mag
+        return HindsightResult(
+            nt=HindsightNtDeltas(
+                dopamine_delta=float(s),
+                acetylcholine_delta=float(s),
+                norepinephrine_delta=float(s),
+                serotonin_delta=float(s),
+                gaba_delta=0.0,
+                endorphin_delta=float(s),
+            ),
+            gaba_target=None,
+            foregone_gain_usdt=0.0,
+            prediction_error_z=float(_z),
+            source="hindsight_good_close",
+        )
 
+    # legibility + regime-persistence gate (conditions 2 & 3)
+    eligible, _reason = is_eligible_for_regret(bundle, outcome.regime_persisted)
+    if not eligible:
+        return _ineligible("ineligible_noise")
+
+    # regret branch: legible premature close, observer-scaled
     regret_frac = foregone_gain / margin
-    regret_frac_normalized = regret_frac
-    if len(pnl_frac_history) >= _MIN_SAMPLES:
-        mad = median_absolute_deviation(pnl_frac_history)
-        if mad > _EPS:
-            regret_frac_normalized = regret_frac / mad
+    mag = derive_magnitude(regret_frac, pnl_frac_history)
+    if mag is None:
+        return _ineligible("ineligible_noise")
+    z, s = mag
 
-    dopamine_delta = -math.tanh(regret_frac_normalized) * REGRET_DOP_CAP
-    return HindsightRegretDeltas(
-        dopamine_delta=float(dopamine_delta),
+    return HindsightResult(
+        nt=HindsightNtDeltas(
+            dopamine_delta=float(-s),
+            acetylcholine_delta=float(s),
+            norepinephrine_delta=float(s),
+            serotonin_delta=float(-s),
+            gaba_delta=float(s),
+            endorphin_delta=0.0,
+        ),
+        gaba_target=gaba_target_key(bundle),
         foregone_gain_usdt=float(foregone_gain),
-        regret_frac=float(regret_frac),
+        prediction_error_z=float(z),
         source="hindsight_regret",
     )
 
@@ -202,13 +310,16 @@ def is_hindsight_regret_live() -> bool:
 
 
 __all__ = [
-    "HindsightWatch",
-    "HindsightRegretDeltas",
+    "HindsightNtDeltas",
+    "CloseSenseBundle",
+    "CounterfactualOutcome",
+    "HindsightResult",
+    "median_and_mad",
     "counterfactual_pnl_usdt",
-    "advance_watch",
-    "median_absolute_deviation",
-    "resolve_regret",
+    "is_continuation_legible",
+    "is_eligible_for_regret",
+    "derive_magnitude",
+    "gaba_target_key",
+    "resolve_hindsight",
     "is_hindsight_regret_live",
-    "REGRET_DOP_CAP",
-    "GOOD_CLOSE_DOP",
 ]

--- a/ml-worker/src/monkey_kernel/hindsight_regret.py
+++ b/ml-worker/src/monkey_kernel/hindsight_regret.py
@@ -1,0 +1,214 @@
+"""hindsight_regret.py — counterfactual-regret reward signal (Python parity).
+
+Mirrors apps/api/src/services/monkey/hindsightRegret.ts exactly.
+
+Operator intent (2026-05-29, verbatim): "rather than a knob, it needs to
+feel the pain of this. not so much that its scared to make a trade but enough
+that it thinks about thinking about the trend a second time before closing."
++ "something akin to hindsight. e.g. 'if i just left it i would have got the
+reward'."
+
+CONCEPT (counterfactual regret minimisation):
+  When the kernel closes a position we keep watching the symbol for a forward
+  window and track what the CLOSED position WOULD have earned had it been
+  held. If holding would have beaten the realised close (the trend continued
+  in the position's favour) emit an AVERSIVE "closed too early" chemistry
+  signal scaled by the foregone gain. If closing was correct (price moved
+  against the old position) emit NO regret — optionally a mild positive
+  "good close" reinforcement.
+
+  The ASYMMETRY is load-bearing: regret fires ONLY when holding would have
+  won. That is what stops the signal from making the kernel scared to ever
+  close — there is no penalty for a correct exit, only for an exit that left
+  money on the table in a continuing favourable trend.
+
+DOCTRINAL ANCHORS:
+  - P1 (Observer sets all params from frozen facts): the regret MAGNITUDE is
+    normalised against the kernel's own realised pnl_frac distribution (MAD),
+    exactly like observer_fib_coefficient / push_reward. No hardcoded "how
+    much a foregone gain should sting" knob. The transform shape (tanh) and
+    output cap are STRUCTURAL design constants, mirroring the trade-outcome
+    reward channel.
+  - P14 (Variable Separation): hindsight regret is its OWN chemistry channel.
+    NOT folded into the realised-pnl reward.
+  - P15 (Fail-Closed Safety): non-finite inputs produce zero deltas; never
+    blocks trading.
+
+This module is PURE (no I/O, no time, no DB). The orchestration that registers
+a watch at close, advances it with live price each tick, and pushes the
+resulting deltas lives in loop.ts behind MONKEY_HINDSIGHT_REGRET_LIVE
+(default OFF). The Py side receives the resolved deltas via the autonomic
+prediction-style channel; this module exists for parity + unit-testable math.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass, replace
+from typing import Optional
+
+# ── Structural constants (NOT operator knobs) ──────────────────────────────
+# REGRET_DOP_CAP mirrors the trade-outcome dopamine cap (0.5 in push_reward).
+# Regret is the same CLASS of signal as a realised loss, so the foregone gain
+# must be able to sting comparably to a real loss — but BOUNDED so a huge
+# foregone gain cannot produce unbounded aversion. tanh saturates into [0, CAP).
+REGRET_DOP_CAP: float = 0.5
+
+# Small positive "good close" reinforcement when the close avoided a worse
+# outcome (counterfactual <= realized). Much smaller than the regret cap so
+# the asymmetry favours "don't punish closing" without teaching eager closing.
+GOOD_CLOSE_DOP: float = 0.05
+
+_EPS: float = 1e-12
+_MIN_SAMPLES: int = 5
+
+
+def _is_finite(x: object) -> bool:
+    return isinstance(x, (int, float)) and math.isfinite(float(x))
+
+
+@dataclass
+class HindsightWatch:
+    """A position that was closed and is now watched for counterfactual pnl."""
+
+    symbol: str
+    side_sign: int  # +1 closed long, -1 closed short
+    qty: float
+    exit_price: float
+    realized_pnl_usdt: float
+    margin_usdt: float
+    closed_at_ms: float
+    expires_at_ms: float
+    best_counterfactual_pnl_usdt: float
+
+
+@dataclass
+class HindsightRegretDeltas:
+    dopamine_delta: float
+    foregone_gain_usdt: float
+    regret_frac: float
+    source: str
+
+
+def counterfactual_pnl_usdt(
+    *,
+    side_sign: int,
+    qty: float,
+    exit_price: float,
+    realized_pnl_usdt: float,
+    price: float,
+) -> Optional[float]:
+    """Counterfactual pnl (USDT) of holding the CLOSED position to ``price``.
+
+    long  : (price - exit_price) * qty
+    short : (exit_price - price) * qty
+
+    Returns the realised pnl PLUS the marginal pnl of holding past the exit
+    (i.e. total "if I'd just left it"). None on any invalid input.
+    """
+    if not _is_finite(price) or price <= 0:
+        return None
+    if not _is_finite(qty) or qty <= 0:
+        return None
+    if not _is_finite(exit_price) or exit_price <= 0:
+        return None
+    if not _is_finite(realized_pnl_usdt):
+        return None
+    if side_sign not in (1, -1):
+        return None
+    marginal = (price - exit_price) * side_sign * qty
+    return float(realized_pnl_usdt + marginal)
+
+
+def advance_watch(watch: HindsightWatch, price: float) -> HindsightWatch:
+    """Update the running best (most favourable) counterfactual pnl. Pure."""
+    cf = counterfactual_pnl_usdt(
+        side_sign=watch.side_sign,
+        qty=watch.qty,
+        exit_price=watch.exit_price,
+        realized_pnl_usdt=watch.realized_pnl_usdt,
+        price=price,
+    )
+    if cf is None:
+        return watch
+    if cf > watch.best_counterfactual_pnl_usdt:
+        return replace(watch, best_counterfactual_pnl_usdt=cf)
+    return watch
+
+
+def median_absolute_deviation(xs: list[float]) -> float:
+    """MAD around the median — robust statistic mirroring push_reward."""
+    finite = [float(x) for x in xs if _is_finite(x)]
+    if not finite:
+        return 0.0
+    s = sorted(finite)
+    n = len(s)
+    median = (s[n // 2 - 1] + s[n // 2]) / 2 if n % 2 == 0 else s[n // 2]
+    devs = sorted(abs(x - median) for x in s)
+    return (devs[n // 2 - 1] + devs[n // 2]) / 2 if n % 2 == 0 else devs[n // 2]
+
+
+def resolve_regret(
+    watch: HindsightWatch,
+    pnl_frac_history: Optional[list[float]] = None,
+) -> HindsightRegretDeltas:
+    """Resolve an (expired) watch into a chemistry delta. Pure.
+
+    foregone_gain = max(0, best_counterfactual - realized).
+      - <= 0 → close avoided a worse outcome → no regret, mild positive.
+      - > 0  → holding would have won → aversive, bounded.
+
+    regret_frac = foregone_gain / margin, then normalised by the MAD of the
+    kernel's own realised pnl_frac history (observer-derived scale, no
+    hardcoded magnitude). dopamine_delta = -tanh(normalised) * REGRET_DOP_CAP.
+    """
+    if pnl_frac_history is None:
+        pnl_frac_history = []
+
+    best = watch.best_counterfactual_pnl_usdt
+    realized = watch.realized_pnl_usdt
+    margin = watch.margin_usdt
+
+    if not _is_finite(best) or not _is_finite(realized):
+        return HindsightRegretDeltas(0.0, 0.0, 0.0, "hindsight_invalid")
+    if not _is_finite(margin) or margin <= 0:
+        return HindsightRegretDeltas(0.0, 0.0, 0.0, "hindsight_no_margin")
+
+    foregone_gain = best - realized
+
+    if foregone_gain <= _EPS:
+        return HindsightRegretDeltas(GOOD_CLOSE_DOP, 0.0, 0.0, "hindsight_good_close")
+
+    regret_frac = foregone_gain / margin
+    regret_frac_normalized = regret_frac
+    if len(pnl_frac_history) >= _MIN_SAMPLES:
+        mad = median_absolute_deviation(pnl_frac_history)
+        if mad > _EPS:
+            regret_frac_normalized = regret_frac / mad
+
+    dopamine_delta = -math.tanh(regret_frac_normalized) * REGRET_DOP_CAP
+    return HindsightRegretDeltas(
+        dopamine_delta=float(dopamine_delta),
+        foregone_gain_usdt=float(foregone_gain),
+        regret_frac=float(regret_frac),
+        source="hindsight_regret",
+    )
+
+
+def is_hindsight_regret_live() -> bool:
+    """Feature flag. Default OFF — behaviour byte-identical when unset."""
+    return os.environ.get("MONKEY_HINDSIGHT_REGRET_LIVE") == "true"
+
+
+__all__ = [
+    "HindsightWatch",
+    "HindsightRegretDeltas",
+    "counterfactual_pnl_usdt",
+    "advance_watch",
+    "median_absolute_deviation",
+    "resolve_regret",
+    "is_hindsight_regret_live",
+    "REGRET_DOP_CAP",
+    "GOOD_CLOSE_DOP",
+]

--- a/ml-worker/src/monkey_kernel/hindsight_regret.py
+++ b/ml-worker/src/monkey_kernel/hindsight_regret.py
@@ -156,7 +156,7 @@ def counterfactual_pnl_usdt(
     return float(realized_pnl_usdt + marginal)
 
 
-def _clamp01(x: float) -> float:
+def _clamp_to_unit_interval(x: float) -> float:
     if not _is_finite(x):
         return 0.0
     return max(0.0, min(1.0, float(x)))
@@ -172,7 +172,7 @@ def legibility_strength(b: CloseSenseBundle, regime_persisted: bool = True) -> f
     if not regime_persisted:
         return 0.0
     warp_strength = (
-        _clamp01(b.warp_expectation_confidence)
+        _clamp_to_unit_interval(b.warp_expectation_confidence)
         if b.warp_expectation_sign == b.side_sign
         else 0.0
     )
@@ -186,7 +186,7 @@ def legibility_strength(b: CloseSenseBundle, regime_persisted: bool = True) -> f
         if _is_finite(b.coherence_streak) and b.coherence_streak > 0
         else 0.0
     )
-    return _clamp01(warp_strength * basin_strength * coherence)
+    return _clamp_to_unit_interval(warp_strength * basin_strength * coherence)
 
 
 def is_continuation_legible(b: CloseSenseBundle) -> bool:

--- a/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
+++ b/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
@@ -39,6 +39,7 @@ from monkey_kernel.hindsight_regret import (  # noqa: E402
     is_continuation_legible,
     is_eligible_for_regret,
     is_hindsight_regret_live,
+    legibility_strength,
     median_and_mad,
     resolve_hindsight,
 )
@@ -124,6 +125,19 @@ def test_eligibility_requires_all_three():
     assert is_eligible_for_regret(legible_short_bundle(kernel_owned_close=False), True)[1] == "not_owned"
     assert is_eligible_for_regret(legible_short_bundle(warp_expectation_sign=1), True)[1] == "not_legible"
     assert is_eligible_for_regret(legible_short_bundle(), False)[1] == "regime_changed"
+
+
+def test_weak_legibility_scales_regret_instead_of_full_gate():
+    strong = legibility_strength(legible_short_bundle())
+    weak = legibility_strength(
+        legible_short_bundle(
+            warp_expectation_confidence=0.001,
+            basin_dir_at_close=-0.000001,
+            coherence_streak=1,
+        )
+    )
+    assert weak > 0.0
+    assert weak < strong
 
 
 # ───────────────────────── resolve_hindsight ─────────────────────────
@@ -245,14 +259,19 @@ def test_flag_default_off(monkeypatch):
 
 # ───────────────────────── TS↔Py fixture-level parity ─────────────────────────
 # These expected values were produced by the TS resolveHindsight() on the SAME
-# fixtures (verified in hindsightRegret.test.ts). salience = tanh(|frac|/MAD).
-#   regret:    frac = 30/100 = 0.30, MAD = 0.01 → z = 30 → salience = tanh(30) ≈ 1.0
+# fixtures (verified in hindsightRegret.test.ts). regret salience =
+# tanh(|frac|/MAD) × legibility.
+#   regret:    frac = 30/100 = 0.30, MAD = 0.01 → z = 30 → salience = tanh(30) × legibility
 #   good close: |−20|/100 = 0.20, MAD = 0.01 → z = 20 → salience = tanh(20) ≈ 1.0
 #   small:     1/100 = 0.01, MAD = 0.01 → z = 1 → salience = tanh(1) ≈ 0.7615941559
 
 
 def _salience(frac: float, mad: float) -> float:
     return math.tanh(abs(frac) / mad)
+
+
+def _regret_salience(frac: float, mad: float) -> float:
+    return _salience(frac, mad) * legibility_strength(legible_short_bundle())
 
 
 @pytest.mark.parametrize(
@@ -268,8 +287,8 @@ def test_parity_signs_and_magnitude(horizon_end, expected_source, expected_dop_s
     )
     assert res.source == expected_source
     frac = abs(horizon_end - 0.0) / 100.0
-    s = _salience(frac, 0.01)
-    # dopamine magnitude == salience (regret = -s, good close = +s).
+    s = _regret_salience(frac, 0.01) if expected_source == "hindsight_regret" else _salience(frac, 0.01)
+    # dopamine magnitude == branch salience (regret is legibility-scaled).
     assert res.nt.dopamine_delta == pytest.approx(expected_dop_sign * s, abs=1e-9)
     # ACh / NE always == +salience on both branches.
     assert res.nt.acetylcholine_delta == pytest.approx(s, abs=1e-9)
@@ -281,7 +300,7 @@ def test_parity_small_foregone_salience():
     res = resolve_hindsight(
         legible_short_bundle(), won_outcome(horizon_end_pnl_usdt=1.0), PNL_FRAC_HISTORY,
     )
-    s = _salience(0.01, 0.01)
+    s = _regret_salience(0.01, 0.01)
     assert res.nt.dopamine_delta == pytest.approx(-s, abs=1e-9)
     assert res.prediction_error_z == pytest.approx(1.0, abs=1e-9)
 
@@ -315,22 +334,23 @@ def test_autonomic_flag_off_byte_identical():
     assert base_nc.as_dict() == hs_nc.as_dict()
 
 
-def test_autonomic_hindsight_fold_moves_all_six_channels():
+def test_autonomic_hindsight_fold_keeps_gaba_targeted_not_global():
     """A pushed hindsight vector folds dop/ser/endo (reward channel) and
-    ACh/NE/GABA (post-derivation) — all six move from the flag-OFF baseline."""
+    ACh/NE (post-derivation). GABA is not applied globally; it is targeted
+    on the TS side until a Py-side targeted executive consumer exists."""
     k = AutonomicKernel(label="t-fold")
     inp = _tick_inputs()
     baseline = k.tick(inp).nc.as_dict()
-    # Aversive-style vector (regret): dop-, ser-, ACh+, NE+, GABA+, endo 0.
+    # Aversive-style vector (regret): dop-, ser-, ACh+, NE+, targeted GABA+, endo 0.
     k.push_hindsight_chemistry(
         dopamine_delta=-0.4, serotonin_delta=-0.4, acetylcholine_delta=0.4,
         norepinephrine_delta=0.4, gaba_delta=0.4, endorphin_delta=0.0,
     )
     after = k.tick(inp).nc.as_dict()
-    # ACh / NE / GABA increased; dop / ser decreased (or stayed at floor).
+    # ACh / NE increased; global GABA does not move; dop / ser decreased (or stayed at floor).
     assert after["acetylcholine"] >= baseline["acetylcholine"]
     assert after["norepinephrine"] > baseline["norepinephrine"]
-    assert after["gaba"] > baseline["gaba"]
+    assert after["gaba"] == baseline["gaba"]
     assert after["dopamine"] <= baseline["dopamine"]
 
 

--- a/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
+++ b/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
@@ -1,0 +1,199 @@
+"""test_hindsight_regret.py — counterfactual-regret reward signal (Py parity).
+
+Mirror of apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts.
+
+Semantic cases (operator spec 2026-05-29):
+  - held-would-have-won  → aversive regret scaled by foregone gain
+  - held-would-have-lost → no regret / mild positive (good close)
+  - regret bounded        → huge foregone gain doesn't blow up chemistry
+  - flag OFF              → loss-side chemistry byte-identical to legacy
+
+Also pins the flag-gated loss-side de-saturation in autonomic.push_reward:
+  - flag OFF → legacy `-tanh(-pnl_frac*0.5)*0.1` (saturating)
+  - flag ON  → MAD-normalised, magnitude-preserving, bounded < win cap
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from monkey_kernel.hindsight_regret import (  # noqa: E402
+    HindsightWatch,
+    counterfactual_pnl_usdt,
+    advance_watch,
+    resolve_regret,
+    median_absolute_deviation,
+    is_hindsight_regret_live,
+    REGRET_DOP_CAP,
+    GOOD_CLOSE_DOP,
+)
+
+
+def _watch(**overrides) -> HindsightWatch:
+    base = dict(
+        symbol="BTC_USDT_PERP",
+        side_sign=-1,  # closed short
+        qty=1.0,
+        exit_price=100.0,
+        realized_pnl_usdt=-36.0,
+        margin_usdt=100.0,
+        closed_at_ms=0.0,
+        expires_at_ms=30 * 60 * 1000.0,
+        best_counterfactual_pnl_usdt=-36.0,
+    )
+    base.update(overrides)
+    return HindsightWatch(**base)
+
+
+def test_counterfactual_short_gains_when_price_falls():
+    cf = counterfactual_pnl_usdt(
+        side_sign=-1, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=90.0
+    )
+    assert cf == pytest.approx(-26.0)
+
+
+def test_counterfactual_short_loses_when_price_rises():
+    cf = counterfactual_pnl_usdt(
+        side_sign=-1, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=110.0
+    )
+    assert cf == pytest.approx(-46.0)
+
+
+def test_counterfactual_long_gains_when_price_rises():
+    cf = counterfactual_pnl_usdt(
+        side_sign=1, qty=2.0, exit_price=50.0, realized_pnl_usdt=5.0, price=55.0
+    )
+    assert cf == pytest.approx(15.0)
+
+
+def test_counterfactual_fails_closed():
+    assert counterfactual_pnl_usdt(side_sign=-1, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=float("nan")) is None
+    assert counterfactual_pnl_usdt(side_sign=-1, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=-1.0) is None
+    assert counterfactual_pnl_usdt(side_sign=0, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=90.0) is None
+
+
+def test_advance_tracks_best():
+    w = _watch()
+    w = advance_watch(w, 95.0)
+    assert w.best_counterfactual_pnl_usdt == pytest.approx(-31.0)
+    w = advance_watch(w, 90.0)
+    assert w.best_counterfactual_pnl_usdt == pytest.approx(-26.0)
+    w = advance_watch(w, 98.0)
+    assert w.best_counterfactual_pnl_usdt == pytest.approx(-26.0)
+    w = advance_watch(w, float("nan"))
+    assert w.best_counterfactual_pnl_usdt == pytest.approx(-26.0)
+
+
+def test_regret_held_would_have_won_aversive():
+    w = _watch(best_counterfactual_pnl_usdt=-10.0)  # foregone = 26
+    d = resolve_regret(w, [])
+    assert d.source == "hindsight_regret"
+    assert d.foregone_gain_usdt == pytest.approx(26.0)
+    assert d.dopamine_delta < 0
+    assert d.dopamine_delta == pytest.approx(-math.tanh(0.26) * REGRET_DOP_CAP)
+
+
+def test_regret_monotone_in_foregone_gain():
+    small = resolve_regret(_watch(best_counterfactual_pnl_usdt=-30.0), [])
+    big = resolve_regret(_watch(best_counterfactual_pnl_usdt=50.0), [])
+    assert abs(big.dopamine_delta) > abs(small.dopamine_delta)
+
+
+def test_good_close_no_regret_mild_positive():
+    w = _watch(best_counterfactual_pnl_usdt=-46.0)  # holding would have lost more
+    d = resolve_regret(w, [])
+    assert d.source == "hindsight_good_close"
+    assert d.foregone_gain_usdt == 0.0
+    assert d.dopamine_delta == GOOD_CLOSE_DOP
+    assert d.dopamine_delta > 0
+
+
+def test_breakeven_is_good_close():
+    d = resolve_regret(_watch(best_counterfactual_pnl_usdt=-36.0), [])
+    assert d.source == "hindsight_good_close"
+
+
+def test_regret_bounded():
+    d = resolve_regret(_watch(best_counterfactual_pnl_usdt=1_000_000.0), [])
+    # tanh asymptotes to 1.0 → delta is bounded AT (never beyond) the cap.
+    assert d.dopamine_delta >= -REGRET_DOP_CAP
+    assert d.dopamine_delta <= 0
+    assert abs(d.dopamine_delta) <= REGRET_DOP_CAP
+
+
+def test_observer_mad_scales_sting():
+    tight = [0.001, 0.002, -0.001, 0.0, 0.0015]
+    wide = [0.5, -0.5, 0.3, -0.3, 0.0]
+    t = resolve_regret(_watch(best_counterfactual_pnl_usdt=-30.0), tight)
+    w = resolve_regret(_watch(best_counterfactual_pnl_usdt=-30.0), wide)
+    assert abs(t.dopamine_delta) > abs(w.dopamine_delta)
+    assert abs(t.dopamine_delta) <= REGRET_DOP_CAP
+
+
+def test_regret_fails_closed():
+    assert resolve_regret(_watch(best_counterfactual_pnl_usdt=10.0, margin_usdt=0.0), []).dopamine_delta == 0
+    assert resolve_regret(_watch(best_counterfactual_pnl_usdt=float("nan")), []).dopamine_delta == 0
+
+
+def test_mad_shape():
+    assert median_absolute_deviation([]) == 0
+    assert median_absolute_deviation([1, 1, 1]) == 0
+    assert median_absolute_deviation([1, 2, 3, 4, 5]) == 1
+
+
+def test_flag_default_off(monkeypatch):
+    monkeypatch.delenv("MONKEY_HINDSIGHT_REGRET_LIVE", raising=False)
+    assert is_hindsight_regret_live() is False
+    monkeypatch.setenv("MONKEY_HINDSIGHT_REGRET_LIVE", "false")
+    assert is_hindsight_regret_live() is False
+    monkeypatch.setenv("MONKEY_HINDSIGHT_REGRET_LIVE", "true")
+    assert is_hindsight_regret_live() is True
+
+
+# ── loss-side de-saturation in autonomic.push_reward (flag-gated) ───────────
+
+from monkey_kernel.autonomic import AutonomicKernel  # noqa: E402
+
+
+def _loss_dop(kernel: AutonomicKernel, pnl_usdt: float, margin: float) -> float:
+    r = kernel.push_reward(
+        source="own_close", realized_pnl_usdt=pnl_usdt, margin_usdt=margin, symbol="BTC_USDT_PERP"
+    )
+    return r.dopamine_delta
+
+
+def test_loss_branch_flag_off_is_legacy(monkeypatch):
+    monkeypatch.delenv("MONKEY_HINDSIGHT_REGRET_LIVE", raising=False)
+    k = AutonomicKernel(label="t-off")
+    # -3% ROE loss on $100 margin → pnl_frac = -0.03
+    dop = _loss_dop(k, -3.0, 100.0)
+    expected = -math.tanh(0.03 * 0.5) * 0.1  # legacy shape
+    assert dop == pytest.approx(expected)
+
+
+def test_loss_branch_flag_on_preserves_magnitude(monkeypatch):
+    monkeypatch.setenv("MONKEY_HINDSIGHT_REGRET_LIVE", "true")
+    k = AutonomicKernel(label="t-on")
+    # Seed a tight realised pnl_frac history so MAD normalisation engages.
+    # History is appended only for polo_authoritative_close source.
+    for _ in range(6):
+        k.push_reward(source="polo_authoritative_close", realized_pnl_usdt=0.2, margin_usdt=100.0, symbol="BTC_USDT_PERP")
+    big_loss = _loss_dop(k, -10.0, 100.0)   # pnl_frac -0.10
+    small_loss = _loss_dop(k, -1.0, 100.0)  # pnl_frac -0.01
+    # De-saturated: a big loss must hurt strictly more than a small one,
+    # and by a margin the legacy saturating formula could not produce.
+    assert abs(big_loss) > abs(small_loss)
+    # Bounded below the win-side cap (0.5) → cap is 0.3 here.
+    assert abs(big_loss) <= 0.3
+    # And it must be meaningfully larger than the legacy value for the same
+    # loss (legacy would give ~-0.005 for -10% / margin scale).
+    legacy_big = -math.tanh(0.10 * 0.5) * 0.1
+    assert abs(big_loss) > abs(legacy_big)

--- a/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
+++ b/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
@@ -336,9 +336,22 @@ def test_autonomic_hindsight_fold_moves_all_six_channels():
 
 def test_autonomic_hindsight_fail_closed_non_finite():
     k = AutonomicKernel(label="t-nan")
-    k.push_hindsight_chemistry(dopamine_delta=float("nan"), gaba_delta=float("inf"))
+    k.push_hindsight_chemistry(
+        dopamine_delta=float("nan"),
+        gaba_delta=float("inf"),
+        serotonin_delta="not-a-number",
+    )
     assert k._cached_hindsight_chemistry["dopamine_delta"] == 0.0
     assert k._cached_hindsight_chemistry["gaba_delta"] == 0.0
+    assert k._cached_hindsight_chemistry["serotonin_delta"] == 0.0
+
+
+def test_autonomic_hindsight_cache_decays_without_new_push():
+    k = AutonomicKernel(label="t-decay")
+    k.push_hindsight_chemistry(gaba_delta=0.8)
+    k._cached_hindsight_chemistry_at_ms = 0.0
+    k.tick(_tick_inputs(now_ms=20 * 60 * 1000.0))
+    assert k._cached_hindsight_chemistry["gaba_delta"] == pytest.approx(0.4, abs=1e-6)
 
 
 def test_autonomic_hindsight_cleared_on_wake():

--- a/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
+++ b/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
@@ -1,16 +1,21 @@
-"""test_hindsight_regret.py — counterfactual-regret reward signal (Py parity).
+"""test_hindsight_regret.py — legibility-gated counterfactual prediction error
+(Python parity).
 
 Mirror of apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts.
 
-Semantic cases (operator spec 2026-05-29):
-  - held-would-have-won  → aversive regret scaled by foregone gain
-  - held-would-have-lost → no regret / mild positive (good close)
-  - regret bounded        → huge foregone gain doesn't blow up chemistry
-  - flag OFF              → loss-side chemistry byte-identical to legacy
+Semantic cases (operator doctrine 2026-05-29, redesign of PR #1038):
+  - legible premature close   → full regret vector, correct signs, observer-scaled
+  - NON-legible continuation  → NO regret (surprise/noise), zero vector
+  - operator / non-owned close → no self-regret
+  - regime changed after close → no/zero regret
+  - good close / avoided loss  → relief vector (no aversion)
+  - targeted GABA              → bound to (regime,side) pattern, never global
+  - observer scale             → magnitude tracks the kernel's own MAD
+  - fail-closed                → invalid price/margin → zero vector
+  - flag OFF                   → byte-identical chemistry
 
-Also pins the flag-gated loss-side de-saturation in autonomic.push_reward:
-  - flag OFF → legacy `-tanh(-pnl_frac*0.5)*0.1` (saturating)
-  - flag ON  → MAD-normalised, magnitude-preserving, bounded < win cap
+The FIXTURES + EXPECTED block is shared with the TS test so TS↔Py outputs are
+asserted equal within tolerance (the parity assertions at the bottom).
 """
 from __future__ import annotations
 
@@ -26,174 +31,318 @@ if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
 from monkey_kernel.hindsight_regret import (  # noqa: E402
-    HindsightWatch,
+    CloseSenseBundle,
+    CounterfactualOutcome,
     counterfactual_pnl_usdt,
-    advance_watch,
-    resolve_regret,
-    median_absolute_deviation,
+    derive_magnitude,
+    gaba_target_key,
+    is_continuation_legible,
+    is_eligible_for_regret,
     is_hindsight_regret_live,
-    REGRET_DOP_CAP,
-    GOOD_CLOSE_DOP,
+    median_and_mad,
+    resolve_hindsight,
 )
 
+# ── Shared fixtures (byte-for-byte with hindsightRegret.test.ts) ──
+PNL_FRAC_HISTORY = [0.0, 0.01, -0.01, 0.02, -0.02, 0.0, 0.01, -0.01]
 
-def _watch(**overrides) -> HindsightWatch:
+
+def legible_short_bundle(**overrides) -> CloseSenseBundle:
     base = dict(
-        symbol="BTC_USDT_PERP",
-        side_sign=-1,  # closed short
-        qty=1.0,
-        exit_price=100.0,
-        realized_pnl_usdt=-36.0,
-        margin_usdt=100.0,
-        closed_at_ms=0.0,
-        expires_at_ms=30 * 60 * 1000.0,
-        best_counterfactual_pnl_usdt=-36.0,
+        kernel_owned_close=True,
+        side_sign=-1,
+        warp_expectation_sign=-1,
+        warp_expectation_confidence=0.7,
+        regime_at_close="aligned",
+        basin_dir_at_close=-0.25,
+        tape_trend_at_close=-0.3,
+        coherence_streak=4,
     )
     base.update(overrides)
-    return HindsightWatch(**base)
+    return CloseSenseBundle(**base)
 
 
-def test_counterfactual_short_gains_when_price_falls():
-    cf = counterfactual_pnl_usdt(
-        side_sign=-1, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=90.0
+def won_outcome(**overrides) -> CounterfactualOutcome:
+    base = dict(
+        realized_pnl_usdt=0.0,
+        horizon_end_pnl_usdt=30.0,
+        margin_usdt=100.0,
+        regime_persisted=True,
     )
-    assert cf == pytest.approx(-26.0)
+    base.update(overrides)
+    return CounterfactualOutcome(**base)
 
 
-def test_counterfactual_short_loses_when_price_rises():
+# ───────────────────────── counterfactual_pnl_usdt ─────────────────────────
+
+
+def test_short_gains_as_price_falls():
     cf = counterfactual_pnl_usdt(
-        side_sign=-1, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=110.0
+        side_sign=-1, qty=2, exit_price=100, realized_pnl_usdt=5, price=90,
     )
-    assert cf == pytest.approx(-46.0)
+    assert cf == pytest.approx(25.0, abs=1e-6)
 
 
-def test_counterfactual_long_gains_when_price_rises():
+def test_long_gains_as_price_rises():
     cf = counterfactual_pnl_usdt(
-        side_sign=1, qty=2.0, exit_price=50.0, realized_pnl_usdt=5.0, price=55.0
+        side_sign=1, qty=2, exit_price=100, realized_pnl_usdt=5, price=110,
     )
-    assert cf == pytest.approx(15.0)
+    assert cf == pytest.approx(25.0, abs=1e-6)
 
 
-def test_counterfactual_fails_closed():
-    assert counterfactual_pnl_usdt(side_sign=-1, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=float("nan")) is None
-    assert counterfactual_pnl_usdt(side_sign=-1, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=-1.0) is None
-    assert counterfactual_pnl_usdt(side_sign=0, qty=1.0, exit_price=100.0, realized_pnl_usdt=-36.0, price=90.0) is None
+def test_counterfactual_fail_closed():
+    assert counterfactual_pnl_usdt(side_sign=1, qty=2, exit_price=100, realized_pnl_usdt=5, price=0) is None
+    assert counterfactual_pnl_usdt(side_sign=1, qty=0, exit_price=100, realized_pnl_usdt=5, price=90) is None
+    assert counterfactual_pnl_usdt(side_sign=1, qty=2, exit_price=-1, realized_pnl_usdt=5, price=90) is None
 
 
-def test_advance_tracks_best():
-    w = _watch()
-    w = advance_watch(w, 95.0)
-    assert w.best_counterfactual_pnl_usdt == pytest.approx(-31.0)
-    w = advance_watch(w, 90.0)
-    assert w.best_counterfactual_pnl_usdt == pytest.approx(-26.0)
-    w = advance_watch(w, 98.0)
-    assert w.best_counterfactual_pnl_usdt == pytest.approx(-26.0)
-    w = advance_watch(w, float("nan"))
-    assert w.best_counterfactual_pnl_usdt == pytest.approx(-26.0)
+# ───────────────────────── legibility gate ─────────────────────────
 
 
-def test_regret_held_would_have_won_aversive():
-    w = _watch(best_counterfactual_pnl_usdt=-10.0)  # foregone = 26
-    d = resolve_regret(w, [])
-    assert d.source == "hindsight_regret"
-    assert d.foregone_gain_usdt == pytest.approx(26.0)
-    assert d.dopamine_delta < 0
-    assert d.dopamine_delta == pytest.approx(-math.tanh(0.26) * REGRET_DOP_CAP)
+def test_legible_when_warp_basin_agree_and_coherent():
+    assert is_continuation_legible(legible_short_bundle()) is True
 
 
-def test_regret_monotone_in_foregone_gain():
-    small = resolve_regret(_watch(best_counterfactual_pnl_usdt=-30.0), [])
-    big = resolve_regret(_watch(best_counterfactual_pnl_usdt=50.0), [])
-    assert abs(big.dopamine_delta) > abs(small.dopamine_delta)
+def test_not_legible_when_warp_disagrees():
+    assert is_continuation_legible(legible_short_bundle(warp_expectation_sign=1)) is False
 
 
-def test_good_close_no_regret_mild_positive():
-    w = _watch(best_counterfactual_pnl_usdt=-46.0)  # holding would have lost more
-    d = resolve_regret(w, [])
-    assert d.source == "hindsight_good_close"
-    assert d.foregone_gain_usdt == 0.0
-    assert d.dopamine_delta == GOOD_CLOSE_DOP
-    assert d.dopamine_delta > 0
+def test_not_legible_when_basin_flips():
+    assert is_continuation_legible(legible_short_bundle(basin_dir_at_close=0.25)) is False
 
 
-def test_breakeven_is_good_close():
-    d = resolve_regret(_watch(best_counterfactual_pnl_usdt=-36.0), [])
-    assert d.source == "hindsight_good_close"
+def test_not_legible_when_warp_flat():
+    assert is_continuation_legible(legible_short_bundle(warp_expectation_sign=0)) is False
 
 
-def test_regret_bounded():
-    d = resolve_regret(_watch(best_counterfactual_pnl_usdt=1_000_000.0), [])
-    # tanh asymptotes to 1.0 → delta is bounded AT (never beyond) the cap.
-    assert d.dopamine_delta >= -REGRET_DOP_CAP
-    assert d.dopamine_delta <= 0
-    assert abs(d.dopamine_delta) <= REGRET_DOP_CAP
+def test_not_legible_when_not_coherent():
+    assert is_continuation_legible(legible_short_bundle(coherence_streak=0)) is False
 
 
-def test_observer_mad_scales_sting():
-    tight = [0.001, 0.002, -0.001, 0.0, 0.0015]
-    wide = [0.5, -0.5, 0.3, -0.3, 0.0]
-    t = resolve_regret(_watch(best_counterfactual_pnl_usdt=-30.0), tight)
-    w = resolve_regret(_watch(best_counterfactual_pnl_usdt=-30.0), wide)
-    assert abs(t.dopamine_delta) > abs(w.dopamine_delta)
-    assert abs(t.dopamine_delta) <= REGRET_DOP_CAP
+def test_eligibility_requires_all_three():
+    assert is_eligible_for_regret(legible_short_bundle(), True) == (True, "eligible")
+    assert is_eligible_for_regret(legible_short_bundle(kernel_owned_close=False), True)[1] == "not_owned"
+    assert is_eligible_for_regret(legible_short_bundle(warp_expectation_sign=1), True)[1] == "not_legible"
+    assert is_eligible_for_regret(legible_short_bundle(), False)[1] == "regime_changed"
 
 
-def test_regret_fails_closed():
-    assert resolve_regret(_watch(best_counterfactual_pnl_usdt=10.0, margin_usdt=0.0), []).dopamine_delta == 0
-    assert resolve_regret(_watch(best_counterfactual_pnl_usdt=float("nan")), []).dopamine_delta == 0
+# ───────────────────────── resolve_hindsight ─────────────────────────
 
 
-def test_mad_shape():
-    assert median_absolute_deviation([]) == 0
-    assert median_absolute_deviation([1, 1, 1]) == 0
-    assert median_absolute_deviation([1, 2, 3, 4, 5]) == 1
+def test_legible_premature_close_full_regret_vector():
+    res = resolve_hindsight(legible_short_bundle(), won_outcome(), PNL_FRAC_HISTORY)
+    assert res.source == "hindsight_regret"
+    assert res.nt.dopamine_delta < 0
+    assert res.nt.serotonin_delta < 0
+    assert res.nt.acetylcholine_delta > 0
+    assert res.nt.norepinephrine_delta > 0
+    assert res.nt.gaba_delta > 0
+    assert res.nt.endorphin_delta == 0
+    assert res.gaba_target == "premature_close:aligned:short"
+    assert res.foregone_gain_usdt == pytest.approx(30.0, abs=1e-6)
+
+
+def test_non_legible_continuation_no_regret():
+    res = resolve_hindsight(
+        legible_short_bundle(warp_expectation_sign=1), won_outcome(), PNL_FRAC_HISTORY,
+    )
+    assert res.source == "ineligible_noise"
+    assert res.nt.dopamine_delta == 0
+    assert res.nt.gaba_delta == 0
+    assert res.gaba_target is None
+
+
+def test_non_owned_close_no_self_regret():
+    res = resolve_hindsight(
+        legible_short_bundle(kernel_owned_close=False), won_outcome(), PNL_FRAC_HISTORY,
+    )
+    assert res.source == "ineligible_not_owned"
+    assert (res.nt.dopamine_delta, res.nt.gaba_delta, res.nt.acetylcholine_delta) == (0, 0, 0)
+
+
+def test_regime_changed_no_regret():
+    res = resolve_hindsight(
+        legible_short_bundle(), won_outcome(regime_persisted=False), PNL_FRAC_HISTORY,
+    )
+    assert res.source == "ineligible_noise"
+    assert res.nt.dopamine_delta == 0
+
+
+def test_good_close_relief_vector():
+    res = resolve_hindsight(
+        legible_short_bundle(),
+        won_outcome(horizon_end_pnl_usdt=-20.0),
+        PNL_FRAC_HISTORY,
+    )
+    assert res.source == "hindsight_good_close"
+    assert res.nt.dopamine_delta > 0
+    assert res.nt.serotonin_delta > 0
+    assert res.nt.acetylcholine_delta > 0
+    assert res.nt.endorphin_delta > 0
+    assert res.nt.gaba_delta == 0
+    assert res.gaba_target is None
+
+
+def test_gaba_stays_targeted_per_pattern():
+    long_res = resolve_hindsight(
+        legible_short_bundle(
+            side_sign=1, warp_expectation_sign=1, basin_dir_at_close=0.25,
+            regime_at_close="reverse_tape",
+        ),
+        won_outcome(), PNL_FRAC_HISTORY,
+    )
+    assert long_res.gaba_target == "premature_close:reverse_tape:long"
+    short_res = resolve_hindsight(legible_short_bundle(), won_outcome(), PNL_FRAC_HISTORY)
+    assert long_res.gaba_target != short_res.gaba_target
+
+
+def test_observer_scale_tracks_own_mad():
+    tight = resolve_hindsight(legible_short_bundle(), won_outcome(), PNL_FRAC_HISTORY)
+    wide = resolve_hindsight(
+        legible_short_bundle(), won_outcome(), [x * 10 for x in PNL_FRAC_HISTORY],
+    )
+    assert abs(wide.nt.dopamine_delta) < abs(tight.nt.dopamine_delta)
+    small = resolve_hindsight(
+        legible_short_bundle(), won_outcome(horizon_end_pnl_usdt=1.0), PNL_FRAC_HISTORY,
+    )
+    assert abs(small.nt.dopamine_delta) < abs(tight.nt.dopamine_delta)
+
+
+def test_cold_start_emits_nothing():
+    res = resolve_hindsight(legible_short_bundle(), won_outcome(), [0.01, 0.02])
+    assert res.source == "ineligible_noise"
+    assert res.nt.dopamine_delta == 0
+
+
+def test_fail_closed_invalid_margin_pnl():
+    assert resolve_hindsight(legible_short_bundle(), won_outcome(margin_usdt=0), PNL_FRAC_HISTORY).source == "hindsight_no_margin"
+    assert resolve_hindsight(legible_short_bundle(), won_outcome(horizon_end_pnl_usdt=float("nan")), PNL_FRAC_HISTORY).source == "hindsight_invalid"
+
+
+def test_median_and_mad_matches_observer_scale():
+    median, mad = median_and_mad(PNL_FRAC_HISTORY)
+    assert median == pytest.approx(0.0, abs=1e-6)
+    assert mad == pytest.approx(0.01, abs=1e-6)
+
+
+def test_derive_magnitude_none_below_min_or_zero_mad():
+    assert derive_magnitude(0.3, [0.01]) is None
+    assert derive_magnitude(0.3, [0.05, 0.05, 0.05, 0.05, 0.05]) is None
+
+
+def test_gaba_target_defaults_unknown_regime():
+    assert gaba_target_key(legible_short_bundle(regime_at_close="")) == "premature_close:unknown:short"
 
 
 def test_flag_default_off(monkeypatch):
     monkeypatch.delenv("MONKEY_HINDSIGHT_REGRET_LIVE", raising=False)
     assert is_hindsight_regret_live() is False
-    monkeypatch.setenv("MONKEY_HINDSIGHT_REGRET_LIVE", "false")
-    assert is_hindsight_regret_live() is False
     monkeypatch.setenv("MONKEY_HINDSIGHT_REGRET_LIVE", "true")
     assert is_hindsight_regret_live() is True
+    monkeypatch.setenv("MONKEY_HINDSIGHT_REGRET_LIVE", "1")
+    assert is_hindsight_regret_live() is False
 
 
-# ── loss-side de-saturation in autonomic.push_reward (flag-gated) ───────────
+# ───────────────────────── TS↔Py fixture-level parity ─────────────────────────
+# These expected values were produced by the TS resolveHindsight() on the SAME
+# fixtures (verified in hindsightRegret.test.ts). salience = tanh(|frac|/MAD).
+#   regret:    frac = 30/100 = 0.30, MAD = 0.01 → z = 30 → salience = tanh(30) ≈ 1.0
+#   good close: |−20|/100 = 0.20, MAD = 0.01 → z = 20 → salience = tanh(20) ≈ 1.0
+#   small:     1/100 = 0.01, MAD = 0.01 → z = 1 → salience = tanh(1) ≈ 0.7615941559
 
-from monkey_kernel.autonomic import AutonomicKernel  # noqa: E402
+
+def _salience(frac: float, mad: float) -> float:
+    return math.tanh(abs(frac) / mad)
 
 
-def _loss_dop(kernel: AutonomicKernel, pnl_usdt: float, margin: float) -> float:
-    r = kernel.push_reward(
-        source="own_close", realized_pnl_usdt=pnl_usdt, margin_usdt=margin, symbol="BTC_USDT_PERP"
+@pytest.mark.parametrize(
+    "horizon_end,expected_source,expected_dop_sign",
+    [
+        (30.0, "hindsight_regret", -1),
+        (-20.0, "hindsight_good_close", +1),
+    ],
+)
+def test_parity_signs_and_magnitude(horizon_end, expected_source, expected_dop_sign):
+    res = resolve_hindsight(
+        legible_short_bundle(), won_outcome(horizon_end_pnl_usdt=horizon_end), PNL_FRAC_HISTORY,
     )
-    return r.dopamine_delta
+    assert res.source == expected_source
+    frac = abs(horizon_end - 0.0) / 100.0
+    s = _salience(frac, 0.01)
+    # dopamine magnitude == salience (regret = -s, good close = +s).
+    assert res.nt.dopamine_delta == pytest.approx(expected_dop_sign * s, abs=1e-9)
+    # ACh / NE always == +salience on both branches.
+    assert res.nt.acetylcholine_delta == pytest.approx(s, abs=1e-9)
+    assert res.nt.norepinephrine_delta == pytest.approx(s, abs=1e-9)
 
 
-def test_loss_branch_flag_off_is_legacy(monkeypatch):
-    monkeypatch.delenv("MONKEY_HINDSIGHT_REGRET_LIVE", raising=False)
-    k = AutonomicKernel(label="t-off")
-    # -3% ROE loss on $100 margin → pnl_frac = -0.03
-    dop = _loss_dop(k, -3.0, 100.0)
-    expected = -math.tanh(0.03 * 0.5) * 0.1  # legacy shape
-    assert dop == pytest.approx(expected)
+def test_parity_small_foregone_salience():
+    # frac 0.01, MAD 0.01 → z 1 → salience tanh(1).
+    res = resolve_hindsight(
+        legible_short_bundle(), won_outcome(horizon_end_pnl_usdt=1.0), PNL_FRAC_HISTORY,
+    )
+    s = _salience(0.01, 0.01)
+    assert res.nt.dopamine_delta == pytest.approx(-s, abs=1e-9)
+    assert res.prediction_error_z == pytest.approx(1.0, abs=1e-9)
 
 
-def test_loss_branch_flag_on_preserves_magnitude(monkeypatch):
-    monkeypatch.setenv("MONKEY_HINDSIGHT_REGRET_LIVE", "true")
-    k = AutonomicKernel(label="t-on")
-    # Seed a tight realised pnl_frac history so MAD normalisation engages.
-    # History is appended only for polo_authoritative_close source.
-    for _ in range(6):
-        k.push_reward(source="polo_authoritative_close", realized_pnl_usdt=0.2, margin_usdt=100.0, symbol="BTC_USDT_PERP")
-    big_loss = _loss_dop(k, -10.0, 100.0)   # pnl_frac -0.10
-    small_loss = _loss_dop(k, -1.0, 100.0)  # pnl_frac -0.01
-    # De-saturated: a big loss must hurt strictly more than a small one,
-    # and by a margin the legacy saturating formula could not produce.
-    assert abs(big_loss) > abs(small_loss)
-    # Bounded below the win-side cap (0.5) → cap is 0.3 here.
-    assert abs(big_loss) <= 0.3
-    # And it must be meaningfully larger than the legacy value for the same
-    # loss (legacy would give ~-0.005 for -10% / margin scale).
-    legacy_big = -math.tanh(0.10 * 0.5) * 0.1
-    assert abs(big_loss) > abs(legacy_big)
+# ───────── AutonomicKernel hindsight fold (flag-OFF byte-identity) ─────────
+
+from monkey_kernel.autonomic import AutonomicKernel, AutonomicTickInputs  # noqa: E402
+
+
+def _tick_inputs(**overrides) -> AutonomicTickInputs:
+    base = dict(
+        phi_delta=0.0,
+        basin_velocity=0.1,
+        surprise=0.2,
+        quantum_weight=0.5,
+        kappa=63.8,
+        external_coupling=0.3,
+    )
+    base.update(overrides)
+    return AutonomicTickInputs(**base)
+
+
+def test_autonomic_flag_off_byte_identical():
+    """No hindsight push → chemistry identical to a kernel that never knew
+    about hindsight (the cache is all-zero, folds add nothing)."""
+    k_base = AutonomicKernel(label="t-base")
+    k_hs = AutonomicKernel(label="t-hs")
+    inp = _tick_inputs()
+    base_nc = k_base.tick(inp).nc
+    hs_nc = k_hs.tick(inp).nc  # never pushed → cache all-zero
+    assert base_nc.as_dict() == hs_nc.as_dict()
+
+
+def test_autonomic_hindsight_fold_moves_all_six_channels():
+    """A pushed hindsight vector folds dop/ser/endo (reward channel) and
+    ACh/NE/GABA (post-derivation) — all six move from the flag-OFF baseline."""
+    k = AutonomicKernel(label="t-fold")
+    inp = _tick_inputs()
+    baseline = k.tick(inp).nc.as_dict()
+    # Aversive-style vector (regret): dop-, ser-, ACh+, NE+, GABA+, endo 0.
+    k.push_hindsight_chemistry(
+        dopamine_delta=-0.4, serotonin_delta=-0.4, acetylcholine_delta=0.4,
+        norepinephrine_delta=0.4, gaba_delta=0.4, endorphin_delta=0.0,
+    )
+    after = k.tick(inp).nc.as_dict()
+    # ACh / NE / GABA increased; dop / ser decreased (or stayed at floor).
+    assert after["acetylcholine"] >= baseline["acetylcholine"]
+    assert after["norepinephrine"] > baseline["norepinephrine"]
+    assert after["gaba"] > baseline["gaba"]
+    assert after["dopamine"] <= baseline["dopamine"]
+
+
+def test_autonomic_hindsight_fail_closed_non_finite():
+    k = AutonomicKernel(label="t-nan")
+    k.push_hindsight_chemistry(dopamine_delta=float("nan"), gaba_delta=float("inf"))
+    assert k._cached_hindsight_chemistry["dopamine_delta"] == 0.0
+    assert k._cached_hindsight_chemistry["gaba_delta"] == 0.0
+
+
+def test_autonomic_hindsight_cleared_on_wake():
+    k = AutonomicKernel(label="t-wake")
+    k.push_hindsight_chemistry(gaba_delta=0.4)
+    k.tick(_tick_inputs(woke=True))
+    assert all(v == 0.0 for v in k._cached_hindsight_chemistry.values())


### PR DESCRIPTION
## DRAFT — DESIGN HYPOTHESIS for operator review. Do not merge. Do not flip the flag.

Rebuild of this PR per the operator-approved doctrine. The original implementation
(fixed 30-min window + fixed dopamine caps `0.5`/`0.05` + best-favourable-excursion
target + dopamine-only "pain") was **a knob dressed as chemistry and is rejected**.

`MONKEY_HINDSIGHT_REGRET_LIVE` remains **default OFF**; flag-OFF behaviour is
byte-identical (verified by tests).

### The signal
Legibility-gated counterfactual **prediction error**, scaled by the kernel's own
outcome distribution (median+MAD z-score — the same observer scale
`observerFibCoefficient`/`observer_fib_coefficient` use). **No fixed caps/taste
constants** — the `0.5`/`0.3`/`0.05`/`30min` are all gone.

`salience = tanh(|foregoneGain/margin| / MAD(own pnl_frac history)) × legibilityStrength`

where `legibilityStrength = warp_confidence × basin_alignment_strength × coherence_strength × regime_persistence_strength`.
Weak close-time legibility now yields weak learning instead of opening a full-strength boolean gate.

### WINDOW = the kernel's own forecast horizon
- Primary: qig-warp expectation horizon (`qig_warp_horizon_hours`, plumbed through
  `ExpectationDecision` and now emitted by the Python expectation bubble from the observed forecast-horizon surface).
- Documented FALLBACK: observed coherence horizon (`coherenceStreak` ticks × `tickMs`)
  — derived from lived observation, not a designer table.

Counterfactual target = pnl at **end of the derived horizon** (and/or regime-flip-
bounded), **not** max favourable excursion.

### PURITY KEYSTONE — the eligibility/legibility gate
Regret fires only when all three hold, and its magnitude is continuously scaled by their strength:
1. the kernel **owned** the close (adopted/operator/liquidation rows are routed away — `ineligible_not_owned`),
2. the continuation was **legible** at close: qig-warp expectation favoured the held side, basinDir still leaned with the position, and the hold was coherent,
3. the **same regime persisted** through the horizon.

If continuation was **not** legible → it was **surprise/noise**, **not** regret → no
aversive signal (`ineligible_noise`). This maps onto QIG canon §31 (Sensory Intake &amp;
Predictive Coding): an unpredictable continuation is surprise, not a learnable mistake.

### Full E6 NT vector (canon: `vex/kernel/consciousness/neurochemistry.py` §29.1 — six Cartan generators)
| chemical | regret (legible premature close) | good close (avoided loss) |
|---|---|---|
| dopamine (AMPLIFY/E2) | − salience (signed prediction error) | + salience (avoided counterfactual loss) |
| acetylcholine (ENTRAIN/E1) | + (bind the cues) | + (bind the good timing) |
| norepinephrine (NUCLEATE/E5) | + (salience) | + (if salient) |
| serotonin (ROTATE/E4) | − (patience/temporal-trust correction) | + (timing confidence) |
| GABA (DAMPEN/E3) | + **TARGETED** to `premature_close:{regime}:{side}` | 0 |
| endorphin (DISSOLVE/E6) | 0 | + (relief) |

**GABA is targeted, never global** — bound to the `(regime, side)` pattern via a
decaying `hindsightGabaTargets` map, so the kernel learns "don't cut THIS kind of
position early," not "be afraid to close." The global GABA fold is removed until
targeted executive consumption is wired. Tested.

### TS/Py parity
Identical formula, derivation, and source labels (`hindsight_regret` /
`hindsight_good_close` / `ineligible_noise` / `ineligible_not_owned`), fail-closed on
invalid price/margin/qty/side → zero vector, and **fixture-level TS↔Py parity tests**
asserting equal magnitudes. New `push_hindsight_chemistry` + `/monkey/autonomic/hindsight`
route + TS `callAutonomicHindsight` fanout keep the Py chemistry surface (which drives
executive sizing + survives restarts) in parity with the TS fold. Py-side hindsight
chemistry decays after TS fanout stops.

### Wiring / money-path safety
- Hindsight watch registration is now gated by `MONKEY_HINDSIGHT_REGRET_LIVE` directly and no longer depends on `CANONICAL_POLO_PNL_LIVE`.
- Canonical Polo closes use authoritative net PnL; synthetic close-path fallback uses best-available exit price / qty / margin.
- Counterfactual exit price is quantity-weighted.
- Regime attribution uses the closing lane when available.
- TS hindsight cache decay runs once per full kernel tick, not once per symbol.

### Tests / gates
- 27 TS (vitest) + 31 Py (pytest) green: legible→scaled regret vector; weak-legibility scaling; non-legible→no
  regret; non-owned→no self-regret; regime-changed→zero; good-close→relief; GABA stays
  targeted; observer-scale tracks own MAD; cold-start→nothing; fail-closed; flag-OFF
  byte-identity; TS↔Py fixture parity; Py cache decay.
- `tsc` clean, API test suite green, qig purity scan clean.
- CodeQL reported 0 alerts on the completed validation run; a later validation rerun timed out after code-review-only comments were addressed.

### Uncertainties for operator review
1. **Warp expectation at close is the *latest* forecast, not a fresh close-time call.**
   The expectation bubble is only invoked on the entry path (reverse-tape). I persist
   the latest `ExpectationDecision` per symbol and read it at close. A fresh close-time
   bubble call would be more precise but adds a synchronous HTTP hop to the close path.
2. **`regimeAtClose`** is read from the closing lane when available, falling back to
   the warp expectation regime. Worth a look that this is the right "regime observed at close" for the persistence gate.
3. **GABA-target consumption is not yet wired into the executive.** The `hindsightGabaTargets`
   map is populated + decayed, and global GABA is intentionally not nudged. Targeted caution at the decision site is a follow-up.
4. **Equal per-channel salience remains a dark-mode draft hypothesis.** Signs follow canon, but per-channel weights are not yet derived from a chemistry envelope/history.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>