### PR TITLE
fix(monkey): restore peer-WR corpus from the live proposal bus (arbiter can defer to the best kernel)

### DIFF
--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -4956,6 +4956,35 @@ export class MonkeyKernel extends EventEmitter {
           reason: consensus.reason,
           verdict: consensus.verdict,
         };
+
+        // Re-populate kernel_parity_log from the LIVE proposal bus so the
+        // retrospective peer-WR (getRetrospectiveShadowMatrix → peer_wr in the
+        // arbiter) has a corpus to score. The former K-shadow fanout that fed
+        // this table was removed (#1065) and was off in prod anyway; the Py
+        // kernel now publishes its proposal on the bus and TS receives it as
+        // `peer` here, so the ts↔py parity is recorded directly — no shadow
+        // call. Only enter-proposals feed the WR (the retrospective query
+        // filters py_action IN enter_long/short). Fire-and-forget, fail-soft.
+        if (peer && (peer.proposed_action === 'enter_long' || peer.proposed_action === 'enter_short')) {
+          const tsSideForParity: 'long' | 'short' | null =
+            direction === 'long' || direction === 'short' ? direction : null;
+          void pool.query(
+            `INSERT INTO kernel_parity_log
+               (tick_id, symbol, symbol_timestamp,
+                ts_action, ts_side, ts_phi, ts_kappa, ts_regime,
+                py_action, py_side, py_phi, py_kappa, py_regime)
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+            [
+              randomUUID(), symbol, new Date().toISOString(),
+              action, tsSideForParity, phi, state.kappa, regimeNow,
+              peer.proposed_action, peer.side, peer.phi, peer.kappa, peer.regime_label,
+            ],
+          ).catch((dbErr) => {
+            logger.debug('[Consensus] parity-log insert failed (fail-soft)', {
+              err: dbErr instanceof Error ? dbErr.message : String(dbErr),
+            });
+          });
+        }
       } catch (err) {
         logger.debug('[Consensus] arbiter computation failed; using raw K-kernel action', {
           symbol, err: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Red flag: `peer_wr:0` on every consensus tick

The operator directive is "the arbiter defers to the most successful kernel." It can't — `peer_wr` is **0** on every tick (`consensus.lesser-observe`).

**Root cause:** `peer_wr` comes from `getRetrospectiveShadowMatrix`, which JOINs **`kernel_parity_log`**. That table was only ever written by the **K-shadow fanout** — gated `MONKEY_K_SHADOW_LIVE` (off in prod) and **removed in #1065**. So the peer kernel's win-rate has no data source → always 0.

## Fix: source the corpus from the live proposal bus

The Py kernel already publishes its proposal on the consensus bus and TS already subscribes (`initProposalBus`), so the ts↔py parity is available right where the arbiter runs (`peer` at loop.ts:4906). Record it there directly — no shadow call:

- At the consensus point, when the peer proposed an **entry** (`py_action IN enter_long/short` — the only rows the retrospective WR scores), `INSERT` a `kernel_parity_log` row with the TS decision + the Py proposal. **Fire-and-forget, fail-soft** — never blocks the tick.

Over time this gives `getRetrospectiveShadowMatrix` a real corpus → `peer_wr` becomes meaningful → the arbiter can defer to the most successful kernel.

## Gates
- `tsc --noEmit`: **0 errors**
- `consensusArbiter` + `wrRetrospective` suites: **27 pass**

Note: this restores the *mechanism*. The kernel currently also holds for a separate reason (conviction gate `disagreement < threshold`) which starves the closed-trade corpus (`predN=0`) — tracked as the next fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)