### PR TITLE
feat(monkey): paper mode = kernel FULLY disengages from live (operator takes over)

### DIFF
--- a/apps/api/src/services/__tests__/stateReconciliationService.test.ts
+++ b/apps/api/src/services/__tests__/stateReconciliationService.test.ts
@@ -15,6 +15,12 @@ vi.mock('../apiCredentialsService.js', () => ({
   },
 }));
 
+// Default 'auto' so the existing ghost/orphan tests run the full path.
+const getExecutionModeMock = vi.fn().mockResolvedValue('auto');
+vi.mock('../executionModeService.js', () => ({
+  getCurrentExecutionMode: (...a: unknown[]) => getExecutionModeMock(...a),
+}));
+
 const getAccountBillsMock = vi.fn().mockResolvedValue([]);
 vi.mock('../poloniexFuturesService.js', () => ({
   default: {
@@ -43,10 +49,36 @@ vi.mock('../monkey/kernel_bus.js', () => ({
   getKernelBus: () => ({ publish: publishMock }),
 }));
 
+describe('stateReconciliationService — operator paper MANDATE', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryMock.mockReset();
+    getExecutionModeMock.mockResolvedValue('auto');
+  });
+
+  it('skips reconciliation (no adopt/close, no live read) when execution mode is not auto', async () => {
+    getExecutionModeMock.mockResolvedValue('paper_only');
+    const { stateReconciliationService } = await import('../stateReconciliationService.js');
+    const polo = (await import('../poloniexFuturesService.js')).default as unknown as {
+      getPositions: ReturnType<typeof vi.fn>;
+      getAccountBalance: ReturnType<typeof vi.fn>;
+    };
+    const res = await stateReconciliationService.reconcile('user-1');
+    expect(res.error).toBe('skipped_execution_mode_not_auto');
+    expect(res.orphans).toEqual([]);
+    expect(res.ghosts).toEqual([]);
+    // The kernel must not touch the live exchange in paper mode.
+    expect(polo.getPositions).not.toHaveBeenCalled();
+    expect(polo.getAccountBalance).not.toHaveBeenCalled();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('stateReconciliationService ghost recovery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     queryMock.mockReset();
+    getExecutionModeMock.mockResolvedValue('auto');
     getAccountBillsMock.mockReset();
     getAccountBillsMock.mockResolvedValue([]);
   });

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -27,7 +27,7 @@ import { apiCache } from '../../utils/apiCache.js';
 import { getEngineVersion } from '../../utils/engineVersion.js';
 import { logger } from '../../utils/logger.js';
 import { apiCredentialsService } from '../apiCredentialsService.js';
-import { getCurrentExecutionMode } from '../executionModeService.js';
+import { getCurrentExecutionMode, type ExecutionMode } from '../executionModeService.js';
 import { getMaxLeverage, getPrecisions } from '../marketCatalog.js';
 import mlPredictionService from '../mlPredictionService.js';
 import poloniexFuturesService from '../poloniexFuturesService.js';
@@ -1249,6 +1249,12 @@ export class MonkeyKernel extends EventEmitter {
    * primary feedback channel; rotation is a structural signal.
    */
   private rotation: RotationState = makeRotationState();
+  /** Operator execution-mode MANDATE, refreshed once per tick from
+   *  agent_execution_mode. 'auto' = kernel may touch the live exchange;
+   *  'paper_only' = kernel trades its OWN paper book only and does NOT
+   *  open, close, adopt or reconcile any live positions (operator takes
+   *  over live); 'pause' = kill switch (no new orders at all). */
+  private executionMode: ExecutionMode = 'auto';
   /**
    * LIMIT_MAKER #793 (Class B #5) — pending post-only scalp orders that
    * have been placed but not yet observed as filled. Key: orderId.
@@ -2163,6 +2169,11 @@ export class MonkeyKernel extends EventEmitter {
     }
     this.tickInFlight = true;
     try {
+      // Refresh the operator execution-mode MANDATE once per tick (cached
+      // for the sync routing/close/reconcile gates). Fail-safe to the last
+      // known value on a transient read error — getCurrentExecutionMode
+      // itself fails CLOSED to 'pause' on DB failure.
+      try { this.executionMode = await getCurrentExecutionMode(); } catch { /* keep last */ }
       this.decayHindsightCachesOncePerTick();
       // LIMIT_MAKER #793 — cancel any stale post-only scalp orders before
       // running the per-symbol pipeline. Stale = older than
@@ -7537,6 +7548,13 @@ export class MonkeyKernel extends EventEmitter {
           L: { pnl: 0, qty: 0 },
         };
         if (rows.length === 0) {
+          // Operator paper MANDATE: with no matching open kernel-instance
+          // rows and the kernel disengaged from live, do NOT paper-close the
+          // bare tradeId — its origin is unknown and a live position would be
+          // booked as a phantom. Leave it for the operator.
+          if (this.executionMode !== 'auto') {
+            return { executed: false, orderId: null, reason: 'paper_mandate_live_position_untouched' };
+          }
           // #931 safe-pnl — compute from the row's own data.
           const updated = await pool.query<{ pnl: string }>(
             `UPDATE autonomous_trades
@@ -7564,6 +7582,18 @@ export class MonkeyKernel extends EventEmitter {
         // accounts for the position's own entry/exit, so is correct per-row).
         let orderId: string | null = null;
         for (const row of rows) {
+          // Operator paper MANDATE: while executionMode != 'auto' the kernel
+          // is fully disengaged from live. A live-origin row (non-paper
+          // order_id) is the operator's to manage — NEVER paper-close it
+          // (that books phantom PnL and orphans the real exchange position).
+          // Leave it open and untouched.
+          const isPaperOrigin = !!(row.order_id && row.order_id.startsWith('paper-'));
+          if (this.executionMode !== 'auto' && !isPaperOrigin) {
+            logger.debug('[Monkey] paper MANDATE — skip live-origin row (operator-owned)', {
+              rowId: row.id, orderId: row.order_id, executionMode: this.executionMode,
+            });
+            continue;
+          }
           const closeOrderId = row.order_id ? `paper-close-${row.order_id}` : `paper-close-${row.id}`;
           let explicitPnl: number | null = null;
           if (row.order_id && row.order_id.startsWith('paper-')) {
@@ -10880,7 +10910,17 @@ export class MonkeyKernel extends EventEmitter {
    *   (see kernel_rotation.ts module header guard-note).
    */
   private shouldRouteOrdersToPaper(): boolean {
-    return isMonkeyPaperMode() || this.rotation.mode === 'paper';
+    // 2026-06-01 — operator paper MANDATE: in 'paper_only' the kernel fully
+    // disengages from the live exchange and trades its own paper book, so
+    // BOTH entries and closes route to paper here. ('pause' is NOT routed to
+    // paper — it blocks new orders entirely via the entry veto; existing
+    // live positions are left for the operator. See executeExit / reconciler
+    // gating which skip live-origin positions whenever executionMode != auto.)
+    return (
+      this.executionMode === 'paper_only' ||
+      isMonkeyPaperMode() ||
+      this.rotation.mode === 'paper'
+    );
   }
 
   /**

--- a/apps/api/src/services/stateReconciliationService.ts
+++ b/apps/api/src/services/stateReconciliationService.ts
@@ -10,6 +10,7 @@ import { pool } from '../db/connection.js';
 import { verifyPnl, checkNotionalConsistency } from './monkey/safePnlSql.js';
 import poloniexFuturesService from './poloniexFuturesService.js';
 import { apiCredentialsService } from './apiCredentialsService.js';
+import { getCurrentExecutionMode } from './executionModeService.js';
 import { monitoringService } from './monitoringService.js';
 import { getEngineVersion } from '../utils/engineVersion.js';
 import { logger } from '../utils/logger.js';
@@ -81,6 +82,19 @@ class StateReconciliationService {
     };
 
     try {
+      // ── 0. Operator paper MANDATE ───────────────────────────────────────────
+      // When execution mode is not 'auto', the kernel is fully disengaged from
+      // the live exchange — the operator has taken over live positions. The
+      // reconciler MUST NOT adopt orphaned exchange positions (the operator's
+      // manual trades) or close ghost rows against the live account. Skip
+      // entirely; resume only in 'auto'.
+      const execMode = await getCurrentExecutionMode();
+      if (execMode !== 'auto') {
+        result.error = 'skipped_execution_mode_not_auto';
+        this.latestResults.set(userId, result);
+        return result;
+      }
+
       // ── 1. Credentials ──────────────────────────────────────────────────────
       const credentials = await apiCredentialsService.getCredentials(userId);
       if (!credentials) {


### PR DESCRIPTION
## Operator directive
When execution mode is **`paper_only`**, the kernel must **not interact with the live exchange at all** — no entries, no closes, no adoption/reconciliation of live positions. The operator takes over live fully; **positions the operator opens must be left untouched**. The kernel trades only its own paper book.

This supersedes #1060's *block-entries-only* semantic and closes the gap where the **reconciler still adopted/closed the operator's manual positions** regardless of mode (it runs un-gated from `index.ts`).

## Design — one canonical gate: *kernel touches live ONLY when `mode === 'auto'`*
- **Cache `executionMode`** on the kernel, refreshed once per tick from `agent_execution_mode` (the authoritative MANDATE surface — DB, not env).
- **`shouldRouteOrdersToPaper()`** returns true under `paper_only` → entries **and** closes route to the paper book. (`pause` still blocks new orders entirely via the entry veto; it is *not* routed to paper.)
- **Paper-close branch skips live-origin rows** (non-`paper-` `order_id`) when `mode != auto` — never paper-closes a real position (no phantom PnL, no orphan); the operator owns it. The `rows.length===0` fallback is likewise guarded.
- **`stateReconciliationService.reconcile()`** early-returns (`skipped_execution_mode_not_auto`) when `mode != auto` — no adopting orphaned exchange positions, no closing ghost rows against the live account.

## Verification
- New test: reconciler skips with **no live read and no DB write** under `paper_only`; all existing ghost/orphan recovery tests still pass under the `auto` default.
- `tsc` clean · **54** reconciler + risk + execution-mode tests pass.

## Note on the broader mandate
This is the safety-critical slice. It reads the MANDATE from `agent_execution_mode` (DB), not env — consistent with the larger **env-knob → UI** migration now scoped (8 MANDATE flags → UI, ~28 calibration → observer-derived, ~33 feature-gates, ~25 dead incl. `loop.ts.bak`), which will land as sequenced follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)