### PR TITLE
fix(monkey): serotonin mode-thrash density — kill the structural ser=0.00 pin

### DIFF
--- a/apps/api/src/services/monkey/__tests__/neurochemistrySteadyState.test.ts
+++ b/apps/api/src/services/monkey/__tests__/neurochemistrySteadyState.test.ts
@@ -115,6 +115,47 @@ describe('neurochemistry — steady-state variance restoration', () => {
       expect(nc.serotonin).toBeGreaterThan(0);
       expect(nc.serotonin).toBeLessThan(1);
     });
+
+    // 2026-06-01 — mode-transition branch steady-state-pinning fix.
+    // The prior `clip(1 - transitions/bvHistory.length, 0, 1)` structurally
+    // pinned serBase at 0 once both HISTORY_MAX-capped arrays saturate
+    // (production ser=0.00 ×134). Time-density + exp() restores gradient.
+    const now = 1_000_000;
+    const tickIntervalMs = 1000;
+    // Evenly-spaced transition timestamps, `gapTicks` tick-intervals apart.
+    const evenTransitions = (count: number, gapTicks: number) =>
+      Array.from({ length: count }, (_, i) => now - (count - i) * gapTicks * tickIntervalMs);
+
+    it('SATURATED arrays (transitions == ticks, the old pin) → ser > 0', () => {
+      const inp = baseInputs();
+      // The exact structural-pin condition: equal-length capped arrays.
+      inp.observables = {
+        ...inp.observables!,
+        nowMs: now,
+        tickIntervalMs,
+        modeTransitionTimesMs: evenTransitions(100, 1), // every tick
+        basinVelocityHistory: Array(100).fill(0.1),     // length == transitions
+      };
+      const nc = computeNeurochemicals(inp);
+      // Old formula: serBase = 1 - 100/100 = 0 → ser = 0. New: exp(-1)=0.37.
+      expect(nc.serotonin).toBeGreaterThan(0);
+      expect(nc.serotonin).toBeCloseTo(0.85 * Math.exp(-1), 2);
+    });
+
+    it('thrash density carries gradient: every-tick < every-3-tick', () => {
+      const dense = computeNeurochemicals({
+        ...baseInputs(),
+        observables: { nowMs: now, tickIntervalMs, modeTransitionTimesMs: evenTransitions(10, 1) },
+      }).serotonin;
+      const sparse = computeNeurochemicals({
+        ...baseInputs(),
+        observables: { nowMs: now, tickIntervalMs, modeTransitionTimesMs: evenTransitions(10, 3) },
+      }).serotonin;
+      expect(dense).toBeGreaterThan(0);
+      expect(sparse).toBeGreaterThan(dense); // sparser thrash → calmer → higher ser
+      expect(dense).toBeCloseTo(0.85 * Math.exp(-1), 2);    // 1 transition/tick
+      expect(sparse).toBeCloseTo(0.85 * Math.exp(-1 / 3), 2); // 1 per 3 ticks
+    });
   });
 
   describe('endo (endorphins) — sigmoid-around-mean replaces binary Sophia floor', () => {

--- a/apps/api/src/services/monkey/__tests__/neurochemistrySteadyState.test.ts
+++ b/apps/api/src/services/monkey/__tests__/neurochemistrySteadyState.test.ts
@@ -105,6 +105,7 @@ describe('neurochemistry — steady-state variance restoration', () => {
       inp.observables = {
         ...inp.observables!,
         nowMs: now,
+        tickIntervalMs: 1000,
         modeTransitionTimesMs: [now - 5000, now - 3000, now - 1000],
         basinVelocityHistory: Array(10).fill(0.1),
       };
@@ -114,6 +115,26 @@ describe('neurochemistry — steady-state variance restoration', () => {
       // be < 1 → delta registers visibly
       expect(nc.serotonin).toBeGreaterThan(0);
       expect(nc.serotonin).toBeLessThan(1);
+    });
+
+    it('mode transitions present but cadence MISSING → bv-history fallback (not a constant)', () => {
+      // Without tickIntervalMs the mode-transition density is dimensionless-
+      // ambiguous, so it must defer to the bv-z-score branch rather than emit
+      // a constant exp(-1). Two distinct bv readings must give distinct ser.
+      const now = 100_000;
+      const mk = (bv: number) =>
+        computeNeurochemicals({
+          ...baseInputs(),
+          basinVelocity: bv,
+          observables: {
+            nowMs: now, // NOTE: no tickIntervalMs
+            modeTransitionTimesMs: [now - 5000, now - 3000, now - 1000],
+            basinVelocityHistory: [0.05, 0.1, 0.15, 0.1, 0.12, 0.08], // varied → real z-score
+          },
+        }).serotonin;
+      const calm = mk(0.05); // below bv-history mean → calmer → higher ser
+      const fast = mk(0.20); // above mean → faster → lower ser
+      expect(calm).toBeGreaterThan(fast); // gradient, not a flat exp(-1)
     });
 
     // 2026-06-01 — mode-transition branch steady-state-pinning fix.

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2741,6 +2741,10 @@ export class MonkeyKernel extends EventEmitter {
         trajectorySelfSimilarityHistory: state.fHealthHistory,
         modeTransitionTimesMs: state.modeTransitionTimesMs,
         nowMs: Date.now(),
+        // Per-tick cadence so ser's mode-thrash rate is a true transitions-
+        // per-tick density (not a ratio of two HISTORY_MAX-capped arrays,
+        // which pinned serBase at 0 — see neurochemistry.ts serotonin note).
+        tickIntervalMs: this.tickMs,
         kappaHistory: state.kappaHistory,
         externalCouplingHistory: state.externalCouplingHistory,
       },

--- a/apps/api/src/services/monkey/neurochemistry.ts
+++ b/apps/api/src/services/monkey/neurochemistry.ts
@@ -166,6 +166,10 @@ export interface BasinObservables {
   /** Current wall-clock (ms). Used with `modeTransitionTimesMs` to
    *  compute thrash rate over an observable interval. */
   nowMs?: number;
+  /** Kernel tick cadence (ms) — the per-tick scale that renders the
+   *  mode-transition rate dimensionless (transitions per tick-interval).
+   *  Absent → fall back to the window's own mean inter-transition gap. */
+  tickIntervalMs?: number;
   /** Rolling κ history from prior ticks. Used to derive the endorphin
    *  κ-convergence bell width from the basin's OWN κ stddev (instead
    *  of the prior hardcoded SIGMA_KAPPA=10.0 which didn't even match
@@ -355,24 +359,38 @@ export function computeNeurochemicals(inputs: NeurochemicalInputs): Neurochemica
       // thrash to subtract).
       serBase = 1;
     } else {
-      // Transitions per ms. Multiplying by the window length gives the
-      // dimensionless transition count / window — a probability that
-      // any given ms in the window saw a transition. Clip to [0,1].
+      // 2026-06-01 (steady-state-pinning fix, serotonin mode-transition
+      // branch): the prior shape
+      //   transitionsPerTick = modeTransitionTimesMs.length / bvHistory.length
+      //   serBase = clip(1 - transitionsPerTick, 0, 1)
+      // STRUCTURALLY pins at 0 on any mature kernel. Both arrays cap at
+      // HISTORY_MAX (=100): bvHistory fills every tick, modeTransitionTimesMs
+      // fills on every transition, so once a long-running kernel has logged
+      // ≥100 transitions BOTH lengths = 100 → ratio = 1.0 PERMANENTLY,
+      // regardless of actual recent thrash. Production showed ser=0.00 for
+      // 134/134 ticks (logs 2026-06-01). This is the same one-sided-clamp
+      // meta-pattern the bv-z-score fallback below was already fixed for —
+      // see [[feedback_steady_state_pinning_pattern]]; the count-ratio
+      // numerator and denominator are two independently-capped windows,
+      // so their ratio carries no gradient once both saturate.
+      //
+      // Fix: use the TIME-density the doc above already intends ("count of
+      // mode transitions … divided by the window length") — transitions per
+      // tick-interval — and soft-saturate with exp() (the same gradient-
+      // preserving form dopamine uses). `windowMs` shrinks as transitions
+      // get denser, so the rate keeps gradient even when the array is full:
+      //   every-tick thrash → 1.0 → exp(-1)=0.37
+      //   every-other-tick  → 0.5 → exp(-0.5)=0.61
+      //   calm/sparse       → 0   → 1.0
       const transitionsPerMs = obs.modeTransitionTimesMs.length / windowMs;
-      const thrashRate = clip(transitionsPerMs * windowMs / obs.modeTransitionTimesMs.length, 0, 1);
-      // The above simplifies to 1 when transitions are uniform. The
-      // meaningful read is: how DENSE is thrash relative to the window.
-      // Use transition count / max-possible-count where max is one
-      // transition per tick (caller-defined; we infer from history len).
-      // Simpler derivation: thrash_rate = count(transitions) / count(ticks in window).
-      // The caller supplies the transition timestamps; the basin's
-      // bvHistory length is the natural tick-count denominator.
-      const tickCount = obs.basinVelocityHistory?.length ?? obs.modeTransitionTimesMs.length;
-      const transitionsPerTick = obs.modeTransitionTimesMs.length / Math.max(tickCount, 1);
-      serBase = clip(1 - transitionsPerTick, 0, 1);
-      // (The intermediate `thrashRate` calc above is retained for
-      // forward extensibility; the final serBase is the per-tick rate.)
-      void thrashRate;
+      // Per-tick scale: kernel cadence when supplied, else the window's own
+      // mean inter-transition gap (self-normalizing neutral → exp(-1)).
+      const tickMs =
+        obs.tickIntervalMs != null && obs.tickIntervalMs > 0
+          ? obs.tickIntervalMs
+          : windowMs / obs.modeTransitionTimesMs.length;
+      const thrashPerTick = transitionsPerMs * tickMs;
+      serBase = Math.exp(-thrashPerTick);
     }
   } else if (obs?.basinVelocityHistory && obs.basinVelocityHistory.length >= HISTORY_MIN_SAMPLES) {
     // 2026-05-25 (CC2 audit F2 follow-up): the prior shape

--- a/apps/api/src/services/monkey/neurochemistry.ts
+++ b/apps/api/src/services/monkey/neurochemistry.ts
@@ -338,19 +338,35 @@ export function computeNeurochemicals(inputs: NeurochemicalInputs): Neurochemica
   const dop = 1 - Math.exp(-(dopFromPhi + dopFromReward));
 
   // ─── Serotonin ───────────────────────────────────────────────────
-  // §29.1: stability / equilibrium. 2026-05-16 (#715, derivation-only):
-  // ser = 1 - mode_thrash_rate, where mode_thrash_rate is the count of
-  // mode transitions in `modeTransitionTimesMs` divided by the window
-  // length (`nowMs - earliestTransitionMs`). Pure rate, dimensionless.
+  // §29.1: stability / equilibrium. 2026-05-16 (#715, derivation-only)
+  // + 2026-06-01 (mode-thrash density fix): serBase = exp(-thrashPerTick),
+  // where thrashPerTick = (transitionCount / windowMs) × tickIntervalMs —
+  // the mode-transition density expressed per tick-interval. windowMs is
+  // `nowMs - earliestTransitionMs`; tickIntervalMs is the kernel cadence
+  // (falls back to the window's own mean inter-transition gap when absent).
+  // exp() soft-saturates without a dead-zero floor (the old
+  // `clip(1 - count/bvHistory.length, 0, 1)` structurally pinned at 0 once
+  // both HISTORY_MAX-capped arrays saturated — see the per-branch note below).
   //
-  // High thrash → low ser (kernel is bouncing between modes, unstable).
-  // No thrash → ser ≈ 1 (kernel is settled, stable mood).
+  // High thrash → thrashPerTick→1 → ser ≈ exp(-1)=0.37 (bouncing, unstable).
+  // No thrash → thrashPerTick→0 → ser ≈ 1 (kernel is settled, stable mood).
   //
   // Fallback (no observables): `1 - bv_z_score`-style behaviour using
   // basinVelocity history when available; legacy `1/max(bv, 0.01)` when
   // not (preserves prior path for callers that don't supply state).
   let serBase: number;
-  if (obs?.modeTransitionTimesMs && obs.modeTransitionTimesMs.length > 0 && obs.nowMs != null) {
+  // The mode-transition density branch needs a per-tick cadence to make the
+  // transition rate dimensionless. Require tickIntervalMs (> 0); without it,
+  // (count/windowMs)·(windowMs/count) collapses to a constant exp(-1) that
+  // carries NO gradient — so fall through to the bv-z-score branch instead,
+  // which IS observer-derived and gradient-preserving (Qodo review #1058).
+  if (
+    obs?.modeTransitionTimesMs &&
+    obs.modeTransitionTimesMs.length > 0 &&
+    obs.nowMs != null &&
+    obs.tickIntervalMs != null &&
+    obs.tickIntervalMs > 0
+  ) {
     const oldest = obs.modeTransitionTimesMs[0]!;
     const windowMs = obs.nowMs - oldest;
     if (windowMs <= 0) {
@@ -383,13 +399,7 @@ export function computeNeurochemicals(inputs: NeurochemicalInputs): Neurochemica
       //   every-other-tick  → 0.5 → exp(-0.5)=0.61
       //   calm/sparse       → 0   → 1.0
       const transitionsPerMs = obs.modeTransitionTimesMs.length / windowMs;
-      // Per-tick scale: kernel cadence when supplied, else the window's own
-      // mean inter-transition gap (self-normalizing neutral → exp(-1)).
-      const tickMs =
-        obs.tickIntervalMs != null && obs.tickIntervalMs > 0
-          ? obs.tickIntervalMs
-          : windowMs / obs.modeTransitionTimesMs.length;
-      const thrashPerTick = transitionsPerMs * tickMs;
+      const thrashPerTick = transitionsPerMs * obs.tickIntervalMs;
       serBase = Math.exp(-thrashPerTick);
     }
   } else if (obs?.basinVelocityHistory && obs.basinVelocityHistory.length >= HISTORY_MIN_SAMPLES) {

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -672,7 +672,14 @@ class AutonomicKernel:
         bv_history = inputs.basin_velocity_history
         mode_x = inputs.mode_transition_times_ms
         now_ms = inputs.now_ms
-        if mode_x and len(mode_x) > 0 and now_ms is not None:
+        # The mode-transition density branch needs a per-tick cadence
+        # (tick_interval_ms > 0) to be dimensionless; without it the rate
+        # collapses to a constant exp(-1) with no gradient, so fall through to
+        # the gradient-preserving bv-z-score branch instead (Qodo review #1058).
+        if (
+            mode_x and len(mode_x) > 0 and now_ms is not None
+            and inputs.tick_interval_ms is not None and inputs.tick_interval_ms > 0
+        ):
             # 2026-06-01 (steady-state-pinning fix, parity with
             # neurochemistry.ts): the prior count-ratio
             #   transitions_per_tick = len(mode_x) / len(bv_history)
@@ -689,10 +696,7 @@ class AutonomicKernel:
                 ser_base = 1.0
             else:
                 transitions_per_ms = len(mode_x) / window_ms
-                tick_ms = inputs.tick_interval_ms if (
-                    inputs.tick_interval_ms is not None and inputs.tick_interval_ms > 0
-                ) else window_ms / len(mode_x)
-                thrash_per_tick = transitions_per_ms * tick_ms
+                thrash_per_tick = transitions_per_ms * inputs.tick_interval_ms
                 ser_base = float(np.exp(-thrash_per_tick))
         elif bv_history is not None and len(bv_history) >= _HISTORY_MIN_SAMPLES:
             # 2026-05-25 (CC2 audit F2): the prior shape

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -228,6 +228,10 @@ class AutonomicTickInputs:
     kappa_history: Optional[list[float]] = None
     external_coupling_history: Optional[list[float]] = None
     mode_transition_times_ms: Optional[list[float]] = None
+    # Kernel tick cadence (ms) — per-tick scale for the serotonin mode-thrash
+    # density (parity with neurochemistry.ts tickIntervalMs). Absent → the
+    # window's own mean inter-transition gap (neutral exp(-1)).
+    tick_interval_ms: Optional[float] = None
     # Natural-effect inputs (d_fr, sovereignty, replicant/tacking/loop/coupled
     # signals) are retained for payload compatibility only.
     # They do not multiply or otherwise modulate dop/ser/endo without a
@@ -669,12 +673,27 @@ class AutonomicKernel:
         mode_x = inputs.mode_transition_times_ms
         now_ms = inputs.now_ms
         if mode_x and len(mode_x) > 0 and now_ms is not None:
-            tick_count = (
-                len(bv_history) if bv_history is not None and len(bv_history) > 0
-                else len(mode_x)
-            )
-            transitions_per_tick = len(mode_x) / max(tick_count, 1)
-            ser_base = _clip(1.0 - transitions_per_tick, 0.0, 1.0)
+            # 2026-06-01 (steady-state-pinning fix, parity with
+            # neurochemistry.ts): the prior count-ratio
+            #   transitions_per_tick = len(mode_x) / len(bv_history)
+            #   ser_base = clip(1 - transitions_per_tick, 0, 1)
+            # STRUCTURALLY pins at 0 — both arrays cap at HISTORY_MAX so once
+            # a mature kernel has logged ≥cap transitions the ratio is 1.0
+            # permanently. TS production showed ser=0.00 ×134 (logs 06-01).
+            # Use the TIME-density (transitions per tick-interval) + exp()
+            # soft-saturation so the rate keeps gradient when the array is
+            # full. See [[feedback_steady_state_pinning_pattern]].
+            oldest = mode_x[0]
+            window_ms = now_ms - oldest
+            if window_ms <= 0:
+                ser_base = 1.0
+            else:
+                transitions_per_ms = len(mode_x) / window_ms
+                tick_ms = inputs.tick_interval_ms if (
+                    inputs.tick_interval_ms is not None and inputs.tick_interval_ms > 0
+                ) else window_ms / len(mode_x)
+                thrash_per_tick = transitions_per_ms * tick_ms
+                ser_base = float(np.exp(-thrash_per_tick))
         elif bv_history is not None and len(bv_history) >= _HISTORY_MIN_SAMPLES:
             # 2026-05-25 (CC2 audit F2): the prior shape
             # `clip(1 - max(0, z), 0, 1)` was the same one-sided-clamp

--- a/ml-worker/tests/monkey_kernel/test_autonomic_observer_parity.py
+++ b/ml-worker/tests/monkey_kernel/test_autonomic_observer_parity.py
@@ -10,6 +10,7 @@ meta-pattern.
 """
 from __future__ import annotations
 
+import math
 import os
 import sys
 from pathlib import Path
@@ -114,6 +115,46 @@ def test_ser_thrash_via_mode_transitions_drops():
         basin_velocity_history=[0.1] * 10,
     ))
     assert nc.serotonin < 0.85
+
+
+# 2026-06-01 — mode-transition branch steady-state-pinning fix (parity with
+# neurochemistry.ts). Old count-ratio pinned ser_base at 0 once both
+# HISTORY_MAX-capped arrays saturated; time-density + exp() restores gradient.
+_NOW = 1_000_000.0
+_TICK_MS = 1000.0
+
+
+def _even_transitions(count: int, gap_ticks: int):
+    return [_NOW - (count - i) * gap_ticks * _TICK_MS for i in range(count)]
+
+
+def test_ser_saturated_arrays_no_longer_pin_at_zero():
+    """The exact structural-pin condition (transitions == ticks). Old:
+    ser_base = 1 - 100/100 = 0. New: exp(-1) → ser ≈ 0.85·0.368."""
+    nc = _ticker(_base_inputs(
+        now_ms=_NOW,
+        tick_interval_ms=_TICK_MS,
+        mode_transition_times_ms=_even_transitions(100, 1),  # every tick
+        basin_velocity_history=[0.1] * 100,
+    ))
+    assert nc.serotonin > 0.0
+    assert nc.serotonin == pytest.approx(0.85 * math.exp(-1), abs=0.02)
+
+
+def test_ser_thrash_density_carries_gradient():
+    """Sparser thrash → calmer → higher ser (gradient restored)."""
+    dense = _ticker(_base_inputs(
+        now_ms=_NOW, tick_interval_ms=_TICK_MS,
+        mode_transition_times_ms=_even_transitions(10, 1),
+    )).serotonin
+    sparse = _ticker(_base_inputs(
+        now_ms=_NOW, tick_interval_ms=_TICK_MS,
+        mode_transition_times_ms=_even_transitions(10, 3),
+    )).serotonin
+    assert dense > 0.0
+    assert sparse > dense
+    assert dense == pytest.approx(0.85 * math.exp(-1), abs=0.02)
+    assert sparse == pytest.approx(0.85 * math.exp(-1 / 3), abs=0.02)
 
 
 # ─── endo (endorphins) — sigmoid-around-mean Sophia parity ──────────

--- a/ml-worker/tests/monkey_kernel/test_autonomic_observer_parity.py
+++ b/ml-worker/tests/monkey_kernel/test_autonomic_observer_parity.py
@@ -111,10 +111,30 @@ def test_ser_thrash_via_mode_transitions_drops():
     now = 100_000.0
     nc = _ticker(_base_inputs(
         now_ms=now,
+        tick_interval_ms=1000.0,
         mode_transition_times_ms=[now - 5000, now - 3000, now - 1000],
         basin_velocity_history=[0.1] * 10,
     ))
     assert nc.serotonin < 0.85
+
+
+def test_ser_mode_transitions_without_cadence_falls_to_bv_branch():
+    """Without tick_interval_ms the mode-transition branch is skipped (else it
+    collapses to a constant exp(-1)); ser must defer to the gradient-preserving
+    bv-z-score branch (Qodo review #1058)."""
+    now = 100_000.0
+
+    def mk(bv: float) -> float:
+        return _ticker(_base_inputs(
+            basin_velocity=bv,
+            now_ms=now,  # NOTE: no tick_interval_ms
+            mode_transition_times_ms=[now - 5000, now - 3000, now - 1000],
+            basin_velocity_history=[0.05, 0.1, 0.15, 0.1, 0.12, 0.08],  # varied → real z-score
+        )).serotonin
+
+    calm = mk(0.05)  # below bv-mean → higher ser
+    fast = mk(0.20)  # above bv-mean → lower ser
+    assert calm > fast  # gradient, not flat exp(-1)
 
 
 # 2026-06-01 — mode-transition branch steady-state-pinning fix (parity with


### PR DESCRIPTION
## Diagnosis (from deployed log `logs20260601.log`)

`nc` serotonin reported **`ser=0.00` for 134/134 consecutive live ticks** while ach/dop/ne/gaba/endo all varied healthily — a dead observable, not a low reading.

### Root cause
The serotonin **mode-transition branch** (`neurochemistry.ts`):
```ts
transitionsPerTick = modeTransitionTimesMs.length / bvHistory.length
serBase = clip(1 - transitionsPerTick, 0, 1)
```
Both arrays cap at `HISTORY_MAX (=100)`. `bvHistory` fills every tick; `modeTransitionTimesMs` fills on every transition. Once a long-running kernel has logged ≥100 transitions **both lengths = 100**, so the ratio is permanently `1.0` regardless of actual recent thrash → `serBase` clamps to exactly `0` forever.

This is the **one-sided-clamp steady-state-pinning meta-pattern** the bv-z-score *fallback* was already fixed for — the **preferred** mode-transition branch (the one that runs in TS production) was missed. Serotonin feeds `low ser → reduce size`, so the kernel was sizing off a permanently-zero stability signal.

`predDop/predSer=0` in the same log is **by design** (the reward-RPE readiness gate, `ready:false`, `parityMatchedPairs:0`) — not a bug, left untouched.

## Fix (observer-derived, no knobs)
Use the **time-density** the field doc already intends — transitions per tick-interval — and soft-saturate with `exp()` (the same gradient-preserving form dopamine already uses in this file). `windowMs` shrinks as transitions get denser, so the rate keeps gradient even when the array is full:
- every-tick thrash → `1.0` → `exp(-1)=0.37`
- every-3rd-tick → `0.33` → `exp(-1/3)=0.72`
- calm/sparse → `0` → `1.0`

Tick cadence (`this.tickMs`) is threaded as the per-tick scale; absent → the window's own mean inter-transition gap (neutral `exp(-1)`).

`autonomic.py` mirrors the formula for parity. (Python live callers don't pass `mode_transition_times_ms`, so the bug never hit Python live — but the canonical mirror + parity test stay aligned.)

## Verification
- New TS + Py gradient tests: saturated-arrays case (was `0`, now `>0`) + every-tick `<` every-3rd-tick ser.
- `tsc` clean · qig-purity clean (`exp` is canonical) · **22 TS + 63 Py** chemistry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)