### PR TITLE
fix(monkey): execution-mode + consensus-bus safety hardening (red-team P1-1, P0-3)

### DIFF
--- a/apps/api/src/services/executionModeService.ts
+++ b/apps/api/src/services/executionModeService.ts
@@ -21,10 +21,12 @@ export type { ExecutionMode } from './riskKernel.js';
 import type { ExecutionMode } from './riskKernel.js';
 
 const CACHE_TTL_MS = 30 * 1000;
-// Shorter TTL on fail-closed entries so a recovered DB is picked up
-// within a minute, but long enough that a sustained outage doesn't
-// send one query per order.
-const FAIL_CLOSED_CACHE_TTL_MS = 30 * 1000;
+// Genuinely shorter TTL on fail-closed entries (5s, not the normal 30s) so a
+// recovered DB — or an operator flipping the kill switch / paper mode right
+// after a transient DB hiccup — is picked up within seconds, while still
+// avoiding a per-order DB query during a sustained outage. The kill switch is
+// the operator's primary safety control; recovery latency must be short.
+const FAIL_CLOSED_CACHE_TTL_MS = 5 * 1000;
 
 interface ModeRecord {
   mode: ExecutionMode;

--- a/apps/api/src/services/monkey/canonical_invariant.ts
+++ b/apps/api/src/services/monkey/canonical_invariant.ts
@@ -174,7 +174,9 @@ export function doctrineFieldCount(): number {
 }
 
 function canonicalInvariantBusLive(): boolean {
-  return process.env.CONSENSUS_PROPOSAL_BUS_LIVE === 'true';
+  // Default ON to match the Python side (see proposal_bus.ts) — symmetric
+  // consensus; the previous default-off was an inverted-default split.
+  return process.env.CONSENSUS_PROPOSAL_BUS_LIVE !== 'false';
 }
 
 let _publisher: RedisClientType | null = null;

--- a/apps/api/src/services/monkey/proposal_bus.ts
+++ b/apps/api/src/services/monkey/proposal_bus.ts
@@ -10,10 +10,10 @@
  *
  * Channel: `monkey:consensus:proposal`
  *
- * Flag: CONSENSUS_PROPOSAL_BUS_LIVE — default off. When off, neither
- * publisher nor subscriber connects (no Redis traffic). When on,
- * proposals stream across the bus and recent peer proposals are
- * available via getRecentPeerProposal().
+ * Flag: CONSENSUS_PROPOSAL_BUS_LIVE — default ON (explicit 'false' disables;
+ * matches the Python side). When off, neither publisher nor subscriber
+ * connects (no Redis traffic). When on, proposals stream across the bus and
+ * recent peer proposals are available via getRecentPeerProposal().
  *
  * Fail-soft: any Redis error logs at debug and returns silently. A
  * dead Redis never blocks a tick.
@@ -48,7 +48,12 @@ export interface ProposalEvent {
 }
 
 function consensusBusLive(): boolean {
-  return process.env.CONSENSUS_PROPOSAL_BUS_LIVE === 'true';
+  // Default ON (explicit 'false' disables) so it MATCHES the Python side
+  // (proposal_bus.py / canonical_invariant.py both default on). The previous
+  // TS default-off was an inverted-default split: with the var unset, Py
+  // published proposals that TS never subscribed to. Symmetric consensus
+  // requires both sides cross-observe — keep them aligned.
+  return process.env.CONSENSUS_PROPOSAL_BUS_LIVE !== 'false';
 }
 
 let _publisher: RedisClientType | null = null;


### PR DESCRIPTION
From the multi-agent red-team of the env-vars→UI migration (role advocacy surfaced these).

## P1-1 — fail-closed recovery wasn't actually faster
`executionModeService` set `FAIL_CLOSED_CACHE_TTL_MS = 30s` (== normal TTL) despite the comment. After a DB hiccup the kernel re-checked the execution mode only every 30s. The **kill switch / paper-mode flip is the operator's primary safety control** — recovery must be fast. Set it to **5s** (still avoids per-order DB hammering; fail-closed default stays `'pause'`, verified safe).

## P0-3 — `CONSENSUS_PROPOSAL_BUS_LIVE` inverted defaults
TS defaulted **OFF** (`=== 'true'`); Python defaults **ON** (`!= "false"`). With the var unset, Py published proposals TS never subscribed to — a silent one-sided consensus split. Aligned the TS reads (`proposal_bus.ts`, `canonical_invariant.ts`) to **default ON**, matching Python + the symmetric-consensus directive. Prod has it set `true` on both services → behaviour-neutral there; removes the latent split.

## Gates
- `tsc`: 0 errors
- `executionModeService` (9) / `canonicalInvariant` (21) / `consensusArbiter` (24) suites: **all pass**

Part of the env-vars→UI program. Remaining red-team P0s (`MONKEY_SHORTS_LIVE` not enforced on Py / post-arbiter; Py trading-engine blind to `agent_execution_mode`) are tracked for the control-plane build; the calibration-trap list is routed to the observer-derivation phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)