### PR TITLE
refactor(monkey): fold MONKEY_EXECUTE/TRADING_PAUSED/PAPER_MODE into executionMode tri-state

### DIFF
--- a/apps/api/src/services/__tests__/paperExchangeSimulator.test.ts
+++ b/apps/api/src/services/__tests__/paperExchangeSimulator.test.ts
@@ -19,11 +19,6 @@ describe('paperExchangeSimulator', () => {
     mockedQuery.mockReset();
   });
 
-  afterEach(() => {
-    delete process.env.MONKEY_TRADING_PAUSED;
-    delete process.env.MONKEY_PAPER_MODE;
-  });
-
   it('paperPlaceOrder returns a synthetic order id prefixed paper-', async () => {
     mockedQuery.mockResolvedValueOnce({ rows: [] });
     const result = await paperPlaceOrder({
@@ -108,14 +103,6 @@ describe('paperExchangeSimulator', () => {
       expect.stringContaining('exit_time IS NULL'),
       ['monkey', 'u-1'],
     );
-  });
-
-  it('MONKEY_TRADING_PAUSED=true takes precedence over MONKEY_PAPER_MODE=true', () => {
-    process.env.MONKEY_TRADING_PAUSED = 'true';
-    process.env.MONKEY_PAPER_MODE = 'true';
-    const shouldRouteToPaper = process.env.MONKEY_TRADING_PAUSED !== 'true'
-      && process.env.MONKEY_PAPER_MODE === 'true';
-    expect(shouldRouteToPaper).toBe(false);
   });
 
 });

--- a/apps/api/src/services/monkey/__tests__/killSwitch.test.ts
+++ b/apps/api/src/services/monkey/__tests__/killSwitch.test.ts
@@ -1,142 +1,93 @@
 /**
- * killSwitch.test.ts — v0.8.7 MONKEY_TRADING_PAUSED env var kill switch.
+ * killSwitch.test.ts — the operator kill switch on the agent_execution_mode
+ * tri-state (executionMode === 'pause').
  *
  * Gates entry-order placement only:
  *   * enter_long, enter_short
  *   * DCA pyramid adds (Agent K and Agent T)
  *   * Reverse-reopen leg (the close still proceeds)
- *   * Agent M entries
+ *   * Agent M / L entries
  *
  * Does NOT gate exit-order placement — existing positions must close
  * cleanly during deploy / incident response (scalp_exit, auto_flatten,
  * hard SL, rejust exits all proceed normally).
  *
- * Read at order-placement time (live, not cached at startup) so the
- * operator can flip the env var on Railway without redeploying.
+ * The former MONKEY_TRADING_PAUSED env var was folded into this tri-state:
+ * loop.ts reads this.executionMode (fetched per-tick from agent_execution_mode)
+ * so the operator flips it from the UI without redeploying.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
-const ENV_KEY = 'MONKEY_TRADING_PAUSED';
+type ExecutionMode = 'auto' | 'paper_only' | 'pause';
 
-describe('MONKEY_TRADING_PAUSED kill switch — env var semantics', () => {
-  let savedEnv: string | undefined;
+// Mirror of the production gate: loop.ts suppresses new entries when
+// this.executionMode === 'pause'. This test pins that contract so a refactor
+// can't accidentally break the kill switch.
+const isPaused = (mode: ExecutionMode): boolean => mode === 'pause';
 
-  beforeEach(() => {
-    savedEnv = process.env[ENV_KEY];
-    delete process.env[ENV_KEY];
+describe("executionMode='pause' kill switch — mode semantics", () => {
+  it("'auto' is unpaused", () => {
+    expect(isPaused('auto')).toBe(false);
   });
 
-  afterEach(() => {
-    if (savedEnv !== undefined) {
-      process.env[ENV_KEY] = savedEnv;
-    } else {
-      delete process.env[ENV_KEY];
-    }
+  it("'paper_only' is unpaused (kernel trades its paper book)", () => {
+    expect(isPaused('paper_only')).toBe(false);
   });
 
-  // We exercise the helper isTradingPaused via an inline mirror of the
-  // semantics. The actual production helper is a module-private const
-  // in loop.ts; the contract is "process.env.MONKEY_TRADING_PAUSED ===
-  // 'true' returns true". This test pins that contract so a refactor
-  // can't accidentally break the kill switch.
-  const isTradingPaused = (): boolean =>
-    process.env[ENV_KEY] === 'true';
-
-  it('default (env unset) is unpaused', () => {
-    expect(isTradingPaused()).toBe(false);
-  });
-
-  it('"true" pauses entries', () => {
-    process.env[ENV_KEY] = 'true';
-    expect(isTradingPaused()).toBe(true);
-  });
-
-  it('"false" does not pause', () => {
-    process.env[ENV_KEY] = 'false';
-    expect(isTradingPaused()).toBe(false);
-  });
-
-  it('any other value does not pause (strict "true" comparison)', () => {
-    process.env[ENV_KEY] = '1';
-    expect(isTradingPaused()).toBe(false);
-    process.env[ENV_KEY] = 'TRUE';
-    expect(isTradingPaused()).toBe(false);
-    process.env[ENV_KEY] = 'yes';
-    expect(isTradingPaused()).toBe(false);
-  });
-
-  it('toggling at runtime takes effect immediately (not cached)', () => {
-    expect(isTradingPaused()).toBe(false);
-    process.env[ENV_KEY] = 'true';
-    expect(isTradingPaused()).toBe(true);
-    process.env[ENV_KEY] = 'false';
-    expect(isTradingPaused()).toBe(false);
-    delete process.env[ENV_KEY];
-    expect(isTradingPaused()).toBe(false);
+  it("'pause' pauses entries", () => {
+    expect(isPaused('pause')).toBe(true);
   });
 });
 
-describe('MONKEY_TRADING_PAUSED kill switch — gating contract', () => {
+describe("executionMode='pause' kill switch — gating contract", () => {
   // The kill switch contract is implemented inline in loop.ts at every
-  // entry-order placement site. These tests pin the contract by
-  // replicating the gate logic and asserting the action is
-  // suppressed / allowed correctly. The integration-level test
-  // (loop.ts processSymbol) is exercised by the live tape on Railway.
-
-  let savedEnv: string | undefined;
-  beforeEach(() => {
-    savedEnv = process.env[ENV_KEY];
-  });
-  afterEach(() => {
-    if (savedEnv !== undefined) {
-      process.env[ENV_KEY] = savedEnv;
-    } else {
-      delete process.env[ENV_KEY];
-    }
-  });
-
-  const tryEnter = (action: string, paused: boolean): { suppressed: boolean } => {
-    process.env[ENV_KEY] = paused ? 'true' : 'false';
+  // entry-order placement site. These tests pin the contract by replicating
+  // the gate logic and asserting the action is suppressed / allowed correctly.
+  // The integration-level test (loop.ts processSymbol) is exercised by the live
+  // tape on Railway.
+  const tryEnter = (action: string, mode: ExecutionMode): { suppressed: boolean } => {
     const isEntry = action === 'enter_long' || action === 'enter_short'
       || action === 'pyramid_long' || action === 'pyramid_short';
-    const suppressed = isEntry && process.env[ENV_KEY] === 'true';
-    return { suppressed };
+    return { suppressed: isEntry && mode === 'pause' };
   };
 
   it('entry actions suppressed when paused', () => {
-    expect(tryEnter('enter_long', true).suppressed).toBe(true);
-    expect(tryEnter('enter_short', true).suppressed).toBe(true);
-    expect(tryEnter('pyramid_long', true).suppressed).toBe(true);
-    expect(tryEnter('pyramid_short', true).suppressed).toBe(true);
+    expect(tryEnter('enter_long', 'pause').suppressed).toBe(true);
+    expect(tryEnter('enter_short', 'pause').suppressed).toBe(true);
+    expect(tryEnter('pyramid_long', 'pause').suppressed).toBe(true);
+    expect(tryEnter('pyramid_short', 'pause').suppressed).toBe(true);
   });
 
-  it('entry actions allowed when unpaused', () => {
-    expect(tryEnter('enter_long', false).suppressed).toBe(false);
-    expect(tryEnter('enter_short', false).suppressed).toBe(false);
-    expect(tryEnter('pyramid_long', false).suppressed).toBe(false);
-    expect(tryEnter('pyramid_short', false).suppressed).toBe(false);
+  it('entry actions allowed in auto and paper_only', () => {
+    for (const mode of ['auto', 'paper_only'] as const) {
+      expect(tryEnter('enter_long', mode).suppressed).toBe(false);
+      expect(tryEnter('enter_short', mode).suppressed).toBe(false);
+      expect(tryEnter('pyramid_long', mode).suppressed).toBe(false);
+      expect(tryEnter('pyramid_short', mode).suppressed).toBe(false);
+    }
   });
 
-  it('exit actions never suppressed (regardless of pause state)', () => {
+  it('exit actions never suppressed (regardless of mode)', () => {
     // The contract: scalp_exit / auto_flatten / exit_stop / exit_donchian
-    // / hard_sl / rejust_exit / override_reverse all flow through their
-    // own close paths which the kill switch does NOT gate.
-    expect(tryEnter('scalp_exit', true).suppressed).toBe(false);
-    expect(tryEnter('scalp_exit', false).suppressed).toBe(false);
-    expect(tryEnter('auto_flatten', true).suppressed).toBe(false);
-    expect(tryEnter('exit_stop', true).suppressed).toBe(false);
-    expect(tryEnter('exit_donchian', true).suppressed).toBe(false);
+    // / hard_sl / rejust_exit / override_reverse all flow through their own
+    // close paths which the kill switch does NOT gate.
+    for (const mode of ['auto', 'paper_only', 'pause'] as const) {
+      expect(tryEnter('scalp_exit', mode).suppressed).toBe(false);
+      expect(tryEnter('auto_flatten', mode).suppressed).toBe(false);
+      expect(tryEnter('exit_stop', mode).suppressed).toBe(false);
+      expect(tryEnter('exit_donchian', mode).suppressed).toBe(false);
+    }
   });
 
   it('reverse close proceeds, reopen leg suppressed when paused', () => {
-    // The reverse path is two-phase: close (always proceeds) then
-    // reopen (gated). The contract surfaces "trading_paused: new <side>
-    // entry suppressed" in the reason string when paused.
-    process.env[ENV_KEY] = 'true';
+    // The reverse path is two-phase: close (always proceeds) then reopen
+    // (gated). The contract surfaces "trading_paused: new <side> entry
+    // suppressed" in the reason string when paused.
     const action = 'reverse_long';
+    const mode: ExecutionMode = 'pause';
     const closeFires = action === 'reverse_long' || action === 'reverse_short';
-    const reopenSuppressed = (action === 'reverse_long' || action === 'reverse_short')
-      && process.env[ENV_KEY] === 'true';
+    const reopenSuppressed =
+      (action === 'reverse_long' || action === 'reverse_short') && mode === 'pause';
     expect(closeFires).toBe(true);
     expect(reopenSuppressed).toBe(true);
   });

--- a/apps/api/src/services/monkey/__tests__/killSwitch.test.ts
+++ b/apps/api/src/services/monkey/__tests__/killSwitch.test.ts
@@ -17,8 +17,7 @@
  * so the operator flips it from the UI without redeploying.
  */
 import { describe, it, expect } from 'vitest';
-
-type ExecutionMode = 'auto' | 'paper_only' | 'pause';
+import type { ExecutionMode } from '../../executionModeService.js';
 
 // Mirror of the production gate: loop.ts suppresses new entries when
 // this.executionMode === 'pause'. This test pins that contract so a refactor

--- a/apps/api/src/services/monkey/__tests__/signalScorer.test.ts
+++ b/apps/api/src/services/monkey/__tests__/signalScorer.test.ts
@@ -27,7 +27,6 @@ function facts(over: Partial<GateFacts>): GateFacts {
     modeCanEnter: true,
     sideShortRefused: false,
     sizeValue: 100,
-    executeEnabled: true,
     tradingPaused: false,
     lVetoed: false,
     cappedMargin: 100,
@@ -49,7 +48,6 @@ describe('resolveEntryGate', () => {
     expect(resolveEntryGate(facts({ modeCanEnter: false }))).toBe('mode');
     expect(resolveEntryGate(facts({ sideShortRefused: true }))).toBe('short_refused');
     expect(resolveEntryGate(facts({ sizeValue: 0 }))).toBe('min_notional');
-    expect(resolveEntryGate(facts({ executeEnabled: false }))).toBe('observe_only');
     expect(resolveEntryGate(facts({ tradingPaused: true }))).toBe('trading_paused');
     expect(resolveEntryGate(facts({ lVetoed: true }))).toBe('l_veto');
     expect(resolveEntryGate(facts({ cappedMargin: 0 }))).toBe('arbiter_zero');

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -497,22 +497,13 @@ export function observerConvictionStreakRequired(
   return Math.max(CONVICTION_STREAK_FLOOR, Math.min(CONVICTION_STREAK_CAP, scaled));
 }
 
-/**
- * v0.8.7 kill switch — when MONKEY_TRADING_PAUSED=true, gate
- * entry-order placement only. Exit orders (scalp_exit, auto_flatten,
- * hard SL, rejust exits) are NOT gated; existing positions must close
- * cleanly during deploy/incident response. Default false (no pause).
- *
- * Reads at order-placement time (live, not cached at startup) so the
- * operator can flip the env var on Railway without redeploying.
- */
-function isTradingPaused(): boolean {
-  return process.env.MONKEY_TRADING_PAUSED === 'true';
-}
-
-function isMonkeyPaperMode(): boolean {
-  return process.env.MONKEY_PAPER_MODE === 'true';
-}
+// Kill switch + paper routing are CANONICAL on the agent_execution_mode
+// tri-state (this.executionMode, fetched per-tick from the DB). 'pause' gates
+// entry-order placement only — exits (scalp_exit, auto_flatten, hard SL, rejust
+// exits) are NOT gated so open positions close cleanly. 'paper_only' routes
+// both entries and closes to the paper book (see shouldRouteOrdersToPaper).
+// The former MONKEY_TRADING_PAUSED / MONKEY_PAPER_MODE / MONKEY_EXECUTE env
+// knobs were folded into this tri-state and removed.
 
 // ─── L-veto-over-K (Option A) ─────────────────────────────────────
 //
@@ -1470,7 +1461,9 @@ export class MonkeyKernel extends EventEmitter {
 
   /**
    * Start Monkey's heartbeat — the 60s tick that drives all live
-   * execution. MONKEY_EXECUTE gates whether ticks place real orders.
+   * execution. The agent_execution_mode tri-state (this.executionMode)
+   * gates whether ticks place real orders ('auto'), paper orders
+   * ('paper_only'), or suppress entries ('pause').
    */
   async start(): Promise<void> {
     for (const sym of this.symbols) {
@@ -1638,7 +1631,7 @@ export class MonkeyKernel extends EventEmitter {
       tickMs: this.tickMs,
       sizeFraction: this.sizeFraction,
       symbols: this.symbols,
-      mode: process.env.MONKEY_EXECUTE === 'true' ? 'EXECUTE' : 'OBSERVE',
+      mode: this.executionMode,
       bankSize: await resonanceBank.bankSize(),
       sovereignty: await resonanceBank.sovereignty(),
     });
@@ -4684,7 +4677,8 @@ export class MonkeyKernel extends EventEmitter {
       });
     }
 
-    // 6b. EXECUTE — gated by MONKEY_EXECUTE=true. Observe-only otherwise.
+    // 6b. EXECUTE — kernel always evaluates; executionMode routes the order
+    //     ('auto'=live, 'paper_only'=paper) and 'pause' suppresses entries.
     //
     // Post agent-separation (K vs M) + Turtle control arm (T): the arbiter
     // is N-agent. T is conditionally included only when account equity is
@@ -4988,17 +4982,18 @@ export class MonkeyKernel extends EventEmitter {
       reason += ` | consensus.${consensusOverride.verdict}`;
     }
 
-    if (process.env.MONKEY_EXECUTE === 'true') {
+    // Kernel always evaluates entries; 'pause' suppresses placement below and
+    // 'paper_only' routes to the paper book (executeEntry/shouldRouteOrdersToPaper).
+    {
       if ((action === 'enter_long' || action === 'enter_short') && size.value > 0) {
-        // v0.8.7 kill switch — pause new entries (including DCA pyramids)
-        // when MONKEY_TRADING_PAUSED=true on Railway. Exits remain
-        // active so open positions can close cleanly.
-        if (isTradingPaused()) {
-          reason += ' | trading_paused: MONKEY_TRADING_PAUSED=true (entry suppressed; exits unaffected)';
+        // Kill switch — 'pause' suppresses new entries (including DCA pyramids).
+        // Exits remain active so open positions can close cleanly.
+        if (this.executionMode === 'pause') {
+          reason += ' | trading_paused: executionMode=pause (entry suppressed; exits unaffected)';
           (derivation as Record<string, unknown>).tradingPausedSkipped = {
             agent: 'K',
             action,
-            reason: 'MONKEY_TRADING_PAUSED env',
+            reason: 'executionMode=pause',
           };
         } else if (lVeto?.vetoed) {
           // 2026-05-16 L-veto-over-K — high-conviction L vote suppresses
@@ -5292,14 +5287,14 @@ export class MonkeyKernel extends EventEmitter {
             delete state.directionalDisagreementStreakByLane[reversalLane];
             delete state.heldSideByLane[reversalLane];
             delete state.entryTimeMsByLane[reversalLane];
-            // v0.8.7 kill switch — close on the reverse path proceeded
+            // Kill switch — the close on the reverse path proceeded
             // (exits unaffected); skip the new-entry leg when paused.
-            if (isTradingPaused()) {
+            if (this.executionMode === 'pause') {
               reason += ` | closed@${lastPrice.toFixed(2)} pnl=${pnlAtDecision.toFixed(4)} | trading_paused: new ${newSide} entry suppressed`;
               (derivation as Record<string, unknown>).tradingPausedSkipped = {
                 agent: 'K',
                 action,
-                reason: 'MONKEY_TRADING_PAUSED env (reverse-reopen leg)',
+                reason: 'executionMode=pause (reverse-reopen leg)',
               };
             } else if (lVeto?.vetoed) {
               // 2026-05-16 L-veto-over-K — close already executed; the
@@ -5419,8 +5414,7 @@ export class MonkeyKernel extends EventEmitter {
         modeCanEnter: MODE_PROFILES[mode].canEnter,
         sideShortRefused,
         sizeValue: size.value,
-        executeEnabled: process.env.MONKEY_EXECUTE === 'true',
-        tradingPaused: isTradingPaused(),
+        tradingPaused: this.executionMode === 'pause',
         lVetoed: Boolean(lVeto?.vetoed),
         cappedMargin,
         entryRejectCode: kEntryRejectCode,
@@ -5452,7 +5446,7 @@ export class MonkeyKernel extends EventEmitter {
       state.recentBusEvents, 'M', state.sessionTicks,
     );
     const mRiskMod = riskModulator(state.agentStates.M);
-    if (process.env.MONKEY_EXECUTE === 'true' && arbiterAllocation.m > 0) {
+    if (arbiterAllocation.m > 0) {
       const mOpenMargin = await this.sumOpenAgentMargin(symbol, 'M');
       const mHeadroom = computeAgentHeadroom(arbiterAllocation.m, mOpenMargin);
       if (mHeadroom <= 0) {
@@ -5557,9 +5551,9 @@ export class MonkeyKernel extends EventEmitter {
         (mDecision.action === 'enter_long' || mDecision.action === 'enter_short')
         && clampedSize > 0
       ) {
-        // v0.8.7 kill switch — pause new entries from Agent M.
-        if (isTradingPaused()) {
-          logger.info('[AgentM] entry suppressed by MONKEY_TRADING_PAUSED', {
+        // Kill switch — 'pause' suppresses new entries from Agent M.
+        if (this.executionMode === 'pause') {
+          logger.info('[AgentM] entry suppressed by executionMode=pause', {
             symbol, side: mDecision.action,
           });
           (derivation as Record<string, unknown>).agentMTradingPausedSkipped = true;
@@ -5614,7 +5608,8 @@ export class MonkeyKernel extends EventEmitter {
     // mid-trade — the equity gate blocks new entries / pyramids, not
     // exits.
     const tAlloc = arbiterAllocationMany.T ?? 0;
-    if (process.env.MONKEY_EXECUTE === 'true') {
+    // Kernel always evaluates Agent T entries; 'pause' suppresses placement below.
+    {
       const tState = this.turtleStates.get(symbol) ?? newTurtleState();
       const tInputs: TurtleAgentInputs = {
         symbol,
@@ -5679,10 +5674,10 @@ export class MonkeyKernel extends EventEmitter {
           || tDecision.action === 'pyramid_long'
           || tDecision.action === 'pyramid_short')
         && tDecision.sizeUsdt > 0
-        && isTradingPaused()
+        && this.executionMode === 'pause'
       ) {
         (derivation as Record<string, unknown>).agentTTradingPausedSkipped = true;
-        logger.info('[AgentT] entry suppressed by MONKEY_TRADING_PAUSED', {
+        logger.info('[AgentT] entry suppressed by executionMode=pause', {
           symbol, action: tDecision.action,
         });
       }
@@ -5692,9 +5687,9 @@ export class MonkeyKernel extends EventEmitter {
           || tDecision.action === 'pyramid_long'
           || tDecision.action === 'pyramid_short')
         && tDecision.sizeUsdt > 0
-        // v0.8.7 kill switch — pause Agent T entries (including pyramids)
-        // when MONKEY_TRADING_PAUSED=true. Exits below are unaffected.
-        && !isTradingPaused()
+        // Kill switch — 'pause' suppresses Agent T entries (including pyramids).
+        // Exits below are unaffected.
+        && this.executionMode !== 'pause'
       ) {
         const tSide: 'long' | 'short' =
           tDecision.action === 'enter_long' || tDecision.action === 'pyramid_long'
@@ -5840,8 +5835,7 @@ export class MonkeyKernel extends EventEmitter {
     const lRiskMod = riskModulator(state.agentStates.L);
     const lAlloc = arbiterAllocationMany.L ?? 0;
     if (
-      process.env.MONKEY_EXECUTE === 'true'
-      && lAlloc > 0
+      lAlloc > 0
       // 2026-05-13 — warmup gate bumped to match recalibrated
       // longWindow (480). 480 ticks × 30s ≈ 4h. K/M/T continue
       // trading during L's warmup.
@@ -5946,9 +5940,9 @@ export class MonkeyKernel extends EventEmitter {
         && (lDecision.action === 'enter_long' || lDecision.action === 'enter_short')
         && lAlloc > 0
       ) {
-        // v0.8.7 kill switch — pause Agent L entries.
-        if (isTradingPaused()) {
-          logger.info('[AgentL] entry suppressed by MONKEY_TRADING_PAUSED', {
+        // Kill switch — 'pause' suppresses Agent L entries.
+        if (this.executionMode === 'pause') {
+          logger.info('[AgentL] entry suppressed by executionMode=pause', {
             symbol, action: lDecision.action,
           });
           (derivation as Record<string, unknown>).agentLTradingPausedSkipped = true;
@@ -6130,10 +6124,7 @@ export class MonkeyKernel extends EventEmitter {
     //
     // Threshold default 0.003 (0.3% on aggregate notional ≈ 4-5%
     // ROI at 14× margin). Env-tunable.
-    if (
-      process.env.MONKEY_EXECUTE === 'true'
-      && !isTradingPaused()
-    ) {
+    if (this.executionMode !== 'pause') {
       try {
         await this.forceHarvestAgentLStack(symbol, lastPrice);
       } catch (err) {
@@ -8427,7 +8418,8 @@ export class MonkeyKernel extends EventEmitter {
    * veto — treat veto as the expected "she decided but kernel blocked"
    * outcome, log it, and continue the tick.
    *
-   * This is gated by process.env.MONKEY_EXECUTE='true' in loop.ts.
+   * Order placement is routed live vs paper by shouldRouteOrdersToPaper()
+   * (executionMode); 'pause' suppresses entries upstream at each agent block.
    * v0.3 order surface: market IOC, no SL/TP (managed loop covers those
    * the same way liveSignalEngine relies on it).
    */
@@ -8788,8 +8780,8 @@ export class MonkeyKernel extends EventEmitter {
     // so the `paper_only && isLiveOrder` block in checkExecutionMode could
     // NEVER fire → the kernel kept opening LIVE positions while the UI
     // showed paper (operator-MANDATE violation, confirmed in prod 06-01).
-    // `!routeToPaper` is the true "this order goes live" predicate (env
-    // MONKEY_PAPER_MODE + internal paper-rotation), captured once at the top
+    // `!routeToPaper` is the true "this order goes live" predicate
+    // (executionMode='paper_only' + internal paper-rotation), captured once at the top
     // of executeEntry so the veto and the actual routing can't diverge. The
     // veto is ENTRY-ONLY, so paper_only now blocks new LIVE ENTRIES while
     // closes of existing real positions still route real (no orphaned positions).
@@ -10786,8 +10778,8 @@ export class MonkeyKernel extends EventEmitter {
    * THE CAPITAL FIREWALL GATE. Decide whether placeOrder calls route to
    * the paper simulator instead of the real exchange. Two paths reach
    * this:
-   *   1. The global `MONKEY_PAPER_MODE=true` env (back-compat, applies
-   *      to ALL kernels — used historically for whole-kernel dry runs).
+   *   1. executionMode === 'paper_only' (the operator paper MANDATE — the
+   *      whole kernel disengages from live and trades its paper book).
    *   2. This kernel's rotation state has been demoted to 'paper'
    *      (per-kernel capital firewall — kernel_rotation.ts).
    * Either path routes the same way through `paperPlaceOrder`, so the
@@ -10815,7 +10807,6 @@ export class MonkeyKernel extends EventEmitter {
     // gating which skip live-origin positions whenever executionMode != auto.)
     return (
       this.executionMode === 'paper_only' ||
-      isMonkeyPaperMode() ||
       this.rotation.mode === 'paper'
     );
   }

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -498,12 +498,13 @@ export function observerConvictionStreakRequired(
 }
 
 // Kill switch + paper routing are CANONICAL on the agent_execution_mode
-// tri-state (this.executionMode, fetched per-tick from the DB). 'pause' gates
-// entry-order placement only — exits (scalp_exit, auto_flatten, hard SL, rejust
-// exits) are NOT gated so open positions close cleanly. 'paper_only' routes
-// both entries and closes to the paper book (see shouldRouteOrdersToPaper).
-// The former MONKEY_TRADING_PAUSED / MONKEY_PAPER_MODE / MONKEY_EXECUTE env
-// knobs were folded into this tri-state and removed.
+// tri-state (this.executionMode, fetched per-tick from the DB). 'pause'
+// suppresses new entries AND discretionary profit-harvest (the Agent L sweep);
+// risk-management exits (scalp_exit, auto_flatten, hard SL, rejust) are NOT
+// gated so open positions still close cleanly. 'paper_only' routes both entries
+// and closes to the paper book (see shouldRouteOrdersToPaper). The former
+// MONKEY_TRADING_PAUSED / MONKEY_PAPER_MODE / MONKEY_EXECUTE env knobs were
+// folded into this tri-state and removed.
 
 // ─── L-veto-over-K (Option A) ─────────────────────────────────────
 //
@@ -8783,8 +8784,10 @@ export class MonkeyKernel extends EventEmitter {
     // `!routeToPaper` is the true "this order goes live" predicate
     // (executionMode='paper_only' + internal paper-rotation), captured once at the top
     // of executeEntry so the veto and the actual routing can't diverge. The
-    // veto is ENTRY-ONLY, so paper_only now blocks new LIVE ENTRIES while
-    // closes of existing real positions still route real (no orphaned positions).
+    // veto is ENTRY-ONLY (it never blocks a close). In paper_only/pause the
+    // close + reconciler paths disengage from live separately (routing to the
+    // paper book / early-returning), so existing live positions are left for
+    // the operator rather than force-closed by the kernel.
     const kernelContext: KernelContext = {
       isLive: !routeToPaper, mode, symbolMaxLeverage,
       monkeyMode: monkeyMode ?? undefined,

--- a/apps/api/src/services/monkey/signal_scorer.ts
+++ b/apps/api/src/services/monkey/signal_scorer.ts
@@ -57,7 +57,7 @@ export interface GateFacts {
   sideShortRefused: boolean;
   /** Derived entry margin before capping. <= 0 means below min notional. */
   sizeValue: number;
-  /** executionMode === 'pause' (the operator kill switch). */
+  /** true when the operator kill switch (executionMode === 'pause') is active. */
   tradingPaused: boolean;
   lVetoed: boolean;
   /** K margin after the arbiter share cap × chop size factor. */

--- a/apps/api/src/services/monkey/signal_scorer.ts
+++ b/apps/api/src/services/monkey/signal_scorer.ts
@@ -38,8 +38,7 @@ import { logger } from '../../utils/logger.js';
  *   mode           — mode profile blocks entry
  *   short_refused  — short side while MONKEY_SHORTS_LIVE=false
  *   min_notional   — sized below the exchange minimum notional
- *   observe_only   — MONKEY_EXECUTE != true
- *   trading_paused — MONKEY_TRADING_PAUSED kill switch
+ *   trading_paused — executionMode === 'pause' (operator kill switch)
  *   l_veto         — agent L vetoed K's entry
  *   arbiter_zero   — K's arbiter capital share was zero
  *   exec:<code>    — executeEntry rejected (margin headroom, funding…)
@@ -58,8 +57,7 @@ export interface GateFacts {
   sideShortRefused: boolean;
   /** Derived entry margin before capping. <= 0 means below min notional. */
   sizeValue: number;
-  /** MONKEY_EXECUTE === 'true'. */
-  executeEnabled: boolean;
+  /** executionMode === 'pause' (the operator kill switch). */
   tradingPaused: boolean;
   lVetoed: boolean;
   /** K margin after the arbiter share cap × chop size factor. */
@@ -80,7 +78,6 @@ export function resolveEntryGate(f: GateFacts): EntryGate {
   if (!f.modeCanEnter) return 'mode';
   if (f.sideShortRefused) return 'short_refused';
   if (f.sizeValue <= 0) return 'min_notional';
-  if (!f.executeEnabled) return 'observe_only';
   if (f.tradingPaused) return 'trading_paused';
   if (f.lVetoed) return 'l_veto';
   if (f.cappedMargin <= 0) return 'arbiter_zero';


### PR DESCRIPTION
## Problem — execution-gating split-brain

The `agent_execution_mode` tri-state (`this.executionMode`, fetched per-tick from the DB — canonical since #1061-#1064) already gated the **live touch** (placeOrder / closes / reconciler). But **three env knobs separately gated the decision path**, and in prod they *contradicted* the tri-state: `MONKEY_EXECUTE=true` while `execution_mode=paper_only`. They were layered (executionMode won at the live touch), but the env knobs were redundant subordinate gates that could disagree.

## Canonical fold (single source of truth)

`this.executionMode` now gates everything:

| mode | behaviour |
|------|-----------|
| `auto` | place **live** orders |
| `paper_only` | place **paper** orders (kernel fully disengaged from live) |
| `pause` | suppress new entries (exits unaffected — kill switch) |

Per the autonomy doctrine (kernel always acts; only kill-switch + paper routing are MANDATE), the **observe-only** state (`MONKEY_EXECUTE=false`) is retired — the kernel always evaluates entries; `executionMode` decides live / paper / suppressed.

## Changes
- **loop.ts**: retire `process.env.MONKEY_EXECUTE` at every agent block (K/M/T/L + force-harvest + waking telemetry). Replace every `isTradingPaused()` with `this.executionMode === 'pause'` (**preserves per-agent pause telemetry — no dead branches**). Delete the `isTradingPaused`/`isMonkeyPaperMode` module helpers; drop the redundant `isMonkeyPaperMode()` OR-arm in `shouldRouteOrdersToPaper`. Refresh all stale flag comments.
- **signal_scorer.ts**: drop the now-impossible `observe_only` EntryGate + its `executeEnabled` GateFact; `tradingPaused` is now `executionMode==='pause'`.
- **tests**: rewrite `killSwitch.test.ts` to the `executionMode='pause'` contract; drop the `observe_only`/`executeEnabled` assertions in `signalScorer.test.ts`; remove the obsolete env-precedence mirror in `paperExchangeSimulator.test.ts`.

## Behaviour
**Neutral in prod.** `execution_mode=paper_only` already won at the live touch; this makes the decision path agree (no contradiction). The kill switch + paper routing semantics are unchanged.

## Gates
- `tsc --noEmit`: **0 errors**
- killSwitch + signalScorer + paperExchangeSimulator: **green**
- full `vitest run src/services/monkey`: **1501 pass / 1 fail** — the fail (`autonomicFeedback` serotonin boundary) reproduces on clean `origin/main`; pre-existing.

## Follow-up
`MONKEY_EXECUTE` / `MONKEY_TRADING_PAUSED` / `MONKEY_PAPER_MODE` Railway vars are now zero-consumer → manual deletion (dashboard/CLI; MCP can't delete). Operator controls the kill switch + paper routing from the UI execution-mode toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fold legacy MONKEY_* environment flag kill switches and paper-mode gating into the canonical agent_execution_mode tri-state, making it the single source of truth for execution routing and pausing.

Bug Fixes:
- Align live vs paper routing and kill-switch behavior with the agent_execution_mode tri-state to remove contradictions between environment variables and DB-backed execution mode.

Enhancements:
- Update Monkey kernel loop to gate entry placement, agent behavior, and paper routing based solely on executionMode, removing redundant env-based helpers and flags.
- Simplify signal scoring gate facts to rely on executionMode-based tradingPaused state instead of an observe_only executeEnabled flag.

Tests:
- Rewrite killSwitch tests to cover executionMode='pause' semantics instead of MONKEY_TRADING_PAUSED env behavior.
- Remove obsolete tests around MONKEY_EXECUTE/MONKEY_PAPER_MODE precedence and update signal scorer tests to match the new gate facts shape.