### PR TITLE
chore(monkey): make-canonical the two already-always-on env gates

### DIFF
--- a/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
+++ b/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
@@ -12,8 +12,7 @@
  *   - fail-closed                → invalid price/margin → zero vector
  *
  * Hindsight is CANONICAL (always on) — the former MONKEY_HINDSIGHT_REGRET_LIVE
- * env gate was removed; there is no off path to test.
- *   - flag OFF                   → isHindsightRegretLive() false by default
+ * env gate was removed entirely; there is no off path to test.
  *
  * The FIXTURES block is shared verbatim with the Python parity test
  * (test_hindsight_regret.py) so TS↔Py outputs are asserted equal within

--- a/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
+++ b/apps/api/src/services/monkey/__tests__/hindsightRegret.test.ts
@@ -10,6 +10,9 @@
  *   - targeted GABA              → bound to (regime,side) pattern, never global
  *   - observer scale             → magnitude tracks the kernel's own MAD
  *   - fail-closed                → invalid price/margin → zero vector
+ *
+ * Hindsight is CANONICAL (always on) — the former MONKEY_HINDSIGHT_REGRET_LIVE
+ * env gate was removed; there is no off path to test.
  *   - flag OFF                   → isHindsightRegretLive() false by default
  *
  * The FIXTURES block is shared verbatim with the Python parity test
@@ -27,7 +30,6 @@ import {
   deriveMagnitude,
   gabaTargetKey,
   medianAndMad,
-  isHindsightRegretLive,
   type CloseSenseBundle,
   type CounterfactualOutcome,
 } from '../hindsightRegret.js';
@@ -246,25 +248,6 @@ describe('deriveMagnitude + medianAndMad', () => {
   it('returns null below MIN_SAMPLES or zero MAD', () => {
     expect(deriveMagnitude(0.3, [0.01])).toBeNull();
     expect(deriveMagnitude(0.3, [0.05, 0.05, 0.05, 0.05, 0.05])).toBeNull(); // MAD 0
-  });
-});
-
-describe('hindsight is canonical (no gate)', () => {
-  it('always live — not env-gated', () => {
-    const _original = process.env.MONKEY_HINDSIGHT_REGRET_LIVE;
-    try {
-      expect(isHindsightRegretLive()).toBe(true);
-      process.env.MONKEY_HINDSIGHT_REGRET_LIVE = 'false';
-      expect(isHindsightRegretLive()).toBe(true);
-      delete process.env.MONKEY_HINDSIGHT_REGRET_LIVE;
-      expect(isHindsightRegretLive()).toBe(true);
-    } finally {
-      if (_original !== undefined) {
-        process.env.MONKEY_HINDSIGHT_REGRET_LIVE = _original;
-      } else {
-        delete process.env.MONKEY_HINDSIGHT_REGRET_LIVE;
-      }
-    }
   });
 });
 

--- a/apps/api/src/services/monkey/__tests__/kernelRotationExpectancy.test.ts
+++ b/apps/api/src/services/monkey/__tests__/kernelRotationExpectancy.test.ts
@@ -18,7 +18,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   applyChronicDemote,
-  expectancyLiveEnabled,
   makeRotationState,
   promoteToLive,
   recordClose,
@@ -100,25 +99,6 @@ describe('rollingExpectancy', () => {
     const e = rollingExpectancy(stateWithPnls([+1, +1, +1, +1, +1, +1, +1, +1, -1, -1]));
     expect(e.edge).toBeCloseTo(0.6, 9);
     expect(e.lossWinRatio).toBeCloseTo(1, 9);
-  });
-});
-
-describe('expectancyLiveEnabled — canonical (no gate)', () => {
-  it('is always on, regardless of env', () => {
-    expect(expectancyLiveEnabled()).toBe(true);
-    const _orig = process.env.MONKEY_ROTATION_EXPECTANCY_LIVE;
-    try {
-      process.env.MONKEY_ROTATION_EXPECTANCY_LIVE = '******';
-      expect(expectancyLiveEnabled()).toBe(true);
-      process.env.MONKEY_ROTATION_EXPECTANCY_LIVE = 'true';
-      expect(expectancyLiveEnabled()).toBe(true);
-    } finally {
-      if (_orig !== undefined) {
-        process.env.MONKEY_ROTATION_EXPECTANCY_LIVE = _orig;
-      } else {
-        delete process.env.MONKEY_ROTATION_EXPECTANCY_LIVE;
-      }
-    }
   });
 });
 

