### PR TITLE
fix(monkey): kernel must NEVER live-close when disengaged (pause leaked live closes)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -7505,7 +7505,15 @@ export class MonkeyKernel extends EventEmitter {
     // #931 exit-attribution: gate name (e.g. 'conviction_failed', 'bracket_sl');
     // defaults to exitReason for back-compat at call-sites we haven't migrated.
     const exitGate = req.exitGate ?? exitReason;
-    if (this.shouldRouteOrdersToPaper()) {
+    // 2026-06-01 — operator MANDATE: the kernel must NEVER place a live close
+    // when it is disengaged from the exchange. ANY non-'auto' execution mode
+    // (paper_only AND pause) routes the close through the paper-close branch,
+    // which skips live-origin rows entirely — the operator owns every live
+    // position. Previously only `shouldRouteOrdersToPaper()` (paper_only) was
+    // checked here, so under 'pause' the kernel still hit the LIVE reduceOnly
+    // path and closed an operator position for a loss. Live closes happen ONLY
+    // in 'auto'.
+    if (this.executionMode !== 'auto' || this.shouldRouteOrdersToPaper()) {
       if (!Number.isFinite(markPrice) || markPrice <= 0) {
         logger.warn('[Monkey] paper mode invalid mark price, skipping close', {
           symbol,


### PR DESCRIPTION
## CRITICAL — cost real money
With execution mode = **`pause`**, the kernel still **closed an operator's live position for a loss**. The operator had taken over a 4h-timeframe downtrend position and the kernel force-closed it.

### Root cause
`executeExit` routes to the **live** `reduceOnly` close path whenever `shouldRouteOrdersToPaper()` is false. That helper returns true only for `paper_only` (+ env/rotation) — **not `pause`**. So under `pause` the close hit the LIVE branch and shut the operator's position. #1061 gated entries and the paper-close branch, but the **live close branch under `pause`** was the gap.

### Fix
Route the close through the paper branch (which already **skips live-origin rows** — the operator owns them) for **any** non-`auto` mode:
```ts
if (this.executionMode !== 'auto' || this.shouldRouteOrdersToPaper())
```
The kernel places a live close **only in `auto`**. `executeExit` is the kernel's sole live-close site (the three `reduceOnly` `placeOrder` calls verified); `closePosition`/`closeAllPositions` are exclusively the operator's manual route (`futures.ts`).

**Net:** once the operator selects `paper_only` **or** `pause`, the kernel does not open, close, adopt, or reconcile any live position — full operator control. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent live reduce-only close orders from being sent when execution mode is set to a non-auto mode such as pause by routing exits through the paper-close path in those modes.