### PR TITLE
feat(monkey): feature-flag control plane (DB + service + route) — env→UI foundation

### DIFF
--- a/apps/api/database/migrations/068_monkey_feature_flags.sql
+++ b/apps/api/database/migrations/068_monkey_feature_flags.sql
@@ -1,0 +1,45 @@
+-- Migration 068: Monkey feature-flag control plane
+--
+-- Moves operator on/off feature controls off Railway env vars and into a
+-- DB-backed table the operator drives from the UI (mirrors agent_execution_mode,
+-- migration 029). One row per flag for per-flag audit (who/when last changed).
+--
+-- ONLY operator MANDATE / FEATURE on-off toggles live here. Numeric CALIBRATION
+-- thresholds (fast-adverse, harvest %, min-tape-strength, …) are deliberately
+-- EXCLUDED — per the P1 doctrine those are observer-derived, never operator knobs.
+--
+-- `value` is TEXT so the service can parse bool ('true'/'false') today and
+-- numeric/CSV values (paper equity, arbiter agents) later without a schema change.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS; seeds use ON CONFLICT DO NOTHING so
+-- re-application never clobbers an operator's chosen value.
+
+CREATE TABLE IF NOT EXISTS monkey_feature_flags (
+    flag_key    TEXT        PRIMARY KEY,
+    value       TEXT        NOT NULL,
+    updated_by  TEXT,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed the operator on/off flags with their CURRENT effective values so that
+-- when loop.ts later reads them from the service instead of process.env, live
+-- behaviour is preserved exactly. Values reflect the production env / code
+-- defaults as of 2026-06-01.
+INSERT INTO monkey_feature_flags (flag_key, value, updated_by) VALUES
+    ('MONKEY_SHORTS_LIVE',           'true',  'migration_068'),
+    ('MONKEY_MARKET_INTEL_LIVE',     'false', 'migration_068'),
+    ('MONKEY_FUNDING_GATE_LIVE',     'false', 'migration_068'),
+    ('MONKEY_MAKER_CLOSE_LIVE',      'false', 'migration_068'),
+    ('MONKEY_WS_PRIVATE_LIVE',       'false', 'migration_068'),
+    ('L_VETO_OVER_K_ENABLED',        'false', 'migration_068'),
+    ('MONKEY_BRACKET_EXIT_LIVE',     'true',  'migration_068'),
+    ('MONKEY_BRACKET_EXTEND_LIVE',   'true',  'migration_068'),
+    ('MONKEY_SLOW_BLEED_LIVE',       'true',  'migration_068'),
+    ('MONKEY_FAST_ADVERSE_LIVE',     'true',  'migration_068'),
+    ('MONKEY_TAPE_OVERRIDE_LIVE',    'true',  'migration_068'),
+    ('MONKEY_MTF_BOOTSTRAP',         'true',  'migration_068'),
+    ('REGIME_COMPOSITIONAL_LIVE',    'true',  'migration_068'),
+    ('REGIME_HELD_EXIT_LIVE',        'true',  'migration_068'),
+    ('SCALP_LIMIT_MAKER_LIVE',       'true',  'migration_068'),
+    ('SCALP_LIMIT_MAKER_BROAD',      'true',  'migration_068')
+ON CONFLICT (flag_key) DO NOTHING;

--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -13,6 +13,10 @@ import {
   setExecutionMode,
   type ExecutionMode,
 } from '../services/executionModeService.js';
+import {
+  getAllFlags,
+  setFlag,
+} from '../services/featureFlagsService.js';
 import poloniexFuturesService from '../services/poloniexFuturesService.js';
 import { strategyLearningEngine } from '../services/strategyLearningEngine.js';
 import { logger } from '../utils/logger.js';
@@ -918,6 +922,60 @@ router.put('/execution-mode', authenticateToken, async (req: Request, res: Respo
   } catch (error: unknown) {
     logger.error('Error updating execution mode:', error);
     return res.status(500).json({ success: false, error: 'Failed to update execution mode' });
+  }
+});
+
+/**
+ * GET /api/agent/feature-flags
+ * List every Monkey on/off feature flag with its current value + audit meta.
+ * The dashboard renders one toggle per row. (Numeric calibration thresholds are
+ * observer-derived per the P1 doctrine and are intentionally NOT exposed here.)
+ */
+router.get('/feature-flags', authenticateToken, async (_req: Request, res: Response) => {
+  try {
+    const flags = await getAllFlags();
+    return res.json({
+      success: true,
+      flags: flags.map((f) => ({
+        key: f.flagKey,
+        value: f.value,
+        updatedAt: f.updatedAt.toISOString(),
+        updatedBy: f.updatedBy,
+      })),
+    });
+  } catch (error: unknown) {
+    logger.error('Error reading feature flags:', error);
+    return res.status(500).json({ success: false, error: 'Failed to read feature flags' });
+  }
+});
+
+/**
+ * PUT /api/agent/feature-flags/:key
+ * Set a single flag. Body: { value }. `value` is a string ('true'/'false' for
+ * toggles). The kernel picks the new value up within one tick via the cache.
+ */
+router.put('/feature-flags/:key', authenticateToken, async (req: Request, res: Response) => {
+  const key = String(req.params.key ?? '').trim();
+  const { value } = (req.body ?? {}) as { value?: unknown };
+  if (!key) {
+    return res.status(400).json({ success: false, error: 'flag key is required' });
+  }
+  if (typeof value !== 'string' || value.length === 0) {
+    return res.status(400).json({ success: false, error: 'value must be a non-empty string' });
+  }
+  const operator = (req.user?.email || req.user?.id || req.user?.userId || 'unknown').toString();
+  try {
+    const record = await setFlag(key, value, operator);
+    return res.json({
+      success: true,
+      key: record.flagKey,
+      value: record.value,
+      updatedAt: record.updatedAt.toISOString(),
+      updatedBy: record.updatedBy,
+    });
+  } catch (error: unknown) {
+    logger.error('Error updating feature flag:', error);
+    return res.status(500).json({ success: false, error: 'Failed to update feature flag' });
   }
 });
 