--- a/apps/api/src/services/monkey/autonomic_client.ts
+++ b/apps/api/src/services/monkey/autonomic_client.ts
@@ -194,7 +194,7 @@ export async function callAutonomicPredictionReward(req: {
 
 /**
  * Fan the resolved hindsight NT vector to the Py autonomic surface
- * (MONKEY_HINDSIGHT_REGRET_LIVE — DESIGN HYPOTHESIS). Mirrors
+ * (hindsight is CANONICAL — always on). Mirrors
  * callAutonomicPredictionReward: best-effort, non-fatal, REPLACES the Py
  * cached hindsight vector. Keeps the Py chemistry (which drives executive
  * sizing + survives restarts) in parity with the TS fold. */

--- a/apps/api/src/services/monkey/hindsightRegret.ts
+++ b/apps/api/src/services/monkey/hindsightRegret.ts
@@ -1,9 +1,9 @@
 /**
  * hindsightRegret.ts — legibility-gated counterfactual PREDICTION ERROR.
  *
- * DESIGN HYPOTHESIS (operator-approved redesign of PR #1038, 2026-05-29).
- * Built cleanly, flag-gated OFF (MONKEY_HINDSIGHT_REGRET_LIVE), for operator
- * review — NOT a finished truth. Replaces the rejected v1 (fixed 30-min
+ * Operator-approved redesign of PR #1038 (2026-05-29). CANONICAL — always on
+ * (the former MONKEY_HINDSIGHT_REGRET_LIVE gate was removed). Replaces the
+ * rejected v1 (fixed 30-min
  * window + fixed dopamine caps + best-favourable-excursion target +
  * dopamine-only "pain") which was a knob dressed as chemistry.
  *

--- a/apps/api/src/services/monkey/hindsightRegret.ts
+++ b/apps/api/src/services/monkey/hindsightRegret.ts
@@ -440,11 +440,7 @@ export function resolveHindsight(
   };
 }
 
-/**
- * Hindsight regret is CANONICAL — the kernel always learns the counterfactual
- * "if I'd held, I'd have earned the reward" signal. Not a knob; built to be
- * used. (Was gated behind MONKEY_HINDSIGHT_REGRET_LIVE; gate removed 2026-05-30.)
- */
-export function isHindsightRegretLive(): boolean {
-  return true;
-}
+// Hindsight regret is CANONICAL — the kernel always learns the counterfactual
+// "if I'd held, I'd have earned the reward" signal. Not a knob; built to be
+// used. The former MONKEY_HINDSIGHT_REGRET_LIVE env gate (an always-true
+// wrapper) was removed entirely — every call site is now unconditional.

--- a/apps/api/src/services/monkey/kernel_rotation.ts
+++ b/apps/api/src/services/monkey/kernel_rotation.ts
@@ -60,7 +60,7 @@
  *
  * This module implements the LIVE/PAPER state machine + the
  * 5-consecutive-loss demotion trigger + WR-based auto-promotion, plus
- * (flag-gated, issue #1032) an expectancy-based chronic demote and a
+ * (canonical, issue #1032) an expectancy-based chronic demote and a
  * profit-shaped promotion gate.
  *
  * The state machine is INSTANCE-LOCAL: each MonkeyKernel owns its own
@@ -330,12 +330,11 @@ export interface RotationPeerSnapshot {
   rollingWinRate: number;        // NaN if no samples yet
   rollingSampleCount: number;
   /** Per-trade realized expectancy (edge), issue #1032. NaN if no
-   *  samples yet. Used by the expectancy-gated membership criterion;
-   *  ignored entirely when MONKEY_ROTATION_EXPECTANCY_LIVE is off. */
+   *  samples yet. Used by the expectancy-gated membership criterion. */
   rollingExpectancy?: number;
   /** Loss:win VALUE ratio |avgLoss|/avgWin, issue #1032. NaN / Infinity
    *  per rollingExpectancy semantics. Used as the cohort-relative bar
-   *  in the expectancy promotion gate; ignored when the flag is off. */
+   *  in the expectancy promotion gate. */
   rollingLossWinRatio?: number;
 }
 
@@ -408,8 +407,9 @@ function withinExpectancyBand(mine: number, best: number): boolean {
  * yet its expectancy sits far below the best live peer's.
  *
  * Fires (returns a reason string) iff:
- *   0. expectancyLive is true (flag MONKEY_ROTATION_EXPECTANCY_LIVE).
- *      When false this ALWAYS returns null — behaviour is unchanged.
+ *   0. expectancyLive is true. This is CANONICAL (always true in the live
+ *      kernel); the parameter is retained only so the pure function stays
+ *      testable in isolation (false ⇒ always returns null).
  *   1. The candidate is currently LIVE.
  *   2. The candidate has ≥ ROTATION_WR_MIN_SAMPLES closes (no demote on
  *      noise).
@@ -480,7 +480,7 @@ export function applyChronicDemote(
  *   4. The candidate's rolling WR must be within
  *      ROTATION_PROMOTION_WR_GAP of the BEST live peer's WR.
  *
- * When `expectancyLive` is true (flag MONKEY_ROTATION_EXPECTANCY_LIVE),
+ * When `expectancyLive` is true (CANONICAL — always true in the live kernel),
  * an ADDITIONAL profit-shaped gate is layered on top of the WR gate:
  *   5. The candidate's expectancy must be within ROTATION_EXPECTANCY_BAND
  *      of the best live peer's expectancy, AND

--- a/apps/api/src/services/monkey/kernel_rotation.ts
+++ b/apps/api/src/services/monkey/kernel_rotation.ts
@@ -137,23 +137,13 @@ export const ROTATION_EXPECTANCY_BAND = 0.10;
  */
 export const ROTATION_TARGET_LOSS_WIN_RATIO = 1 / 8;
 
-/**
- * Historical env-flag name for the chronic-expectancy membership criterion.
- * The expectancy firewall is now CANONICAL (always on); this constant is
- * retained for reference/telemetry only. `expectancyLiveEnabled()` ignores
- * this env var and always returns `true`.
- */
-export const ROTATION_EXPECTANCY_FLAG = 'MONKEY_ROTATION_EXPECTANCY_LIVE';
-
-/**
- * The expectancy-membership capital firewall is CANONICAL — always on. It's how
- * the kernel governs its own capital (negative-EV bleeders route to paper while
- * the kernel keeps ticking blind), not an operator dial. Built to be used.
- * (Was gated behind MONKEY_ROTATION_EXPECTANCY_LIVE; gate removed 2026-05-30.)
- */
-export function expectancyLiveEnabled(): boolean {
-  return true;
-}
+// The expectancy-membership capital firewall is CANONICAL — always on. It's how
+// the kernel governs its own capital (negative-EV bleeders route to paper while
+// the kernel keeps ticking blind), not an operator dial. The former
+// MONKEY_ROTATION_EXPECTANCY_LIVE env gate (an always-true wrapper) was removed
+// entirely; callers pass `expectancyLive = true` unconditionally. The internal
+// `expectancyLive` parameter is retained only as a pure-function input so the
+// demote/promote helpers stay testable in isolation.
 
 export type KernelOperationalMode = 'live' | 'paper';
 

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -871,7 +871,7 @@ interface SymbolState {
     tapeTrend: number;
     computedAtMs: number;
   } | null;
-  /** 2026-05-29 hindsight (flag-gated): the most recent qig-warp expectation
+  /** 2026-05-29 hindsight: the most recent qig-warp expectation
    *  decision computed for this symbol (entry path), kept so the hindsight
    *  legibility gate at close time can read the kernel's own latest forecast
    *  direction + confidence + observed regime-persistence horizon. Null until
@@ -1129,8 +1129,8 @@ export class MonkeyKernel extends EventEmitter {
    *  predictionEmitterTimer. Null until the first emitter pass. */
   private cachedPredictionChemistry: PredictionChemistryDeltas | null = null;
   /**
-   * Hindsight / counterfactual-regret subsystem (MONKEY_HINDSIGHT_REGRET_LIVE,
-   * default OFF; DESIGN HYPOTHESIS for operator review — see hindsightRegret.ts).
+   * Hindsight / counterfactual-regret subsystem (CANONICAL — always on;
+   * see hindsightRegret.ts).
    *
    * After a KERNEL-OWNED close we keep watching the symbol until the derived
    * HORIZON elapses (observer-derived regime-persistence window — NOT a fixed
@@ -2692,7 +2692,7 @@ export class MonkeyKernel extends EventEmitter {
     const predDop = predChem?.dopamineDelta ?? 0;
     const predSer = predChem?.serotoninDelta ?? 0;
 
-    // Hindsight / counterfactual-regret NT vector (flag-gated, default OFF).
+    // Hindsight / counterfactual-regret NT vector (CANONICAL — always on).
     // The `cachedHindsight*` caches accumulate the resolved E6 NT deltas
     // (evaluateHindsightWatches). tick() decays them ONCE before the per-symbol
     // loop so all symbols see the same vector for a kernel tick (no symbol-order
@@ -3012,7 +3012,7 @@ export class MonkeyKernel extends EventEmitter {
       basin,
     ]);
 
-    // Hindsight / counterfactual-regret evaluation (flag-gated, default OFF).
+    // Hindsight / counterfactual-regret evaluation (CANONICAL — always on).
     // Advance any active watches for this symbol with the fresh price + live
     // regime: track the horizon-end counterfactual pnl and whether the regime
     // observed at close still holds. Resolve the watches whose derived horizon
@@ -4495,10 +4495,8 @@ export class MonkeyKernel extends EventEmitter {
         } catch (err) {
           expectationDecision = null;
         }
-        // 2026-05-29 hindsight (flag-gated): persist the kernel's latest
-        // qig-warp forecast so the close-time legibility gate can read it.
-        // Stored regardless of the flag (cheap, no behavioural effect when
-        // the flag is OFF — nothing reads it).
+        // 2026-05-29 hindsight: persist the kernel's latest qig-warp forecast
+        // so the close-time legibility gate can read it.
         if (expectationDecision !== null) {
           state.lastExpectation = {
             direction: expectationDecision.expectation_direction,
@@ -9497,7 +9495,7 @@ export class MonkeyKernel extends EventEmitter {
 
   /**
    * Advance + resolve hindsight/counterfactual-regret watches for one symbol
-   * (MONKEY_HINDSIGHT_REGRET_LIVE, default OFF; caller gates; DESIGN HYPOTHESIS).
+   * (CANONICAL — always on).
    *
    * For each active watch this tick:
    *   1. update `lastCounterfactualPnlUsdt` = pnl of having HELD to NOW (this
@@ -10662,7 +10660,7 @@ export class MonkeyKernel extends EventEmitter {
     // 2026-05-29 (issue #1032) — CHRONIC expectancy-based membership
     // demote. Catches the negative-EV bleeder the 5-consecutive-loss
     // breaker misses (tiny wins interspersed between large losses never
-    // hit 5-in-a-row). Flag-gated behind MONKEY_ROTATION_EXPECTANCY_LIVE
+    // hit 5-in-a-row).
     // The expectancy firewall is CANONICAL (always on) — it's how the kernel
     // governs its own capital, not an operator dial. Only evaluated when the
     // acute breaker did NOT already demote and the kernel is still live.

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -126,7 +126,6 @@ import { computeMotivators } from './motivators.js';
 import { computeNeurochemicals, summarizeNC, type NeurochemicalState } from './neurochemistry.js';
 import {
   applyChronicDemote,
-  expectancyLiveEnabled,
   makeRotationState,
   promoteToLive,
   recordClose as recordRotationClose,
@@ -238,7 +237,6 @@ import {
 import {
   counterfactualPnlUsdt,
   resolveHindsight,
-  isHindsightRegretLive,
   type CloseSenseBundle,
   type CounterfactualOutcome,
 } from './hindsightRegret.js';
@@ -2195,7 +2193,6 @@ export class MonkeyKernel extends EventEmitter {
   }
 
   private decayHindsightCachesOncePerTick(): void {
-    if (!isHindsightRegretLive()) return;
     const HINDSIGHT_HALF_LIFE_MS = 20 * 60 * 1000;
     const decay = Math.pow(0.5, this.tickMs / HINDSIGHT_HALF_LIFE_MS);
     this.cachedHindsightDopamine *= decay;
@@ -2709,7 +2706,7 @@ export class MonkeyKernel extends EventEmitter {
     let hindsightAch = 0;
     let hindsightNe = 0;
     let hindsightEndo = 0;
-    if (isHindsightRegretLive()) {
+    {
       hindsightDop = this.cachedHindsightDopamine;
       hindsightSer = this.cachedHindsightSerotonin;
       hindsightAch = this.cachedHindsightAcetylcholine;
@@ -3020,9 +3017,7 @@ export class MonkeyKernel extends EventEmitter {
     // regime: track the horizon-end counterfactual pnl and whether the regime
     // observed at close still holds. Resolve the watches whose derived horizon
     // has elapsed into the E6 NT vector. Best-effort; never throws into tick.
-    if (isHindsightRegretLive()) {
-      this.evaluateHindsightWatches(symbol, lastPrice, String(regimeReading.regime));
-    }
+    this.evaluateHindsightWatches(symbol, lastPrice, String(regimeReading.regime));
 
     // Phase B — geometry-derived TP/SL bracket. Recompute each tick from
     // the current φ, regime confidence and ATR(14); stash on symbol state
@@ -9628,7 +9623,6 @@ export class MonkeyKernel extends EventEmitter {
     closeLane?: 'scalp' | 'swing' | 'trend';
     regimeAtClose?: string;
   }): Promise<void> {
-    if (!isHindsightRegretLive()) return;
     try {
       const { tradeIds, symbol, side } = params;
       const sideSign: 1 | -1 = side === 'long' ? 1 : -1;
@@ -10669,11 +10663,10 @@ export class MonkeyKernel extends EventEmitter {
     // demote. Catches the negative-EV bleeder the 5-consecutive-loss
     // breaker misses (tiny wins interspersed between large losses never
     // hit 5-in-a-row). Flag-gated behind MONKEY_ROTATION_EXPECTANCY_LIVE
-    // (default OFF). When off, applyChronicDemote returns demoted:false
-    // unconditionally and behaviour is byte-for-byte unchanged. Only
-    // evaluated when the acute breaker did NOT already demote and the
-    // kernel is still live.
-    const expectancyLive = expectancyLiveEnabled();
+    // The expectancy firewall is CANONICAL (always on) — it's how the kernel
+    // governs its own capital, not an operator dial. Only evaluated when the
+    // acute breaker did NOT already demote and the kernel is still live.
+    const expectancyLive = true;
     if (expectancyLive && !rotationResult.demoted && this.rotation.mode === 'live') {
       const peers = this.buildRotationPeerSnapshots(expectancyLive);
       const chronic = applyChronicDemote(this.rotation, peers, expectancyLive);
@@ -10742,7 +10735,7 @@ export class MonkeyKernel extends EventEmitter {
    * kernel's paper-mode WR has reached the gate, promotes.
    */
   private tryAutoPromote(symbol: string | undefined): void {
-    const expectancyLive = expectancyLiveEnabled();
+    const expectancyLive = true;
     const peers = this.buildRotationPeerSnapshots(expectancyLive);
     const reason = shouldAutoPromote(this.rotation, peers, expectancyLive);
     if (!reason) return;

--- a/apps/api/src/services/monkey/neurochemistry.ts
+++ b/apps/api/src/services/monkey/neurochemistry.ts
@@ -212,7 +212,7 @@ export interface NeurochemicalInputs {
   /** As above — peak-state reward on strong-regime wins. */
   rewardEndorphinDelta?: number;
   /**
-   * 2026-05-29 (hindsight, MONKEY_HINDSIGHT_REGRET_LIVE — DESIGN HYPOTHESIS):
+   * 2026-05-29 (hindsight — CANONICAL, always on):
    * additive ACh / NE / GABA reward deltas from the hindsight NT vector. The
    * trade-outcome reward channel only carries dop/ser/endo; the hindsight
    * signal also wants to bind cues (ACh↑), mark salience (NE↑), and apply


### PR DESCRIPTION
## What

`isHindsightRegretLive()` and `expectancyLiveEnabled()` were both reduced to a hardcoded `return true` when their gates were removed 2026-05-30, but the env-reading wrapper functions, their call-site conditionals, and their flag-behaviour tests lingered — and the matching Railway vars (`MONKEY_HINDSIGHT_REGRET_LIVE`, `MONKEY_ROTATION_EXPECTANCY_LIVE`, both `=true` in prod) still look like live operator knobs. Per the zero-env-feature-knob doctrine, removed the vestigial gates.

## Changes
- **hindsightRegret.ts**: delete `isHindsightRegretLive()` (was `return true`).
- **loop.ts**: make all four hindsight call sites unconditional; drop the import. Replace the two `expectancyLiveEnabled()` reads with `true`; drop the import.
- **kernel_rotation.ts**: delete `expectancyLiveEnabled()` + the dead `ROTATION_EXPECTANCY_FLAG`. The internal `expectancyLive` parameter stays (pure-function input for testability — not an env knob).
- **tests**: remove the two flag-behaviour blocks (only asserted the always-true wrappers) + imports.

## Behaviour
**Neutral.** Both wrappers already returned `true`; prod had both vars `=true`. No runtime path changes.

## Gates
- `tsc --noEmit`: **0 errors**
- hindsight + kernelRotation + kernelRotationExpectancy suites: **71/71 pass**
- full `vitest run src/services/monkey`: **1503 pass / 1 fail** — the fail (`autonomicFeedback` serotonin boundary) reproduces on clean `origin/main`; pre-existing.

## Deploy follow-up
Retire the now-zero-consumer Railway vars: `MONKEY_HINDSIGHT_REGRET_LIVE` (polytrade-be + ml-worker), `MONKEY_ROTATION_EXPECTANCY_LIVE` (polytrade-be), and `MONKEY_REWARD_EXTERNAL_CLOSES_LIVE` (polytrade-be — 0 code refs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove vestigial environment-gated wrappers for canonical hindsight regret and rotation expectancy behaviour in the monkey kernel, making these mechanisms unconditionally active in code.

Enhancements:
- Inline hindsight regret usage in the monkey kernel loop and remove the now-redundant isHindsightRegretLive helper.
- Remove the obsolete rotation expectancy env flag and helper, documenting expectancy as an always-on capital firewall while keeping the internal parameter for testability.

Tests:
- Delete tests that only asserted the always-true behaviour of the removed env-gated wrappers, reflecting the canonical always-on behaviour in code comments instead.