### PR TITLE
fix(monkey): honor paper_only execution-mode MANDATE — stop live entries when UI says paper

### DIFF
--- a/apps/api/src/services/__tests__/riskKernel.test.ts
+++ b/apps/api/src/services/__tests__/riskKernel.test.ts
@@ -211,22 +211,14 @@ describe('evaluatePreTradeVetoes composition', () => {
     expect(evaluatePreTradeVetoes(btcOrder, emptyAccount, liveAutoContext).allowed).toBe(true);
   });
 
-  // 2026-06-01 — paper_only MANDATE. The caller (loop.ts) MUST set
-  // context.isLive = !shouldRouteOrdersToPaper() (the order's REAL routing),
-  // NOT `mode === 'auto'`. The prior circular wiring made isLive always
-  // false under paper_only, so this veto never fired and the kernel kept
-  // opening LIVE positions while the operator's UI said paper.
-  it('blocks a LIVE order under paper_only (operator MANDATE)', () => {
-    const livePaperOnly: KernelContext = { isLive: true, mode: 'paper_only', symbolMaxLeverage: BTC_MAX_LEV };
-    const decision = evaluatePreTradeVetoes(btcOrder, emptyAccount, livePaperOnly);
-    expect(decision.allowed).toBe(false);
-    expect(decision.code).toBe('execution_mode_paper_only_blocks_live');
-  });
-
-  it('passes a PAPER-routed order under paper_only (paper continues)', () => {
-    const paperPaperOnly: KernelContext = { isLive: false, mode: 'paper_only', symbolMaxLeverage: BTC_MAX_LEV };
-    expect(evaluatePreTradeVetoes(btcOrder, emptyAccount, paperPaperOnly).allowed).toBe(true);
-  });
+  // 2026-06-01 — paper_only MANDATE wiring requirement (the actual #1060 bug
+  // lived in the CALLER, not here): loop.ts executeEntry MUST build
+  // KernelContext with `isLive: !routeToPaper` (the order's REAL routing),
+  // NOT `mode === 'auto'`. That prior circular wiring made isLive always
+  // false under paper_only, so the composition cases below (which already
+  // pass with correct inputs) never fired in production. No new assertion
+  // here — the live/paper composition is covered by
+  // 'execution-mode paper_only blocks a live order' / '… allows a paper order'.
 
   it('passes a clean short order', () => {
     expect(

--- a/apps/api/src/services/__tests__/riskKernel.test.ts
+++ b/apps/api/src/services/__tests__/riskKernel.test.ts
@@ -211,6 +211,23 @@ describe('evaluatePreTradeVetoes composition', () => {
     expect(evaluatePreTradeVetoes(btcOrder, emptyAccount, liveAutoContext).allowed).toBe(true);
   });
 
+  // 2026-06-01 — paper_only MANDATE. The caller (loop.ts) MUST set
+  // context.isLive = !shouldRouteOrdersToPaper() (the order's REAL routing),
+  // NOT `mode === 'auto'`. The prior circular wiring made isLive always
+  // false under paper_only, so this veto never fired and the kernel kept
+  // opening LIVE positions while the operator's UI said paper.
+  it('blocks a LIVE order under paper_only (operator MANDATE)', () => {
+    const livePaperOnly: KernelContext = { isLive: true, mode: 'paper_only', symbolMaxLeverage: BTC_MAX_LEV };
+    const decision = evaluatePreTradeVetoes(btcOrder, emptyAccount, livePaperOnly);
+    expect(decision.allowed).toBe(false);
+    expect(decision.code).toBe('execution_mode_paper_only_blocks_live');
+  });
+
+  it('passes a PAPER-routed order under paper_only (paper continues)', () => {
+    const paperPaperOnly: KernelContext = { isLive: false, mode: 'paper_only', symbolMaxLeverage: BTC_MAX_LEV };
+    expect(evaluatePreTradeVetoes(btcOrder, emptyAccount, paperPaperOnly).allowed).toBe(true);
+  });
+
   it('passes a clean short order', () => {
     expect(
       evaluatePreTradeVetoes({ ...btcOrder, side: 'short' }, emptyAccount, autoContext).allowed,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -8539,6 +8539,13 @@ export class MonkeyKernel extends EventEmitter {
     cellDirection?: 'TREND_UP' | 'CHOP' | 'TREND_DOWN' | null;
   }): Promise<{ executed: boolean; orderId: string | null; reason: string; tradeId?: string | null }> {
     const { symbol, side, marginUsdt, entryPrice, minNotional } = req;
+    // 2026-06-01 — capture the paper/live routing decision ONCE for the whole
+    // entry. shouldRouteOrdersToPaper() reads internal rotation state that a
+    // concurrent close-reward can mutate; evaluating it separately for the
+    // veto's `isLive`, the paper credential/state setup, and the final routing
+    // branch (with awaits between) could let them disagree and re-open a
+    // paper_only bypass (Copilot review #1060). One snapshot, used everywhere.
+    const routeToPaper = this.shouldRouteOrdersToPaper();
     // 2026-05-13 — continuous-regime leverage sanity bound.
     //
     // Discrete mode leverage (50× EXPLORATION / 5× INTEGRATION) can
@@ -8750,7 +8757,7 @@ export class MonkeyKernel extends EventEmitter {
       );
       userId = String((userRow.rows[0] as { user_id?: string } | undefined)?.user_id ?? '');
       if (!userId) {
-        if (this.shouldRouteOrdersToPaper()) {
+        if (routeToPaper) {
           // Paper mode — resolve a user_id that satisfies the
           // autonomous_trades.user_id → users(id) foreign key. Prefer
           // any existing user; on a fresh paper/staging DB (empty
@@ -8783,7 +8790,7 @@ export class MonkeyKernel extends EventEmitter {
           return { executed: false, orderId: null, reason: 'no_credentials' };
         }
       }
-      if (this.shouldRouteOrdersToPaper()) {
+      if (routeToPaper) {
         // Paper mode — synthetic risk-kernel state at the paper
         // bankroll, no exchange call. Equity matches what the sizing
         // path (fetchAccountContext) used, so the risk kernel's
@@ -8852,12 +8859,13 @@ export class MonkeyKernel extends EventEmitter {
     // so the `paper_only && isLiveOrder` block in checkExecutionMode could
     // NEVER fire → the kernel kept opening LIVE positions while the UI
     // showed paper (operator-MANDATE violation, confirmed in prod 06-01).
-    // `!shouldRouteOrdersToPaper()` is the true "this order goes live"
-    // predicate (env MONKEY_PAPER_MODE + internal paper-rotation). The veto
-    // is ENTRY-ONLY, so paper_only now blocks new LIVE ENTRIES while closes
-    // of existing real positions still route real (no orphaned positions).
+    // `!routeToPaper` is the true "this order goes live" predicate (env
+    // MONKEY_PAPER_MODE + internal paper-rotation), captured once at the top
+    // of executeEntry so the veto and the actual routing can't diverge. The
+    // veto is ENTRY-ONLY, so paper_only now blocks new LIVE ENTRIES while
+    // closes of existing real positions still route real (no orphaned positions).
     const kernelContext: KernelContext = {
-      isLive: !this.shouldRouteOrdersToPaper(), mode, symbolMaxLeverage,
+      isLive: !routeToPaper, mode, symbolMaxLeverage,
       monkeyMode: monkeyMode ?? undefined,
     };
     const decision = evaluatePreTradeVetoes(order, kernelState, kernelContext);
@@ -9060,7 +9068,7 @@ export class MonkeyKernel extends EventEmitter {
         ? (req.side === 'long' ? 'LONG' : 'SHORT')
         : undefined;
 
-    if (this.shouldRouteOrdersToPaper()) {
+    if (routeToPaper) {
       if (!Number.isFinite(entryPrice) || entryPrice <= 0) {
         logger.warn('[Monkey] paper mode invalid mark price, skipping entry', {
           symbol,

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -8844,8 +8844,20 @@ export class MonkeyKernel extends EventEmitter {
     // 2026-05-13 — pass monkeyMode through so risk kernel's headroom
     // check is regime-conditional (35% reserve EXPLORATION, 15% INTEGRATION).
     const monkeyMode = symState?.lastMode ?? undefined;
+    // 2026-06-01 (paper_only MANDATE fix): `isLive` is the flag
+    // checkExecutionMode uses to decide whether THIS order would hit the
+    // live exchange — so it MUST describe the order's actual routing, not
+    // the mode. The prior `mode === 'auto'` was circular: when the operator
+    // set execution mode = 'paper_only', isLive was false by construction,
+    // so the `paper_only && isLiveOrder` block in checkExecutionMode could
+    // NEVER fire → the kernel kept opening LIVE positions while the UI
+    // showed paper (operator-MANDATE violation, confirmed in prod 06-01).
+    // `!shouldRouteOrdersToPaper()` is the true "this order goes live"
+    // predicate (env MONKEY_PAPER_MODE + internal paper-rotation). The veto
+    // is ENTRY-ONLY, so paper_only now blocks new LIVE ENTRIES while closes
+    // of existing real positions still route real (no orphaned positions).
     const kernelContext: KernelContext = {
-      isLive: mode === 'auto', mode, symbolMaxLeverage,
+      isLive: !this.shouldRouteOrdersToPaper(), mode, symbolMaxLeverage,
       monkeyMode: monkeyMode ?? undefined,
     };
     const decision = evaluatePreTradeVetoes(order, kernelState, kernelContext);


### PR DESCRIPTION
## 🔴 Live-money operator-MANDATE violation (confirmed in production)

The operator set execution mode = **`paper_only`** via the UI at **01:29 UTC** (`agent_execution_mode`, `updatedBy=braden`, `reason=ui_toggle`), yet the kernel kept opening **real exchange positions** (`orderId 584319…`, `lev 5x`) **27+ minutes later**. The UI's paper selection had **no effect on live trading**.

### Root cause — the `paper_only` gate was structurally dead
`riskKernel.checkExecutionMode(isLiveOrder, mode)` correctly blocks `paper_only && isLiveOrder`. But `loop.ts` built the kernel context with:
```ts
isLive: mode === 'auto'
```
This is **circular**: when `mode === 'paper_only'`, `isLive` is `false` by construction, so the `paper_only && isLiveOrder` branch can **never fire**. Meanwhile `shouldRouteOrdersToPaper()` (the routing decision) only checks `MONKEY_PAPER_MODE` (unset in prod) and the internal paper-rotation — it **never reads `agent_execution_mode`**. So `paper_only` neither blocked nor paper-routed the order → it went **live**.

The `execution_mode → routing` wiring was lost when FAT/LiveSignal (the old risk-kernel enforcer) was deleted in #878; `isLiveExecutionAllowed` is now dead code. (`pause` still works — `checkExecutionMode` blocks it unconditionally — only `paper_only` was broken.)

### Fix
`isLive` must describe the order's **actual routing**, not the mode:
```ts
isLive: !this.shouldRouteOrdersToPaper()
```
Now `checkExecutionMode` sees a true live order under `paper_only` and vetoes it (`execution_mode_paper_only_blocks_live`). The veto is **entry-only**, so `paper_only` blocks new **live entries** while **closes of existing real positions still route real — no orphaned positions**. `pause`/`auto` unchanged.

### Scope note
Under `paper_only` with prod config (`MONKEY_PAPER_MODE` unset, rotation live), new entries are **blocked** rather than paper-routed. Full "paper continues" (paper *entries* under `paper_only`) needs close-by-position-origin routing so paper positions don't try to close on the real exchange — **tracked as a follow-up**. This PR is the safe MANDATE-honoring fix.

### Verification
- New `evaluatePreTradeVetoes` tests: blocks a live order under `paper_only`, passes a paper-routed order.
- `tsc` clean · **51** risk + execution-mode tests pass · no banned vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Honor the operator paper-only execution-mode mandate by correctly treating orders as live based on their actual routing and blocking new live entries when the UI is set to paper-only.

Bug Fixes:
- Ensure live orders are vetoed under paper_only execution mode by basing isLive on real routing instead of the selected mode.
- Allow paper-routed orders to proceed under paper_only so paper trading can continue while live entries are blocked.

Tests:
- Add risk kernel tests verifying that live orders are blocked and paper-routed orders are allowed when execution mode is paper_only.