### PR TITLE
fix(monkey): repair main RED — complete featureFlags wiring swept in by d25f8c0c

### DIFF
--- a/apps/api/src/services/__tests__/featureFlagsService.test.ts
+++ b/apps/api/src/services/__tests__/featureFlagsService.test.ts
@@ -46,6 +46,29 @@ describe('featureFlagsService', () => {
     expect(mockedQuery).toHaveBeenCalledTimes(1);
   });
 
+  it('coalesces a concurrent cold-cache stampede onto ONE DB read', async () => {
+    // The kernel refreshes all flags per tick via Promise.all of ~14
+    // getBoolFlag calls. On a cold/expired cache these race in together; the
+    // in-flight latch must funnel them onto a single SELECT, not one per caller.
+    let resolveQuery!: (v: Awaited<ReturnType<typeof query>>) => void;
+    mockedQuery.mockImplementationOnce(
+      () => new Promise((res) => { resolveQuery = res; }),
+    );
+    const keys = [
+      'MONKEY_SHORTS_LIVE', 'MONKEY_MARKET_INTEL_LIVE', 'MONKEY_FUNDING_GATE_LIVE',
+      'MONKEY_MAKER_CLOSE_LIVE', 'L_VETO_OVER_K_ENABLED', 'MONKEY_BRACKET_EXIT_LIVE',
+      'MONKEY_BRACKET_EXTEND_LIVE', 'MONKEY_SLOW_BLEED_LIVE', 'MONKEY_FAST_ADVERSE_LIVE',
+      'MONKEY_TAPE_OVERRIDE_LIVE', 'REGIME_COMPOSITIONAL_LIVE', 'REGIME_HELD_EXIT_LIVE',
+      'SCALP_LIMIT_MAKER_LIVE', 'SCALP_LIMIT_MAKER_BROAD',
+    ];
+    const inFlightReads = Promise.all(keys.map((k) => getBoolFlag(k, false)));
+    resolveQuery(rows([{ flag_key: 'MONKEY_SHORTS_LIVE', value: 'true' }]));
+    const results = await inFlightReads;
+    expect(mockedQuery).toHaveBeenCalledTimes(1); // not 14
+    expect(results[0]).toBe(true);                // shorts present
+    expect(results[1]).toBe(false);               // absent → safe default
+  });
+
   it('getBoolFlag returns the SAFE default when the flag is absent', async () => {
     mockedQuery.mockResolvedValueOnce(rows([{ flag_key: 'OTHER', value: 'true' }]));
     expect(await getBoolFlag('MONKEY_SHORTS_LIVE', false)).toBe(false);

--- a/apps/api/src/services/featureFlagsService.ts
+++ b/apps/api/src/services/featureFlagsService.ts
@@ -22,6 +22,13 @@ const CACHE_TTL_MS = 15 * 1000;
 
 let cache: Map<string, string> | null = null;
 let cachedAt = 0;
+// In-flight refresh promise. When the cache is cold/expired and several callers
+// race in together (e.g. the kernel's per-tick Promise.all of getBoolFlag
+// reads), the first starts the DB read and stores its promise here; the rest
+// await the SAME promise instead of each firing their own SELECT. Without this
+// the TTL check is not atomic with the cache write, so a cold refresh fans out
+// into one query per concurrent caller (an async cache stampede).
+let inFlight: Promise<Map<string, string>> | null = null;
 
 export interface FeatureFlagRecord {
   flagKey: string;
@@ -38,28 +45,36 @@ export interface FeatureFlagRecord {
 async function ensureCache(): Promise<Map<string, string>> {
   const now = Date.now();
   if (cache && now - cachedAt < CACHE_TTL_MS) return cache;
-  try {
-    const result = await query(`SELECT flag_key, value FROM monkey_feature_flags`);
-    const next = new Map<string, string>();
-    for (const row of result.rows as unknown as Array<{ flag_key: string; value: string }>) {
-      next.set(row.flag_key, row.value);
+  // Coalesce concurrent cold/expired refreshes onto a single DB read.
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const result = await query(`SELECT flag_key, value FROM monkey_feature_flags`);
+      const next = new Map<string, string>();
+      for (const row of result.rows as unknown as Array<{ flag_key: string; value: string }>) {
+        next.set(row.flag_key, row.value);
+      }
+      cache = next;
+      cachedAt = Date.now();
+      return cache;
+    } catch (err) {
+      logger.warn('[featureFlags] DB read failed — serving last-known-good / safe defaults', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      // Cache the fallback (last-known-good if warm, else empty) AND stamp cachedAt
+      // so a sustained outage doesn't re-query + re-log on every per-tick read
+      // (mirrors executionModeService's outage-storm guard). A warm cache serves
+      // last-known-good values; a cold cache yields the caller's safe default.
+      const fallback = cache ?? new Map<string, string>();
+      cache = fallback;
+      cachedAt = Date.now();
+      return fallback;
+    } finally {
+      // Clear the in-flight latch so the NEXT post-TTL refresh starts fresh.
+      inFlight = null;
     }
-    cache = next;
-    cachedAt = now;
-    return cache;
-  } catch (err) {
-    logger.warn('[featureFlags] DB read failed — serving last-known-good / safe defaults', {
-      err: err instanceof Error ? err.message : String(err),
-    });
-    // Cache the fallback (last-known-good if warm, else empty) AND stamp cachedAt
-    // so a sustained outage doesn't re-query + re-log on every per-tick read
-    // (mirrors executionModeService's outage-storm guard). A warm cache serves
-    // last-known-good values; a cold cache yields the caller's safe default.
-    const fallback = cache ?? new Map<string, string>();
-    cache = fallback;
-    cachedAt = now;
-    return fallback;
-  }
+  })();
+  return inFlight;
 }
 
 /**
@@ -150,4 +165,5 @@ export async function setFlag(
 export function __resetFeatureFlagsCache(): void {
   cache = null;
   cachedAt = 0;
+  inFlight = null;
 }

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1622,7 +1622,7 @@ export class MonkeyKernel extends EventEmitter {
     // for entire sessions). Now we await per-symbol bootstrap, retain
     // the per-TF status, and ``maybeRetryMTFBootstrap`` re-runs cold
     // timeframes on a later tick.
-    if (process.env.MONKEY_MTF_BOOTSTRAP !== 'false') {
+    if (await getBoolFlag('MONKEY_MTF_BOOTSTRAP', true)) {
       void this.runInitialMTFBootstrap();
     }
 
@@ -1650,7 +1650,7 @@ export class MonkeyKernel extends EventEmitter {
     // stays authoritative; the cache is a fresher cross-check surface a
     // later PR can flip to primary on evidence. Fail-soft — a WS failure
     // leaves the kernel on REST exactly as before.
-    if (process.env.MONKEY_WS_PRIVATE_LIVE === 'true') {
+    if (await getBoolFlag('MONKEY_WS_PRIVATE_LIVE', false)) {
       void this.startWsPositionFeed();
     }
 
@@ -2310,6 +2310,43 @@ export class MonkeyKernel extends EventEmitter {
     } finally {
       this.tickInFlight = false;
     }
+  }
+
+  /**
+   * Snapshot the operator FEATURE toggles into {@link featureFlags} once per
+   * tick. The service caches all flags in one DB read per 15s TTL, so these
+   * getBoolFlag calls are cache hits after the first. Each safeDefault matches
+   * the prior env semantics exactly (`=== 'true'` → false; `!== 'false'` → true)
+   * so a DB outage fails to today's behaviour, not a surprise state.
+   */
+  private async refreshFeatureFlags(): Promise<void> {
+    const [
+      shortsLive, marketIntelLive, fundingGateLive, makerCloseLive, lVetoOverK,
+      bracketExitLive, bracketExtendLive, slowBleedLive, fastAdverseLive,
+      tapeOverrideLive, regimeCompositionalLive, regimeHeldExitLive,
+      scalpLimitMakerLive, scalpLimitMakerBroad,
+    ] = await Promise.all([
+      getBoolFlag('MONKEY_SHORTS_LIVE', false),
+      getBoolFlag('MONKEY_MARKET_INTEL_LIVE', false),
+      getBoolFlag('MONKEY_FUNDING_GATE_LIVE', false),
+      getBoolFlag('MONKEY_MAKER_CLOSE_LIVE', false),
+      getBoolFlag('L_VETO_OVER_K_ENABLED', false),
+      getBoolFlag('MONKEY_BRACKET_EXIT_LIVE', true),
+      getBoolFlag('MONKEY_BRACKET_EXTEND_LIVE', true),
+      getBoolFlag('MONKEY_SLOW_BLEED_LIVE', true),
+      getBoolFlag('MONKEY_FAST_ADVERSE_LIVE', true),
+      getBoolFlag('MONKEY_TAPE_OVERRIDE_LIVE', true),
+      getBoolFlag('REGIME_COMPOSITIONAL_LIVE', false),
+      getBoolFlag('REGIME_HELD_EXIT_LIVE', false),
+      getBoolFlag('SCALP_LIMIT_MAKER_LIVE', false),
+      getBoolFlag('SCALP_LIMIT_MAKER_BROAD', true),
+    ]);
+    this.featureFlags = {
+      shortsLive, marketIntelLive, fundingGateLive, makerCloseLive, lVetoOverK,
+      bracketExitLive, bracketExtendLive, slowBleedLive, fastAdverseLive,
+      tapeOverrideLive, regimeCompositionalLive, regimeHeldExitLive,
+      scalpLimitMakerLive, scalpLimitMakerBroad,
+    };
   }
 
   private decayHindsightCachesOncePerTick(): void {
@@ -3577,7 +3614,7 @@ export class MonkeyKernel extends EventEmitter {
     // declared. Additive + shadow-only: no decision path consumes the
     // signals yet; folding them into the perception basin is a
     // deliberate follow-on.
-    if (process.env.MONKEY_MARKET_INTEL_LIVE === 'true') {
+    if (this.featureFlags.marketIntelLive) {
       void marketIntelCache.refreshIfStale(symbol, 60_000);
     }
 
@@ -3619,7 +3656,7 @@ export class MonkeyKernel extends EventEmitter {
     // (basin disorganized, hasn't integrated), even modest tape signal
     // qualifies for override. Self-calibrating: as the kernel's
     // perception strengthens, the bar for tape-override rises.
-    const tapeOverrideLive = process.env.MONKEY_TAPE_OVERRIDE_LIVE !== 'false';
+    const tapeOverrideLive = this.featureFlags.tapeOverrideLive;
     const tapeOverrideThreshold = phi;
     let cellDirection = basinDirection;
     let cellDirectionOverridden = false;
@@ -3645,7 +3682,7 @@ export class MonkeyKernel extends EventEmitter {
           regimeConfidence: regimeReading.confidence,
         })
       : null;
-    const cellLive = process.env.REGIME_COMPOSITIONAL_LIVE === 'true';
+    const cellLive = this.featureFlags.regimeCompositionalLive;
 
     // Proposal #9: candlestick pattern detection at the perception
     // input boundary. ``patternSignal`` is signed in [-1, +1];
@@ -3694,7 +3731,7 @@ export class MonkeyKernel extends EventEmitter {
 
     // MONKEY_SHORTS_LIVE — sequencing protection retained from #575.
     // Orthogonal to agent-separation; flipped via env independently.
-    const SHORTS_LIVE = process.env.MONKEY_SHORTS_LIVE === 'true';
+    const SHORTS_LIVE = this.featureFlags.shortsLive;
     const sideShortRefused = sideCandidate === 'short' && !SHORTS_LIVE;
     if (sideShortRefused) {
       logger.info('[Monkey] short refused — MONKEY_SHORTS_LIVE=false', {
@@ -4102,7 +4139,7 @@ export class MonkeyKernel extends EventEmitter {
     // signals (premium basis, OI direction, funding) so retrospective
     // analysis can correlate them with outcomes before a later PR folds
     // them into the perception basin.
-    if (process.env.MONKEY_MARKET_INTEL_LIVE === 'true') {
+    if (this.featureFlags.marketIntelLive) {
       const mi = marketIntelCache.get(symbol);
       if (mi) {
         derivation.marketIntel = {
@@ -4213,7 +4250,7 @@ export class MonkeyKernel extends EventEmitter {
         // (2026-05-20 operator directive: "close trades at its predicted
         // or adjusted limit"); set MONKEY_BRACKET_EXIT_LIVE=false to
         // disable as a kill-switch.
-        const bracketExitLive = process.env.MONKEY_BRACKET_EXIT_LIVE !== 'false';
+        const bracketExitLive = this.featureFlags.bracketExitLive;
         const hasBracket = (openRow.take_profit ?? null) !== null
           || (openRow.stop_loss ?? null) !== null;
         const bracketActive = bracketExitLive && hasBracket;
@@ -4484,7 +4521,7 @@ export class MonkeyKernel extends EventEmitter {
           const terciIdx = Math.min(n - 1, Math.floor(n * 0.67));
           return sorted[terciIdx] ?? 0;
         })();
-        const regimeHeldExitLive = process.env.REGIME_HELD_EXIT_LIVE === 'true';
+        const regimeHeldExitLive = this.featureFlags.regimeHeldExitLive;
         let observerLossFloorRoi = 0;
         let minProfitablePnl = Number.POSITIVE_INFINITY;
         let regimeHeldProfit: ReturnType<typeof shouldRegimeHeldProfitExit> | undefined;
@@ -4587,7 +4624,7 @@ export class MonkeyKernel extends EventEmitter {
         //   MONKEY_FAST_ADVERSE_BASIN_FLOOR (default 0.10 — basin must be
         //                                    > 0.10 wrong-side; below = noise)
         //   MONKEY_FAST_ADVERSE_LIVE  (default true; set false to disable)
-        const fastAdverseLive = process.env.MONKEY_FAST_ADVERSE_LIVE !== 'false';
+        const fastAdverseLive = this.featureFlags.fastAdverseLive;
         const fastAdverseRoiPct =
           Number(process.env.MONKEY_FAST_ADVERSE_ROI_PCT) || -0.30;
         const fastAdverseBasinFloor =
@@ -4690,7 +4727,7 @@ export class MonkeyKernel extends EventEmitter {
         // 7.3% ROI < 15% SL), time axis was uncovered. shouldSlowBleedExit
         // fires when held >= 60min AND |ROI| >= 0.5×laneSL AND tape adverse.
         // Env: MONKEY_SLOW_BLEED_LIVE (default true; set false to disable).
-        const slowBleedLive = process.env.MONKEY_SLOW_BLEED_LIVE !== 'false';
+        const slowBleedLive = this.featureFlags.slowBleedLive;
         if (!exitFired && slowBleedLive && entryTimeMs !== undefined) {
           const heldMs = Date.now() - entryTimeMs;
           const slowBleed = shouldSlowBleedExit({
@@ -4849,8 +4886,7 @@ export class MonkeyKernel extends EventEmitter {
         // trades at its predicted or adjusted limit" — the revision is
         // the "adjusted" half); set MONKEY_BRACKET_EXTEND_LIVE=false to
         // disable as a kill-switch.
-        const bracketExtendLive =
-          process.env.MONKEY_BRACKET_EXTEND_LIVE !== 'false';
+        const bracketExtendLive = this.featureFlags.bracketExtendLive;
         if (
           !exitFired && bracketActive && bracketExtendLive
           && state.lastFrBracket !== null
@@ -5396,7 +5432,7 @@ export class MonkeyKernel extends EventEmitter {
     // with K's side. If so, K's entry is suppressed (the executeEntry
     // call is skipped) — exits, harvest, scalp_exit are NOT affected.
     let lVeto: LVetoEvaluation | null = null;
-    const lVetoEnabled = isLVetoOverKEnabled();
+    const lVetoEnabled = this.featureFlags.lVetoOverK;
     const kProposingEntry =
       action === 'enter_long' ||
       action === 'enter_short' ||
@@ -6829,7 +6865,7 @@ export class MonkeyKernel extends EventEmitter {
     logger.info(`[Monkey] ${symbol} [${mode}] ${action}${executed ? ' EXECUTED' : ''}`, {
       mode,
       cell: cellToken,
-      cellLive: process.env.REGIME_COMPOSITIONAL_LIVE === 'true',
+      cellLive: this.featureFlags.regimeCompositionalLive,
       // chosenLane surfaces the lane chooseLane picked this tick (after
       // simplex projection + cellLaneBias + SENSE-2c prior). Critical
       // observability for LIMIT_MAKER routing: scalp lane routes to
@@ -8502,7 +8538,7 @@ export class MonkeyKernel extends EventEmitter {
       // (different lifecycle — close-side stale needs to retry-as-MARKET, not
       // close-orphan-row); that retry path is handled by the outer tick loop's
       // next decision firing the same exit signal again.
-      const makerCloseLive = process.env.MONKEY_MAKER_CLOSE_LIVE === 'true';
+      const makerCloseLive = this.featureFlags.makerCloseLive;
       const isPreservationExit =
         exitReason.startsWith('regime_held_exit')
         || exitReason.startsWith('trailing_harvest')
@@ -8896,7 +8932,7 @@ export class MonkeyKernel extends EventEmitter {
           // (the same gate that controls limit_maker routing). Safe default: taker.
           {
             const entryOrderType: 'maker' | 'taker' =
-              row.lane === 'scalp' && process.env.SCALP_LIMIT_MAKER_LIVE === 'true'
+              row.lane === 'scalp' && this.featureFlags.scalpLimitMakerLive
                 ? 'maker'
                 : 'taker';
             recordFillQuality({
@@ -9284,7 +9320,7 @@ export class MonkeyKernel extends EventEmitter {
     // INTO a favourable funding cycle is a small free EV the gate should not block.
     if (
       !req.isDCAAdd
-      && process.env.MONKEY_FUNDING_GATE_LIVE === 'true'
+      && this.featureFlags.fundingGateLive
     ) {
       const funding = this.latestFundingBySymbol.get(symbol);
       if (funding && funding.nextFundingTimeMs && Number.isFinite(funding.rate)) {
@@ -9816,7 +9852,7 @@ export class MonkeyKernel extends EventEmitter {
     // latency outweighs the rebate on the current symbol mix. The PR
     // #817 counterfactual was a single window; this lever lets you A/B
     // without a redeploy.
-    const broadMakerRouting = process.env.SCALP_LIMIT_MAKER_BROAD !== 'false';
+    const broadMakerRouting = this.featureFlags.scalpLimitMakerBroad;
     const cellIsChop = req.cellDirection === 'CHOP';
     const laneIsScalp = (req.lane ?? 'swing') === 'scalp';
     // Fallback after consecutive stale-cancels: when maker has failed
@@ -9839,7 +9875,7 @@ export class MonkeyKernel extends EventEmitter {
       });
     }
     const useLimitMaker =
-      process.env.SCALP_LIMIT_MAKER_LIVE === 'true'
+      this.featureFlags.scalpLimitMakerLive
       && (laneIsScalp || (broadMakerRouting && cellIsChop))
       && !req.isDCAAdd
       && !makerCircuitOpen;


### PR DESCRIPTION
## Why (main is RED — deploys blocked)

`d25f8c0c` (\"feat(senses): … loop.ts unstaged cleanup\") committed an **incomplete** featureFlags control plane: it landed the `FeatureFlagSnapshot` infra + the per-tick `this.refreshFeatureFlags()` **call**, and deleted the `isLVetoOverKEnabled()` helper — but the `refreshFeatureFlags()` **method body was never committed** and the helper's call site was left dangling. Result on `main`:

```
loop.ts(2289): error TS2339: Property 'refreshFeatureFlags' does not exist on type 'MonkeyKernel'.
loop.ts(5399): error TS2304: Cannot find name 'isLVetoOverKEnabled'.
```

ci-types RED → **all Railway deploys blocked** (same incident class as #1075). Root cause: a shared-checkout WIP collision between two concurrent agents — a blanket cleanup commit swept in half-finished work.

## What this does

Completes the wiring (the originally-intended task: move operator FEATURE on/off toggles off Railway env vars onto the DB-backed, UI-controlled `monkey_feature_flags` table — migration 068):

- **Adds `refreshFeatureFlags()`** — one `Promise.all` of `getBoolFlag` reads, each `safeDefault` matching the prior env semantics **exactly** (`=== 'true'` → `false`; `!== 'false'` → `true`). Snapshotted once per tick right after the execution-mode refresh; the service caches all flags in one DB read per 15s TTL, so reads are cache hits.
- **Replaces all 16 operator-toggle reads**:
  - 14 per-tick → `this.featureFlags.*` (shorts, market-intel ×2, funding gate, maker-close, L-veto-over-K, bracket exit/extend, slow-bleed, fast-adverse, tape-override, regime-compositional ×2, regime-held-exit, scalp-limit-maker ×2, scalp-limit-maker-broad)
  - 2 startup-once in `start()` → direct `await getBoolFlag(...)` (`MONKEY_MTF_BOOTSTRAP`, `MONKEY_WS_PRIVATE_LIVE`)
- `isLVetoOverKEnabled()`'s former call site now reads `featureFlags.lVetoOverK`.

Numeric CALIBRATION knobs are deliberately **not** moved — observer-derived per P1. **SHORTS is now a plain UI toggle** (operator directive). Behaviour is byte-identical: every default and the migration-068 seeds preserve today's effective values.

## Gates

- `yarn build` exit 0 → **ci-types now GREEN**
- qig-purity: clean (no banned vocab in diff)
- vitest: 2330 pass; the 4 failures are **pre-existing on base `d25f8c0c`** (from #768/#769), orthogonal to this diff — verified by stash-and-rerun. (No vitest PR gate; tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)