--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -960,11 +960,19 @@ router.put('/feature-flags/:key', authenticateToken, async (req: Request, res: R
   if (!key) {
     return res.status(400).json({ success: false, error: 'flag key is required' });
   }
-  if (typeof value !== 'string' || value.length === 0) {
-    return res.status(400).json({ success: false, error: 'value must be a non-empty string' });
+  // All current flags are boolean toggles — accept only canonical 'true'/'false'
+  // (relax when value-typed flags are introduced). Prevents '1'/'yes'/typos from
+  // silently flipping a flag.
+  if (value !== 'true' && value !== 'false') {
+    return res.status(400).json({ success: false, error: "value must be 'true' or 'false'" });
   }
   const operator = (req.user?.email || req.user?.id || req.user?.userId || 'unknown').toString();
   try {
+    // Reject unknown keys so a typo can't create a phantom flag the kernel never reads.
+    const known = await getAllFlags();
+    if (!known.some((f) => f.flagKey === key)) {
+      return res.status(404).json({ success: false, error: `unknown feature flag: ${key}` });
+    }
     const record = await setFlag(key, value, operator);
     return res.json({
       success: true,

--- a/apps/api/src/services/__tests__/featureFlagsService.test.ts
+++ b/apps/api/src/services/__tests__/featureFlagsService.test.ts
@@ -51,6 +51,17 @@ describe('featureFlagsService', () => {
     expect(await getBoolFlag('MONKEY_SHORTS_LIVE', false)).toBe(false);
   });
 
+  it('getBoolFlag returns the safe default for a malformed (non-boolean) value', async () => {
+    mockedQuery.mockResolvedValueOnce(rows([
+      { flag_key: 'MONKEY_BRACKET_EXIT_LIVE', value: 'yes' },   // garbage
+      { flag_key: 'MONKEY_SHORTS_LIVE', value: '1' },           // garbage
+    ]));
+    // protective exit safe default is true — a 'yes' must NOT silently disable it
+    expect(await getBoolFlag('MONKEY_BRACKET_EXIT_LIVE', true)).toBe(true);
+    // shorts safe default is false
+    expect(await getBoolFlag('MONKEY_SHORTS_LIVE', false)).toBe(false);
+  });
+
   it('getBoolFlag fails SOFT to the safe default on DB error', async () => {
     mockedQuery.mockRejectedValueOnce(new Error('db down'));
     // shorts → false is the safe default (no shorts when unknown)

--- a/apps/api/src/services/__tests__/featureFlagsService.test.ts
+++ b/apps/api/src/services/__tests__/featureFlagsService.test.ts
@@ -1,0 +1,90 @@
+/**
+ * featureFlagsService — DB-backed operator on/off control plane tests.
+ *
+ * DB is mocked so every branch (cache hit, absent flag, DB error fail-soft,
+ * upsert + readback) runs without a real database.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../db/connection.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../../db/connection.js';
+import {
+  __resetFeatureFlagsCache,
+  getBoolFlag,
+  getNumberFlag,
+  getStringFlag,
+  setFlag,
+} from '../featureFlagsService.js';
+
+const mockedQuery = vi.mocked(query);
+
+function rows(r: unknown[]) {
+  return { rows: r } as unknown as Awaited<ReturnType<typeof query>>;
+}
+
+describe('featureFlagsService', () => {
+  beforeEach(() => {
+    mockedQuery.mockReset();
+    __resetFeatureFlagsCache();
+  });
+  afterEach(() => {
+    __resetFeatureFlagsCache();
+  });
+
+  it('getBoolFlag returns the stored value when present', async () => {
+    mockedQuery.mockResolvedValueOnce(rows([
+      { flag_key: 'MONKEY_SHORTS_LIVE', value: 'true' },
+      { flag_key: 'MONKEY_MAKER_CLOSE_LIVE', value: 'false' },
+    ]));
+    expect(await getBoolFlag('MONKEY_SHORTS_LIVE', false)).toBe(true);
+    // cached — no second query
+    expect(await getBoolFlag('MONKEY_MAKER_CLOSE_LIVE', true)).toBe(false);
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('getBoolFlag returns the SAFE default when the flag is absent', async () => {
+    mockedQuery.mockResolvedValueOnce(rows([{ flag_key: 'OTHER', value: 'true' }]));
+    expect(await getBoolFlag('MONKEY_SHORTS_LIVE', false)).toBe(false);
+  });
+
+  it('getBoolFlag fails SOFT to the safe default on DB error', async () => {
+    mockedQuery.mockRejectedValueOnce(new Error('db down'));
+    // shorts → false is the safe default (no shorts when unknown)
+    expect(await getBoolFlag('MONKEY_SHORTS_LIVE', false)).toBe(false);
+    // protective exit → true is its safe default
+    __resetFeatureFlagsCache();
+    mockedQuery.mockRejectedValueOnce(new Error('db down'));
+    expect(await getBoolFlag('MONKEY_BRACKET_EXIT_LIVE', true)).toBe(true);
+  });
+
+  it('getNumberFlag parses numbers and falls back on garbage', async () => {
+    mockedQuery.mockResolvedValueOnce(rows([
+      { flag_key: 'N', value: '42' },
+      { flag_key: 'BAD', value: 'not-a-number' },
+    ]));
+    expect(await getNumberFlag('N', 7)).toBe(42);
+    expect(await getNumberFlag('BAD', 7)).toBe(7);
+    expect(await getNumberFlag('MISSING', 7)).toBe(7);
+  });
+
+  it('getStringFlag returns value or default', async () => {
+    mockedQuery.mockResolvedValueOnce(rows([{ flag_key: 'CSV', value: 'K,M,T' }]));
+    expect(await getStringFlag('CSV', 'K')).toBe('K,M,T');
+    expect(await getStringFlag('MISSING', 'K')).toBe('K');
+  });
+
+  it('setFlag upserts then reads back the row', async () => {
+    mockedQuery
+      .mockResolvedValueOnce(rows([])) // INSERT ... ON CONFLICT
+      .mockResolvedValueOnce(rows([
+        { flag_key: 'MONKEY_SHORTS_LIVE', value: 'false', updated_by: 'op@x', updated_at: '2026-06-01T00:00:00Z' },
+      ]));
+    const rec = await setFlag('MONKEY_SHORTS_LIVE', 'false', 'op@x');
+    expect(rec.value).toBe('false');
+    expect(rec.updatedBy).toBe('op@x');
+  });
+});

--- a/apps/api/src/services/featureFlagsService.ts
+++ b/apps/api/src/services/featureFlagsService.ts
@@ -48,12 +48,17 @@ async function ensureCache(): Promise<Map<string, string>> {
     cachedAt = now;
     return cache;
   } catch (err) {
-    logger.warn('[featureFlags] DB read failed — callers fall back to safe defaults', {
+    logger.warn('[featureFlags] DB read failed — serving last-known-good / safe defaults', {
       err: err instanceof Error ? err.message : String(err),
     });
-    // Keep whatever we had; if cold, return an empty map so callers use their
-    // own safe default rather than crashing.
-    return cache ?? new Map<string, string>();
+    // Cache the fallback (last-known-good if warm, else empty) AND stamp cachedAt
+    // so a sustained outage doesn't re-query + re-log on every per-tick read
+    // (mirrors executionModeService's outage-storm guard). A warm cache serves
+    // last-known-good values; a cold cache yields the caller's safe default.
+    const fallback = cache ?? new Map<string, string>();
+    cache = fallback;
+    cachedAt = now;
+    return fallback;
   }
 }
 
@@ -66,7 +71,13 @@ export async function getBoolFlag(key: string, safeDefault: boolean): Promise<bo
   const flags = await ensureCache();
   const raw = flags.get(key);
   if (raw === undefined) return safeDefault;
-  return raw.trim().toLowerCase() === 'true';
+  const v = raw.trim().toLowerCase();
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  // Malformed value must NOT silently disable a flag whose safe state is ON
+  // (e.g. protective exits) — honour the caller's safe default instead.
+  logger.warn('[featureFlags] non-boolean value — using safe default', { key, raw });
+  return safeDefault;
 }
 
 /** Numeric flag (for future value controls). Returns safeDefault when absent/unparseable. */

--- a/apps/api/src/services/featureFlagsService.ts
+++ b/apps/api/src/services/featureFlagsService.ts
@@ -41,7 +41,7 @@ async function ensureCache(): Promise<Map<string, string>> {
   try {
     const result = await query(`SELECT flag_key, value FROM monkey_feature_flags`);
     const next = new Map<string, string>();
-    for (const row of result.rows as Array<{ flag_key: string; value: string }>) {
+    for (const row of result.rows as unknown as Array<{ flag_key: string; value: string }>) {
       next.set(row.flag_key, row.value);
     }
     cache = next;
@@ -92,7 +92,7 @@ export async function getAllFlags(): Promise<FeatureFlagRecord[]> {
     `SELECT flag_key, value, updated_by, updated_at
        FROM monkey_feature_flags ORDER BY flag_key`,
   );
-  return (result.rows as Array<{ flag_key: string; value: string; updated_by: string | null; updated_at: string }>)
+  return (result.rows as unknown as Array<{ flag_key: string; value: string; updated_by: string | null; updated_at: string }>)
     .map((r) => ({
       flagKey: r.flag_key,
       value: r.value,
@@ -124,7 +124,7 @@ export async function setFlag(
     `SELECT flag_key, value, updated_by, updated_at FROM monkey_feature_flags WHERE flag_key = $1`,
     [key],
   );
-  const row = (result.rows as Array<{ flag_key: string; value: string; updated_by: string | null; updated_at: string }>)[0];
+  const row = (result.rows as unknown as Array<{ flag_key: string; value: string; updated_by: string | null; updated_at: string }>)[0];
   if (!row) throw new Error(`Failed to read back feature flag after upsert: ${key}`);
   logger.info('[featureFlags] updated', { flagKey: key, value, updatedBy: operator });
   return {

--- a/apps/api/src/services/featureFlagsService.ts
+++ b/apps/api/src/services/featureFlagsService.ts
@@ -1,0 +1,142 @@
+/**
+ * Feature Flags — DB-backed operator control plane for Monkey on/off toggles.
+ *
+ * Mirrors executionModeService (the proven pattern): a single source of truth
+ * in `monkey_feature_flags`, read through a short-TTL cache so the kernel's
+ * per-tick reads aren't a DB roundtrip each, and an operator UI writes via the
+ * route. This replaces the scatter of `process.env.MONKEY_*_LIVE` reads so the
+ * operator controls every feature from one pane of glass instead of Railway env.
+ *
+ * Scope: ONLY operator MANDATE / FEATURE on-off toggles. Numeric CALIBRATION
+ * thresholds are observer-derived per the P1 doctrine and never live here.
+ *
+ * Fail-soft: on a DB error the cache simply isn't refreshed and each getter
+ * returns the SAFE default the caller supplies (the same default the prior env
+ * read used). Callers must pass a default that fails to the safe state.
+ */
+
+import { query } from '../db/connection.js';
+import { logger } from '../utils/logger.js';
+
+const CACHE_TTL_MS = 15 * 1000;
+
+let cache: Map<string, string> | null = null;
+let cachedAt = 0;
+
+export interface FeatureFlagRecord {
+  flagKey: string;
+  value: string;
+  updatedBy: string | null;
+  updatedAt: Date;
+}
+
+/**
+ * Load all flags into the cache (TTL-bounded). On DB error the previous cache
+ * is kept (or stays null on a cold failure); getters then fall back to the
+ * caller's safe default.
+ */
+async function ensureCache(): Promise<Map<string, string>> {
+  const now = Date.now();
+  if (cache && now - cachedAt < CACHE_TTL_MS) return cache;
+  try {
+    const result = await query(`SELECT flag_key, value FROM monkey_feature_flags`);
+    const next = new Map<string, string>();
+    for (const row of result.rows as Array<{ flag_key: string; value: string }>) {
+      next.set(row.flag_key, row.value);
+    }
+    cache = next;
+    cachedAt = now;
+    return cache;
+  } catch (err) {
+    logger.warn('[featureFlags] DB read failed — callers fall back to safe defaults', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    // Keep whatever we had; if cold, return an empty map so callers use their
+    // own safe default rather than crashing.
+    return cache ?? new Map<string, string>();
+  }
+}
+
+/**
+ * Boolean flag. `safeDefault` is returned when the flag is absent or the DB is
+ * unreachable — it MUST be the value that fails to the safe state for this flag
+ * (e.g. shorts → false; protective exits → true).
+ */
+export async function getBoolFlag(key: string, safeDefault: boolean): Promise<boolean> {
+  const flags = await ensureCache();
+  const raw = flags.get(key);
+  if (raw === undefined) return safeDefault;
+  return raw.trim().toLowerCase() === 'true';
+}
+
+/** Numeric flag (for future value controls). Returns safeDefault when absent/unparseable. */
+export async function getNumberFlag(key: string, safeDefault: number): Promise<number> {
+  const flags = await ensureCache();
+  const raw = flags.get(key);
+  if (raw === undefined) return safeDefault;
+  const v = Number(raw);
+  return Number.isFinite(v) ? v : safeDefault;
+}
+
+/** String flag (for future CSV/value controls). */
+export async function getStringFlag(key: string, safeDefault: string): Promise<string> {
+  const flags = await ensureCache();
+  return flags.get(key) ?? safeDefault;
+}
+
+/** Full list for the UI/audit endpoint (forces a fresh read). */
+export async function getAllFlags(): Promise<FeatureFlagRecord[]> {
+  cachedAt = 0; // force refresh so the UI sees current metadata
+  await ensureCache();
+  const result = await query(
+    `SELECT flag_key, value, updated_by, updated_at
+       FROM monkey_feature_flags ORDER BY flag_key`,
+  );
+  return (result.rows as Array<{ flag_key: string; value: string; updated_by: string | null; updated_at: string }>)
+    .map((r) => ({
+      flagKey: r.flag_key,
+      value: r.value,
+      updatedBy: r.updated_by ?? null,
+      updatedAt: new Date(r.updated_at),
+    }));
+}
+
+/**
+ * Set a flag. Upserts the row, invalidates the cache so the next read (≤ one
+ * tick later) sees the new value. Returns the updated record.
+ */
+export async function setFlag(
+  key: string,
+  value: string,
+  operator: string,
+): Promise<FeatureFlagRecord> {
+  await query(
+    `INSERT INTO monkey_feature_flags (flag_key, value, updated_by, updated_at)
+       VALUES ($1, $2, $3, NOW())
+     ON CONFLICT (flag_key)
+       DO UPDATE SET value = EXCLUDED.value,
+                     updated_by = EXCLUDED.updated_by,
+                     updated_at = NOW()`,
+    [key, value, operator],
+  );
+  cachedAt = 0; // invalidate
+  const result = await query(
+    `SELECT flag_key, value, updated_by, updated_at FROM monkey_feature_flags WHERE flag_key = $1`,
+    [key],
+  );
+  const row = (result.rows as Array<{ flag_key: string; value: string; updated_by: string | null; updated_at: string }>)[0];
+  if (!row) throw new Error(`Failed to read back feature flag after upsert: ${key}`);
+  logger.info('[featureFlags] updated', { flagKey: key, value, updatedBy: operator });
+  return {
+    flagKey: row.flag_key,
+    value: row.value,
+    updatedBy: row.updated_by ?? null,
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+/** Exposed for tests to clear the cache between cases. */
+export function __resetFeatureFlagsCache(): void {
+  cache = null;
+  cachedAt = 0;
+}

--- a/apps/api/src/tests/agent.test.ts
+++ b/apps/api/src/tests/agent.test.ts
@@ -187,4 +187,47 @@ describeIfSupertest('Autonomous Agent API', () => {
       expect(res.body.success).toBe(false);
     });
   });
+
+  describe('Feature Flags', () => {
+    test('should list feature flags', async () => {
+      const res = await requestClient(API_URL)
+        .get('/api/agent/feature-flags')
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.flags)).toBe(true);
+    });
+
+    test('should update a known boolean flag', async () => {
+      const res = await requestClient(API_URL)
+        .put('/api/agent/feature-flags/MONKEY_SHORTS_LIVE')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ value: 'false' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.value).toBe('false');
+    });
+
+    test('should reject a non-boolean value', async () => {
+      const res = await requestClient(API_URL)
+        .put('/api/agent/feature-flags/MONKEY_SHORTS_LIVE')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ value: 'yes' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    test('should reject an unknown flag key', async () => {
+      const res = await requestClient(API_URL)
+        .put('/api/agent/feature-flags/NOT_A_REAL_FLAG')
+        .set('Authorization', `Bearer ${authToken}`)
+        .send({ value: 'true' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
**Step 1** of moving every operator on/off control off Railway env vars into a UI-driven DB control plane, mirroring the proven `executionModeService` pattern. **Additive infrastructure only** — the live kernel path is unchanged until a follow-up wires `loop.ts` reads to the service; the UI can already read/write flags.

## Changes
- **migration 068** `monkey_feature_flags` (`flag_key/value/updated_by/updated_at`, one row per flag for audit), seeded with the **16 operator on/off toggles** at their CURRENT effective values so behaviour is preserved when `loop.ts` later reads them from here. Idempotent. **Only MANDATE/FEATURE toggles** — numeric CALIBRATION thresholds excluded (observer-derived per P1).
- **`featureFlagsService.ts`** mirrors `executionModeService`: load-all cached (15s TTL), `getBoolFlag/getNumberFlag/getStringFlag` with a **SAFE-default fallback** (DB error → caller's safe default), `getAllFlags` + `setFlag` (upsert + cache invalidate).
- **routes** `GET /api/agent/feature-flags` (dashboard list) + `PUT /api/agent/feature-flags/:key` (operator set) — mirror the execution-mode route (auth, validation, audit).

## Gates
- `tsc`: 0 errors
- `featureFlagsService` suite: **6 pass** (cache hit, absent→safe-default, DB-error fail-soft, number parse, upsert readback)

## Next (sequenced)
Wire `loop.ts` MANDATE/FEATURE reads → the service (+ Py side, per the red-team P0s: `SHORTS_LIVE` enforcement on Py + post-arbiter veto; Py reads `agent_execution_mode`); then the dashboard "Kernel Controls" panel. Calibration knobs → phase (b) observer-derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)