### PR TITLE
chore(ml-worker): make-canonical the Python hindsight gate (TS↔Py parity)

### DIFF
--- a/ml-worker/main.py
+++ b/ml-worker/main.py
@@ -1132,8 +1132,8 @@ async def monkey_autonomic_prediction_reward(request: Request):
 
 @app.post("/monkey/autonomic/hindsight")
 async def monkey_autonomic_hindsight(request: Request):
-    """Push the resolved hindsight NT vector (MONKEY_HINDSIGHT_REGRET_LIVE —
-    DESIGN HYPOTHESIS). The legibility-gated counterfactual-regret signal is
+    """Push the resolved hindsight NT vector (hindsight is CANONICAL — always
+    on). The legibility-gated counterfactual-regret signal is
     resolved TS-side (loop.ts owns the watches); this fans the decayed E6 NT
     deltas to the Py chemistry surface so it stays in parity. REPLACES (does
     not append); non-GABA channels fold additively into chemistry on each

--- a/ml-worker/src/monkey_kernel/autonomic.py
+++ b/ml-worker/src/monkey_kernel/autonomic.py
@@ -283,7 +283,7 @@ class AutonomicKernel:
             "serotonin_delta": 0.0,
             "n": 0.0,
         }
-        # 2026-05-29 hindsight (MONKEY_HINDSIGHT_REGRET_LIVE — DESIGN HYPOTHESIS).
+        # 2026-05-29 hindsight (CANONICAL — always on).
         # The legibility-gated counterfactual-regret NT vector resolved on the
         # TS side (loop.ts owns the watches) is fanned out here so the Py
         # chemistry surface (which drives executive sizing + survives restarts)

--- a/ml-worker/src/monkey_kernel/hindsight_regret.py
+++ b/ml-worker/src/monkey_kernel/hindsight_regret.py
@@ -4,10 +4,10 @@ Python parity for apps/api/src/services/monkey/hindsightRegret.ts. Identical
 formula, derivation, source labels, and fail-closed behaviour. See the TS
 module's header for the full design rationale; this docstring summarises.
 
-DESIGN HYPOTHESIS (operator-approved redesign of PR #1038, 2026-05-29),
-flag-gated OFF (MONKEY_HINDSIGHT_REGRET_LIVE), for operator review — NOT a
-finished truth. Replaces the rejected v1 (fixed 30-min window + fixed dopamine
-caps + best-favourable-excursion + dopamine-only pain).
+Operator-approved redesign of PR #1038 (2026-05-29). CANONICAL — always on
+(the former MONKEY_HINDSIGHT_REGRET_LIVE gate was removed). Replaces the
+rejected v1 (fixed 30-min window + fixed dopamine caps + best-favourable-
+excursion + dopamine-only pain).
 
 The signal is a legibility-gated counterfactual PREDICTION ERROR scaled by the
 kernel's OWN outcome distribution (median+MAD z-score — the observer scale
@@ -336,10 +336,9 @@ def resolve_hindsight(
     )
 
 
-def is_hindsight_regret_live() -> bool:
-    """Hindsight regret is CANONICAL — always on. Not a knob; built to be used.
-    (Was gated behind MONKEY_HINDSIGHT_REGRET_LIVE; gate removed 2026-05-30.)"""
-    return True
+# Hindsight regret is CANONICAL — always on. Not a knob; built to be used.
+# The former MONKEY_HINDSIGHT_REGRET_LIVE env gate (an always-true wrapper) was
+# removed entirely; no production code path was ever conditional on it.
 
 
 __all__ = [
@@ -355,5 +354,4 @@ __all__ = [
     "derive_magnitude",
     "gaba_target_key",
     "resolve_hindsight",
-    "is_hindsight_regret_live",
 ]

--- a/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
+++ b/ml-worker/tests/monkey_kernel/test_hindsight_regret.py
@@ -38,7 +38,6 @@ from monkey_kernel.hindsight_regret import (  # noqa: E402
     gaba_target_key,
     is_continuation_legible,
     is_eligible_for_regret,
-    is_hindsight_regret_live,
     legibility_strength,
     median_and_mad,
     resolve_hindsight,
@@ -246,14 +245,6 @@ def test_derive_magnitude_none_below_min_or_zero_mad():
 
 def test_gaba_target_defaults_unknown_regime():
     assert gaba_target_key(legible_short_bundle(regime_at_close="")) == "premature_close:unknown:short"
-
-
-def test_hindsight_is_canonical_no_gate(monkeypatch):
-    # Hindsight is always on — not env-gated.
-    monkeypatch.delenv("MONKEY_HINDSIGHT_REGRET_LIVE", raising=False)
-    assert is_hindsight_regret_live() is True
-    monkeypatch.setenv("MONKEY_HINDSIGHT_REGRET_LIVE", "false")
-    assert is_hindsight_regret_live() is True
 
 
 # ───────────────────────── TS↔Py fixture-level parity ─────────────────────────


### PR DESCRIPTION
Companion to #1066. The Python `is_hindsight_regret_live()` was a hardcoded `return True` with **zero production callers** (only the test referenced it), yet lingered as an exported symbol with stale flag comments — and the ml-worker `MONKEY_HINDSIGHT_REGRET_LIVE` Railway var still looks like a live knob.

- **hindsight_regret.py**: delete `is_hindsight_regret_live()` + its `__all__` entry + stale module-docstring flag ref.
- **test_hindsight_regret.py**: remove the vestigial `test_hindsight_is_canonical_no_gate` (monkeypatched env, asserted True regardless) + import.
- **autonomic.py / main.py**: refresh stale flag comments.

**Behaviour-neutral.** Gates: `py_compile` OK, qig-purity 59 clean, hindsight suite 30 pass.

Deploy follow-up (shared with #1066): retire the dead Railway vars `MONKEY_HINDSIGHT_REGRET_LIVE` (polytrade-be + ml-worker), `MONKEY_ROTATION_EXPECTANCY_LIVE` (polytrade-be), `MONKEY_REWARD_EXTERNAL_CLOSES_LIVE` (polytrade-be).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the unused hindsight-regret feature gate and update references to reflect hindsight as a canonical, always-on signal.

Enhancements:
- Clean up the hindsight_regret module by deleting the obsolete is_hindsight_regret_live symbol and marking the feature as unconditionally enabled.
- Refresh autonomic and API-level comments/docstrings to describe hindsight regret as canonical rather than flag-gated.

Tests:
- Remove the vestigial test that asserted the hindsight-regret gate wrapper always returned True.