### PR TITLE
feat(monkey): complete featureFlags migration — 16 toggles off env onto UI control plane

### DIFF
--- a/apps/api/src/services/__tests__/featureFlagsService.test.ts
+++ b/apps/api/src/services/__tests__/featureFlagsService.test.ts
@@ -46,6 +46,29 @@ describe('featureFlagsService', () => {
     expect(mockedQuery).toHaveBeenCalledTimes(1);
   });
 
+  it('coalesces a concurrent cold-cache stampede onto ONE DB read', async () => {
+    // The kernel refreshes all flags per tick via Promise.all of ~14
+    // getBoolFlag calls. On a cold/expired cache these race in together; the
+    // in-flight latch must funnel them onto a single SELECT, not one per caller.
+    let resolveQuery!: (v: Awaited<ReturnType<typeof query>>) => void;
+    mockedQuery.mockImplementationOnce(
+      () => new Promise((res) => { resolveQuery = res; }),
+    );
+    const keys = [
+      'MONKEY_SHORTS_LIVE', 'MONKEY_MARKET_INTEL_LIVE', 'MONKEY_FUNDING_GATE_LIVE',
+      'MONKEY_MAKER_CLOSE_LIVE', 'L_VETO_OVER_K_ENABLED', 'MONKEY_BRACKET_EXIT_LIVE',
+      'MONKEY_BRACKET_EXTEND_LIVE', 'MONKEY_SLOW_BLEED_LIVE', 'MONKEY_FAST_ADVERSE_LIVE',
+      'MONKEY_TAPE_OVERRIDE_LIVE', 'REGIME_COMPOSITIONAL_LIVE', 'REGIME_HELD_EXIT_LIVE',
+      'SCALP_LIMIT_MAKER_LIVE', 'SCALP_LIMIT_MAKER_BROAD',
+    ];
+    const inFlightReads = Promise.all(keys.map((k) => getBoolFlag(k, false)));
+    resolveQuery(rows([{ flag_key: 'MONKEY_SHORTS_LIVE', value: 'true' }]));
+    const results = await inFlightReads;
+    expect(mockedQuery).toHaveBeenCalledTimes(1); // not 14
+    expect(results[0]).toBe(true);                // shorts present
+    expect(results[1]).toBe(false);               // absent → safe default
+  });
+
   it('getBoolFlag returns the SAFE default when the flag is absent', async () => {
     mockedQuery.mockResolvedValueOnce(rows([{ flag_key: 'OTHER', value: 'true' }]));
     expect(await getBoolFlag('MONKEY_SHORTS_LIVE', false)).toBe(false);

--- a/apps/api/src/services/featureFlagsService.ts
+++ b/apps/api/src/services/featureFlagsService.ts
@@ -22,6 +22,13 @@ const CACHE_TTL_MS = 15 * 1000;
 
 let cache: Map<string, string> | null = null;
 let cachedAt = 0;
+// In-flight refresh promise. When the cache is cold/expired and several callers
+// race in together (e.g. the kernel's per-tick Promise.all of getBoolFlag
+// reads), the first starts the DB read and stores its promise here; the rest
+// await the SAME promise instead of each firing their own SELECT. Without this
+// the TTL check is not atomic with the cache write, so a cold refresh fans out
+// into one query per concurrent caller (an async cache stampede).
+let inFlight: Promise<Map<string, string>> | null = null;
 
 export interface FeatureFlagRecord {
   flagKey: string;
@@ -38,28 +45,36 @@ export interface FeatureFlagRecord {
 async function ensureCache(): Promise<Map<string, string>> {
   const now = Date.now();
   if (cache && now - cachedAt < CACHE_TTL_MS) return cache;
-  try {
-    const result = await query(`SELECT flag_key, value FROM monkey_feature_flags`);
-    const next = new Map<string, string>();
-    for (const row of result.rows as unknown as Array<{ flag_key: string; value: string }>) {
-      next.set(row.flag_key, row.value);
+  // Coalesce concurrent cold/expired refreshes onto a single DB read.
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const result = await query(`SELECT flag_key, value FROM monkey_feature_flags`);
+      const next = new Map<string, string>();
+      for (const row of result.rows as unknown as Array<{ flag_key: string; value: string }>) {
+        next.set(row.flag_key, row.value);
+      }
+      cache = next;
+      cachedAt = Date.now();
+      return cache;
+    } catch (err) {
+      logger.warn('[featureFlags] DB read failed — serving last-known-good / safe defaults', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      // Cache the fallback (last-known-good if warm, else empty) AND stamp cachedAt
+      // so a sustained outage doesn't re-query + re-log on every per-tick read
+      // (mirrors executionModeService's outage-storm guard). A warm cache serves
+      // last-known-good values; a cold cache yields the caller's safe default.
+      const fallback = cache ?? new Map<string, string>();
+      cache = fallback;
+      cachedAt = Date.now();
+      return fallback;
+    } finally {
+      // Clear the in-flight latch so the NEXT post-TTL refresh starts fresh.
+      inFlight = null;
     }
-    cache = next;
-    cachedAt = now;
-    return cache;
-  } catch (err) {
-    logger.warn('[featureFlags] DB read failed — serving last-known-good / safe defaults', {
-      err: err instanceof Error ? err.message : String(err),
-    });
-    // Cache the fallback (last-known-good if warm, else empty) AND stamp cachedAt
-    // so a sustained outage doesn't re-query + re-log on every per-tick read
-    // (mirrors executionModeService's outage-storm guard). A warm cache serves
-    // last-known-good values; a cold cache yields the caller's safe default.
-    const fallback = cache ?? new Map<string, string>();
-    cache = fallback;
-    cachedAt = now;
-    return fallback;
-  }
+  })();
+  return inFlight;
 }
 
 /**
@@ -150,4 +165,5 @@ export async function setFlag(
 export function __resetFeatureFlagsCache(): void {
   cache = null;
   cachedAt = 0;
+  inFlight = null;
 }

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -1622,7 +1622,7 @@ export class MonkeyKernel extends EventEmitter {
     // for entire sessions). Now we await per-symbol bootstrap, retain
     // the per-TF status, and ``maybeRetryMTFBootstrap`` re-runs cold
     // timeframes on a later tick.
-    if (process.env.MONKEY_MTF_BOOTSTRAP !== 'false') {
+    if (await getBoolFlag('MONKEY_MTF_BOOTSTRAP', true)) {
       void this.runInitialMTFBootstrap();
     }
 
@@ -1650,7 +1650,7 @@ export class MonkeyKernel extends EventEmitter {
     // stays authoritative; the cache is a fresher cross-check surface a
     // later PR can flip to primary on evidence. Fail-soft — a WS failure
     // leaves the kernel on REST exactly as before.
-    if (process.env.MONKEY_WS_PRIVATE_LIVE === 'true') {
+    if (await getBoolFlag('MONKEY_WS_PRIVATE_LIVE', false)) {
       void this.startWsPositionFeed();
     }
 
@@ -3610,7 +3610,7 @@ export class MonkeyKernel extends EventEmitter {
     // declared. Additive + shadow-only: no decision path consumes the
     // signals yet; folding them into the perception basin is a
     // deliberate follow-on.
-    if (process.env.MONKEY_MARKET_INTEL_LIVE === 'true') {
+    if (this.featureFlags.marketIntelLive) {
       void marketIntelCache.refreshIfStale(symbol, 60_000);
     }
 
@@ -3652,7 +3652,7 @@ export class MonkeyKernel extends EventEmitter {
     // (basin disorganized, hasn't integrated), even modest tape signal
     // qualifies for override. Self-calibrating: as the kernel's
     // perception strengthens, the bar for tape-override rises.
-    const tapeOverrideLive = process.env.MONKEY_TAPE_OVERRIDE_LIVE !== 'false';
+    const tapeOverrideLive = this.featureFlags.tapeOverrideLive;
     const tapeOverrideThreshold = phi;
     let cellDirection = basinDirection;
     let cellDirectionOverridden = false;
@@ -3678,7 +3678,7 @@ export class MonkeyKernel extends EventEmitter {
           regimeConfidence: regimeReading.confidence,
         })
       : null;
-    const cellLive = process.env.REGIME_COMPOSITIONAL_LIVE === 'true';
+    const cellLive = this.featureFlags.regimeCompositionalLive;
 
     // Proposal #9: candlestick pattern detection at the perception
     // input boundary. ``patternSignal`` is signed in [-1, +1];
@@ -3727,7 +3727,7 @@ export class MonkeyKernel extends EventEmitter {
 
     // MONKEY_SHORTS_LIVE — sequencing protection retained from #575.
     // Orthogonal to agent-separation; flipped via env independently.
-    const SHORTS_LIVE = process.env.MONKEY_SHORTS_LIVE === 'true';
+    const SHORTS_LIVE = this.featureFlags.shortsLive;
     const sideShortRefused = sideCandidate === 'short' && !SHORTS_LIVE;
     if (sideShortRefused) {
       logger.info('[Monkey] short refused — MONKEY_SHORTS_LIVE=false', {
@@ -4135,7 +4135,7 @@ export class MonkeyKernel extends EventEmitter {
     // signals (premium basis, OI direction, funding) so retrospective
     // analysis can correlate them with outcomes before a later PR folds
     // them into the perception basin.
-    if (process.env.MONKEY_MARKET_INTEL_LIVE === 'true') {
+    if (this.featureFlags.marketIntelLive) {
       const mi = marketIntelCache.get(symbol);
       if (mi) {
         derivation.marketIntel = {
@@ -4246,7 +4246,7 @@ export class MonkeyKernel extends EventEmitter {
         // (2026-05-20 operator directive: "close trades at its predicted
         // or adjusted limit"); set MONKEY_BRACKET_EXIT_LIVE=false to
         // disable as a kill-switch.
-        const bracketExitLive = process.env.MONKEY_BRACKET_EXIT_LIVE !== 'false';
+        const bracketExitLive = this.featureFlags.bracketExitLive;
         const hasBracket = (openRow.take_profit ?? null) !== null
           || (openRow.stop_loss ?? null) !== null;
         const bracketActive = bracketExitLive && hasBracket;
@@ -4517,7 +4517,7 @@ export class MonkeyKernel extends EventEmitter {
           const terciIdx = Math.min(n - 1, Math.floor(n * 0.67));
           return sorted[terciIdx] ?? 0;
         })();
-        const regimeHeldExitLive = process.env.REGIME_HELD_EXIT_LIVE === 'true';
+        const regimeHeldExitLive = this.featureFlags.regimeHeldExitLive;
         let observerLossFloorRoi = 0;
         let minProfitablePnl = Number.POSITIVE_INFINITY;
         let regimeHeldProfit: ReturnType<typeof shouldRegimeHeldProfitExit> | undefined;
@@ -4620,7 +4620,7 @@ export class MonkeyKernel extends EventEmitter {
         //   MONKEY_FAST_ADVERSE_BASIN_FLOOR (default 0.10 — basin must be
         //                                    > 0.10 wrong-side; below = noise)
         //   MONKEY_FAST_ADVERSE_LIVE  (default true; set false to disable)
-        const fastAdverseLive = process.env.MONKEY_FAST_ADVERSE_LIVE !== 'false';
+        const fastAdverseLive = this.featureFlags.fastAdverseLive;
         const fastAdverseRoiPct =
           Number(process.env.MONKEY_FAST_ADVERSE_ROI_PCT) || -0.30;
         const fastAdverseBasinFloor =
@@ -4723,7 +4723,7 @@ export class MonkeyKernel extends EventEmitter {
         // 7.3% ROI < 15% SL), time axis was uncovered. shouldSlowBleedExit
         // fires when held >= 60min AND |ROI| >= 0.5×laneSL AND tape adverse.
         // Env: MONKEY_SLOW_BLEED_LIVE (default true; set false to disable).
-        const slowBleedLive = process.env.MONKEY_SLOW_BLEED_LIVE !== 'false';
+        const slowBleedLive = this.featureFlags.slowBleedLive;
         if (!exitFired && slowBleedLive && entryTimeMs !== undefined) {
           const heldMs = Date.now() - entryTimeMs;
           const slowBleed = shouldSlowBleedExit({
@@ -4883,7 +4883,7 @@ export class MonkeyKernel extends EventEmitter {
         // the "adjusted" half); set MONKEY_BRACKET_EXTEND_LIVE=false to
         // disable as a kill-switch.
         const bracketExtendLive =
-          process.env.MONKEY_BRACKET_EXTEND_LIVE !== 'false';
+          this.featureFlags.bracketExtendLive;
         if (
           !exitFired && bracketActive && bracketExtendLive
           && state.lastFrBracket !== null
@@ -6862,7 +6862,7 @@ export class MonkeyKernel extends EventEmitter {
     logger.info(`[Monkey] ${symbol} [${mode}] ${action}${executed ? ' EXECUTED' : ''}`, {
       mode,
       cell: cellToken,
-      cellLive: process.env.REGIME_COMPOSITIONAL_LIVE === 'true',
+      cellLive: this.featureFlags.regimeCompositionalLive,
       // chosenLane surfaces the lane chooseLane picked this tick (after
       // simplex projection + cellLaneBias + SENSE-2c prior). Critical
       // observability for LIMIT_MAKER routing: scalp lane routes to
@@ -8535,7 +8535,7 @@ export class MonkeyKernel extends EventEmitter {
       // (different lifecycle — close-side stale needs to retry-as-MARKET, not
       // close-orphan-row); that retry path is handled by the outer tick loop's
       // next decision firing the same exit signal again.
-      const makerCloseLive = process.env.MONKEY_MAKER_CLOSE_LIVE === 'true';
+      const makerCloseLive = this.featureFlags.makerCloseLive;
       const isPreservationExit =
         exitReason.startsWith('regime_held_exit')
         || exitReason.startsWith('trailing_harvest')
@@ -8929,7 +8929,7 @@ export class MonkeyKernel extends EventEmitter {
           // (the same gate that controls limit_maker routing). Safe default: taker.
           {
             const entryOrderType: 'maker' | 'taker' =
-              row.lane === 'scalp' && process.env.SCALP_LIMIT_MAKER_LIVE === 'true'
+              row.lane === 'scalp' && this.featureFlags.scalpLimitMakerLive
                 ? 'maker'
                 : 'taker';
             recordFillQuality({
@@ -9317,7 +9317,7 @@ export class MonkeyKernel extends EventEmitter {
     // INTO a favourable funding cycle is a small free EV the gate should not block.
     if (
       !req.isDCAAdd
-      && process.env.MONKEY_FUNDING_GATE_LIVE === 'true'
+      && this.featureFlags.fundingGateLive
     ) {
       const funding = this.latestFundingBySymbol.get(symbol);
       if (funding && funding.nextFundingTimeMs && Number.isFinite(funding.rate)) {
@@ -9849,7 +9849,7 @@ export class MonkeyKernel extends EventEmitter {
     // latency outweighs the rebate on the current symbol mix. The PR
     // #817 counterfactual was a single window; this lever lets you A/B
     // without a redeploy.
-    const broadMakerRouting = process.env.SCALP_LIMIT_MAKER_BROAD !== 'false';
+    const broadMakerRouting = this.featureFlags.scalpLimitMakerBroad;
     const cellIsChop = req.cellDirection === 'CHOP';
     const laneIsScalp = (req.lane ?? 'swing') === 'scalp';
     // Fallback after consecutive stale-cancels: when maker has failed
@@ -9872,7 +9872,7 @@ export class MonkeyKernel extends EventEmitter {
       });
     }
     const useLimitMaker =
-      process.env.SCALP_LIMIT_MAKER_LIVE === 'true'
+      this.featureFlags.scalpLimitMakerLive
       && (laneIsScalp || (broadMakerRouting && cellIsChop))
       && !req.isDCAAdd
       && !makerCircuitOpen;

--- a/apps/api/src/services/monkey/loop.ts
+++ b/apps/api/src/services/monkey/loop.ts
@@ -3641,7 +3641,7 @@ export class MonkeyKernel extends EventEmitter {
     // order-of-magnitude as the existing cross-agent tape-veto (0.20)
     // but tighter — we want STRONG tape signal before overriding.
     //
-    // Env: MONKEY_TAPE_OVERRIDE_LIVE (default true; kill switch only).
+    // UI flag MONKEY_TAPE_OVERRIDE_LIVE (monkey_feature_flags; default true; kill-switch toggle only).
     //
     // Phase 5 doctrine (2026-05-26): tape-override threshold replaced
     // by phi-derived. MONKEY_TAPE_OVERRIDE_THRESHOLD (was 0.40) removed.
@@ -3726,7 +3726,8 @@ export class MonkeyKernel extends EventEmitter {
     // Stage 2 stud topology). TS does not implement REVERSION yet.
 
     // MONKEY_SHORTS_LIVE — sequencing protection retained from #575.
-    // Orthogonal to agent-separation; flipped via env independently.
+    // Orthogonal to agent-separation; a plain UI toggle (monkey_feature_flags),
+    // snapshotted per tick into this.featureFlags.shortsLive.
     const SHORTS_LIVE = this.featureFlags.shortsLive;
     const sideShortRefused = sideCandidate === 'short' && !SHORTS_LIVE;
     if (sideShortRefused) {
@@ -4244,8 +4245,8 @@ export class MonkeyKernel extends EventEmitter {
         // The loss-side safety gates (hard SL, fast-adverse, slow-bleed)
         // still run — a price stop is not a time/tape stop. Default ON
         // (2026-05-20 operator directive: "close trades at its predicted
-        // or adjusted limit"); set MONKEY_BRACKET_EXIT_LIVE=false to
-        // disable as a kill-switch.
+        // or adjusted limit"); toggle MONKEY_BRACKET_EXIT_LIVE off in the UI
+        // (monkey_feature_flags) to disable as a kill-switch.
         const bracketExitLive = this.featureFlags.bracketExitLive;
         const hasBracket = (openRow.take_profit ?? null) !== null
           || (openRow.stop_loss ?? null) !== null;
@@ -4615,11 +4616,13 @@ export class MonkeyKernel extends EventEmitter {
         // both (a) the position is losing money, (b) basin signal supports
         // the OTHER side. Combined = "we were wrong, get out."
         //
-        // Env overrides (all conservative defaults):
+        // Live toggle: MONKEY_FAST_ADVERSE_LIVE — UI flag (monkey_feature_flags;
+        // default true; toggle off to disable), snapshotted into featureFlags.
+        // Numeric CALIBRATION env overrides remain env (observer-derived knobs
+        // out of scope for the UI control plane, all conservative defaults):
         //   MONKEY_FAST_ADVERSE_ROI_PCT  (default -0.30 — fire when ROI < -0.30%)
         //   MONKEY_FAST_ADVERSE_BASIN_FLOOR (default 0.10 — basin must be
         //                                    > 0.10 wrong-side; below = noise)
-        //   MONKEY_FAST_ADVERSE_LIVE  (default true; set false to disable)
         const fastAdverseLive = this.featureFlags.fastAdverseLive;
         const fastAdverseRoiPct =
           Number(process.env.MONKEY_FAST_ADVERSE_ROI_PCT) || -0.30;
@@ -4722,7 +4725,7 @@ export class MonkeyKernel extends EventEmitter {
         // through 0.334% adverse — SL gate held by design (lev=22 →
         // 7.3% ROI < 15% SL), time axis was uncovered. shouldSlowBleedExit
         // fires when held >= 60min AND |ROI| >= 0.5×laneSL AND tape adverse.
-        // Env: MONKEY_SLOW_BLEED_LIVE (default true; set false to disable).
+        // UI flag MONKEY_SLOW_BLEED_LIVE (monkey_feature_flags; default true; toggle off to disable).
         const slowBleedLive = this.featureFlags.slowBleedLive;
         if (!exitFired && slowBleedLive && entryTimeMs !== undefined) {
           const heldMs = Date.now() - entryTimeMs;
@@ -4880,8 +4883,8 @@ export class MonkeyKernel extends EventEmitter {
         // enforces it), so revising every tick can only improve the
         // bracket. Default ON (2026-05-20 operator directive: "close
         // trades at its predicted or adjusted limit" — the revision is
-        // the "adjusted" half); set MONKEY_BRACKET_EXTEND_LIVE=false to
-        // disable as a kill-switch.
+        // the "adjusted" half); toggle MONKEY_BRACKET_EXTEND_LIVE off in the UI
+        // (monkey_feature_flags) to disable as a kill-switch.
         const bracketExtendLive =
           this.featureFlags.bracketExtendLive;
         if (
@@ -8521,7 +8524,7 @@ export class MonkeyKernel extends EventEmitter {
       // the fee burden the rebate strategy was meant to avoid.
       //
       // Conservative gating:
-      //   1. Env flag MONKEY_MAKER_CLOSE_LIVE=true (default OFF, safe rollout)
+      //   1. UI flag MONKEY_MAKER_CLOSE_LIVE ON (monkey_feature_flags; default OFF, safe rollout)
       //   2. Single-chunk only (chunkSizes.length === 1) — multi-chunk maker
       //      close has unhandled partial-fill complexity, defer to follow-up
       //   3. Exit reason matches preservation pattern (regime_held_exit,
@@ -8925,7 +8928,7 @@ export class MonkeyKernel extends EventEmitter {
           perAgentTotals[agentLabel].qty += rowQty;
 
           // #827: record fill quality for symbol-scope analysis (best-effort, non-blocking).
-          // Derives entry order_type: scalp lane + SCALP_LIMIT_MAKER_LIVE env = maker
+          // Derives entry order_type: scalp lane + SCALP_LIMIT_MAKER_LIVE UI flag = maker
           // (the same gate that controls limit_maker routing). Safe default: taker.
           {
             const entryOrderType: 'maker' | 'taker' =
@@ -9309,7 +9312,7 @@ export class MonkeyKernel extends EventEmitter {
     //   active when |now - nextFundingTime| <= FUNDING_GATE_WINDOW_MIN (default 10 min)
     //
     // Bypass conditions:
-    //   - MONKEY_FUNDING_GATE_LIVE != 'true'  → gate disabled
+    //   - MONKEY_FUNDING_GATE_LIVE UI flag off → gate disabled
     //   - nextFundingTimeMs absent             → schedule unknown, fail-open
     //   - req.isDCAAdd                         → defending existing position
     //
@@ -9844,7 +9847,8 @@ export class MonkeyKernel extends EventEmitter {
       }
     }
 
-    // Operator-toggleable scope: SCALP_LIMIT_MAKER_BROAD=false reverts
+    // Operator-toggleable scope: toggle SCALP_LIMIT_MAKER_BROAD off in the UI
+    // (monkey_feature_flags) to revert
     // to the original scalp-lane-only routing if broad-CHOP routing's
     // latency outweighs the rebate on the current symbol mix. The PR
     // #817 counterfactual was a single window; this lever lets you A/B


### PR DESCRIPTION
Replaces #1076 (closed — main moved twice underneath it). Conflict-free branch off current main.

## Context

`7a146a8c` repaired the RED compile (added the `refreshFeatureFlags()` body + fixed the `isLVetoOverKEnabled()` call) but **left the actual migration unfinished** — loop.ts still read the operator FEATURE toggles from `process.env` at **18 sites**. So `main` compiles, but the toggles are NOT yet on the UI control plane.

## What this does

Finishes the job: the toggles now come from the DB-backed, UI-controlled `monkey_feature_flags` table (migration 068) — the operator drives every feature from one pane of glass instead of Railway env vars (standing "everything via UI" directive).

- **16 per-tick reads → `this.featureFlags.*`** (shorts, market-intel ×2, funding gate, maker-close, bracket exit/extend, slow-bleed, fast-adverse, tape-override, regime-compositional ×2, regime-held-exit, scalp-limit-maker ×2, scalp-limit-maker-broad) — snapshotted once per tick by the existing `refreshFeatureFlags()`.
- **2 startup-once in `start()` → `await getBoolFlag(...)`** (`MONKEY_MTF_BOOTSTRAP`, `MONKEY_WS_PRIVATE_LIVE`).
- **Carries the featureFlagsService cold-cache stampede dedupe** (in-flight promise latch + test) — addresses the Copilot finding from #1076 that the per-tick `Promise.all` of 14 `getBoolFlag` reads fanned out to 14 concurrent SELECTs on every expired tick.

Behaviour is **byte-identical**: every `safeDefault` matches the prior env semantics (`=== 'true'` → false; `!== 'false'` → true) and the migration-068 seeds carry today's effective values. **SHORTS is now a plain UI toggle** (operator directive). Numeric CALIBRATION knobs stay observer-derived per P1 — not moved.

## Gates

- `yarn build` exit 0 (ci-types)
- qig-purity: clean (no banned vocab in diff)
- featureFlagsService suite 8/8 (incl. new stampede test asserting one SELECT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)