### PR TITLE
fix(monkey): predDop/predSer=0 — stop open-trade contamination of the RPE corpus

### DIFF
--- a/apps/api/src/services/monkey/predictionResidualJob.ts
+++ b/apps/api/src/services/monkey/predictionResidualJob.ts
@@ -126,8 +126,22 @@ export async function scanPredictionResiduals(): Promise<ResidualScanResult> {
             `SELECT pnl, status FROM autonomous_trades WHERE id = $1`,
             [row.trade_id],
           );
-          if (tradeQ.rows[0]?.status === 'closed') {
+          const tradeStatus = tradeQ.rows[0]?.status;
+          if (tradeStatus === 'closed') {
             realisedPnl = Number(tradeQ.rows[0].pnl ?? 0);
+          } else if (tradeStatus) {
+            // 2026-06-01 — DEFER undecided. The parent trade is still OPEN, so
+            // the realised value is not yet known. Writing a realisedPnl=0
+            // residual here makes direction_match structurally false
+            // (Math.sign(0) ≠ ±1) and — because the NOT EXISTS scan guard then
+            // stops the row being re-evaluated — that false row PERMANENTLY
+            // contaminates the prediction-skill window: it drags
+            // directionMatchRate below 0.5, which predictionRewardEmitter's
+            // anti-windup gate reads as "no skill" and zeroes BOTH predDop and
+            // predSer (prod symptom: predDop/predSer=0.000 indefinitely). Skip
+            // until the trade closes — re-selected next pass (no residual row
+            // yet), so the corpus only ever records DECIDED outcomes.
+            continue;
           }
         }
 

--- a/apps/api/src/services/monkey/predictionRewardEmitter.ts
+++ b/apps/api/src/services/monkey/predictionRewardEmitter.ts
@@ -102,10 +102,20 @@ export async function summariseRecentResiduals(
       within_1_sigma: boolean;
       residual_normalized: string | number;
     }>(
-      `SELECT direction_match, within_1_sigma, residual_normalized
-         FROM kernel_outcome_residuals
-        WHERE evaluated_at >= NOW() - ($1 || ' milliseconds')::INTERVAL
-        ORDER BY evaluated_at DESC
+      // 2026-06-01 — count ONLY residuals tied to a CLOSED trade. A prediction
+      // with no parent trade (a HOLD forecast) or an open trade has no realised
+      // outcome; its placeholder realisedPnl=0 row reads as a
+      // direction_match=false miss and would drag the skill rate below chance.
+      // Restricting the corpus to decided outcomes makes directionMatchRate
+      // reflect real forecast skill (and releases predDop/predSer once skill is
+      // demonstrated). Pairs with predictionResidualJob deferring open trades.
+      `SELECT r.direction_match, r.within_1_sigma, r.residual_normalized
+         FROM kernel_outcome_residuals r
+         JOIN kernel_predictions p ON p.id = r.prediction_id
+         JOIN autonomous_trades t ON t.id = p.trade_id
+        WHERE r.evaluated_at >= NOW() - ($1 || ' milliseconds')::INTERVAL
+          AND t.status = 'closed'
+        ORDER BY r.evaluated_at DESC
         LIMIT 500`,
       [windowMs],
     );


### PR DESCRIPTION
## Symptom
`predDop`/`predSer` = `0.000` on **every** live decision tick, indefinitely, despite `predN=76-88`. (You flagged this directly.) Source is `cachedPredictionChemistry` ← `predictionChemistryDeltas()` ← the 5-min `kernel_outcome_residuals` window — **not** the readiness gate (which only governs a separate degrade-revert flag; my earlier "by-design" call was wrong).

## Root cause — structural `direction_match` contamination
`predictionResidualJob` writes a residual for every elapsed prediction. For a prediction whose parent trade is still **OPEN** (or has no trade), `realisedPnl` is a placeholder `0`, so:
```js
directionMatch = Math.sign(0) === Math.sign(predictedDirection) && dir!==0  // always false
```
Predictions fire every tick; trades close rarely → the window fills with these `false` rows → `directionMatchRate < 0.5` → `predictionChemistryDeltas`' anti-windup gate early-returns `{ dopamineDelta: 0, serotoninDelta: 0 }` → **predDop/predSer pinned at 0 forever**. The `NOT EXISTS` scan guard then never corrects the open-time row after the trade closes.

## Fix (no migration — the channel was wired end-to-end, just inert by a data bug)
1. **`predictionResidualJob` defers undecided predictions** — when the parent trade is OPEN, `continue` instead of writing a `realisedPnl=0` row. It's re-selected on the next pass, so the corpus only ever records **decided** outcomes (real closed pnl).
2. **`predictionRewardEmitter.summariseRecentResiduals` counts only closed-trade residuals** (JOIN to the parent trade, `status='closed'`) — excludes no-trade HOLD forecasts that can never realise.

`directionMatchRate` now reflects real forecast skill, so the anti-windup gate releases `predDop`/`predSer` once skill is demonstrated.

`tsc` clean · 17 `predictionRewardEmitter` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent open or undecided trades from contaminating prediction outcome residuals so that reward chemistry reflects actual realised forecast performance.

Bug Fixes:
- Avoid treating open or no-trade predictions as permanent direction-miss residuals that zero out predDop/predSer.
- Ensure only residuals from closed trades contribute to directionMatchRate and reward chemistry calculations.

Enhancements:
- Defer residual creation for predictions whose parent trade is still open so the residual corpus only records decided outcomes.