### PR TITLE
fix(monkey): gate stale-order cancel on auto — kernel touches live ONLY in auto

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -2179,7 +2179,12 @@ export class MonkeyKernel extends EventEmitter {
       // running the per-symbol pipeline. Stale = older than
       // LIMIT_MAKER_STALE_MS (2 min). Errors are non-fatal — the next
       // tick retries cancel.
-      try { await this.cancelStaleLimitMakers(); } catch { /* non-fatal */ }
+      // Operator MANDATE: only touch the live exchange in 'auto'. When the
+      // operator has taken over (paper_only / pause) the kernel must not even
+      // cancel resting orders — it is fully disengaged from the live account.
+      if (this.executionMode === 'auto') {
+        try { await this.cancelStaleLimitMakers(); } catch { /* non-fatal */ }
+      }
       for (const sym of this.symbols) {
         try {
           await this.processSymbol(sym);


### PR DESCRIPTION
Completes the disengagement guarantee. `cancelStaleLimitMakers` ran at the top of every tick **ungated**, so under `paper_only`/`pause` the kernel would still cancel resting live orders. Now it runs **only in `auto`**.

Combined with the entry veto, the close-path gate (#1063), and the reconciler gate (#1061), the kernel touches the live exchange **exclusively in `auto`** — in `paper_only`/`pause` the operator has complete control of live. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent stale-order cancellation from affecting live accounts when the system is in paper_only or pause modes.